### PR TITLE
Move `export PYTHONPATH` from `install_ascend.sh` to `set_env.sh`

### DIFF
--- a/install_ascend.sh
+++ b/install_ascend.sh
@@ -147,25 +147,5 @@ fi
 
 cd ..
 
-# Step 11: Set environment variables
-TILELANG_PATH="$(pwd)"
-echo "TileLang path set to: $TILELANG_PATH"
-echo "Configuring environment variables for TVM..."
-EXPORT_PYTHONPATH="export PYTHONPATH=${TILELANG_PATH}:\$PYTHONPATH"
-if ! grep -qxF "$EXPORT_PYTHONPATH" ~/.bashrc; then
-    echo "$EXPORT_PYTHONPATH" >> ~/.bashrc
-fi
-
-# Step 12: Source .bashrc to apply changes
-echo "Applying environment changes by sourcing .bashrc..."
-source ~/.bashrc
-if [ $? -ne 0 ]; then
-    echo "Error: Failed to source .bashrc."
-    exit 1
-else
-    echo "Environment configured successfully."
-fi
-
 echo "Installation script completed successfully."
-exec bash
 

--- a/install_ascend.sh
+++ b/install_ascend.sh
@@ -151,7 +151,10 @@ cd ..
 TILELANG_PATH="$(pwd)"
 echo "TileLang path set to: $TILELANG_PATH"
 echo "Configuring environment variables for TVM..."
-echo "export PYTHONPATH=${TILELANG_PATH}:\$PYTHONPATH" >> ~/.bashrc
+EXPORT_PYTHONPATH="export PYTHONPATH=${TILELANG_PATH}:\$PYTHONPATH"
+if ! grep -qxF "$EXPORT_PYTHONPATH" ~/.bashrc; then
+    echo "$EXPORT_PYTHONPATH" >> ~/.bashrc
+fi
 
 # Step 12: Source .bashrc to apply changes
 echo "Applying environment changes by sourcing .bashrc..."

--- a/set_env.sh
+++ b/set_env.sh
@@ -2,6 +2,7 @@
 
 TL_ROOT=$(readlink -f "${BASH_SOURCE[0]}")
 export TL_ROOT=$(dirname "$TL_ROOT")
+export PYTHONPATH=${TL_ROOT}:$PYTHONPATH
 
 # disable the import of tvm when using torch_npu
 export ACL_OP_INIT_MODE=1


### PR DESCRIPTION
Avoid polluting `~/.bashrc` with multiple `export PYTHONPATH=...` when executing `install_ascend.sh`. 
Instead, inserting `PYTHONPATH` in `set_env.sh`.
Also avoid starting new bash subprocesses in `install_ascend.sh`, which seems to be more friendly to Docker and Conda environments.

