### PR TITLE
[Fix] Remove the return value of lib.call in CythonKernelWrapper

### DIFF
--- a/tilelang/jit/adapter/cython/cython_wrapper.pyx
+++ b/tilelang/jit/adapter/cython/cython_wrapper.pyx
@@ -183,10 +183,7 @@ cdef class CythonKernelWrapper:
         call_args.append(ctypes.c_void_p(stream))
 
         # Execute the kernel
-        result = self.lib.call(*call_args)
-        if result != 0:
-            error_msg = self.lib.get_last_error().decode('utf-8')
-            raise RuntimeError(f"Kernel call failed: {error_msg}")
+        self.lib.call(*call_args)
 
         # Return output tensor(s)
         if len(self.result_idx) == 1:


### PR DESCRIPTION
Remove the return value of lib.call as the corresponding `extern "C" void call(...)` should not have a return value. 