### PR TITLE
[AscendNPU-IR][Developer] Fix bug when one operand of binary op is scalar

### DIFF
--- a/src/target/codegen_npuir_api.cc
+++ b/src/target/codegen_npuir_api.cc
@@ -1433,6 +1433,32 @@ void CodeGenTileLangNPUIRAPI::BitcastCodegen(const CallNode *op) {
   }
 }
 
+mlir::Value CodeGenTileLangNPUIRAPI::GenMemrefLoadFromRegion(const BufferLoadNode *op) {
+  auto buffer = op->buffer;
+  auto indices = op->indices;
+
+  // Check pre-conditions
+  if (op->dtype.lanes() != 1) {
+    LOG(FATAL) << "lanes not one";
+  }
+  if (op->dtype != buffer->dtype) {
+    LOG(FATAL) << "The load type and buffer element type do not match";
+  }
+
+  // Convert buffer from Buffer in TIR 2 memref in MLIR
+  auto mem = GetVarValue(buffer->data.get());
+
+  // Convert index from PrimExpr in TIR 2 index type in MLIR
+  SmallVector<mlir::Value> convert_inds;
+  for (auto index : indices) {
+    mlir::Value indexVal = CreateIndexCastOp(MakeValue(index));
+    convert_inds.push_back(indexVal);
+  }
+
+  // Create memef.load op in MLIR
+  return builder.create<mlir::memref::LoadOp>(builder.getUnknownLoc(), mem, convert_inds);
+}
+
 template <typename T>
 void CodeGenTileLangNPUIRAPI::CreateHIVMBinaryVectorOp(const CallNode *op) {
   auto processImm = [&](mlir::Value &src, int arg_id,
@@ -1451,8 +1477,23 @@ void CodeGenTileLangNPUIRAPI::CreateHIVMBinaryVectorOp(const CallNode *op) {
     } else {
       // Vector case
       const CallNode *region_node = op->args[arg_id].as<CallNode>();
-      buffer_shape = region_node->args[0].as<BufferLoadNode>()->buffer->shape;
-      src = GenSubviewFromRegion(region_node);
+      auto buffer_node = region_node->args[0].as<BufferLoadNode>();
+      buffer_shape = buffer_node->buffer->shape;
+      bool is_scalar_load = true;
+      for (int i = 0; i < buffer_shape.size(); i++) {
+        const IntImmNode* int_imm = region_node->args[2 + i].as<IntImmNode>();
+        if (!int_imm || int_imm->value != 1) {
+          is_scalar_load = false;
+          break;
+        }
+      }
+      const IntImmNode* int_imm = region_node->args[2].as<IntImmNode>();
+      // If load only one element, do not use memref.subview, use memref.load as a scalar
+      if(is_scalar_load) {
+        src = GenMemrefLoadFromRegion(buffer_node);
+      } else {
+        src = GenSubviewFromRegion(region_node);
+      }
     }
   };
   // src0 src1

--- a/src/target/codegen_npuir_api.h
+++ b/src/target/codegen_npuir_api.h
@@ -259,6 +259,7 @@ private:
 
   friend void PrintConst(const FloatImmNode *op, CodeGenTileLangNPUIRAPI *p);
 
+  mlir::Value GenMemrefLoadFromRegion(const BufferLoadNode *op);
   mlir::Value GenSubviewFromRegion(const CallNode *region_node);
   mlir::Value GenSubviewFromRegion(Buffer buffer_data, Array<Range> range);
   mlir::Value CreateIndexCastOp(mlir::Value src);

--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1939,6 +1939,38 @@ void CodeGenTileLangNPUIRDEV::DotCodegen(const CallNode *op) {
   SetVarValue(npuirop.dst, newMmadL1OpValue);
 }
 
+mlir::Value CodeGenTileLangNPUIRDEV::GenMemrefLoadFromRegion(const BufferLoadNode *op) {
+  auto buffer = op->buffer;
+  auto indices = op->indices;
+
+  // Check pre-conditions
+  if (op->dtype.lanes() != 1) {
+    LOG(FATAL) << "lanes not one";
+  }
+  if (op->dtype != buffer->dtype) {
+    LOG(FATAL) << "The load type and buffer element type do not match";
+  }
+
+  // Convert buffer from Buffer in TIR 2 memref in MLIR
+  auto mem = GetVarValue(buffer->data.get());
+  if (auto tensor = mem.getType().dyn_cast<TensorType>()) {
+    MemRefType memref_type = MemRefType::get(tensor.getShape(), tensor.getElementType());
+    mem = builder.create<bufferization::ToMemrefOp>(
+      builder.getUnknownLoc(), memref_type, mem
+    );
+  }
+
+  // Convert index from PrimExpr in TIR 2 index type in MLIR
+  SmallVector<mlir::Value> convert_inds;
+  for (auto index : indices) {
+    mlir::Value indexVal = CreateIndexCastOp(MakeValue(index));
+    convert_inds.push_back(indexVal);
+  }
+
+  // Create memef.load op in MLIR
+  return builder.create<mlir::memref::LoadOp>(builder.getUnknownLoc(), mem, convert_inds);
+}
+
 /// Generate hivm.hir.vadd for tl.npuir_add.
 /// Generate hivm.hir.vcmp for tl.npuir_cmp.
 /// Generate hivm.hir.vdiv for tl.npuir_div.
@@ -1970,8 +2002,23 @@ void CodeGenTileLangNPUIRDEV::CreateHIVMBinaryVectorOp(const CallNode *op) {
     } else {
       // Vector case
       const CallNode *region_node = op->args[arg_id].as<CallNode>();
-      buffer_shape = region_node->args[0].as<BufferLoadNode>()->buffer->shape;
-      src = GetVarValue(region_node);
+      auto buffer_node = region_node->args[0].as<BufferLoadNode>();
+      buffer_shape = buffer_node->buffer->shape;
+      bool is_scalar_load = true;
+      for (int i = 0; i < buffer_shape.size(); i++) {
+        const IntImmNode* int_imm = region_node->args[2 + i].as<IntImmNode>();
+        if (!int_imm || int_imm->value != 1) {
+          is_scalar_load = false;
+          break;
+        }
+      }
+      const IntImmNode* int_imm = region_node->args[2].as<IntImmNode>();
+      // If load only one element, do not use memref.subview, use memref.load as a scalar
+      if(is_scalar_load) {
+        src = GenMemrefLoadFromRegion(buffer_node);
+      } else {
+        src = GetVarValue(region_node);
+      }
     }
   };
   // src0 src1

--- a/src/target/codegen_npuir_dev.h
+++ b/src/target/codegen_npuir_dev.h
@@ -265,6 +265,7 @@ private:
 
   friend void PrintConst(const FloatImmNode *op, CodeGenTileLangNPUIRDEV *p);
 
+  mlir::Value GenMemrefLoadFromRegion(const BufferLoadNode *op);
   mlir::Value GenSubviewFromRegion(const CallNode *region_node);
   mlir::Value GenSubviewFromRegion(Buffer buffer_data, Array<Range> range);
   mlir::Value CreateIndexCastOp(mlir::Value src);


### PR DESCRIPTION
As shown in `examples/vectorization_in_parallel.py`
``` python
for i in T.Parallel(block_N):
	C_VEC[i] = A_VEC[i] * B_VEC[2] + B_VEC[i]
```

To make `B_VEC[2]` codegen `f32` type (scalar type) instead of `memref<1xf32>` (vector type), in order to directly perform binary operations on vectors and scalars.