### PR TITLE
[AscendNPU-IR][Developer]Support Slice in ReduceOp

### DIFF
--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1526,13 +1526,34 @@ void CodeGenTileLangNPUIRDEV::VreduceCodegen(const CallNode *op) {
   tvm::tl::NpuirReduce npuirop(op->args, this->vmap);
   Value src = GetVarValue(npuirop.src);
   Value dst = GetVarValue(npuirop.dst);
+  SmallVector<OpFoldResult> offsets, sizes, strides;
+  for (const auto& r : npuirop.src_range) {
+      if (auto* i = as_const_int(r->min)) {
+        offsets.push_back(builder.getI64IntegerAttr(*i));
+      } else {
+        offsets.push_back(CreateIndexCastOp(MakeValue(r->min)));
+      }
+      if (auto* i = as_const_int(r->extent)) {
+        sizes.push_back(builder.getI64IntegerAttr(*i));
+      } else {
+        sizes.push_back(CreateIndexCastOp(MakeValue(r->extent)));
+      }
+      strides.push_back(builder.getI64IntegerAttr(1));
+  }
+  Value sliced_src = builder.create<mlir::tensor::ExtractSliceOp>(
+      builder.getUnknownLoc(),
+      src,
+      offsets,
+      sizes,
+      strides
+  );
   auto reduce_mode = npuirop.reduce_mode;
   mlir::hivm::ReduceOpAttr mode =
       mlir::hivm::ReduceOpAttr::get(&context, NPUIR_STR_REDUCEOP[reduce_mode]);
   mlir::Type dst_type = dst.getType();
   mlir::TypeRange result_tensors(&dst_type, 1);
   auto reduceOp = builder.create<mlir::hivm::VReduceOp>(
-      builder.getUnknownLoc(), result_tensors, src, dst, mode,
+      builder.getUnknownLoc(), result_tensors, sliced_src, dst, mode,
       builder.getDenseI64ArrayAttr(npuirop.reduce_dims));
   SetVarValue(npuirop.dst, reduceOp->getResult(0));
 }


### PR DESCRIPTION
Support Slice in VReduceOp in Dev mode

This MR enchances the 'tl.npuir_reduce' codegen to support two key features:
1. **Partial tensor reduction**: Reduce operations can now be applied to a sub-region(slice) of the source tensor, specified by 'src_range' (min/extent per dimension).
2. Hybrid static/dynamic range building: The offset and size of the reduction region can be either compile-time constants or runtime values, enabling flexible kernel generation for both static and dynamic shapes.
 
The implementation inserts a 'tensor.extract_slice' before the 'hivm.vreduce' op to materialize the input view, ensuring correct memory access on Asceng NPU.

Usage example:  T.reduce(A, row_max, dims=1, size=[4,4], clear=True) where A is (4,8) but only A[:,:4] is calculated in reduce_max.