### PR TITLE
[AscendNPU-IR][JIT] Update jit to make CANN8.5 work

### DIFF
--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -153,6 +153,14 @@ def _get_npucompiler_path() -> str:
         npu_compiler_path = os.path.join(npu_compiler_root, "npuc")
     return npu_compiler_path
 
+def _get_npucompiler_opt_path() -> str:
+    npu_compiler_opt_path = shutil.which("bishengir-opt")
+    if npu_compiler_opt_path is None:
+        raise EnvironmentError(
+            "Couldn't find executable bishengir-opt."
+        )
+    return npu_compiler_opt_path
+
 
 def convert_sigtype_to_int(sigty: str):
     MAP_SIGTYPE_TO_INT = {
@@ -1254,6 +1262,27 @@ class compiler_npu:
             Path(ttadapter_path).write_text(linalg)
             bin_file = os.path.join(tmpdir, "kernel")
             bin_path = os.path.join(tmpdir, "kernel.o")
+            
+            # Hot fix for CANN 8.5
+            # Run --adapt-triton-kernel pass before running compilation pipeline
+            # TODO: temporary fix, will be updated when bishengir-compile
+            # and hivmc gets updated in CANN 8.5
+            npu_compiler_opt_path = _get_npucompiler_opt_path()
+            
+            _opt_option_list = [
+               "--adapt-triton-kernel"
+            ]
+            
+            opt_cmd_list = (
+                [npu_compiler_opt_path, ttadapter_path]
+                + _opt_option_list
+                + ["-o", ttadapter_path]
+            )
+            ret = subprocess.run(
+                opt_cmd_list, capture_output=True, check=True, text=True
+            )
+            print("AscendNPU IR OPT success:", ret.stdout)
+            # Hot fix for CANN 8.5 ends here
 
             npu_compiler_path = _get_npucompiler_path()
             # TileLang Ascend JIT Runtime now follows Triton JIT style.


### PR DESCRIPTION
This PR fixes issues of TileLang with CANN 8.5. The pass `adapt-triton-kernel` has been moved from HIVM to HFusion pipeline. TileLang doesn't enable HFusion pipeline. This PR selectively runs `adapt-triton-kernel` pass before running the TileLang compilation pipeline to make final executables compatible with triton executables.

Issue on CANN 8.5 without this PR:

```
WARNING: synchronous waiting (in Close) failed; there might be a device assert failure.
Traceback (most recent call last):
RuntimeError: SUSPECT REMOTE ERROR, EE8888: Inner Error!
        rtGetDevMsg execute failed, reason=[suspect remote error][FUNC:FuncErrorReason][FILE:error_message_manage.cc][LINE:53]

[ERROR] 2026-01-14-09:38:40 (PID:4043460, Device:0, RankID:-1) ERR00100 PTA call acl api failed
```