### PR TITLE
[AscendNPU-IR][Expert]fix dot codegen: do not do subview for mmadL1's inputs and output

### DIFF
--- a/src/target/codegen_npuir_api.cc
+++ b/src/target/codegen_npuir_api.cc
@@ -1387,9 +1387,9 @@ void CodeGenTileLangNPUIRAPI::DotCodegen(const CallNode *op) {
 
   mlir::Location unknown_loc = builder.getUnknownLoc();
   mlir::IndexType idx_ty = builder.getIndexType();
-  mlir::Value a = GenSubviewFromRegion(npuirop.src0, npuirop.src0_range);
-  mlir::Value b = GenSubviewFromRegion(npuirop.src1, npuirop.src1_range);
-  mlir::Value c = GenSubviewFromRegion(npuirop.dst, npuirop.dst_range);
+  mlir::Value a = GetVarValue(npuirop.src0->data.get());
+  mlir::Value b = GetVarValue(npuirop.src1->data.get());
+  mlir::Value c = GetVarValue(npuirop.dst->data.get());
   mlir::TypeRange result_tensors = {};
   mlir::Value init_condition = MakeValue(npuirop.initC);
   mlir::Value real_m = CreateIndexCastOp(MakeValue(a_region_shape[0]));


### PR DESCRIPTION
``` python
scf.for %arg12 = %c0_i32 to %c3_i32 step %c1_i32  : i32 {
  %alloc_3 = memref.alloc() : memref<32x32xf16, strided<[32, 1]>, #hivm.address_space<cbuf>>
  %alloc_4 = memref.alloc() : memref<32x32xf16, strided<[32, 1]>, #hivm.address_space<cbuf>>
  %c72_i32 = arith.constant 72 : i32
  %c32_i32_5 = arith.constant 32 : i32
  %5 = arith.muli %arg12, %c32_i32_5 : i32
  %6 = arith.subi %c72_i32, %5 : i32
  %7 = arith.minsi %6, %c32_i32_5 : i32
  %8 = arith.index_cast %3 : i32 to index
  %9 = arith.index_cast %5 : i32 to index
  %10 = arith.index_cast %7 : i32 to index
  %subview_6 = memref.subview %reinterpret_cast[%8, %9] [32, %10] [1, 1] : memref<32x72xf16, strided<[72, 1]>, #hivm.address_space<gm>> to memref<32x?xf16, strided<[72, 1], offset: ?>, #hivm.address_space<gm>>
  %subview_7 = memref.subview %alloc_3[0, 0] [32, %10] [1, 1] : memref<32x32xf16, strided<[32, 1]>, #hivm.address_space<cbuf>> to memref<32x?xf16, strided<[32, 1]>, #hivm.address_space<cbuf>>
  hivm.hir.nd2nz {dst_continuous} ins(%subview_6 : memref<32x?xf16, strided<[72, 1], offset: ?>, #hivm.address_space<gm>>) outs(%subview_7 : memref<32x?xf16, strided<[32, 1]>, #hivm.address_space<cbuf>>) init_out_buffer = false
  %subview_8 = memref.subview %reinterpret_cast_1[%8, %9] [32, %10] [1, 1] : memref<32x72xf16, strided<[72, 1]>, #hivm.address_space<gm>> to memref<32x?xf16, strided<[72, 1], offset: ?>, #hivm.address_space<gm>>
  %subview_9 = memref.subview %alloc_4[0, 0] [32, %10] [1, 1] : memref<32x32xf16, strided<[32, 1]>, #hivm.address_space<cbuf>> to memref<32x?xf16, strided<[32, 1]>, #hivm.address_space<cbuf>>
  hivm.hir.nd2nz {dst_continuous} ins(%subview_8 : memref<32x?xf16, strided<[72, 1], offset: ?>, #hivm.address_space<gm>>) outs(%subview_9 : memref<32x?xf16, strided<[32, 1]>, #hivm.address_space<cbuf>>) init_out_buffer = false
  %subview_10 = memref.subview %alloc_3[0, 0] [32, %10] [1, 1] : memref<32x32xf16, strided<[32, 1]>, #hivm.address_space<cbuf>> to memref<32x?xf16, strided<[32, 1]>, #hivm.address_space<cbuf>>
  %subview_11 = memref.subview %alloc_4[0, 0] [%10, 32] [1, 1] : memref<32x32xf16, strided<[32, 1]>, #hivm.address_space<cbuf>> to memref<?x32xf16, strided<[32, 1]>, #hivm.address_space<cbuf>>
  %subview_12 = memref.subview %alloc[0, 0] [32, 32] [1, 1] : memref<32x32xf32, strided<[32, 1]>, #hivm.address_space<cc>> to memref<32x32xf32, strided<[32, 1]>, #hivm.address_space<cc>>
  %c0_i32_13 = arith.constant 0 : i32
  %11 = arith.cmpi eq, %arg12, %c0_i32_13 : i32
  %12 = arith.index_cast %c32_i32_5 : i32 to index
  hivm.hir.mmadL1 {b_transpose} ins(%subview_10, %subview_11, %11, %12, %10, %12 : memref<32x?xf16, strided<[32, 1]>, #hivm.address_space<cbuf>>, memref<?x32xf16, strided<[32, 1]>, #hivm.address_space<cbuf>>, i1, index, index, index) outs(%subview_12 : memref<32x32xf32, strided<[32, 1]>, #hivm.address_space<cc>>)
}
```

As shown in the above example, after the `hivm.hir.nd2nz` operation, the data in `%alloc_3` is arranged continuously. If `subview` it again, when the tail block is processed, discontinuous access will be performed to the data in `%alloc_3` (due to `strided<[32, 1]>`, the tail block may be less than `32` columns). As a result, the `mmadL1` calculation result of the tail block is incorrect.