### PR TITLE
[AscendNPU-IR][developer] Fix vector broadcast

### DIFF
--- a/examples/elementwise/vec_add_auto_brc.py
+++ b/examples/elementwise/vec_add_auto_brc.py
@@ -1,0 +1,62 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025.
+import os
+import argparse
+import torch
+import tilelang
+import tilelang.language as T
+
+
+def ref_program(x, y):
+    return x + y[0, :]
+
+
+@tilelang.jit(out_idx=[-1], target="npuir")
+def elementwise_add(M, N, block_M, block_N, in_dtype="float32", out_dtype="float32"):
+    @T.prim_func
+    def elemAdd(
+            A: T.Tensor((M, N), in_dtype),
+            B: T.Tensor((M, N), in_dtype),
+            C: T.Tensor((M, N), out_dtype)
+    ):
+        with T.Kernel(T.ceildiv(N, block_N) * T.ceildiv(M, block_M), is_npu=True) as (cid, _):
+            by = cid // T.ceildiv(N, block_N)
+            bx = cid % T.ceildiv(N, block_N)
+
+            A_shared = T.alloc_shared((block_M, block_N), in_dtype)
+            B_shared = T.alloc_shared((block_M, block_N), in_dtype)
+            C_local = T.alloc_fragment((block_M, block_N), out_dtype)
+            C_shared = T.alloc_shared((block_M, block_N), out_dtype)
+
+            T.copy(A[by * block_M, bx * block_N], A_shared)
+            T.copy(B[0, bx * block_N], B_shared)
+            T.npuir_add(A_shared[:, :], B_shared[0, :], C_local[:, :])
+            T.copy(C_local, C_shared)
+            T.copy(C_shared, C[by * block_M, bx * block_N])
+
+    return elemAdd
+
+
+def main(M=256, N=256, use_autotune=False):
+    os.environ["TILELANG_ASCEND_MODE"] = "Developer"
+    a = torch.randn(M, N, dtype=torch.float32, device="npu")
+    b = torch.randn(M, N, dtype=torch.float32, device="npu")
+    c = torch.zeros(M, N, dtype=torch.float32, device="npu")
+
+    if use_autotune:
+        kernel = elementwise_add(M, N, in_dtype="float32", out_dtype="float32")
+    else:
+        # Default config
+        config = {"block_M": 64, "block_N": 64}
+        kernel = elementwise_add(M, N, **config, in_dtype="float32", out_dtype="float32")
+
+    kernel(a, b, c)
+    torch.testing.assert_close(c, ref_program(a, b), rtol=1e-2, atol=1e-2)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--m", type=int, default=256)
+    parser.add_argument("--n", type=int, default=256)
+    args, _ = parser.parse_known_args()
+    main(args.m, args.n)
+    print("\033[92mAll check passed!\033[0m")

--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1979,22 +1979,25 @@ void CodeGenTileLangNPUIRDEV::CreateHIVMBinaryVectorOp(const CallNode *op) {
       // Vector case
       const CallNode *region_node = op->args[arg_id].as<CallNode>();
       auto buffer_node = region_node->args[0].as<BufferLoadNode>();
-      Array<PrimExpr> tmp_buffer_shape = buffer_node->buffer->shape;
+      size_t ndim = buffer_node->buffer->shape.size();
+      Array<PrimExpr> region_extent;
+      for (size_t i = 0; i < ndim; i++) {
+        region_extent.push_back(region_node->args[2 + i]);
+      }
       bool is_scalar_load = true;
-      for (int i = 0; i < tmp_buffer_shape.size(); i++) {
+      for (size_t i = 0; i < ndim; i++) {
         const IntImmNode* int_imm = region_node->args[2 + i].as<IntImmNode>();
         if (!int_imm || int_imm->value != 1) {
           is_scalar_load = false;
           break;
         }
       }
-      const IntImmNode* int_imm = region_node->args[2].as<IntImmNode>();
       // If load only one element, do not use memref.subview, use memref.load as a scalar
-      if(is_scalar_load) {
+      if (is_scalar_load) {
         src = VisitExpr_(buffer_node);
       } else {
-        src = GetVarValue(region_node);
-        buffer_shape = tmp_buffer_shape;
+        src = GenExtractSliceFromRegion(region_node);
+        buffer_shape = region_extent;
       }
     }
   };


### PR DESCRIPTION
Fix Ascend NPU IR codegen for vector broadcast (e.g. `A[:,:] + B[0,:]`) by using region extent instead of buffer shape when building the slice, and add `vec_add_auto_brc.py` as a regression example.