### PR TITLE
feat(jit): support TL_DEBUG_ROOT_PATH environment variable

### DIFF
--- a/tilelang/jit/__init__.py
+++ b/tilelang/jit/__init__.py
@@ -23,7 +23,7 @@ from tvm.target import Target
 
 from tilelang.jit.kernel import JITKernel
 from tilelang.cache import cached
-from os import path, makedirs
+from os import path, makedirs, environ
 from logging import getLogger
 import functools
 import inspect
@@ -153,6 +153,8 @@ class _JitImplementation:
         self.signature = None
 
         # Corrected debug_root_path handling
+        if debug_root_path is None:
+            debug_root_path = environ.get("TL_DEBUG_ROOT_PATH")
         self.debug_root_path = debug_root_path
         if self.debug_root_path is not None and not path.isabs(self.debug_root_path):
             try:


### PR DESCRIPTION
Added support for setting the debug root path via the `TL_DEBUG_ROOT_PATH`
environment variable. This allows users to enable debug code export globally
without modifying the constructor arguments in the script.

If `debug_root_path` is not explicitly provided during initialization,
the system will now fallback to this environment variable.