### PR TITLE
[AscendNPU-IR] Update jit for CANN8.5 stable release

### DIFF
--- a/src/target/codegen_npuir_api.cc
+++ b/src/target/codegen_npuir_api.cc
@@ -2409,6 +2409,9 @@ void CodeGenTileLangNPUIRAPI::AddFunction(const GlobalVar& gvar, const PrimFunc&
   this->module->getOperation()->setAttr(mlir::hivm::TModuleCoreTypeAttr::name,
                                         moduleCoreType);
 
+  this->module->getOperation()->setAttr("memref.memref_as_ptr",
+                                        UnitAttr::get(builder.getContext()));
+
   if (this->func_coretype == NPU_CORETYPE::MIX ||
       this->func_coretype == NPU_CORETYPE::AIC) {
     this->current_coretype = NPU_CORETYPE::AIC;

--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -2635,6 +2635,9 @@ void CodeGenTileLangNPUIRDEV::AddFunction(const GlobalVar& gvar, const PrimFunc&
         mlir::hivm::TModuleCoreTypeAttr::get(&this->context, NPUIR_MODULECORETYPE_STR[this->func_coretype]);
     this->module->getOperation()->setAttr(mlir::hivm::TModuleCoreTypeAttr::name, moduleCoreType);
 
+    this->module->getOperation()->setAttr("memref.memref_as_ptr",
+                                        UnitAttr::get(builder.getContext()));
+
     switch (this->func_coretype) {
         case NPU_CORETYPE::AIC:
             this->current_coretype = NPU_CORETYPE::AIC;

--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -517,7 +517,7 @@ extern "C" {
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 {'#include <torch_npu/csrc/framework/OpCommand.h>' if enable_taskqueue else ''}
-#include "experiment/runtime/runtime/rt.h"
+#include "runtime/runtime/rt.h"
 {extract_device_print_code_from_cann()}
 
 #define TENSOR_KIND_INPUT 0
@@ -722,7 +722,7 @@ def generate_npu_utils_src():
 #include <tuple>
 #include <unordered_map>
 
-#include "experiment/runtime/runtime/rt.h"
+#include "runtime/runtime/rt.h"
 
 // Use map to differentiate same name functions from different binary
 static std::unordered_map<std::string, size_t> registered_names;
@@ -1370,6 +1370,13 @@ class compiler_npu:
         cc_cmd += [f"-I{os.path.dirname(os.path.realpath(__file__))}"]
         # find the ascend library
         asc_path = self._get_ascend_path()
+
+        rt_path = os.path.join(asc_path, "include/experiment/runtime/runtime/rt.h")
+        if not os.path.exists(rt_path):
+            cc_cmd += [
+                f"-I{os.path.join(asc_path, 'pkg_inc')}",
+                f"-I{os.path.join(asc_path, 'pkg_inc/profiling')}",
+            ]
 
         cc_cmd += [
             f"-I{os.path.join(asc_path, 'include')}",


### PR DESCRIPTION
Two updates for `CANN 8.5 2026.1.16 release` in this PR:

1) Added a new attribute `memref.memref_as_ptr` in the module. This is required to make TileLang kernel compatible with runtime on `CANN 8.5 2026.1.16 release`.
2) Updated path for `"runtime/runtime/rt.h"` as required for `CANN 8.5 2026.1.16 release`. Also ensured backward compatibility.

These changes have been tested with `CANN 8.3` and `CANN 8.5` using following versions:
`torch_npu:` 2.9.0
`driver:`  25.5.0
`python:` 3.11.13