### PR TITLE
[Enhancement] support BufferRegion type for src1 in binary ops

### DIFF
--- a/examples/elementwise/elementwise_add_pipeline.py
+++ b/examples/elementwise/elementwise_add_pipeline.py
@@ -1,0 +1,101 @@
+import argparse
+
+import tilelang
+import tilelang.language as T
+import torch
+
+tilelang.cache.clear_cache()
+
+parser = argparse.ArgumentParser(description="NPU Kernel Compilation")
+parser.add_argument("--m", type=int, default=1024, help="Matrix M dimension")
+parser.add_argument("--n", type=int, default=1024, help="Matrix N dimension")
+args = parser.parse_args()
+
+M = args.m
+N = args.n
+
+
+@tilelang.jit(out_idx=[-1])
+def vec_add_pipeline(M, N, block_M, block_N, sub_M, dtype="float"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    VEC_NUM = 2
+    stages = 2
+
+    @T.macro
+    def init_flag():
+        T.set_flag("mte3", "mte2", 0)
+        T.set_flag("mte3", "mte2", 1)
+  
+    @T.macro
+    def clear_flag():
+        T.wait_flag("mte3", "mte2", 0)
+        T.wait_flag("mte3", "mte2", 1)
+
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, N), dtype),
+            B: T.Tensor((M, N), dtype),
+            C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+          
+            vec_proc = block_M // sub_M
+
+            a_ub = T.alloc_ub((stages, sub_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((stages, sub_M // VEC_NUM, block_N), dtype)
+            c_ub = T.alloc_ub((stages, sub_M // VEC_NUM, block_N), dtype)
+
+            with T.Scope("V"):
+                init_flag()
+                T.wait_flag("mte3", "mte2", 0)
+                T.copy(A[bx * block_M + vid * sub_M // VEC_NUM + 0 * sub_M, by * block_N], a_ub[0, :, :])
+                T.copy(B[bx * block_M + vid * sub_M // VEC_NUM + 0 * sub_M, by * block_N], b_ub[0, :, :])
+                T.set_flag("mte2", "v", 0)
+
+                for mm in T.serial(vec_proc):
+                    cur = mm % stages
+                    nxt = (mm + 1) % stages
+
+                    if mm < vec_proc -1:
+                        T.wait_flag("mte3", "mte2", nxt)
+                        T.copy(A[bx * block_M + vid * sub_M // VEC_NUM + (mm + 1) * sub_M, by * block_N], a_ub[nxt, :, :])
+                        T.copy(B[bx * block_M + vid * sub_M // VEC_NUM + (mm + 1) * sub_M, by * block_N], b_ub[nxt, :, :])
+                        T.set_flag("mte2", "v", nxt)
+
+                    T.wait_flag("mte2", "v", cur)
+                    T.tile.add(c_ub[cur, :, :], a_ub[cur, :, :], b_ub[cur, :, :])
+                    T.set_flag("v", "mte3", cur)
+                    T.wait_flag("v", "mte3", cur)
+
+                    T.copy(c_ub[cur, :, :], C[bx * block_M + vid * sub_M // VEC_NUM + mm * sub_M, by * block_N])
+                    T.set_flag("mte3", "mte2", cur)
+
+
+                clear_flag()
+
+    return main
+
+
+func = vec_add_pipeline(M, N, 128, 128, 32)
+
+torch.manual_seed(0)
+
+a = torch.randn(M, N).npu()
+b = torch.randn(M, N).npu()
+
+torch.npu.synchronize()
+print("init successful!")
+
+c = func(a, b)
+
+torch.npu.synchronize()
+torch.set_printoptions(threshold = float('inf'), sci_mode = False)
+
+ref_c = a + b
+
+torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
+print("Kernel Output Match!")

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -162,9 +162,8 @@ def brcb(dst: Buffer, src: Buffer, repeat_times: PrimExpr, dst_blk_stride: PrimE
     return T.call_extern("handle", f"tl::ascend::brcb<{_dtype(src)}>", dst_ptr, src_ptr,
                          repeat_times, dst_blk_stride, dst_repeat_stride)
 
-
 def binary_op(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion],
-              src1: Union[Buffer, BufferLoad, PrimExpr, float], op: str):
+              src1: Union[Buffer, BufferRegion, BufferLoad, PrimExpr, float], op: str):
 
     def _handle_buffer_region(br: BufferRegion, mask):
         bf = br.buffer
@@ -197,38 +196,43 @@ def binary_op(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion
 
     elif isinstance(src1, (PrimExpr, float, int)):
         return T.call_extern("handle", f"AscendC::{op}s", dst_ptr, src0_ptr, src1, size_0)
+    elif isinstance(src1, BufferRegion):
+        src1_ptr, src1_extent = _handle_buffer_region(src1, "r")
+        size_2 = math.prod(src1_extent)
+        assert size_0 == size_2, "size must be same"
+        return T.call_extern("handle", f"AscendC::{op}", dst_ptr, src0_ptr, src1_ptr, size_0)
     else:
         return T.call_extern("handle", f"AscendC::{op}", dst_ptr, src0_ptr, src1.access_ptr("r"),
                              size_0)
 
 
-def add(dst: Buffer, src0: Buffer, src1: Union[Buffer, BufferLoad, PrimExpr]):
+def add(dst: Buffer, src0: Buffer, src1: Union[Buffer, BufferRegion, BufferLoad, PrimExpr]):
     return binary_op(dst, src0, src1, "Add")
 
 
-def sub(dst: Buffer, src0: Buffer, src1: Union[Buffer, BufferLoad]):
+def sub(dst: Buffer, src0: Buffer, src1: Union[Buffer, BufferRegion, BufferLoad]):
     return binary_op(dst, src0, src1, "Sub")
 
 
-def mul(dst: Buffer, src0: Buffer, src1: Union[Buffer, BufferLoad, PrimExpr]):
+def mul(dst: Buffer, src0: Buffer, src1: Union[Buffer, BufferRegion, BufferLoad, PrimExpr]):
     return binary_op(dst, src0, src1, "Mul")
 
 
-def div(dst: Buffer, src0: Buffer, src1: Union[Buffer, BufferLoad]):
+def div(dst: Buffer, src0: Buffer, src1: Union[Buffer, BufferRegion, BufferLoad]):
     return binary_op(dst, src0, src1, "Div")
 
 
-def max(dst: Buffer, src0: Buffer, src1: Union[Buffer]):
+def max(dst: Buffer, src0: Buffer, src1: Union[Buffer, BufferRegion]):
     return binary_op(dst, src0, src1, "Max")
 
 
-def min(dst: Buffer, src0: Buffer, src1: Union[Buffer]):
+def min(dst: Buffer, src0: Buffer, src1: Union[Buffer, BufferRegion]):
     return binary_op(dst, src0, src1, "Min")
 
-def and_tl(dst: Buffer, src0: Buffer, src1: Union[Buffer, BufferLoad, PrimExpr]):
+def and_tl(dst: Buffer, src0: Buffer, src1: Union[Buffer, BufferRegion, BufferLoad, PrimExpr]):
     return binary_op(dst, src0, src1, "And")
 
-def or_tl(dst: Buffer, src0: Buffer, src1: Union[Buffer, BufferLoad, PrimExpr]):
+def or_tl(dst: Buffer, src0: Buffer, src1: Union[Buffer, BufferRegion, BufferLoad, PrimExpr]):
     return binary_op(dst, src0, src1, "Or")
 
 


### PR DESCRIPTION
**Support BufferRegion type for src1 in binary ops.**

* The following code was not supported before

`T.tile.add(c_ub[cur, :, :], a_ub[cur, :, :], b_ub[cur, :, :])`

**Add vector db example.**
 
 * This change prepares for future validation of T.Parallel processing 
with double buffer scenarios (3D LocalTensor).