### PR TITLE
[Enhancement] Add dynamic shape example for lightning indexer and support auto strideN calculation for gm-ops

### DIFF
--- a/src/op/ascend.h
+++ b/src/op/ascend.h
@@ -30,7 +30,7 @@ private:
   Buffer src, dst;
 
   Array<Range> src_range, dst_range;
-
+  Array<PrimExpr> src_extents, dst_extents;
   int srcN;
   bool enRelu;
 };

--- a/src/op/op.cc
+++ b/src/op/op.cc
@@ -64,6 +64,7 @@ RegionOp::RegionOp(Array<PrimExpr> args, BufferMap vmap) {
     PrimExpr min = load->indices[i];
     PrimExpr extent = args[2 + i];
     ranges_.push_back(Range::FromMinExtent(min, extent));
+    extents_.push_back(extent);
   }
 }
 

--- a/src/op/op.h
+++ b/src/op/op.h
@@ -83,6 +83,7 @@ public:
 
   const Buffer &GetBuffer() const { return buffer_; }
   const Array<Range> &GetRanges() const { return ranges_; }
+  const Array<PrimExpr> &GetExtents() const { return extents_; }
   int GetAccessMask() const { return access_mask_; }
   bool IsFullRegion() const;
 
@@ -90,6 +91,7 @@ private:
   Buffer buffer_;
   Array<Range> ranges_;
   int access_mask_;
+  Array<PrimExpr> extents_;
 };
 
 Var GetVarFromAccessPtr(const PrimExpr &expr);

--- a/tilelang/language/copy.py
+++ b/tilelang/language/copy.py
@@ -179,7 +179,6 @@ def c2d_im2col(
 
 def npu_copy_v2(src: Union[tir.Buffer, tir.BufferLoad, tir.BufferRegion],
                 dst: Union[tir.Buffer, tir.BufferLoad],
-                srcN=-1,
                 enable_relu: bool = False):
     """Copy data between memory regions.
 
@@ -228,8 +227,5 @@ def npu_copy_v2(src: Union[tir.Buffer, tir.BufferLoad, tir.BufferRegion],
 
     src = _to_region(src, "r")
     dst = _to_region(dst, "w")
-    if srcN == -1:
-        # TODO: need check
-        srcN = src_shape[-1]
 
-    return tir.call_intrin("handle", tir.op.Op.get("tl.ascend_copy"), src, dst, srcN, enable_relu)
+    return tir.call_intrin("handle", tir.op.Op.get("tl.ascend_copy"), src, dst, enable_relu)


### PR DESCRIPTION
[Enhancement] Add dynamic shape example for lightning indexer and support auto strideN calculation for GM-related data movement instructions.

    * Add a dynamic shape usage example for the lightning indexer to demonstrate flexible tensor dimensions.
    * Enable automatic strideN computation for GM-related data movement instructions, reducing manual configuration.
    * Refactor the codegen portion of the copy instruction.