### PR TITLE
[AscendNPU-IR][Expert][Developer] Support vector-scalar arithmetic in add, sub, mul, div

### DIFF
--- a/src/target/codegen_npuir_api.cc
+++ b/src/target/codegen_npuir_api.cc
@@ -1437,7 +1437,8 @@ template <typename T>
 void CodeGenTileLangNPUIRAPI::CreateHIVMBinaryVectorOp(const CallNode *op) {
   auto processImm = [&](mlir::Value &src, int arg_id,
                         Array<PrimExpr> &buffer_shape) {
-    if (op->args[arg_id].as<IntImm>() || op->args[arg_id].as<FloatImm>()) {
+    if (op->args[arg_id].as<IntImm>() || op->args[arg_id].as<FloatImm>() || 
+        op->args[arg_id].as<tir::VarNode>() || op->args[arg_id].as<tir::BufferLoadNode>()) {
       // Scalar case
       const CallNode *region_node = op->args[1 - arg_id].as<CallNode>();
       const BufferLoadNode *buffer_load_node =

--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1956,7 +1956,8 @@ template <typename T>
 void CodeGenTileLangNPUIRDEV::CreateHIVMBinaryVectorOp(const CallNode *op) {
   auto processImm = [&](mlir::Value &src, int arg_id,
                         Array<PrimExpr> &buffer_shape) {
-    if (op->args[arg_id].as<IntImm>() || op->args[arg_id].as<FloatImm>()) {
+    if (op->args[arg_id].as<IntImm>() || op->args[arg_id].as<FloatImm>() || 
+        op->args[arg_id].as<tir::VarNode>() || op->args[arg_id].as<tir::BufferLoadNode>()) {
       // Scalar case
       const CallNode *region_node = op->args[1 - arg_id].as<CallNode>();
       const BufferLoadNode *buffer_load_node =

--- a/testing/npuir/test_vec_add_2d_scalar.py
+++ b/testing/npuir/test_vec_add_2d_scalar.py
@@ -1,0 +1,66 @@
+import sys
+import os
+import argparse
+import torch
+
+import tilelang
+import tilelang.language as T
+
+torch.npu.set_device(0)
+tilelang.cache.clear_cache()
+
+def vec_add(block_M, block_N):
+    M = T.symbolic("M")
+    N = T.symbolic("N")
+    m_num = M // block_M
+    n_num = N // block_N
+    dtype = "float16"
+    BLOCK_SIZE = 20
+
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, N), dtype),
+            B: T.Tensor((N), dtype),
+            C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(BLOCK_SIZE, is_npu=True) as (cid, _):
+            A_VEC = T.alloc_ub((block_M, block_N), dtype)
+            B_VEC = T.alloc_ub((block_N), dtype)
+            C_VEC = T.alloc_ub((block_M, block_N), dtype)
+            for i in T.serial(T.ceildiv(m_num*n_num, BLOCK_SIZE)):
+                block_id = i * BLOCK_SIZE + cid
+                if block_id < m_num * n_num:
+                    block_id_m = block_id // n_num
+                    block_id_n = block_id % n_num
+                    bx = block_id_m * block_M
+                    by = block_id_n * block_N
+                    T.copy(A[bx, by], A_VEC)
+                    T.copy(B[:block_N], B_VEC)
+                    T.npuir_add(A_VEC, B_VEC[0], C_VEC)
+                    T.copy(C_VEC, C[bx, by])
+
+    return main
+
+def run_test():
+    M, N = 128, 256
+    func = vec_add(32, 32)
+    compiled_kernel = tilelang.compile(func, target='npuir')
+
+    a = torch.randn(M, N).half().npu()
+    b = torch.randn(N).half().npu()
+    c = torch.randn(M, N).half().npu()
+
+    torch.manual_seed(88888888)  # set the random seed for torch
+    dtype = "float16"
+
+    ref_output = a + b[0]
+    compiled_kernel(a, b, c)
+    print("Actual Result:")
+    print(c)
+    print("Expected Result:")
+    print(ref_output)
+    torch.testing.assert_close(c, ref_output, rtol=1e-2, atol=1e-2)
+    print("\033[92mAll check passed!\033[0m")
+
+if __name__ == "__main__":
+    run_test()

--- a/tilelang/language/customize_npuir.py
+++ b/tilelang/language/customize_npuir.py
@@ -43,6 +43,7 @@ def _buffer_to_tile_region_with_extent(buffer: tir.Buffer, access_type: str, ext
 def _to_region(data, access_type, extent):
     if isinstance(data, tir.Var) and T.has_let_value(data):
         data = T.get_let_value(data)
+        return data
     if isinstance(data, tir.Buffer):
         return _buffer_to_tile_region_with_extent(data, access_type, extent)
     elif isinstance(data, tir.BufferRegion):
@@ -107,25 +108,73 @@ class AscendBinaryOp(object):
         self.__src1 = src1
         self.__dst = dst
     def buildTirCall(self):
-        src0 = _to_region(self.__src0, "r", _get_extent(self.__src0))
-        src1 = _to_region(self.__src1, "r", _get_extent(self.__src1))
+        src0 = self.__src0 if isinstance(self.__src0, tir.BufferLoad) else _to_region(self.__src0, "r", _get_extent(self.__src0))
+        src1 = self.__src1 if isinstance(self.__src1, tir.BufferLoad) else _to_region(self.__src1, "r", _get_extent(self.__src1))
         dst = _to_region(self.__dst, "w", _get_extent(self.__dst))
         return tir.call_intrin("handle", tir.op.Op.get("tl.npuir_" + self.__opName), src0, src1, dst)
 
 """npuir add at tile-level."""
 def npuir_add(A, B, C):
+    """Element-wise addition: C = A + B.
+    
+    Args:
+        A: First input tensor
+        B: Second input tensor or scalar value
+        C: Output tensor
+    
+    Returns:
+        tir.Call: The TIR call for the addition operation
+    """
+    if isinstance(B,(int,float)):
+        B = tir.const(B, C.dtype)
     return AscendBinaryOp("add", A, B, C).buildTirCall()
 
 """npuir sub at tile-level."""
 def npuir_sub(A, B, C):
+    """Element-wise subtraction: C = A - B.
+    
+    Args:
+        A: First input tensor
+        B: Second input tensor or scalar value
+        C: Output tensor
+    
+    Returns:
+        tir.Call: The TIR call for the subtraction operation
+    """
+    if isinstance(B,(int,float)):
+        B = tir.const(B, C.dtype)
     return AscendBinaryOp("sub", A, B, C).buildTirCall()
 
 """npuir mul at tile-level."""
 def npuir_mul(A, B, C):
+    """Element-wise multiplication: C = A * B.
+    
+    Args:
+        A: First input tensor
+        B: Second input tensor or scalar value
+        C: Output tensor
+    
+    Returns:
+        tir.Call: The TIR call for the multiplication operation
+    """
+    if isinstance(B,(int,float)):
+        B = tir.const(B, C.dtype)
     return AscendBinaryOp("mul", A, B, C).buildTirCall()
 
 """npuir div at tile-level."""
 def npuir_div(A, B, C):
+    """Element-wise division: C = A / B.
+    
+    Args:
+        A: First input tensor
+        B: Second input tensor or scalar value
+        C: Output tensor
+    
+    Returns:
+        tir.Call: The TIR call for the division operation
+    """
+    if isinstance(B,(int,float)):
+        B = tir.const(B, C.dtype)
     return AscendBinaryOp("div", A, B, C).buildTirCall()
 
 """npuir max at tile-level."""


### PR DESCRIPTION
This MR enables broadcasting-style arithmetic between a vector and a scalar value
eg: A + x where A is a vector and x is a scalar.

A scalar operand in NPU IR is defined as following:
  - constant integer or float (IntImm, FloatImm)
  - A TIR variable (tir:: VarNode); eg: loop index, shape parameter.
  - A BufferLoad from a 0-dimensional buffer (scalar load) ; eg: B[0] where B.shape = (N)