### PR TITLE
[AscendNPU-IR][Developer] Support T.copy tensor2memref 2D dynamic shape

### DIFF
--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1017,6 +1017,122 @@ mlir::Value CodeGenTileLangNPUIRDEV::MaybeReshapeTensor(mlir::Value src_tensor, 
   return reshapeOp.getResult();
 }
 
+// Helper: Compute reassociation indices for shape collapse/expansion.
+llvm::SmallVector<mlir::ReassociationIndices> 
+CodeGenTileLangNPUIRDEV::ComputeReassociationIndices(
+    int64_t src_rank, int64_t dst_rank, 
+    mlir::MemRefType src_type, llvm::ArrayRef<mlir::OpFoldResult> dst_sizes) {
+  
+  bool is_collapse = src_rank > dst_rank;
+  int64_t large_rank = is_collapse ? src_rank : dst_rank;
+  int64_t small_rank = is_collapse ? dst_rank : src_rank;
+  
+  // Use explicit mlir::ReassociationIndices type.
+  llvm::SmallVector<mlir::ReassociationIndices> reassociation(small_rank);
+  
+  int large_idx = large_rank - 1;
+  int small_idx = small_rank - 1;
+  
+  // Greedy back-to-front mapping.
+  while (large_idx >= 0 && small_idx >= 0) {
+    reassociation[small_idx].push_back(large_idx);
+    large_idx--;
+    
+    if (large_idx + 1 == small_idx) {
+      small_idx--;
+    } 
+  }
+  
+  for (auto &group : reassociation) {
+    std::reverse(group.begin(), group.end());
+  }
+  
+  return reassociation;
+}
+
+// Reshape the source MemRef to match the rank and shape defined by `target_sizes`.
+mlir::Value CodeGenTileLangNPUIRDEV::MayReshapeMemRef(mlir::Value src_memref, llvm::ArrayRef<mlir::OpFoldResult> target_sizes) {
+  auto loc = builder.getUnknownLoc();
+  auto src_type = src_memref.getType().cast<mlir::MemRefType>();
+  int64_t src_rank = src_type.getRank();
+  int64_t dst_rank = target_sizes.size();
+
+  // 0. Optimization: Return early if ranks match.
+  if (src_rank == dst_rank) return src_memref;
+
+  // 1. Expand (Low Rank -> High Rank).
+  if (src_rank < dst_rank) {
+    auto indices = ComputeReassociationIndices(src_rank, dst_rank, src_type, target_sizes);
+    
+    llvm::SmallVector<int64_t> static_target_shape;
+    bool has_dynamic = false;
+    for (auto s : target_sizes) {
+      if (auto attr = s.dyn_cast<mlir::Attribute>()) 
+        static_target_shape.push_back(attr.cast<mlir::IntegerAttr>().getInt());
+      else {
+        static_target_shape.push_back(mlir::ShapedType::kDynamic);
+        has_dynamic = true;
+      }
+    }
+    
+    auto resultType = mlir::MemRefType::get(
+        static_target_shape, src_type.getElementType(), 
+        /*layout=*/nullptr, src_type.getMemorySpace());
+
+    if (has_dynamic) {
+         return builder.create<mlir::memref::ExpandShapeOp>(
+            loc, resultType, src_memref, indices, target_sizes).getResult();
+    } else {
+         return builder.create<mlir::memref::ExpandShapeOp>(
+            loc, resultType, src_memref, indices).getResult();
+    }
+  }
+
+  // 2. Collapse (High Rank -> Low Rank).
+  if (src_rank > dst_rank) {
+      // A. Retrieve original offset and strides.
+      auto extract = builder.create<mlir::memref::ExtractStridedMetadataOp>(loc, src_memref);
+      mlir::Value offset = extract.getOffset();
+      auto src_strides_values = extract.getStrides();
+
+      // B. Compute Reassociation Indices to map Dst -> [Src...]
+      auto indices = ComputeReassociationIndices(src_rank, dst_rank, src_type, target_sizes);
+
+      // C. Compute Target Strides from Source Strides.
+      llvm::SmallVector<mlir::OpFoldResult> strides;
+      for (const auto& group : indices) {
+          int64_t last_src_dim = group.back();
+          strides.push_back(src_strides_values[last_src_dim]);
+      }
+
+      // D. Construct target MemRef type.
+      llvm::SmallVector<int64_t> static_shape;
+      for(auto s : target_sizes) {
+        if (auto attr = s.dyn_cast<mlir::Attribute>()) 
+          static_shape.push_back(attr.cast<mlir::IntegerAttr>().getInt());
+        else 
+          static_shape.push_back(mlir::ShapedType::kDynamic);
+      }
+
+      // Use dynamic layout because strides are runtime values from ExtractStridedMetadataOp
+      auto layout = mlir::StridedLayoutAttr::get(&context, mlir::ShapedType::kDynamic, 
+                                                 llvm::SmallVector<int64_t>(dst_rank, mlir::ShapedType::kDynamic));
+      
+      auto resultType = mlir::MemRefType::get(
+          static_shape, src_type.getElementType(), 
+          layout, src_type.getMemorySpace());
+
+      // E. Create ReinterpretCastOp.
+      return builder.create<mlir::memref::ReinterpretCastOp>(
+          loc, resultType, src_memref, 
+          llvm::SmallVector<mlir::OpFoldResult>{offset}, 
+          target_sizes, 
+          strides).getResult();
+  }
+  
+  return src_memref;
+}
+
 // Convert TVM Range to MLIR OpFoldResult arrays
 std::tuple<SmallVector<mlir::OpFoldResult>, 
            SmallVector<mlir::OpFoldResult>, 
@@ -1341,7 +1457,7 @@ void CodeGenTileLangNPUIRDEV::AscendCopyCodegen(const CallNode *op) {
     return;
   }
 
-  // Case 3: Tensor -> MemRef (Store / Materialize)
+  // Case 2: Tensor -> MemRef (Store / Materialize)
   if (dst_is_memref_core) { 
     // 1. Extract Slice from SRC
     mlir::Value src_slice = builder.create<mlir::tensor::ExtractSliceOp>(
@@ -1352,12 +1468,12 @@ void CodeGenTileLangNPUIRDEV::AscendCopyCodegen(const CallNode *op) {
         loc, dst_memref_view, dst_offs, dst_sizes, dst_strides);
     
     // 3. Cast & Reshape
-    src_slice = CreateCastIfTypeMismatch(src_slice, dst_view);
-    src_slice = MaybeReshapeTensor(src_slice, dst_view.getType().cast<mlir::MemRefType>().getShape());
+    mlir::Value reshaped_dst_view = MayReshapeMemRef(dst_view, src_sizes);
+    src_slice = CreateCastIfTypeMismatch(src_slice, reshaped_dst_view);
 
     // 4. Materialize (Write to Buffer)
     auto store = builder.create<mlir::bufferization::MaterializeInDestinationOp>(
-      loc, src_slice, dst_view);
+      loc, src_slice, reshaped_dst_view);
     store.setWritable(true);
 
     // 5. State Sync

--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1051,7 +1051,8 @@ CodeGenTileLangNPUIRDEV::ComputeReassociationIndices(
 }
 
 // Reshape the source MemRef to match the rank and shape defined by `target_sizes`.
-mlir::Value CodeGenTileLangNPUIRDEV::MayReshapeMemRef(mlir::Value src_memref, llvm::ArrayRef<mlir::OpFoldResult> target_sizes) {
+mlir::Value CodeGenTileLangNPUIRDEV::MayReshapeMemRef(
+  mlir::Value src_memref, llvm::ArrayRef<mlir::OpFoldResult> target_sizes) {
   auto loc = builder.getUnknownLoc();
   auto src_type = src_memref.getType().cast<mlir::MemRefType>();
   int64_t src_rank = src_type.getRank();
@@ -1080,54 +1081,54 @@ mlir::Value CodeGenTileLangNPUIRDEV::MayReshapeMemRef(mlir::Value src_memref, ll
         /*layout=*/nullptr, src_type.getMemorySpace());
 
     if (has_dynamic) {
-         return builder.create<mlir::memref::ExpandShapeOp>(
-            loc, resultType, src_memref, indices, target_sizes).getResult();
+      return builder.create<mlir::memref::ExpandShapeOp>(
+          loc, resultType, src_memref, indices, target_sizes).getResult();
     } else {
-         return builder.create<mlir::memref::ExpandShapeOp>(
-            loc, resultType, src_memref, indices).getResult();
+      return builder.create<mlir::memref::ExpandShapeOp>(
+          loc, resultType, src_memref, indices).getResult();
     }
   }
 
   // 2. Collapse (High Rank -> Low Rank).
   if (src_rank > dst_rank) {
-      // A. Retrieve original offset and strides.
-      auto extract = builder.create<mlir::memref::ExtractStridedMetadataOp>(loc, src_memref);
-      mlir::Value offset = extract.getOffset();
-      auto src_strides_values = extract.getStrides();
+    // A. Retrieve original offset and strides.
+    auto extract = builder.create<mlir::memref::ExtractStridedMetadataOp>(loc, src_memref);
+    mlir::Value offset = extract.getOffset();
+    auto src_strides_values = extract.getStrides();
 
-      // B. Compute Reassociation Indices to map Dst -> [Src...]
-      auto indices = ComputeReassociationIndices(src_rank, dst_rank, src_type, target_sizes);
+    // B. Compute Reassociation Indices to map Dst -> [Src...]
+    auto indices = ComputeReassociationIndices(src_rank, dst_rank, src_type, target_sizes);
 
-      // C. Compute Target Strides from Source Strides.
-      llvm::SmallVector<mlir::OpFoldResult> strides;
-      for (const auto& group : indices) {
-          int64_t last_src_dim = group.back();
-          strides.push_back(src_strides_values[last_src_dim]);
-      }
+    // C. Compute Target Strides from Source Strides.
+    llvm::SmallVector<mlir::OpFoldResult> strides;
+    for (const auto& group : indices) {
+      int64_t last_src_dim = group.back();
+      strides.push_back(src_strides_values[last_src_dim]);
+    }
 
-      // D. Construct target MemRef type.
-      llvm::SmallVector<int64_t> static_shape;
-      for(auto s : target_sizes) {
-        if (auto attr = s.dyn_cast<mlir::Attribute>()) 
-          static_shape.push_back(attr.cast<mlir::IntegerAttr>().getInt());
-        else 
-          static_shape.push_back(mlir::ShapedType::kDynamic);
-      }
+    // D. Construct target MemRef type.
+    llvm::SmallVector<int64_t> static_shape;
+    for(auto s : target_sizes) {
+      if (auto attr = s.dyn_cast<mlir::Attribute>()) 
+        static_shape.push_back(attr.cast<mlir::IntegerAttr>().getInt());
+      else 
+        static_shape.push_back(mlir::ShapedType::kDynamic);
+    }
 
-      // Use dynamic layout because strides are runtime values from ExtractStridedMetadataOp
-      auto layout = mlir::StridedLayoutAttr::get(&context, mlir::ShapedType::kDynamic, 
-                                                 llvm::SmallVector<int64_t>(dst_rank, mlir::ShapedType::kDynamic));
-      
-      auto resultType = mlir::MemRefType::get(
-          static_shape, src_type.getElementType(), 
-          layout, src_type.getMemorySpace());
+    // Use dynamic layout because strides are runtime values from ExtractStridedMetadataOp
+    auto layout = mlir::StridedLayoutAttr::get(&context, mlir::ShapedType::kDynamic,
+        llvm::SmallVector<int64_t>(dst_rank, mlir::ShapedType::kDynamic));
+    
+    auto resultType = mlir::MemRefType::get(
+        static_shape, src_type.getElementType(), 
+        layout, src_type.getMemorySpace());
 
-      // E. Create ReinterpretCastOp.
-      return builder.create<mlir::memref::ReinterpretCastOp>(
-          loc, resultType, src_memref, 
-          llvm::SmallVector<mlir::OpFoldResult>{offset}, 
-          target_sizes, 
-          strides).getResult();
+    // E. Create ReinterpretCastOp.
+    return builder.create<mlir::memref::ReinterpretCastOp>(
+        loc, resultType, src_memref, 
+        llvm::SmallVector<mlir::OpFoldResult>{offset}, 
+        target_sizes, 
+        strides).getResult();
   }
   
   return src_memref;

--- a/src/target/codegen_npuir_dev.h
+++ b/src/target/codegen_npuir_dev.h
@@ -290,6 +290,10 @@ private:
   void SmartMemRefCopy(mlir::Value src, mlir::Value dst);
   mlir::Value GetOrInsertMasterTensor(mlir::Value memref);
   llvm::DenseMap<mlir::Operation*, mlir::Value> alloc_memo_;
+  mlir::Value MayReshapeMemRef(mlir::Value src_memref, llvm::ArrayRef<mlir::OpFoldResult> target_sizes);
+  llvm::SmallVector<mlir::ReassociationIndices> ComputeReassociationIndices(
+    int64_t src_rank, int64_t dst_rank, 
+    mlir::MemRefType src_type, llvm::ArrayRef<mlir::OpFoldResult> dst_sizes);
 
   NPU_CORETYPE func_coretype;
 

--- a/testing/npuir/test_copy_ts2mem_dynamic.py
+++ b/testing/npuir/test_copy_ts2mem_dynamic.py
@@ -1,0 +1,151 @@
+import os
+import torch
+import tilelang
+import tilelang.language as T
+
+# Set Environment
+os.environ['TILELANG_ASCEND_MODE'] = 'Developer'
+dtype = "float32"
+
+# ==========================================
+# Kernel 1: 1D Dynamic Shape + Rank Change
+# ==========================================
+@tilelang.jit(out_idx=[-1], target="npuir")
+def kernel_1d(M, N, K_split):
+    """
+    Simulate GEMM Epilogue: 
+    1. Frag(Reg) -> Cast -> Frag(Reg) (Generates Tensor SSA Value)
+    2. Frag(2D) -> Global(3D) (Triggers Rank Change 2D->3D)
+    3. Slice with `real_m` (Triggers Dynamic Shape)
+    """
+    assert N % K_split == 0
+    N_dim1 = N // K_split
+    block_M = 64
+    
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype), 
+        B: T.Tensor((M, N_dim1, K_split), dtype)
+    ):
+        with T.Kernel(T.ceildiv(M, block_M), is_npu=True) as (bid, _):
+
+            frag_raw = T.alloc_fragment((block_M, N), dtype)
+            frag_cast = T.alloc_fragment((block_M, N), dtype) 
+            
+            offset_m = bid * block_M
+            real_m = T.min(block_M, M - offset_m)
+            
+            T.copy(A[offset_m:offset_m+real_m, 0:N], frag_raw[0:real_m, 0:N])
+            
+            T.npuir_cast(frag_raw[0:block_M, 0:N], frag_cast[0:block_M, 0:N], "rint")
+
+            T.copy(
+                frag_cast[0:real_m, 0:N], 
+                B[offset_m:offset_m+real_m, 0:N_dim1, 0:K_split]
+            )
+    return main
+
+def test_1d():
+    print("\n" + "="*20 + " Running Test 1D: GEMM Epilogue (Dynamic M) " + "="*20)
+    
+    # M=100 (64+36), N=128, K=16
+    M, N, K = 100, 128, 16
+
+    # Execution
+    kernel = kernel_1d(M, N, K)
+    
+    torch.npu.set_device(0)
+    a_cpu = torch.randn(M, N)
+    b_cpu = torch.zeros(M, N // K, K)
+    
+    a_npu = a_cpu.npu()
+    b_npu = b_cpu.npu()
+    
+    kernel(a_npu, b_npu)
+    
+    # Verification
+    # Simulate Cast (rint) + Reshape
+    a_ref = torch.round(a_npu)
+    b_flat = b_npu.reshape(M, N)
+    
+    try:
+        torch.testing.assert_close(a_ref, b_flat, rtol=1e-3, atol=1e-3)
+        print("\033[92m[PASS] Test 1D (Dynamic M + Reshape) Verified!\033[0m")
+    except Exception as e:
+        print("\033[91m[FAIL] Test 1D Result Mismatch!\033[0m")
+        print(e)
+
+# ==========================================
+# Kernel 2: 2D Double Dynamic Dimensions
+# ==========================================
+@tilelang.jit(out_idx=[-1], target="npuir")
+def kernel_2d(M, N):
+    """
+    Scenario: Input [M, N] -> Output [M, N, 1]
+    1. Grid X handles M -> generates dynamic variable `real_m`
+    2. Grid Y handles N -> generates dynamic variable `real_n`
+    3. Copy operation reshapes (real_m, real_n) to (real_m, real_n, 1)
+    """
+    block_M = 64
+    block_N = 64 
+    
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype), 
+        B: T.Tensor((M, N, 1), dtype)
+    ):
+        with T.Kernel(T.ceildiv(M, block_M) * T.ceildiv(N, block_N), is_npu=True) as (bid, _):
+            idx_m = bid // T.ceildiv(N, block_N)
+            idx_n = bid % T.ceildiv(N, block_N)
+            
+            offset_m = idx_m * block_M
+            offset_n = idx_n * block_N
+            
+            real_m = T.min(block_M, M - offset_m)
+            real_n = T.min(block_N, N - offset_n)
+            
+            frag_raw = T.alloc_fragment((block_M, block_N), dtype)
+            frag_cast = T.alloc_fragment((block_M, block_N), dtype)
+            
+            T.copy(A[offset_m:offset_m+real_m, offset_n:offset_n+real_n], 
+                   frag_raw[0:real_m, 0:real_n])
+            
+            T.npuir_cast(frag_raw[0:block_M, 0:block_N], frag_cast[0:block_M, 0:block_N], "rint")
+
+            T.copy(
+                frag_cast[0:real_m, 0:real_n],
+                B[offset_m:offset_m+real_m, offset_n:offset_n+real_n, 0:1]
+            )
+    return main
+
+def test_2d():
+    print("\n" + "="*20 + " Running Test 2D: Double Dynamic Dims " + "="*20)
+    
+    # M=100 (64+36), N=100 (64+36)
+    M, N = 100, 100
+
+    # Execution
+    kernel = kernel_2d(M, N)
+    
+    torch.npu.set_device(0)
+    a_cpu = torch.randn(M, N)
+    b_cpu = torch.zeros(M, N, 1)
+    
+    a_npu = a_cpu.npu()
+    b_npu = b_cpu.npu()
+    
+    kernel(a_npu, b_npu)
+    
+    # Verification
+    a_ref = torch.round(a_npu).unsqueeze(-1) 
+    
+    try:
+        torch.testing.assert_close(a_ref, b_npu, rtol=1e-3, atol=1e-3)
+        print("\033[92m[PASS] Test 2D (Double Dynamic Dims) Verified!\033[0m")
+    except Exception as e:
+        print("\033[91m[FAIL] Test 2D Result Mismatch!\033[0m")
+        print(e)
+
+if __name__ == "__main__":
+    test_1d()
+    test_2d()


### PR DESCRIPTION
1. Use mayReshapeMemref (reinterpret_cast) in case tensor2memref instead of mayReshapeTensor
2. support 2D tail block dynamic shape 
3. add 2D tail block dynamic shape testcase