### PR TITLE
[NPUIR] support vectorization in T.Parallel

### DIFF
--- a/examples/vectorization_in_parallel.py
+++ b/examples/vectorization_in_parallel.py
@@ -1,0 +1,342 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+
+import os
+
+import tilelang
+import tilelang.language as T
+
+import torch
+import torch_npu
+
+# Clear any previously cached compiled kernels to ensure a clean run
+tilelang.cache.clear_cache()
+
+# Define data type and sequence length for the vector addition
+dtype = "float32"
+seq_len = 4096  # Length of the vectors to be added
+
+def unary_simple(N, block_N, dtype="float32"):
+    n_num = N // block_N  # Number of blocks (each block processes `block_N` elements)
+
+    @T.prim_func
+    def unarySimple(A: T.Tensor((N), dtype), C: T.Tensor((N), dtype), shape: T.int32):
+        # Launch kernel with `n_num` parallel threads on the NPU
+        with T.Kernel(n_num, is_npu=True) as (cid, _):
+            # Allocate on-chip Unified Buffer (UB) for local computation
+            A_VEC = T.alloc_ub((block_N), dtype)
+            C_VEC = T.alloc_ub((block_N), dtype)
+
+            # Calculate the starting index for this thread
+            start_idx = cid * block_N
+            # Compute remaining elements from this start index to the end of the tensor
+            remaining = shape - start_idx
+            # Determine how many elements this thread should actually process (handles tail)
+            tail_size = T.min(block_N, remaining)
+
+            # Copy data from global memory (A, B) into on-chip buffers (A_VEC, B_VEC)
+            T.copy(A[start_idx], A_VEC, [tail_size])
+
+            for i in T.Parallel(block_N):
+                C_VEC[i] = T.exp(A_VEC[i])
+
+            # Write the result back from on-chip buffer (C_VEC) to global memory (C)
+            T.copy(C_VEC, C[start_idx], [tail_size])
+
+    return unarySimple
+
+
+def unary_compound(N, block_N, dtype="float32"):
+    n_num = N // block_N  # Number of blocks (each block processes `block_N` elements)
+
+    @T.prim_func
+    def unaryCompound(A: T.Tensor((N), dtype), B: T.Tensor((N), dtype), C: T.Tensor((N), dtype), shape: T.int32):
+        # Launch kernel with `n_num` parallel threads on the NPU
+        with T.Kernel(n_num, is_npu=True) as (cid, _):
+            # Allocate on-chip Unified Buffer (UB) for local computation
+            A_VEC = T.alloc_ub((block_N), dtype)
+            B_VEC = T.alloc_ub((block_N), dtype)
+            C_VEC = T.alloc_ub((block_N), dtype)
+
+            # Calculate the starting index for this thread
+            start_idx = cid * block_N
+            # Compute remaining elements from this start index to the end of the tensor
+            remaining = shape - start_idx
+            # Determine how many elements this thread should actually process (handles tail)
+            tail_size = T.min(block_N, remaining)
+
+            # Copy data from global memory (A, B) into on-chip buffers (A_VEC, B_VEC)
+            T.copy(A[start_idx], A_VEC, [tail_size])
+            T.copy(B[start_idx], B_VEC, [tail_size])
+
+            for i in T.Parallel(block_N):
+                C_VEC[i] = T.exp(A_VEC[i] + B_VEC[i])
+
+            # Write the result back from on-chip buffer (C_VEC) to global memory (C)
+            T.copy(C_VEC, C[start_idx], [tail_size])
+
+    return unaryCompound
+
+
+def binary_simple(N, block_N, dtype="float32"):
+    n_num = N // block_N  # Number of blocks (each block processes `block_N` elements)
+
+    @T.prim_func
+    def binarySimple(A: T.Tensor((N), dtype), B: T.Tensor((N), dtype), C: T.Tensor((N), dtype), shape: T.int32):
+        # Launch kernel with `n_num` parallel threads on the NPU
+        with T.Kernel(n_num, is_npu=True) as (cid, _):
+            # Allocate on-chip Unified Buffer (UB) for local computation
+            A_VEC = T.alloc_ub((block_N), dtype)
+            B_VEC = T.alloc_ub((block_N), dtype)
+            C_VEC = T.alloc_ub((block_N), dtype)
+
+            # Calculate the starting index for this thread
+            start_idx = cid * block_N
+            # Compute remaining elements from this start index to the end of the tensor
+            remaining = shape - start_idx
+            # Determine how many elements this thread should actually process (handles tail)
+            tail_size = T.min(block_N, remaining)
+
+            # Copy data from global memory (A, B) into on-chip buffers (A_VEC, B_VEC)
+            T.copy(A[start_idx], A_VEC, [tail_size])
+            T.copy(B[start_idx], B_VEC, [tail_size])
+
+            for i in T.Parallel(block_N):
+                C_VEC[i] = A_VEC[i] + B_VEC[i]
+
+            # Write the result back from on-chip buffer (C_VEC) to global memory (C)
+            T.copy(C_VEC, C[start_idx], [tail_size])
+
+    return binarySimple
+
+
+def binary_compound(N, block_N, dtype="float32"):
+    n_num = N // block_N  # Number of blocks (each block processes `block_N` elements)
+
+    @T.prim_func
+    def binaryCompound(A: T.Tensor((N), dtype), B: T.Tensor((N), dtype), C: T.Tensor((N), dtype), shape: T.int32):
+        # Launch kernel with `n_num` parallel threads on the NPU
+        with T.Kernel(n_num, is_npu=True) as (cid, _):
+            # Allocate on-chip Unified Buffer (UB) for local computation
+            A_VEC = T.alloc_ub((block_N), dtype)
+            B_VEC = T.alloc_ub((block_N), dtype)
+            C_VEC = T.alloc_ub((block_N), dtype)
+
+            # Calculate the starting index for this thread
+            start_idx = cid * block_N
+            # Compute remaining elements from this start index to the end of the tensor
+            remaining = shape - start_idx
+            # Determine how many elements this thread should actually process (handles tail)
+            tail_size = T.min(block_N, remaining)
+
+            # Copy data from global memory (A, B) into on-chip buffers (A_VEC, B_VEC)
+            T.copy(A[start_idx], A_VEC, [tail_size])
+            T.copy(B[start_idx], B_VEC, [tail_size])
+
+            for i in T.Parallel(block_N):
+                C_VEC[i] = A_VEC[i] + B_VEC[i] * 3.14
+
+            # Write the result back from on-chip buffer (C_VEC) to global memory (C)
+            T.copy(C_VEC, C[start_idx], [tail_size])
+
+    return binaryCompound
+
+
+def binary_compound_loop_invariant(N, block_N, dtype="float32"):
+    n_num = N // block_N  # Number of blocks (each block processes `block_N` elements)
+
+    @T.prim_func
+    def binaryCompoundLoopInvariant(A: T.Tensor((N), dtype), B: T.Tensor((N), dtype), C: T.Tensor((N), dtype), shape: T.int32):
+        # Launch kernel with `n_num` parallel threads on the NPU
+        with T.Kernel(n_num, is_npu=True) as (cid, _):
+            # Allocate on-chip Unified Buffer (UB) for local computation
+            A_VEC = T.alloc_ub((block_N), dtype)
+            B_VEC = T.alloc_ub((block_N), dtype)
+            C_VEC = T.alloc_ub((block_N), dtype)
+
+            # Calculate the starting index for this thread
+            start_idx = cid * block_N
+            # Compute remaining elements from this start index to the end of the tensor
+            remaining = shape - start_idx
+            # Determine how many elements this thread should actually process (handles tail)
+            tail_size = T.min(block_N, remaining)
+
+            # Copy data from global memory (A, B) into on-chip buffers (A_VEC, B_VEC)
+            T.copy(A[start_idx], A_VEC, [tail_size])
+            T.copy(B[start_idx], B_VEC, [tail_size])
+
+            for i in T.Parallel(block_N):
+                C_VEC[i] = A_VEC[i] * B_VEC[2] + B_VEC[i]
+
+            # Write the result back from on-chip buffer (C_VEC) to global memory (C)
+            T.copy(C_VEC, C[start_idx], [tail_size])
+
+    return binaryCompoundLoopInvariant
+
+def binary_compound_elementwise(N, block_N, dtype="float32"):
+    n_num = N // block_N  # Number of blocks (each block processes `block_N` elements)
+
+    @T.prim_func
+    def binaryCompoundElementwise(A: T.Tensor((N), dtype), B: T.Tensor((N), dtype), C: T.Tensor((N), dtype), shape: T.int32):
+        # Launch kernel with `n_num` parallel threads on the NPU
+        with T.Kernel(n_num, is_npu=True) as (cid, _):
+            # Allocate on-chip Unified Buffer (UB) for local computation
+            A_VEC = T.alloc_ub((block_N), dtype)
+            B_VEC = T.alloc_ub((block_N), dtype)
+            C_VEC = T.alloc_ub((block_N), dtype)
+
+            # Calculate the starting index for this thread
+            start_idx = cid * block_N
+            # Compute remaining elements from this start index to the end of the tensor
+            remaining = shape - start_idx
+            # Determine how many elements this thread should actually process (handles tail)
+            tail_size = T.min(block_N, remaining)
+
+            # Copy data from global memory (A, B) into on-chip buffers (A_VEC, B_VEC)
+            T.copy(A[start_idx], A_VEC, [tail_size])
+            T.copy(B[start_idx], B_VEC, [tail_size])
+
+            for i in T.Parallel(block_N):
+                C_VEC[i] = A_VEC[i] * B_VEC[i] + A_VEC[i]
+
+            # Write the result back from on-chip buffer (C_VEC) to global memory (C)
+            T.copy(C_VEC, C[start_idx], [tail_size])
+
+    return binaryCompoundElementwise
+
+
+def test_unary_simple(v1, v3):
+    # Instantiate the vector addition kernel for the full sequence length (single block)
+    func = unary_simple(seq_len, seq_len)
+
+    # Compile the TileLang function to NPU IR for execution on the NPU
+    compiled_kernel = tilelang.compile(func, target="npuir")
+
+    # Compute reference result using PyTorch's native addition (on NPU)
+    y_ref = torch.exp(v1)
+
+    # Launch the compiled TileLang kernel
+    compiled_kernel(v1, v3, seq_len)
+
+    # Print both results for visual comparison (should be nearly identical)
+    print("Reference result (PyTorch):")
+    print(y_ref)
+    print("TileLang kernel result:")
+    print(v3)
+
+
+def test_unary_compound(v1, v2, v3):
+    # Instantiate the vector addition kernel for the full sequence length (single block)
+    func = unary_compound(seq_len, seq_len)
+
+    # Compile the TileLang function to NPU IR for execution on the NPU
+    compiled_kernel = tilelang.compile(func, target="npuir")
+
+    # Compute reference result using PyTorch's native addition (on NPU)
+    y_ref = torch.exp(v1 + v2)
+
+    # Launch the compiled TileLang kernel
+    compiled_kernel(v1, v2, v3, seq_len)
+
+    # Print both results for visual comparison (should be nearly identical)
+    print("Reference result (PyTorch):")
+    print(y_ref)
+    print("TileLang kernel result:")
+    print(v3)
+
+
+def test_binary_simple(v1, v2, v3):
+    # Instantiate the vector addition kernel for the full sequence length (single block)
+    func = binary_simple(seq_len, seq_len)
+
+    # Compile the TileLang function to NPU IR for execution on the NPU
+    compiled_kernel = tilelang.compile(func, target="npuir")
+
+    # Compute reference result using PyTorch's native addition (on NPU)
+    y_ref = v1 + v2
+
+    # Launch the compiled TileLang kernel
+    compiled_kernel(v1, v2, v3, seq_len)
+
+    # Print both results for visual comparison (should be nearly identical)
+    print("Reference result (PyTorch):")
+    print(y_ref)
+    print("TileLang kernel result:")
+    print(v3)
+
+
+def test_binary_compound(v1, v2, v3):
+    # Instantiate the vector addition kernel for the full sequence length (single block)
+    func = binary_compound(seq_len, seq_len)
+
+    # Compile the TileLang function to NPU IR for execution on the NPU
+    compiled_kernel = tilelang.compile(func, target="npuir")
+
+    # Compute reference result using PyTorch's native addition (on NPU)
+    y_ref = v1 + v2 * 3.14
+
+    # Launch the compiled TileLang kernel
+    compiled_kernel(v1, v2, v3, seq_len)
+
+    # Print both results for visual comparison (should be nearly identical)
+    print("Reference result (PyTorch):")
+    print(y_ref)
+    print("TileLang kernel result:")
+    print(v3)
+
+
+def test_binary_compound_loop_invariant(v1, v2, v3):
+    # Instantiate the vector addition kernel for the full sequence length (single block)
+    func = binary_compound_loop_invariant(seq_len, seq_len)
+
+    # Compile the TileLang function to NPU IR for execution on the NPU
+    compiled_kernel = tilelang.compile(func, target="npuir")
+
+    # Compute reference result using PyTorch's native addition (on NPU)
+    y_ref = v1 * v2[2] + v2
+
+    # Launch the compiled TileLang kernel
+    compiled_kernel(v1, v2, v3, seq_len)
+
+    # Print both results for visual comparison (should be nearly identical)
+    print("Reference result (PyTorch):")
+    print(y_ref)
+    print("TileLang kernel result:")
+    print(v3)
+
+
+def test_binary_compound_elementwise(v1, v2, v3):
+    # Instantiate the vector addition kernel for the full sequence length (single block)
+    func = binary_compound_elementwise(seq_len, seq_len)
+
+    # Compile the TileLang function to NPU IR for execution on the NPU
+    compiled_kernel = tilelang.compile(func, target="npuir")
+
+    # Compute reference result using PyTorch's native addition (on NPU)
+    y_ref = v1 * v2 + v1
+
+    # Launch the compiled TileLang kernel
+    compiled_kernel(v1, v2, v3, seq_len)
+
+    # Print both results for visual comparison (should be nearly identical)
+    print("Reference result (PyTorch):")
+    print(y_ref)
+    print("TileLang kernel result:")
+    print(v3)
+
+
+if __name__ == "__main__":
+    torch.npu.set_device(6)
+    # Create random input tensors on the NPU
+    v1 = torch.randn(size=[seq_len], dtype=eval("torch." + dtype)).npu()
+    v2 = torch.randn(size=[seq_len], dtype=eval("torch." + dtype)).npu()
+    v3 = torch.zeros(size=[seq_len], dtype=eval("torch." + dtype)).npu()  # Output buffer
+
+    
+    # test_unary_simple(v1, v3)
+    # test_unary_compound(v1, v2, v3)
+    test_binary_simple(v1, v2, v3)
+    # test_binary_compound(v1, v2, v3)
+    # test_binary_compound_loop_invariant(v1, v2, v3)
+    # test_binary_compound_elementwise(v1, v2, v3)
+

--- a/src/target/codegen_npuir_api.h
+++ b/src/target/codegen_npuir_api.h
@@ -247,6 +247,7 @@ private:
 
   friend void PrintConst(const FloatImmNode *op, CodeGenTileLangNPUIRAPI *p);
 
+  mlir::Value GenMemrefLoadFromRegion(const BufferLoadNode *op);
   mlir::Value GenSubviewFromRegion(const CallNode *region_node);
   mlir::Value GenSubviewFromRegion(Buffer buffer_data, Array<Range> range);
   mlir::Value CreateIndexCastOp(mlir::Value src);

--- a/src/transform/npu_loop_vectorize.cc
+++ b/src/transform/npu_loop_vectorize.cc
@@ -1,0 +1,389 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file npu_loop_vectorize.cc
+ * \brief vectorize the loop
+ */
+
+#include "arith/ir_mutator_with_analyzer.h"
+#include "tir/analysis/var_use_def_analysis.h"
+
+#include <tvm/arith/analyzer.h>
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/builtin.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+#include <tvm/tir/op.h>
+#include <tvm/tir/expr.h>
+#include <tvm/tir/stmt.h>
+#include <tvm/runtime/registry.h>
+
+#include "arith/scalable_expression.h"
+#include "tir/analysis/check_contains.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+
+std::unordered_map<std::string, std::string> TirOps2NpuirOps = {
+    {"tir.exp", "tl.npuir_exp"},
+    {"tir.fabs", "tl.npuir_abs"},
+    {"Add", "tl.npuir_add"},
+    {"Mul", "tl.npuir_mul"},
+    {"Sub", "tl.npuir_sub"},
+    {"Div", "tl.npuir_div"}
+};
+
+class LoopVectorizer : public StmtMutator {
+private:
+  PrimExpr BuildRegionCall(Buffer buffer, PrimExpr offset_expr, int region_id, int size) {
+    PrimExpr buffer_load = BufferLoad(buffer, {offset_expr});
+    Array<PrimExpr> args = {
+      buffer_load,
+      make_const(DataType::Int(32), region_id),
+      make_const(DataType::Int(32), size)
+    };
+    Op region_op = Op::Get("tl.region");
+    return Call(DataType::Handle(), region_op, args);
+  }
+  
+  Stmt BuildNPUIRBinaryCall(std::string op_name, Buffer buffer_a, Buffer buffer_b, Buffer buffer_c, int offset, int size) {
+    PrimExpr offset_expr = {make_const(DataType::Int(32), offset)};
+    PrimExpr region_a = BuildRegionCall(buffer_a, offset_expr, 1, size);
+    PrimExpr region_b = BuildRegionCall(buffer_b, offset_expr, 1, size);
+    PrimExpr region_c = BuildRegionCall(buffer_c, offset_expr, 2, size);
+    auto op_type = Op::Get(TirOps2NpuirOps[op_name]);
+
+    Array<PrimExpr> args = {region_a, region_b, region_c};
+    PrimExpr call = Call(DataType::Void(), op_type, args);
+    return Evaluate(call);
+  }
+
+  Stmt BuildNpuirBinaryCall(std::string op_name, PrimExpr a, PrimExpr b, PrimExpr c) {
+    auto op_type = Op::Get(TirOps2NpuirOps[op_name]);
+    Array<PrimExpr> args = {a, b, c};
+    PrimExpr call = Call(DataType::Void(), op_type, args);
+    return Evaluate(call);
+  }
+
+  Stmt BuildNPUIRUnaryCall(std::string op_name, Buffer buffer_in, Buffer buffer_out, int offset, int size) {
+    PrimExpr offset_expr = {make_const(DataType::Int(32), offset)};
+    PrimExpr region_in = BuildRegionCall(buffer_in, offset_expr, 1, size);
+    PrimExpr region_out = BuildRegionCall(buffer_out, offset_expr, 2, size);
+    auto op_type = Op::Get(TirOps2NpuirOps[op_name]);
+
+    Array<PrimExpr> args = {region_in, region_out};
+    PrimExpr call =  Call(DataType::Void(), op_type, args);
+    return Evaluate(call);
+  }
+
+  bool IsUnaryOp(const PrimExpr& expr) {
+    if (auto call = expr.as<CallNode>()) {
+      std::string op_name;
+
+      if (auto* op_ptr = call->op.as<OpNode>()) {
+        op_name = op_ptr->name;
+        if (op_name == "tir.exp" || op_name == "tir.fabs") {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  bool IsBinaryOp(const PrimExpr& expr, std::string* op_type, Array<PrimExpr>* operands) {
+    if (auto node = expr.as<AddNode>()) {
+      if (op_type) *op_type = "Add";
+      if (operands) {
+        operands->push_back(node->a);
+        operands->push_back(node->b);
+      }
+      return true;
+    } else if (auto node = expr.as<MulNode>()) {
+      if (op_type) *op_type = "Mul";
+      if (operands) {
+        operands->push_back(node->a);
+        operands->push_back(node->b);
+      }
+      return true;
+    } else if (auto node = expr.as<SubNode>()) {
+      if (op_type) *op_type = "Sub";
+      if (operands) {
+        operands->push_back(node->a);
+        operands->push_back(node->b);
+      }
+      return true;
+    } else if (auto node = expr.as<DivNode>()) {
+      if (op_type) *op_type = "Div";
+      if (operands) {
+        operands->push_back(node->a);
+        operands->push_back(node->b);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  bool IsScalar(const PrimExpr& expr) {
+    return expr.as<IntImmNode>() || expr.as<FloatImmNode>();
+  }
+
+  bool IsLoopInvariant(const Array<PrimExpr>& indices,
+                       const std::vector<const VarNode*>& loop_vars) {
+    for (const auto& idx : indices) {
+      if (auto var = idx.as<VarNode>()) {
+        for (auto it = loop_vars.begin(); it != loop_vars.end(); ++it) {
+          if (*it == var) {
+            return false;
+          }
+        }
+      }
+    }
+    return true;
+  }
+
+  bool IndicesSameAsLoopVars(const Array<PrimExpr>& indices,
+                             const std::vector<const VarNode*>& loop_vars) {
+    if (indices.size() != loop_vars.size()) {
+      return false;
+    }
+    for (int i = 0; i < indices.size(); i++) {
+      if (indices[i].as<VarNode>() != loop_vars[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool IsScalarLike(const PrimExpr& expr,
+                    const std::vector<const VarNode*>& loop_vars) {
+    if (IsScalar(expr)) {
+      return true;
+    }
+
+    if (auto load = expr.as<BufferLoadNode>()) {
+      return IsLoopInvariant(load->indices, loop_vars);
+    }
+
+    return false;
+  }
+
+  bool HandleSimpleExpression(const std::string& op_name, const Array<PrimExpr>& operands,
+                              const Buffer& output_buffer, int size,
+                              const std::vector<const VarNode*>& loop_vars, Array<Stmt>* statements) {
+    auto load_a = operands[0].as<BufferLoadNode>();
+    auto load_b = operands[1].as<BufferLoadNode>();
+    // vector OP const-scalar
+    if (load_a && IsScalar(operands[1]) || load_b && IsScalar(operands[0])) {
+      if (load_a && !IndicesSameAsLoopVars(load_a->indices, loop_vars)) {
+        return false;
+      }
+      if (load_b && !IndicesSameAsLoopVars(load_b->indices, loop_vars)) {
+        return false;
+      }
+      int buffer_idx = 0;
+      int scalar_idx = 1;
+      if (operands[1].as<BufferLoadNode>() && IsScalar(operands[0])) {
+        scalar_idx = 0;
+        buffer_idx = 1;
+      }
+      const BufferLoadNode* node_a = operands[buffer_idx].as<BufferLoadNode>();
+      PrimExpr offset_expr = {make_const(DataType::Int(32), 0)};
+      PrimExpr region_a = BuildRegionCall(node_a->buffer, offset_expr, 1, size);
+      PrimExpr region_c = BuildRegionCall(output_buffer, offset_expr, 2, size);
+      auto stmt = BuildNpuirBinaryCall(op_name, region_a, operands[scalar_idx], region_c);
+      statements->push_back(stmt);
+      return true;
+    }
+
+    if (load_a && load_b) {
+      // lis means loop invariant scalar
+      bool vector_lis = !IsLoopInvariant(load_a->indices, loop_vars) && IsLoopInvariant(load_b->indices, loop_vars);
+      bool lis_vector = IsLoopInvariant(load_a->indices, loop_vars) && !IsLoopInvariant(load_b->indices, loop_vars);
+      bool vector_vector = !IsLoopInvariant(load_a->indices, loop_vars) && !IsLoopInvariant(load_b->indices, loop_vars);
+      auto op_type = Op::Get(TirOps2NpuirOps[op_name]);
+      int offset = 0;
+      Buffer buffer_a = load_a->buffer;
+      Buffer buffer_b = load_b->buffer;
+      PrimExpr offset_expr_b = load_b->indices[0];
+
+      // vector OP lis
+      if (vector_lis || lis_vector) {
+        if (lis_vector) {
+           buffer_a = load_b->buffer;
+           buffer_b = load_a->buffer;
+           offset_expr_b = load_a->indices[0];
+        }
+        PrimExpr offset_expr = {make_const(DataType::Int(32), offset)};
+        PrimExpr region_a = BuildRegionCall(buffer_a, offset_expr, 1, size);
+        PrimExpr region_b = BuildRegionCall(buffer_b, offset_expr_b, 1, 1);
+        PrimExpr region_c = BuildRegionCall(output_buffer, offset_expr, 2, size);
+
+        Array<PrimExpr> args = {region_a, region_b, region_c};
+        PrimExpr call = Call(DataType::Void(), op_type, args);
+        auto stmt = Evaluate(call);
+        statements->push_back(stmt);
+        return true;
+      }
+      // vector OP vector
+      if (vector_vector) {
+        PrimExpr offset_expr = {make_const(DataType::Int(32), offset)};
+        PrimExpr region_a = BuildRegionCall(buffer_a, offset_expr, 1, size);
+        PrimExpr region_b = BuildRegionCall(buffer_b, offset_expr, 1, size);
+        PrimExpr region_c = BuildRegionCall(output_buffer, offset_expr, 2, size);
+
+        Array<PrimExpr> args = {region_a, region_b, region_c};
+        PrimExpr call = Call(DataType::Void(), op_type, args);
+        auto stmt = Evaluate(call);
+        statements->push_back(stmt);
+        return true;
+      }
+    }
+    return false;
+  }
+
+
+  bool HandleUnaryExpression(const PrimExpr& expr, const Buffer& output_buffer, int size,
+                             const std::vector<const VarNode*>& loop_vars, Array<Stmt>* statements) {
+    auto* call = expr.as<CallNode>();
+    auto* op_ptr = call->op.as<OpNode>();
+    std::string op_name = op_ptr->name;
+    if (auto load = call->args[0].as<BufferLoadNode>()) {
+      if (!IndicesSameAsLoopVars(load->indices, loop_vars)) {
+        return false;
+      }
+      // If indices are consistent with loop vars, it means the address offset of the buffer is 0
+      int offset = 0;
+      Stmt statement = BuildNPUIRUnaryCall(op_name, load->buffer, output_buffer, offset, size);
+      statements->push_back(statement);
+      return true;
+    } else {
+      if (DecomposeExpression(call->args[0], output_buffer, size, loop_vars, statements)) {
+        int offset = 0;
+        // For an unary op, its input and output can share the same buffer.
+        Stmt statement = BuildNPUIRUnaryCall(op_name, output_buffer, output_buffer, offset, size);
+        statements->push_back(statement);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool HandleBinaryExpression(std::string op_type, const Array<PrimExpr>& operands,
+                              const Buffer& output_buffer, int size,
+                              const std::vector<const VarNode*>& loop_vars, Array<Stmt>* statements) {
+    bool left_is_simple = operands[0].as<BufferLoadNode>() || IsScalarLike(operands[0], loop_vars);
+    bool right_is_simple = operands[1].as<BufferLoadNode>() || IsScalarLike(operands[1], loop_vars);
+
+    if (left_is_simple && right_is_simple) {
+      return HandleSimpleExpression(op_type, operands, output_buffer, size, loop_vars, statements);
+    } else if (!left_is_simple && right_is_simple) {
+      if (DecomposeExpression(operands[0], output_buffer, size, loop_vars, statements)) {
+        auto load_b = operands[1].as<BufferLoadNode>();
+        Buffer buffer_b = load_b->buffer;
+        int offset = 0;
+        Stmt statement = BuildNPUIRBinaryCall(op_type, output_buffer, buffer_b, output_buffer, offset, size);
+        statements->push_back(statement);
+        return true;
+      }
+    } else if (left_is_simple && !right_is_simple) {
+      if (DecomposeExpression(operands[1], output_buffer, size, loop_vars, statements)) {
+        auto load_a = operands[0].as<BufferLoadNode>();
+        int offset = 0;
+        Stmt statement = BuildNPUIRBinaryCall(op_type, load_a->buffer, output_buffer, output_buffer, offset, size);
+        statements->push_back(statement);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool DecomposeExpression(const PrimExpr& expr, const Buffer& output_buffer, int size,
+                           const std::vector<const VarNode*>& loop_vars, Array<Stmt>* statements) {
+    if(IsUnaryOp(expr)) {
+      return HandleUnaryExpression(expr, output_buffer, size, loop_vars, statements);
+    }
+
+    std::string op_type;
+    Array<PrimExpr> operands;
+    if (IsBinaryOp(expr, &op_type, &operands)) {
+      return HandleBinaryExpression(op_type, operands, output_buffer, size, loop_vars, statements);
+    }
+    return false;
+  }
+
+  Stmt VectorizeSingleStatement(const ForNode *op, int loop_count) {
+    const BufferStoreNode* store = op->body.as<BufferStoreNode>();
+    // Now only a single-layer for loop is supported, that is, one-dimensional vectorization.
+    if (store->indices.size() != 1) {
+      return StmtMutator::VisitStmt_(op);
+    }
+    PrimExpr index = store->indices[0];
+    const VarNode* var = index.as<VarNode>();
+    if (!var || var != op->loop_var.get()) {
+      return StmtMutator::VisitStmt_(op);
+    }
+
+    std::vector<const VarNode*> loop_vars;
+    loop_vars.push_back(op->loop_var.get());
+    Array<Stmt> statements;
+    bool ret = DecomposeExpression(store->value, store->buffer, loop_count, loop_vars, &statements);
+    return ret ?  SeqStmt::Flatten(statements) : StmtMutator::VisitStmt_(op);
+  }
+
+
+  Stmt VisitStmt_(const ForNode *op) final {
+    if (op->kind != ForKind::kParallel) {
+      return StmtMutator::VisitStmt_(op);
+    }
+
+    const IntImmNode* loop_extent = op->extent.as<IntImmNode>();
+    if (!loop_extent) {
+      return StmtMutator::VisitStmt_(op);
+    }
+
+    if (!op->body.as<BufferStoreNode>()) {
+      return StmtMutator::VisitStmt_(op);
+    }
+
+    auto vectorized = VectorizeSingleStatement(op, loop_extent->value);
+    if (vectorized.defined()) {
+      return vectorized;
+    }
+    return StmtMutator::VisitStmt_(op);
+  }
+};
+
+using namespace tir::transform;
+
+tvm::transform::Pass NpuLoopVectorize() {
+  auto pass_func = [=](PrimFunc f,IRModule m,PassContext ctx) {
+    auto *new_pf = f.CopyOnWrite();
+    new_pf->body = LoopVectorizer()(std::move(new_pf->body));
+    return f;
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.NpuLoopVectorize", {});
+}
+
+TVM_REGISTER_GLOBAL("tl.transform.NpuLoopVectorize").set_body_typed(NpuLoopVectorize);
+
+} // namespace tl
+} // namespace tvm

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -97,6 +97,7 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
     elif target.kind.name == "npuir":
         mod = tir.transform.LowerOpaqueBlock()(mod)
         mod = tir.transform.RemoveNoOp()(mod)
+        mod = tilelang.transform.NpuLoopVectorize()(mod)
         return mod
     else:
         mod = tilelang.transform.IfStmtBinding()(mod)

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -344,3 +344,13 @@ def MergeSharedMemoryAllocations():
         The result pass
     """
     return _ffi_api.MergeSharedMemoryAllocations()  # type: ignore
+
+def NpuLoopVectorize():
+    """Lower one dimensional parallel loops to vector api for npu
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
+    return _ffi_api.NpuLoopVectorize()  # type: ignore


### PR DESCRIPTION
Enable vectorization for performance gains of Scheduling Primitives T.Parallel. 
Some basic cases are supported currently as shown in `examples/vectorization_in_parallel.py`