### PR TITLE
[bugfix]Fix the issues preventing the two examples, sparse_flash_attn_gqa_pipeline_pto.py and example_sparse_flash_attn_gqa_pto_developer.py, from running properly

### DIFF
--- a/examples/pipeline/sparse_flash_attn_gqa_pipeline_pto.py
+++ b/examples/pipeline/sparse_flash_attn_gqa_pipeline_pto.py
@@ -198,7 +198,7 @@ def sparse_attention_fwd(
                 T.tile.add(acc_o, acc_o, acc_o_ub)
 
             for h_i in range(v_block):
-                T.tile.div(acc_o[:, h_i], acc_o[:, h_i], sumexp[h_i])
+                T.tile.div(acc_o[h_i, :], acc_o[h_i, :], sumexp[h_i])
 
             T.copy(acc_o, acc_o_half)
             T.copy(acc_o_half, Output[b_i, s_i, H0 + vid * v_block:H1 + vid * v_block, :])

--- a/examples/sparse_flash_attention/example_sparse_flash_attn_gqa_pto_developer.py
+++ b/examples/sparse_flash_attention/example_sparse_flash_attn_gqa_pto_developer.py
@@ -196,7 +196,7 @@ def sparse_attention_fwd(
                 T.tile.add(acc_o, acc_o, acc_o_ub)
 
             for h_i in range(v_block):
-                T.tile.div(acc_o[:, h_i], acc_o[:, h_i], sumexp[h_i])
+                T.tile.div(acc_o[h_i, :], acc_o[h_i, :], sumexp[h_i])
 
             T.copy(acc_o, acc_o_half)
             T.copy(acc_o_half, Output[b_i, s_i, H0 + vid * v_block:H1 + vid * v_block, :])


### PR DESCRIPTION
Fix the issues preventing the two examples, sparse_flash_attn_gqa_pipeline_pto.py and example_sparse_flash_attn_gqa_pto_developer.py, from running properly