### PR TITLE
fix(ascend): skip PIPE_V barrier insertion for A5 platform

### DIFF
--- a/src/transform/ascend_sync_insert.cc
+++ b/src/transform/ascend_sync_insert.cc
@@ -48,9 +48,9 @@ TVM_REGISTER_PASS_CONFIG_OPTION(kAscendAutoSync, Bool);
 
 class AscendSyncInsert : public arith::IRMutatorWithAnalyzer {
 public:
-  static PrimFunc Substitute(PrimFunc f, const std::string& config_path, PassContext ctx) {
+  static PrimFunc Substitute(PrimFunc f, const std::string& config_path, PassContext ctx, Target target, std::string platform) {
     arith::Analyzer analyzer;
-    AscendSyncInsert syncInserter(&analyzer);
+    AscendSyncInsert syncInserter(&analyzer, target, platform);
 
     auto address_map = f->GetAttr<Map<Var, PrimExpr>>("address_map").value_or(Map<Var, PrimExpr>());
     syncInserter.InitConfig(config_path, address_map);
@@ -71,6 +71,9 @@ public:
 
     return f;
   }
+
+  explicit AscendSyncInsert(arith::Analyzer* analyzer, Target target, std::string platform)
+      : arith::IRMutatorWithAnalyzer(analyzer), target_(target), platform_(platform) {}
 
 private:
   using arith::IRMutatorWithAnalyzer::IRMutatorWithAnalyzer;
@@ -1551,6 +1554,10 @@ private:
       stmts.push_back(CreatePipeBarrier("PIPE_ALL"));
     } else if (sync_type.find("PipeBarrier_") == 0) {
       std::string pipeline = sync_type.substr(12);
+      // A5 AIC dont need PIPE_V
+      if (pipeline == "PIPE_V" && this->platform_ == "A5") {
+        return;
+      }
       stmts.push_back(CreatePipeBarrier(pipeline));
     } else if (sync_type.find("EventPair_") == 0) {
       std::string event_type = sync_type.substr(10);
@@ -1588,11 +1595,13 @@ private:
   std::unordered_map<std::string, OperationConfig> operation_config_;
   std::unordered_map<std::string, BufferAccess> current_access_history_;
   Map<Var, PrimExpr> address_map_;
+  std::string platform_;
+  Target target_;
 };
 
-tvm::transform::Pass AscendSyncInsert() {
+tvm::transform::Pass AscendSyncInsert(Target target, std::string platform) {
   auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
-    auto new_func = AscendSyncInsert::Substitute(std::move(f), "config_path", ctx);
+    auto new_func = AscendSyncInsert::Substitute(std::move(f), "config_path", ctx, target, platform);
     return new_func;
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.AscendSyncInsert", {});

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -225,7 +225,7 @@ def lower(
     mod = LowerAndLegalize(mod, target)
 
     # Phase 2: Optimize the IR for the target
-    mod = OptimizeForTarget(mod, target)
+    mod = OptimizeForTarget(mod, target, platform)
 
     codegen_mod = device_codegen(mod, target, platform)
 

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -75,7 +75,7 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
     return mod
 
 
-def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
+def OptimizeForTarget(mod: IRModule, target: Target, platform: str) -> IRModule:
     pass_ctx = tilelang.transform.get_pass_context()
     mod = tir.transform.PlanAndUpdateBufferAllocationLocation()(mod)
     mod = tilelang.transform.CrossCorePipeline()(mod)
@@ -97,6 +97,6 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
     mod = tir.transform.RewriteUnsafeSelect()(mod)
     mod = tir.transform.HoistIfThenElse()(mod)
     mod = tilelang.transform.AscendMemoryPlanning()(mod)
-    mod = tilelang.transform.AscendSyncInsert()(mod)
+    mod = tilelang.transform.AscendSyncInsert(target, platform)(mod)
     # print(mod)
     return mod

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -8,6 +8,7 @@ from .simplify import Simplify, simplify_prim_func  # noqa: F401
 from .pass_config import PassConfigKey  # noqa: F401
 from tilelang import tvm as tvm  # noqa: F401
 from tvm.ir.transform import PassContext  # noqa: F401
+from tvm.target import Target
 
 def HostProcesser():
     """HostProcesser
@@ -367,7 +368,7 @@ def AscendMemoryPlanning():
     return _ffi_api.AscendMemoryPlanning()  # type: ignore
 
 
-def AscendSyncInsert():
+def AscendSyncInsert(target: Target, platform: str):
     """Auto insert sync for Ascend.
 
     Returns
@@ -376,7 +377,7 @@ def AscendSyncInsert():
         The result pass
     ----
     """
-    return _ffi_api.AscendSyncInsert()  # type: ignore
+    return _ffi_api.AscendSyncInsert(target, platform)  # type: ignore
 
 
 def CombineCV():


### PR DESCRIPTION
- feat: pass `platform` and `target` arguments through `AscendSyncInsert` pipeline (files: lower.py, phase.py, __init__.py).
- fix: modify `ascend_sync_insert.cc` to ignore `PIPE_V` barrier generation specifically for A5 architecture to match hardware requirements.