### PR TITLE
[AscendNPU-IR][Developer] Support to vectorize more cases, include n-D, for T.parallel

### DIFF
--- a/examples/elementwise/example_elementwise_add.py
+++ b/examples/elementwise/example_elementwise_add.py
@@ -1,0 +1,64 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025.
+import os
+import argparse
+import torch
+import tilelang
+import tilelang.language as T
+
+
+def ref_program(x, y):
+    return x + y
+
+
+@tilelang.jit(out_idx=[-1], target="npuir")
+def elementwise_add(M, N, block_M, block_N, in_dtype="float32", out_dtype="float32"):
+    @T.prim_func
+    def elemAdd(
+            A: T.Tensor((M, N), in_dtype),
+            B: T.Tensor((M, N), in_dtype),
+            C: T.Tensor((M, N), out_dtype)
+    ):
+        with T.Kernel(T.ceildiv(N, block_N) * T.ceildiv(M, block_M), is_npu=True) as (cid, _):
+            by = cid // T.ceildiv(N, block_N)
+            bx = cid % T.ceildiv(N, block_N)
+
+            A_shared = T.alloc_shared((block_M, block_N), in_dtype)
+            B_shared = T.alloc_shared((block_M, block_N), in_dtype)
+            C_local = T.alloc_fragment((block_M, block_N), out_dtype)
+            C_shared = T.alloc_shared((block_M, block_N), out_dtype)
+
+            T.copy(A[by * block_M, bx * block_N], A_shared)
+            T.copy(B[by * block_M, bx * block_N], B_shared)
+            for local_y, local_x in T.Parallel(block_M, block_N):
+                C_local[local_y, local_x] = A_shared[local_y, local_x] + B_shared[local_y, local_x]
+            T.copy(C_local, C_shared)
+            T.copy(C_shared, C[by * block_M, bx * block_N])
+
+    return elemAdd
+
+
+def main(M=1024, N=1024, use_autotune=False):
+    os.environ["TILELANG_ASCEND_MODE"] = "Developer"
+    a = torch.randn(M, N, dtype=torch.float32, device="npu")
+    b = torch.randn(M, N, dtype=torch.float32, device="npu")
+    c = torch.zeros(M, N, dtype=torch.float32, device="npu")
+
+    if use_autotune:
+        kernel = elementwise_add(M, N, in_dtype="float32", out_dtype="float32")
+    else:
+        # Default config
+        config = {"block_M": 32, "block_N": 32}
+        kernel = elementwise_add(M, N, **config, in_dtype="float32", out_dtype="float32")
+
+    kernel(a, b, c)
+    torch.testing.assert_close(c, ref_program(a, b), rtol=1e-2, atol=1e-2)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--m", type=int, default=1024)
+    parser.add_argument("--n", type=int, default=1024)
+    args, _ = parser.parse_known_args()
+    main(args.m, args.n)
+    print("\033[92mAll check passed!\033[0m")
+

--- a/src/transform/npu_loop_vectorize.cc
+++ b/src/transform/npu_loop_vectorize.cc
@@ -43,33 +43,77 @@ namespace tl {
 
 using namespace tir;
 
-std::unordered_map<std::string, std::string> TirOps2NpuirOps = {
+class LoopDecompose : public StmtMutator {
+private:
+  inline static std::unordered_map<std::string, std::string> TirOps2NpuirOps = {
     {"tir.exp", "tl.npuir_exp"},
     {"tir.fabs", "tl.npuir_abs"},
     {"Add", "tl.npuir_add"},
     {"Mul", "tl.npuir_mul"},
     {"Sub", "tl.npuir_sub"},
-    {"Div", "tl.npuir_div"}
-};
+    {"Div", "tl.npuir_div"},
+  };
 
-class LoopVectorizer : public StmtMutator {
-private:
-  PrimExpr BuildRegionCall(Buffer buffer, PrimExpr offset_expr, int region_id, int size) {
-    PrimExpr buffer_load = BufferLoad(buffer, {offset_expr});
-    Array<PrimExpr> args = {
+  struct BufferAccessInfo {
+    Buffer buffer;
+    Array<PrimExpr> indices;
+    bool is_load;  // true for BufferLoad, false for BufferStore
+  };
+
+  inline BufferAccessInfo ExtractBufferAccessInfo(const ObjectRef& node) {
+    BufferAccessInfo info;
+
+    if (auto load = node.as<BufferLoadNode>()) {
+      info.buffer = load->buffer;
+      info.indices = load->indices;
+      info.is_load = true;
+    } else if (auto store = node.as<BufferStoreNode>()) {
+      info.buffer = store->buffer;
+      info.indices = store->indices;
+      info.is_load = false;
+    } else {
+      LOG(FATAL) << "Expected BufferLoad or BufferStore, but got: "
+                 << node->GetTypeKey();
+    }
+
+    return info;
+  }
+
+  PrimExpr BuildRegionCall(const BufferAccessInfo& buffer, int region_id, int size) {
+    PrimExpr buffer_load = BufferLoad(buffer.buffer, buffer.indices);
+    std::vector<PrimExpr> args_vec = {
       buffer_load,
       make_const(DataType::Int(32), region_id),
-      make_const(DataType::Int(32), size)
     };
+    for (int i = 0; i < buffer.indices.size(); ++i) {
+      args_vec.push_back(size);
+    }
     Op region_op = Op::Get("tl.region");
-    return Call(DataType::Handle(), region_op, args);
+    return Call(DataType::Handle(), region_op, {args_vec});
   }
-  
-  Stmt BuildNPUIRBinaryCall(std::string op_name, Buffer buffer_a, Buffer buffer_b, Buffer buffer_c, int offset, int size) {
+
+  Stmt ReplaceForBody(const ForNode* op, const Array<Stmt>& statements) {
+    Stmt new_body = SeqStmt::Flatten(statements);
+
+    // replace for body with new body
+    return For(op->loop_var,
+               op->min,
+               op->extent,
+               op->kind,
+               new_body,
+               op->thread_binding,
+               op->annotations);
+  }
+
+  Stmt BuildNPUIRBinaryCall(std::string op_name,
+                            const BufferAccessInfo& buffer_a,
+                            const BufferAccessInfo& buffer_b,
+                            const BufferAccessInfo& buffer_c,
+                            int offset, int size) {
     PrimExpr offset_expr = {make_const(DataType::Int(32), offset)};
-    PrimExpr region_a = BuildRegionCall(buffer_a, offset_expr, 1, size);
-    PrimExpr region_b = BuildRegionCall(buffer_b, offset_expr, 1, size);
-    PrimExpr region_c = BuildRegionCall(buffer_c, offset_expr, 2, size);
+    PrimExpr region_a = BuildRegionCall(buffer_a, 1, 1);
+    PrimExpr region_b = BuildRegionCall(buffer_b, 1, 1);
+    PrimExpr region_c = BuildRegionCall(buffer_c, 2, 1);
     auto op_type = Op::Get(TirOps2NpuirOps[op_name]);
 
     Array<PrimExpr> args = {region_a, region_b, region_c};
@@ -84,14 +128,15 @@ private:
     return Evaluate(call);
   }
 
-  Stmt BuildNPUIRUnaryCall(std::string op_name, Buffer buffer_in, Buffer buffer_out, int offset, int size) {
+  Stmt BuildNPUIRUnaryCall(std::string op_name, const BufferAccessInfo& buffer_in, const BufferAccessInfo& buffer_out,
+                           int offset, int size) {
     PrimExpr offset_expr = {make_const(DataType::Int(32), offset)};
-    PrimExpr region_in = BuildRegionCall(buffer_in, offset_expr, 1, size);
-    PrimExpr region_out = BuildRegionCall(buffer_out, offset_expr, 2, size);
+    PrimExpr region_in = BuildRegionCall(buffer_in, 1, 1);
+    PrimExpr region_out = BuildRegionCall(buffer_out, 2, 1);
     auto op_type = Op::Get(TirOps2NpuirOps[op_name]);
 
     Array<PrimExpr> args = {region_in, region_out};
-    PrimExpr call =  Call(DataType::Void(), op_type, args);
+    PrimExpr call = Call(DataType::Void(), op_type, args);
     return Evaluate(call);
   }
 
@@ -173,6 +218,24 @@ private:
     return true;
   }
 
+  bool ValidBufferIndices(const Array<PrimExpr>& indices) {
+    for (const auto& index : indices) {
+      // Case of constant int
+      if (const auto* int_imm = index.as<tir::IntImmNode>()) {
+        continue;
+      }
+
+      // Case of constant var
+      if (const auto* var = index.as<tir::VarNode>()) {
+        if (var->dtype.is_int()) {
+          continue;
+        }
+      }
+      return false;
+    }
+    return true;
+  }
+
   bool IsScalarLike(const PrimExpr& expr,
                     const std::vector<const VarNode*>& loop_vars) {
     if (IsScalar(expr)) {
@@ -187,16 +250,16 @@ private:
   }
 
   bool HandleSimpleExpression(const std::string& op_name, const Array<PrimExpr>& operands,
-                              const Buffer& output_buffer, int size,
+                              const BufferAccessInfo& output_buffer, int size,
                               const std::vector<const VarNode*>& loop_vars, Array<Stmt>* statements) {
     auto load_a = operands[0].as<BufferLoadNode>();
     auto load_b = operands[1].as<BufferLoadNode>();
     // vector OP const-scalar
-    if (load_a && IsScalar(operands[1]) || load_b && IsScalar(operands[0])) {
-      if (load_a && !IndicesSameAsLoopVars(load_a->indices, loop_vars)) {
+    if ((load_a && IsScalar(operands[1])) || (load_b && IsScalar(operands[0]))) {
+      if (load_a && !ValidBufferIndices(load_a->indices)) {
         return false;
       }
-      if (load_b && !IndicesSameAsLoopVars(load_b->indices, loop_vars)) {
+      if (load_b && !ValidBufferIndices(load_b->indices)) {
         return false;
       }
       int buffer_idx = 0;
@@ -205,10 +268,8 @@ private:
         scalar_idx = 0;
         buffer_idx = 1;
       }
-      const BufferLoadNode* node_a = operands[buffer_idx].as<BufferLoadNode>();
-      PrimExpr offset_expr = {make_const(DataType::Int(32), 0)};
-      PrimExpr region_a = BuildRegionCall(node_a->buffer, offset_expr, 1, size);
-      PrimExpr region_c = BuildRegionCall(output_buffer, offset_expr, 2, size);
+      PrimExpr region_a = BuildRegionCall(ExtractBufferAccessInfo(operands[buffer_idx]), 1, 1);
+      PrimExpr region_c = BuildRegionCall(output_buffer, 2, 1);
       auto stmt = BuildNpuirBinaryCall(op_name, region_a, operands[scalar_idx], region_c);
       statements->push_back(stmt);
       return true;
@@ -221,21 +282,19 @@ private:
       bool vector_vector = !IsLoopInvariant(load_a->indices, loop_vars) && !IsLoopInvariant(load_b->indices, loop_vars);
       auto op_type = Op::Get(TirOps2NpuirOps[op_name]);
       int offset = 0;
-      Buffer buffer_a = load_a->buffer;
-      Buffer buffer_b = load_b->buffer;
-      PrimExpr offset_expr_b = load_b->indices[0];
+      auto buffer_a = ExtractBufferAccessInfo(operands[0]);
+      auto buffer_b = ExtractBufferAccessInfo(operands[1]);
 
       // vector OP lis
       if (vector_lis || lis_vector) {
         if (lis_vector) {
-           buffer_a = load_b->buffer;
-           buffer_b = load_a->buffer;
-           offset_expr_b = load_a->indices[0];
+          buffer_a = ExtractBufferAccessInfo(operands[1]);
+          buffer_b = ExtractBufferAccessInfo(operands[0]);
         }
         PrimExpr offset_expr = {make_const(DataType::Int(32), offset)};
-        PrimExpr region_a = BuildRegionCall(buffer_a, offset_expr, 1, size);
-        PrimExpr region_b = BuildRegionCall(buffer_b, offset_expr_b, 1, 1);
-        PrimExpr region_c = BuildRegionCall(output_buffer, offset_expr, 2, size);
+        PrimExpr region_a = BuildRegionCall(buffer_a, 1, 1);
+        PrimExpr region_b = BuildRegionCall(buffer_b, 1, 1);
+        PrimExpr region_c = BuildRegionCall(output_buffer, 2, 1);
 
         Array<PrimExpr> args = {region_a, region_b, region_c};
         PrimExpr call = Call(DataType::Void(), op_type, args);
@@ -246,9 +305,9 @@ private:
       // vector OP vector
       if (vector_vector) {
         PrimExpr offset_expr = {make_const(DataType::Int(32), offset)};
-        PrimExpr region_a = BuildRegionCall(buffer_a, offset_expr, 1, size);
-        PrimExpr region_b = BuildRegionCall(buffer_b, offset_expr, 1, size);
-        PrimExpr region_c = BuildRegionCall(output_buffer, offset_expr, 2, size);
+        PrimExpr region_a = BuildRegionCall(buffer_a, 1, 1);
+        PrimExpr region_b = BuildRegionCall(buffer_b, 1, 1);
+        PrimExpr region_c = BuildRegionCall(output_buffer, 2, 1);
 
         Array<PrimExpr> args = {region_a, region_b, region_c};
         PrimExpr call = Call(DataType::Void(), op_type, args);
@@ -260,19 +319,18 @@ private:
     return false;
   }
 
-
-  bool HandleUnaryExpression(const PrimExpr& expr, const Buffer& output_buffer, int size,
+  bool HandleUnaryExpression(const PrimExpr& expr, const BufferAccessInfo& output_buffer, int size,
                              const std::vector<const VarNode*>& loop_vars, Array<Stmt>* statements) {
     auto* call = expr.as<CallNode>();
     auto* op_ptr = call->op.as<OpNode>();
     std::string op_name = op_ptr->name;
     if (auto load = call->args[0].as<BufferLoadNode>()) {
-      if (!IndicesSameAsLoopVars(load->indices, loop_vars)) {
+      if (!ValidBufferIndices(load->indices)) {
         return false;
       }
       // If indices are consistent with loop vars, it means the address offset of the buffer is 0
       int offset = 0;
-      Stmt statement = BuildNPUIRUnaryCall(op_name, load->buffer, output_buffer, offset, size);
+      Stmt statement = BuildNPUIRUnaryCall(op_name, ExtractBufferAccessInfo(call->args[0]), output_buffer, offset, size);
       statements->push_back(statement);
       return true;
     } else {
@@ -288,7 +346,7 @@ private:
   }
 
   bool HandleBinaryExpression(std::string op_type, const Array<PrimExpr>& operands,
-                              const Buffer& output_buffer, int size,
+                              const BufferAccessInfo& output_buffer, int size,
                               const std::vector<const VarNode*>& loop_vars, Array<Stmt>* statements) {
     bool left_is_simple = operands[0].as<BufferLoadNode>() || IsScalarLike(operands[0], loop_vars);
     bool right_is_simple = operands[1].as<BufferLoadNode>() || IsScalarLike(operands[1], loop_vars);
@@ -297,18 +355,15 @@ private:
       return HandleSimpleExpression(op_type, operands, output_buffer, size, loop_vars, statements);
     } else if (!left_is_simple && right_is_simple) {
       if (DecomposeExpression(operands[0], output_buffer, size, loop_vars, statements)) {
-        auto load_b = operands[1].as<BufferLoadNode>();
-        Buffer buffer_b = load_b->buffer;
         int offset = 0;
-        Stmt statement = BuildNPUIRBinaryCall(op_type, output_buffer, buffer_b, output_buffer, offset, size);
+        Stmt statement = BuildNPUIRBinaryCall(op_type, output_buffer, ExtractBufferAccessInfo(operands[1]), output_buffer, offset, size);
         statements->push_back(statement);
         return true;
       }
     } else if (left_is_simple && !right_is_simple) {
       if (DecomposeExpression(operands[1], output_buffer, size, loop_vars, statements)) {
-        auto load_a = operands[0].as<BufferLoadNode>();
         int offset = 0;
-        Stmt statement = BuildNPUIRBinaryCall(op_type, load_a->buffer, output_buffer, output_buffer, offset, size);
+        Stmt statement = BuildNPUIRBinaryCall(op_type, ExtractBufferAccessInfo(operands[0]), output_buffer, output_buffer, offset, size);
         statements->push_back(statement);
         return true;
       }
@@ -316,9 +371,9 @@ private:
     return false;
   }
 
-  bool DecomposeExpression(const PrimExpr& expr, const Buffer& output_buffer, int size,
+  bool DecomposeExpression(const PrimExpr& expr, const BufferAccessInfo& output_buffer, int size,
                            const std::vector<const VarNode*>& loop_vars, Array<Stmt>* statements) {
-    if(IsUnaryOp(expr)) {
+    if (IsUnaryOp(expr)) {
       return HandleUnaryExpression(expr, output_buffer, size, loop_vars, statements);
     }
 
@@ -332,23 +387,19 @@ private:
 
   Stmt VectorizeSingleStatement(const ForNode *op, int loop_count) {
     const BufferStoreNode* store = op->body.as<BufferStoreNode>();
-    // Now only a single-layer for loop is supported, that is, one-dimensional vectorization.
-    if (store->indices.size() != 1) {
-      return StmtMutator::VisitStmt_(op);
-    }
-    PrimExpr index = store->indices[0];
-    const VarNode* var = index.as<VarNode>();
-    if (!var || var != op->loop_var.get()) {
-      return StmtMutator::VisitStmt_(op);
+    for (const auto& index : store->indices) {
+      const VarNode* var = index.as<VarNode>();
+      if (!var && !IsScalar(index)) {
+        return StmtMutator::VisitStmt_(op);
+      }
     }
 
     std::vector<const VarNode*> loop_vars;
     loop_vars.push_back(op->loop_var.get());
     Array<Stmt> statements;
-    bool ret = DecomposeExpression(store->value, store->buffer, loop_count, loop_vars, &statements);
-    return ret ?  SeqStmt::Flatten(statements) : StmtMutator::VisitStmt_(op);
+    bool ret = DecomposeExpression(store->value, ExtractBufferAccessInfo(op->body), loop_count, loop_vars, &statements);
+    return ret ? ReplaceForBody(op, statements) : StmtMutator::VisitStmt_(op);
   }
-
 
   Stmt VisitStmt_(const ForNode *op) final {
     if (op->kind != ForKind::kParallel) {
@@ -372,12 +423,310 @@ private:
   }
 };
 
+class LoopVectorize : public StmtMutator {
+private:
+  inline static std::unordered_set<std::string> CandidateVectorizationOps = {
+    "tl.npuir_exp",
+    "tl.npuir_abs",
+    "tl.npuir_add",
+    "tl.npuir_mul",
+    "tl.npuir_sub",
+    "tl.npuir_div",
+  };
+
+  bool IsScalar(const PrimExpr& expr) {
+    return expr.as<IntImmNode>() || expr.as<FloatImmNode>();
+  }
+
+  // return a integer if the input is able to be converted, else return null
+  std::optional<int64_t> TryGetConstIntValue(const tvm::PrimExpr& expr, tvm::arith::Analyzer* analyzer = nullptr) {
+    // Method 1: Direct check for IntImmNode
+    if (const tvm::tir::IntImmNode* int_imm = expr.as<tvm::tir::IntImmNode>()) {
+      return int_imm->value;
+    }
+
+    // Method 2: Use arith::Analyzer for simplification
+    tvm::arith::Analyzer local_analyzer;
+    tvm::arith::Analyzer* used_analyzer = analyzer ? analyzer : &local_analyzer;
+
+    tvm::PrimExpr simplified = used_analyzer->Simplify(expr);
+    if (const tvm::tir::IntImmNode* simplified_int = simplified.as<tvm::tir::IntImmNode>()) {
+      return simplified_int->value;
+    }
+
+    // Method 3: Try to get constant bounds
+    tvm::arith::ConstIntBound bound = used_analyzer->const_int_bound(expr);
+    if (bound->min_value == bound->max_value) {
+      return bound->min_value;
+    }
+
+    // Method 4: Handle common expression patterns
+    if (const tvm::tir::SubNode* sub = expr.as<tvm::tir::SubNode>()) {
+      if (sub->a.same_as(sub->b)) {
+        return 0;
+      }
+    }
+
+    return std::nullopt;
+  }
+
+  // return a Call to tl.region -> str: T.region(buffer[offset_expr], region_id, size)
+  PrimExpr BuildRegionCall(Buffer buffer, const std::vector<PrimExpr>& offset_expr, int region_id, const std::vector<size_t>& size) {
+    PrimExpr buffer_load = BufferLoad(buffer, {offset_expr});
+    std::vector<PrimExpr> args_vec = {
+      buffer_load,
+      make_const(DataType::Int(32), region_id),
+    };
+    for (auto x : size) {
+      args_vec.push_back(make_const(DataType::Int(32), x));
+    }
+    Array<PrimExpr> args(args_vec);
+    Op region_op = Op::Get("tl.region");
+    return Call(DataType::Handle(), region_op, args);
+  }
+
+ /**
+  * Find the index of the offset containing the loop variable.
+  * Returns -1 if not found, -2 if found in multiple offsets.
+  */
+  int FindLoopVarInOffsets(const Array<PrimExpr>& offsets, const VarNode* loop_var) {
+    int found_dim = -1;
+    arith::Analyzer analyzer;
+
+    for (int i = 0; i < static_cast<int>(offsets.size()); ++i) {
+      class LoopVarVisitor : public ExprVisitor {
+      public:
+        const VarNode* target_var;
+        bool found = false;
+
+        explicit LoopVarVisitor(const VarNode* var) : target_var(var) {}
+
+        void VisitExpr_(const VarNode* op) override {
+          if (op == target_var) found = true;
+          ExprVisitor::VisitExpr_(op);
+        }
+      } visitor(loop_var);
+
+      visitor(offsets[i]);
+
+      if (visitor.found) {
+        if (found_dim == -1) {
+          found_dim = i;
+        } else {
+          return -2;
+        }
+      }
+    }
+
+    return found_dim;
+  }
+
+  bool RegionInLoopEnableVectorize(const PrimExpr& expr, const VarNode* loop_var) {
+    // 1. must be a CallNode
+    const auto* call = expr.as<CallNode>();
+    if (!call) return false;
+
+    // 2. must be tl.region
+    const auto* op_node = call->op.as<tvm::OpNode>();
+    if (!op_node) return false;
+    tvm::Op op = tvm::GetRef<tvm::Op>(op_node);
+
+    static const auto* region_op = Op::Get("tl.region").as<OpNode>();
+    if (op.get() != region_op) return false;
+
+    // 3. check the number of args and extract attributes
+    if (call->args.size() < 3) return false;
+
+    const auto* buffer_load = call->args[0].as<BufferLoadNode>();
+    if (!buffer_load) return false;
+
+    Buffer buffer = buffer_load->buffer;
+    Array<PrimExpr> offsets = buffer_load->indices;
+
+    // 4. check the shapes
+    int d = buffer->shape.size();
+    if (offsets.size() != d) return false;
+    if (call->args.size() != d + 2) return false;
+
+    // 5. check the loop var
+    int loop_var_dim = FindLoopVarInOffsets(offsets, loop_var);
+    arith::Analyzer analyzer;
+
+    if (loop_var_dim == -1) {  // -1 -> not found -> invariant -> enable to vectorize
+      return true;
+    } else if (loop_var_dim == -2) {  // -2 -> multiple found -> dispersed mem access -> disable to vectorize
+      return false;
+    }
+
+    // check the sizes to ensure the continuity of mem access
+    for (int i = 0; i < d; ++i) {
+      const PrimExpr& size = call->args[i + 2];
+
+      if (i <= loop_var_dim) {
+        if (!analyzer.CanProveEqual(size, 1)) {
+          return false;
+        }
+      } else {
+        if (!analyzer.CanProveEqual(size, buffer->shape[i])) {
+          return false;
+        }
+
+        if (!analyzer.CanProveEqual(offsets[i], 0)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  // check whether a single call statement can be vectorized
+  bool CallExternEnableVectorize(const Stmt& stmt) {
+    if (const auto* evaluate = stmt.as<EvaluateNode>()) {
+      const tvm::PrimExpr& value = evaluate->value;
+
+      if (const auto* call = value.as<tvm::tir::CallNode>()) {
+        if (const auto* op_node = call->op.as<tvm::OpNode>()) {
+          tvm::Op op = tvm::GetRef<tvm::Op>(op_node);
+          return static_cast<bool>(CandidateVectorizationOps.count(op->name));
+        }
+      }
+    }
+    return false;
+  }
+
+  // vectorize a region which belong to a call statement
+  PrimExpr VectorizeRegionInLoop(const PrimExpr& expr, const VarNode* loop_var, size_t start, size_t loop_count) {
+    const auto* call = expr.as<CallNode>();
+    const auto* buffer_load = call->args[0].as<BufferLoadNode>();
+
+    Buffer buffer = buffer_load->buffer;
+    Array<PrimExpr> offsets = buffer_load->indices;
+    std::vector<PrimExpr> offsets_vec;
+    for (const auto& offset : offsets) {
+      offsets_vec.push_back(offset);
+    }
+
+    int regionId = static_cast<int>(*TryGetConstIntValue(call->args[1]));
+    int dim = buffer->shape.size();
+    std::vector<size_t> size_vec;
+    for (int i = 2; i < dim + 2; ++i) {
+      size_vec.push_back(static_cast<size_t>(*TryGetConstIntValue(call->args[i])));
+    }
+
+    int loop_var_dim = FindLoopVarInOffsets(offsets, loop_var);
+    if (loop_var_dim >= 0) {
+      offsets_vec[loop_var_dim] = make_const(DataType::Int(32), start);
+      size_vec[loop_var_dim] = loop_count;
+    }
+
+    return BuildRegionCall(buffer, offsets_vec, regionId, size_vec);
+  }
+
+  // vectorize a single call statement
+  Stmt VectorizeCallExtern(const ForNode* for_node, const Stmt& stmt) {
+    const auto* evaluate = stmt.as<tvm::tir::EvaluateNode>();
+    if (!evaluate) return StmtMutator::VisitStmt_(for_node);
+
+    const auto* call = evaluate->value.as<tvm::tir::CallNode>();
+    if (!call) return StmtMutator::VisitStmt_(for_node);
+
+    bool flag_region_vectorizable = true;
+    auto loop_var_node_ptr = for_node->loop_var.get();
+
+    for (const auto& region : call->args) {
+      if (IsScalar(region)) continue;
+      if (!RegionInLoopEnableVectorize(region, loop_var_node_ptr)) {
+        flag_region_vectorizable = false;
+      }
+    }
+
+    if (!flag_region_vectorizable) {
+      return StmtMutator::VisitStmt_(for_node);
+    }
+
+    auto loop_min_value = TryGetConstIntValue(for_node->min);
+    auto loop_extent_value = TryGetConstIntValue(for_node->extent);
+    if (!loop_min_value || !loop_extent_value) {
+      return StmtMutator::VisitStmt_(for_node);
+    }
+
+    std::vector<PrimExpr> new_regions;
+    for (const auto& region : call->args) {
+      if (IsScalar(region)) {
+        new_regions.push_back(region);
+        continue;
+      }
+      new_regions.push_back(VectorizeRegionInLoop(region, loop_var_node_ptr, *loop_min_value, *loop_extent_value));
+    }
+
+    Array<PrimExpr> args(new_regions);
+    PrimExpr new_call = Call(DataType::Void(), call->op, args);
+    auto result = Evaluate(new_call);
+    return SeqStmt::Flatten(result);
+  }
+
+  Stmt VectorizeForBody(const ForNode* forNode, const Stmt& stmt) {
+    if (CallExternEnableVectorize(stmt)) {
+      return VectorizeCallExtern(forNode, stmt);
+    }
+
+    Var new_loop_var = Var(
+      forNode->loop_var->name_hint + "_split",
+      forNode->loop_var->dtype
+    );
+
+    Map<Var, PrimExpr> var_map;
+    var_map.Set(forNode->loop_var, new_loop_var);
+    Stmt new_body = Substitute(stmt, var_map);
+
+    return For(new_loop_var,
+               forNode->min,
+               forNode->extent,
+               forNode->kind,
+               new_body,
+               forNode->thread_binding,
+               forNode->annotations,
+               forNode->span);
+  }
+
+  Stmt VectorizeForBody(const ForNode* forNode, const SeqStmt& seqStmt) {
+    std::vector<Stmt> result_vec;
+    for (size_t i = 0; i < seqStmt->size(); ++i) {
+      result_vec.push_back(VectorizeForBody(forNode, seqStmt[i]));
+    }
+    Array<Stmt> result_arr(result_vec);
+    return SeqStmt::Flatten(SeqStmt(result_arr));
+  }
+
+  Stmt VisitStmt_(const ForNode* op) final {
+    // try vectorize only when marked as parallel
+    if (op->kind != ForKind::kParallel) {
+      return StmtMutator::VisitStmt_(op);
+    }
+
+    // recursive processing
+    Stmt body = op->body;
+    if (const auto* forNode = body.as<ForNode>()) {
+      body = VisitStmt_(forNode);
+    }
+
+    if (const auto* seqStmtNode = body.as<SeqStmtNode>()) {
+      return VectorizeForBody(op, GetRef<SeqStmt>(seqStmtNode));
+    } else if (const auto* stmtNode = body.as<EvaluateNode>()) {
+      return VectorizeForBody(op, GetRef<Evaluate>(stmtNode));
+    } else {
+      return StmtMutator::VisitStmt_(op);
+    }
+  }
+};
+
 using namespace tir::transform;
 
 tvm::transform::Pass NpuLoopVectorize() {
   auto pass_func = [=](PrimFunc f,IRModule m,PassContext ctx) {
     auto *new_pf = f.CopyOnWrite();
-    new_pf->body = LoopVectorizer()(std::move(new_pf->body));
+    new_pf->body = LoopDecompose()(std::move(new_pf->body));
+    new_pf->body = LoopVectorize()(std::move(new_pf->body));
     return f;
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.NpuLoopVectorize", {});


### PR DESCRIPTION
'tl.transform.NpuLoopVectorize' has been refactored to extend the functionality. Now, the decomposition of compound expressions and vectorization are performed by two separate classes.