### PR TITLE
[Bugfix] Fix dtype handling in KernelParam

### DIFF
--- a/tilelang/engine/param.py
+++ b/tilelang/engine/param.py
@@ -99,7 +99,9 @@ class KernelParam:
             bool: True if parameter is a boolean type, False otherwise
         """
         dtype_str = str(self.dtype)
-        return dtype_str[6:] if dtype_str.startswith("torch.") else dtype_str.startswith("bool")
+        if dtype_str.startswith("torch."):
+            dtype_str = dtype_str[6:]
+        return dtype_str.startswith("bool")
 
 
 @dataclass


### PR DESCRIPTION
The current implementation of the `is_boolean` method is inconsistent with its docstring.

This pull request grabs a small fix about the issue, which had already been done in the tilelang main repository. 👉[See here](https://github.com/tile-ai/tilelang/pull/564/files)