### PR TITLE
[AscendNPU-IR] Update AscendNPU-IR to 31f6903

### DIFF
--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -477,7 +477,11 @@ NpuirPad::NpuirPad(Array<PrimExpr> args, BufferMap vmap) {
   }
 }
 
-NpuirFlip::NpuirFlip(Array<PrimExpr> args, BufferMap vmap){NPUIR_SRC_DST_BUF}
+NpuirFlip::NpuirFlip(Array<PrimExpr> args, BufferMap vmap){
+  NPUIR_SRC_DST_BUF
+
+  this->axis = args[2].as<IntImm>().value()->value;
+}
 
 NpuirBitcast::NpuirBitcast(Array<PrimExpr> args, BufferMap vmap) {
   NPUIR_GEN_BUF(args[0])
@@ -747,7 +751,7 @@ TIR_REGISTER_TL_OP(NpuirPad, npuir_pad)
                                Integer(CallEffectKind::kOpaque));
 
 TIR_REGISTER_TL_OP(NpuirFlip, npuir_flip)
-    .set_num_inputs(2)
+    .set_num_inputs(3)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 

--- a/src/op/ascend.h
+++ b/src/op/ascend.h
@@ -12,6 +12,7 @@
 
 #include "op.h"
 #include "tvm/ir/expr.h"
+#include <sys/types.h>
 
 namespace tvm {
 namespace tl {
@@ -472,6 +473,7 @@ public:
 
   Buffer src;
   Buffer dst;
+  u_int64_t axis;
 
   Array<Range> src_range;
   Array<Range> dst_range;

--- a/src/target/codegen_npuir_api.cc
+++ b/src/target/codegen_npuir_api.cc
@@ -1291,7 +1291,7 @@ void CodeGenTileLangNPUIRAPI::VflipCodegen(const CallNode *op) {
   Value src = GenSubviewFromRegion(npuirop.src, npuirop.src_range);
   Value dst = GenSubviewFromRegion(npuirop.dst, npuirop.dst_range);
   builder.create<mlir::hivm::VFlipOp>(builder.getUnknownLoc(), TypeRange{}, src,
-                                      dst);
+                                      dst, npuirop.axis);
 }
 
 void CodeGenTileLangNPUIRAPI::Nd2NzCodegen(const CallNode *op) {

--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1828,7 +1828,7 @@ void CodeGenTileLangNPUIRDEV::VflipCodegen(const CallNode *op) {
   Value src = GenSubviewFromRegion(npuirop.src, npuirop.src_range);
   Value dst = GenSubviewFromRegion(npuirop.dst, npuirop.dst_range);
   builder.create<mlir::hivm::VFlipOp>(builder.getUnknownLoc(), TypeRange{}, src,
-                                      dst);
+                                      dst, npuirop.axis);
 }
 
 void CodeGenTileLangNPUIRDEV::Nd2NzCodegen(const CallNode *op) {

--- a/tilelang/language/customize_npuir.py
+++ b/tilelang/language/customize_npuir.py
@@ -1088,7 +1088,7 @@ def npuir_pad(src, dst, pad_value, low: Union[list, tuple], high: Union[list, tu
  
     return _tir_call_intrin(src, dst, pad_value, pad_dim, s_low_str, s_high_str, num_dynamic_low, *dynamic)
 
-def npuir_flip(src, dst, size=[]):
+def npuir_flip(src, dst, axis: int, size=[]):
     """Flips a tensor along the last dimension.
  
     Args:
@@ -1104,7 +1104,7 @@ def npuir_flip(src, dst, size=[]):
     src = _to_region(src, "r", src_extent)
     dst = _to_region(dst, "w", dst_extent)
  
-    return tir.call_intrin("handle", tir.op.Op.get("tl.npuir_flip"), src, dst)
+    return tir.call_intrin("handle", tir.op.Op.get("tl.npuir_flip"), src, dst, axis)
 
 def npuir_bitcast(src, dtype, size = []):
     """Reinterprets the bits of a shaped value without changing data.


### PR DESCRIPTION
This PR updates AscendNPU-IR in TileLang-Ascend and associate commit `31f690369d1247fbd5529a3f88b758f7d470ae4f` (dated 2026.1.14). Previous associated AscendNPU-IR commit: `e3e21af` (dated 2025.10.30).

VFlipOp builders also require `axis` as input in latest version of AscendNPU-IR and respective codegen has been updated in this PR.