### PR TITLE
[Enhancement] enable passing basic dtype var as args

### DIFF
--- a/examples/elementwise/elementwise_subs.py
+++ b/examples/elementwise/elementwise_subs.py
@@ -1,0 +1,67 @@
+import argparse
+
+import tilelang
+import tilelang.language as T
+import torch
+
+tilelang.cache.clear_cache()
+
+parser = argparse.ArgumentParser(description="NPU Kernel Compilation")
+parser.add_argument("--m", type=int, default=1024, help="Matrix M dimension")
+parser.add_argument("--n", type=int, default=1024, help="Matrix N dimension")
+args = parser.parse_args()
+
+M = args.m
+N = args.n
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+}
+
+@tilelang.jit(out_idx=[1], pass_configs=pass_configs)
+def vec_subs(M, N, block_M, block_N, dtype="float"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    VEC_NUM = 2
+
+    @T.prim_func
+    def main(
+            A: T.Tensor[(M, N), dtype],
+            B: T.Tensor[(M, N), dtype],
+            s: T.float32,
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            a_ub = T.alloc_shared((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_shared((block_M // VEC_NUM, block_N), dtype)
+
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+
+            T.tile.sub(b_ub, a_ub, s)
+
+            T.copy(b_ub, B[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    return main
+
+
+func = vec_subs(M, N, 128, 256)
+
+torch.manual_seed(0)
+
+a = torch.randn(M, N).npu()
+s = 3.0
+
+torch.npu.synchronize()
+print("init successful!")
+
+b = func(a, s)
+
+ref_b = a - s
+
+torch.testing.assert_close(b, ref_b, rtol=1e-2, atol=1e-2)
+print("Kernel Output Match!")

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -1536,7 +1536,11 @@ void CodeGenTileLangAscend::PrintHostFunc(const PrimFunc &f, const std::string &
       os << ", ";
     }
     arg_names.push_back(v->name_hint);
-    os << "uint8_t* " << v->name_hint;
+    if (v.dtype().is_handle()) {
+      os << "uint8_t* " << v->name_hint;
+    } else {
+      os << getType(v.dtype()) << " " << v->name_hint;
+    }   
   }
   ProcessHostInput(os, arg_names, shape_vars);
   os << ", aclrtStream stream) {\n  ";


### PR DESCRIPTION
Previously, codegen considers all params as handle. Added support for non-handle cases.