### PR TITLE
[WIP][AscendNPU-IR][Developer] Use expand_shape & collapse_shape in Copy reshape

### DIFF
--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1017,57 +1017,26 @@ mlir::Value CodeGenTileLangNPUIRDEV::InsertSlice(
 // Smart reshape tensor using expand_shape or collapse_shape when possible,
 // falling back to collapse_shape + expand_shape only when necessary.
 // 
+// Core implementation of tensor reshape.
 // Common cases in copy operations:
 // - [M, N] -> [1, 1, M, N]: use expand_shape only
 // - [1, 1, M, N] -> [M, N]: use collapse_shape only
 // - [M, N] -> [N, M]: use collapse + expand (incompatible)
-mlir::Value CodeGenTileLangNPUIRDEV::MaybeReshapeTensor(mlir::Value src, mlir::Value dst) {
+mlir::Value CodeGenTileLangNPUIRDEV::ReshapeTensorImpl(
+    mlir::Value src,
+    llvm::ArrayRef<int64_t> dstShapeStatic,
+    llvm::ArrayRef<mlir::OpFoldResult> dstShapeOFR) {
 
   ICHECK(src.getType().isa<mlir::TensorType>()) << "src must be a tensor";
   auto srcTensorTy = src.getType().cast<mlir::RankedTensorType>();
   auto loc = builder.getUnknownLoc();
   auto srcShape = srcTensorTy.getShape();
   int64_t srcRank = srcTensorTy.getRank();
+  int64_t dstRank = (int64_t)dstShapeStatic.size();
 
-  // Build target shape values: handle dynamic dimensions
-  llvm::SmallVector<mlir::OpFoldResult> dstShapeOFR;
-  llvm::SmallVector<int64_t> dstShapeStatic;
-  int64_t dstRank = 0;
-  
-  if (dst.getType().isa<mlir::MemRefType>()) {
-    auto dstType = dst.getType().cast<mlir::MemRefType>();
-    if (srcShape == dstType.getShape()) {
-      return src;
-    }
-    dstRank = dstType.getRank();
-    for (int i = 0; i < dstRank; ++i) {
-      int64_t dim = dstType.getDimSize(i);
-      if (mlir::ShapedType::isDynamic(dim)) {
-        mlir::Value dimVal = builder.create<mlir::memref::DimOp>(loc, dst, i);
-        dstShapeOFR.push_back(dimVal);
-        dstShapeStatic.push_back(mlir::ShapedType::kDynamic);
-      } else {
-        dstShapeOFR.push_back(builder.getIndexAttr(dim));
-        dstShapeStatic.push_back(dim);
-      }
-    }
-  } else if (dst.getType().isa<mlir::RankedTensorType>()) {
-    auto dstType = dst.getType().cast<mlir::RankedTensorType>();
-    if (srcShape == dstType.getShape()) {
-      return src;
-    }
-    dstRank = dstType.getRank();
-    for (int i = 0; i < dstRank; ++i) {
-      int64_t dim = dstType.getDimSize(i);
-      if (mlir::ShapedType::isDynamic(dim)) {
-        mlir::Value dimVal = builder.create<mlir::tensor::DimOp>(loc, dst, i);
-        dstShapeOFR.push_back(dimVal);
-        dstShapeStatic.push_back(mlir::ShapedType::kDynamic);
-      } else {
-        dstShapeOFR.push_back(builder.getIndexAttr(dim));
-        dstShapeStatic.push_back(dim);
-      }
-    }
+  // Check if shapes are already the same
+  if (srcShape == llvm::ArrayRef<int64_t>(dstShapeStatic)) {
+    return src;
   }
 
   auto dstTensorTy = mlir::RankedTensorType::get(
@@ -1167,17 +1136,49 @@ mlir::Value CodeGenTileLangNPUIRDEV::MaybeReshapeTensor(mlir::Value src, mlir::V
       loc, dstTensorTy, collapsed, expandReassoc, dstShapeOFR);
 }
 
-// Smart reshape tensor based on destination sizes.
-// Uses expand_shape or collapse_shape when possible, fallback to collapse+expand.
+// Reshape tensor to match destination Value's shape (MemRef or Tensor).
+mlir::Value CodeGenTileLangNPUIRDEV::MaybeReshapeTensor(mlir::Value src, mlir::Value dst) {
+  auto loc = builder.getUnknownLoc();
+  llvm::SmallVector<mlir::OpFoldResult> dstShapeOFR;
+  llvm::SmallVector<int64_t> dstShapeStatic;
+
+  if (dst.getType().isa<mlir::MemRefType>()) {
+    auto dstType = dst.getType().cast<mlir::MemRefType>();
+    int64_t dstRank = dstType.getRank();
+    for (int i = 0; i < dstRank; ++i) {
+      int64_t dim = dstType.getDimSize(i);
+      if (mlir::ShapedType::isDynamic(dim)) {
+        mlir::Value dimVal = builder.create<mlir::memref::DimOp>(loc, dst, i);
+        dstShapeOFR.push_back(dimVal);
+        dstShapeStatic.push_back(mlir::ShapedType::kDynamic);
+      } else {
+        dstShapeOFR.push_back(builder.getIndexAttr(dim));
+        dstShapeStatic.push_back(dim);
+      }
+    }
+  } else if (dst.getType().isa<mlir::RankedTensorType>()) {
+    auto dstType = dst.getType().cast<mlir::RankedTensorType>();
+    int64_t dstRank = dstType.getRank();
+    for (int i = 0; i < dstRank; ++i) {
+      int64_t dim = dstType.getDimSize(i);
+      if (mlir::ShapedType::isDynamic(dim)) {
+        mlir::Value dimVal = builder.create<mlir::tensor::DimOp>(loc, dst, i);
+        dstShapeOFR.push_back(dimVal);
+        dstShapeStatic.push_back(mlir::ShapedType::kDynamic);
+      } else {
+        dstShapeOFR.push_back(builder.getIndexAttr(dim));
+        dstShapeStatic.push_back(dim);
+      }
+    }
+  }
+
+  return ReshapeTensorImpl(src, dstShapeStatic, dstShapeOFR);
+}
+
+// Reshape tensor based on destination sizes (OpFoldResult array).
 mlir::Value CodeGenTileLangNPUIRDEV::MaybeReshapeTensorByDstSize(
     mlir::Value src,
     llvm::ArrayRef<mlir::OpFoldResult> sizes) {
-
-  ICHECK(src.getType().isa<mlir::TensorType>()) << "src must be a tensor";
-  auto srcTensorTy = src.getType().cast<mlir::RankedTensorType>();
-  auto loc = builder.getUnknownLoc();
-  auto srcShape = srcTensorTy.getShape();
-  int64_t srcRank = srcTensorTy.getRank();
 
   llvm::SmallVector<mlir::OpFoldResult> dstShapeOFR;
   llvm::SmallVector<int64_t> dstShapeStatic;
@@ -1196,107 +1197,7 @@ mlir::Value CodeGenTileLangNPUIRDEV::MaybeReshapeTensorByDstSize(
     }
   }
 
-  int64_t dstRank = (int64_t)dstShapeStatic.size();
-
-  // Check if shapes are already the same
-  if (srcRank == dstRank) {
-    bool same = true;
-    for (int i = 0; i < srcRank; ++i) {
-      if (srcShape[i] != dstShapeStatic[i]) {
-        same = false;
-        break;
-      }
-    }
-    if (same) return src;
-  }
-
-  auto dstTensorTy = mlir::RankedTensorType::get(
-      dstShapeStatic, srcTensorTy.getElementType());
-
-  if (srcRank < dstRank) {
-    // Try expand_shape: [M, N] -> [1, 1, M, N]
-    llvm::SmallVector<mlir::ReassociationIndices> reassoc;
-    int64_t extraDims = dstRank - srcRank;
-    
-    for (int64_t srcIdx = 0; srcIdx < srcRank; ++srcIdx) {
-      mlir::ReassociationIndices group;
-      if (srcIdx == 0) {
-        // First src dimension gets all the leading extra dimensions
-        for (int64_t i = 0; i <= extraDims; ++i) {
-          group.push_back(i);
-        }
-      } else {
-        // Other dimensions map 1-to-1
-        group.push_back(extraDims + srcIdx);
-      }
-      reassoc.push_back(group);
-    }
-    
-    return builder.create<mlir::tensor::ExpandShapeOp>(
-        loc, dstTensorTy, src, reassoc, dstShapeOFR);
-  }
-  
-  if (srcRank > dstRank) {
-    // Try collapse_shape: [1, 1, M, N] -> [M, N]
-    llvm::SmallVector<mlir::ReassociationIndices> reassoc;
-    int64_t extraDims = srcRank - dstRank;
-    
-    for (int64_t dstIdx = 0; dstIdx < dstRank; ++dstIdx) {
-      mlir::ReassociationIndices group;
-      if (dstIdx == 0) {
-        // First dst dimension absorbs all the leading extra dimensions
-        for (int64_t i = 0; i <= extraDims; ++i) {
-          group.push_back(i);
-        }
-      } else {
-        // Other dimensions map 1-to-1
-        group.push_back(extraDims + dstIdx);
-      }
-      reassoc.push_back(group);
-    }
-    
-    return builder.create<mlir::tensor::CollapseShapeOp>(
-        loc, dstTensorTy, src, reassoc);
-  }
-
-  // srcRank == dstRank but shapes differ: fallback to collapse + expand
-  llvm::SmallVector<mlir::ReassociationIndices> collapseReassoc;
-  if (srcRank > 0) {
-    mlir::ReassociationIndices allDims;
-    for (int64_t i = 0; i < srcRank; ++i) {
-      allDims.push_back(i);
-    }
-    collapseReassoc.push_back(allDims);
-  }
-
-  int64_t totalStaticSize = 1;
-  bool hasDynamic = false;
-  for (int64_t dim : srcShape) {
-    if (mlir::ShapedType::isDynamic(dim)) {
-      hasDynamic = true;
-      break;
-    }
-    totalStaticSize *= dim;
-  }
-
-  int64_t collapsed1DSize = hasDynamic ? mlir::ShapedType::kDynamic : totalStaticSize;
-  auto collapsed1DTy = mlir::RankedTensorType::get(
-      {collapsed1DSize}, srcTensorTy.getElementType());
-
-  mlir::Value collapsed = builder.create<mlir::tensor::CollapseShapeOp>(
-      loc, collapsed1DTy, src, collapseReassoc);
-
-  llvm::SmallVector<mlir::ReassociationIndices> expandReassoc;
-  if (dstRank > 0) {
-    mlir::ReassociationIndices allDims;
-    for (int64_t i = 0; i < dstRank; ++i) {
-      allDims.push_back(i);
-    }
-    expandReassoc.push_back(allDims);
-  }
-
-  return builder.create<mlir::tensor::ExpandShapeOp>(
-      loc, dstTensorTy, collapsed, expandReassoc, dstShapeOFR);
+  return ReshapeTensorImpl(src, dstShapeStatic, dstShapeOFR);
 }
 
 // Converts a TileLang range/region descriptor into {offs, sizes, strides}.

--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1014,161 +1014,289 @@ mlir::Value CodeGenTileLangNPUIRDEV::InsertSlice(
   return insertOp.getResult();
 }
 
-// Reshape tensor
-// Note: src type must be a tensor
+// Smart reshape tensor using expand_shape or collapse_shape when possible,
+// falling back to collapse_shape + expand_shape only when necessary.
+// 
+// Common cases in copy operations:
+// - [M, N] -> [1, 1, M, N]: use expand_shape only
+// - [1, 1, M, N] -> [M, N]: use collapse_shape only
+// - [M, N] -> [N, M]: use collapse + expand (incompatible)
 mlir::Value CodeGenTileLangNPUIRDEV::MaybeReshapeTensor(mlir::Value src, mlir::Value dst) {
 
   ICHECK(src.getType().isa<mlir::TensorType>()) << "src must be a tensor";
-  auto src_tensor_type = src.getType().cast<mlir::TensorType>();
+  auto srcTensorTy = src.getType().cast<mlir::RankedTensorType>();
+  auto loc = builder.getUnknownLoc();
+  auto srcShape = srcTensorTy.getShape();
+  int64_t srcRank = srcTensorTy.getRank();
 
   // Build target shape values: handle dynamic dimensions
-  llvm::SmallVector<mlir::Value> target_shape_vals;
-  llvm::SmallVector<int64_t> target_shape_static;
+  llvm::SmallVector<mlir::OpFoldResult> dstShapeOFR;
+  llvm::SmallVector<int64_t> dstShapeStatic;
+  int64_t dstRank = 0;
+  
   if (dst.getType().isa<mlir::MemRefType>()) {
-    auto dst_type = dst.getType().cast<mlir::MemRefType>();
-    if (src_tensor_type.getShape() == dst_type.getShape()) {
+    auto dstType = dst.getType().cast<mlir::MemRefType>();
+    if (srcShape == dstType.getShape()) {
       return src;
     }
-    // Iterate through destination memref dimensions
-    for (int i = 0; i < dst_type.getRank(); ++i) {
-      int64_t dim = dst_type.getDimSize(i);
-      
+    dstRank = dstType.getRank();
+    for (int i = 0; i < dstRank; ++i) {
+      int64_t dim = dstType.getDimSize(i);
       if (mlir::ShapedType::isDynamic(dim)) {
-        // Dynamic dimension: get actual size at runtime using memref.dim
-        mlir::Value dim_val = builder.create<mlir::memref::DimOp>(builder.getUnknownLoc(), dst, i);
-        target_shape_vals.push_back(dim_val);
-        target_shape_static.push_back(mlir::ShapedType::kDynamic);
+        mlir::Value dimVal = builder.create<mlir::memref::DimOp>(loc, dst, i);
+        dstShapeOFR.push_back(dimVal);
+        dstShapeStatic.push_back(mlir::ShapedType::kDynamic);
       } else {
-        // Static dimension: create constant index value 
-        mlir::Value dim_val = builder.create<mlir::arith::ConstantIndexOp>(builder.getUnknownLoc(), dim);
-        target_shape_vals.push_back(dim_val);
-        target_shape_static.push_back(dim);
+        dstShapeOFR.push_back(builder.getIndexAttr(dim));
+        dstShapeStatic.push_back(dim);
       }
     }
   } else if (dst.getType().isa<mlir::RankedTensorType>()) {
-    auto dst_type = dst.getType().cast<mlir::RankedTensorType>();
-    if (src_tensor_type.getShape() == dst_type.getShape()) {
+    auto dstType = dst.getType().cast<mlir::RankedTensorType>();
+    if (srcShape == dstType.getShape()) {
       return src;
     }
-    // Iterate through destination memref dimensions
-    for (int i = 0; i < dst_type.getRank(); ++i) {
-      int64_t dim = dst_type.getDimSize(i);
+    dstRank = dstType.getRank();
+    for (int i = 0; i < dstRank; ++i) {
+      int64_t dim = dstType.getDimSize(i);
       if (mlir::ShapedType::isDynamic(dim)) {
-        // Dynamic dimension: get actual size at runtime using tensor.dim
-        mlir::Value dim_val = builder.create<mlir::tensor::DimOp>(builder.getUnknownLoc(), dst, i);
-        target_shape_vals.push_back(dim_val);
-        target_shape_static.push_back(mlir::ShapedType::kDynamic);
+        mlir::Value dimVal = builder.create<mlir::tensor::DimOp>(loc, dst, i);
+        dstShapeOFR.push_back(dimVal);
+        dstShapeStatic.push_back(mlir::ShapedType::kDynamic);
       } else {
-        // Static dimension: create constant index value 
-        mlir::Value dim_val = builder.create<mlir::arith::ConstantIndexOp>(builder.getUnknownLoc(), dim);
-        target_shape_vals.push_back(dim_val);
-        target_shape_static.push_back(dim);
+        dstShapeOFR.push_back(builder.getIndexAttr(dim));
+        dstShapeStatic.push_back(dim);
       }
-    }    
-
+    }
   }
 
-  // Create target shape type for the reshape operation
-  auto target_shape_type = mlir::RankedTensorType::get(
-      target_shape_static,  // Shape with dynamic dimension markers
-      src_tensor_type.getElementType());
+  auto dstTensorTy = mlir::RankedTensorType::get(
+      dstShapeStatic, srcTensorTy.getElementType());
+
+  // Try to build reassociation for direct expand or collapse
+  // Strategy: match dimensions from the end (trailing dimensions usually match)
+  // and group leading 1-dimensions together
   
-  // Create shape tensor (1D tensor containing all dimension sizes)
-  mlir::Value shape_tensor;
-  
-  if (target_shape_vals.size() == 1) {
-    // For 1D case, create tensor directly
-    shape_tensor = builder.create<mlir::tensor::FromElementsOp>(
-        builder.getUnknownLoc(), target_shape_vals);
-  } else {
-    // For multi-dimensional case, create 1D tensor of indices
-    auto shape_tensor_type = mlir::RankedTensorType::get(
-        {static_cast<int64_t>(target_shape_vals.size())},
-        builder.getIndexType());
-    shape_tensor = builder.create<mlir::tensor::FromElementsOp>(
-        builder.getUnknownLoc(), shape_tensor_type, target_shape_vals);
+  if (srcRank < dstRank) {
+    // Try expand_shape: [M, N] -> [1, 1, M, N]
+    // Reassociation maps each src dim to a group of dst dims
+    llvm::SmallVector<mlir::ReassociationIndices> reassoc;
+    int64_t extraDims = dstRank - srcRank;
+    
+    for (int64_t srcIdx = 0; srcIdx < srcRank; ++srcIdx) {
+      mlir::ReassociationIndices group;
+      if (srcIdx == 0) {
+        // First src dimension gets all the leading extra dimensions
+        for (int64_t i = 0; i <= extraDims; ++i) {
+          group.push_back(i);
+        }
+      } else {
+        // Other dimensions map 1-to-1
+        group.push_back(extraDims + srcIdx);
+      }
+      reassoc.push_back(group);
+    }
+    
+    return builder.create<mlir::tensor::ExpandShapeOp>(
+        loc, dstTensorTy, src, reassoc, dstShapeOFR);
   }
   
-  // Create tensor.reshape operation to match destination shape
-  mlir::Value reshaped_tensor = builder.create<mlir::tensor::ReshapeOp>(
-      builder.getUnknownLoc(),
-      target_shape_type,
-      src,
-      shape_tensor);
+  if (srcRank > dstRank) {
+    // Try collapse_shape: [1, 1, M, N] -> [M, N]
+    // Reassociation maps each dst dim to a group of src dims
+    llvm::SmallVector<mlir::ReassociationIndices> reassoc;
+    int64_t extraDims = srcRank - dstRank;
+    
+    for (int64_t dstIdx = 0; dstIdx < dstRank; ++dstIdx) {
+      mlir::ReassociationIndices group;
+      if (dstIdx == 0) {
+        // First dst dimension absorbs all the leading extra dimensions
+        for (int64_t i = 0; i <= extraDims; ++i) {
+          group.push_back(i);
+        }
+      } else {
+        // Other dimensions map 1-to-1
+        group.push_back(extraDims + dstIdx);
+      }
+      reassoc.push_back(group);
+    }
+    
+    return builder.create<mlir::tensor::CollapseShapeOp>(
+        loc, dstTensorTy, src, reassoc);
+  }
   
-  return reshaped_tensor;
+  // srcRank == dstRank but shapes differ: fallback to collapse + expand
+  // Step 1: Collapse to 1D
+  llvm::SmallVector<mlir::ReassociationIndices> collapseReassoc;
+  if (srcRank > 0) {
+    mlir::ReassociationIndices allDims;
+    for (int64_t i = 0; i < srcRank; ++i) {
+      allDims.push_back(i);
+    }
+    collapseReassoc.push_back(allDims);
+  }
+
+  int64_t totalStaticSize = 1;
+  bool hasDynamic = false;
+  for (int64_t dim : srcShape) {
+    if (mlir::ShapedType::isDynamic(dim)) {
+      hasDynamic = true;
+      break;
+    }
+    totalStaticSize *= dim;
+  }
+
+  int64_t collapsed1DSize = hasDynamic ? mlir::ShapedType::kDynamic : totalStaticSize;
+  auto collapsed1DTy = mlir::RankedTensorType::get(
+      {collapsed1DSize}, srcTensorTy.getElementType());
+
+  mlir::Value collapsed = builder.create<mlir::tensor::CollapseShapeOp>(
+      loc, collapsed1DTy, src, collapseReassoc);
+
+  // Step 2: Expand to target shape
+  llvm::SmallVector<mlir::ReassociationIndices> expandReassoc;
+  if (dstRank > 0) {
+    mlir::ReassociationIndices allDims;
+    for (int64_t i = 0; i < dstRank; ++i) {
+      allDims.push_back(i);
+    }
+    expandReassoc.push_back(allDims);
+  }
+
+  return builder.create<mlir::tensor::ExpandShapeOp>(
+      loc, dstTensorTy, collapsed, expandReassoc, dstShapeOFR);
 }
 
+// Smart reshape tensor based on destination sizes.
+// Uses expand_shape or collapse_shape when possible, fallback to collapse+expand.
 mlir::Value CodeGenTileLangNPUIRDEV::MaybeReshapeTensorByDstSize(
     mlir::Value src,
     llvm::ArrayRef<mlir::OpFoldResult> sizes) {
 
   ICHECK(src.getType().isa<mlir::TensorType>()) << "src must be a tensor";
-  auto srcTensorTy = src.getType().cast<mlir::TensorType>();
+  auto srcTensorTy = src.getType().cast<mlir::RankedTensorType>();
   auto loc = builder.getUnknownLoc();
+  auto srcShape = srcTensorTy.getShape();
+  int64_t srcRank = srcTensorTy.getRank();
 
-  llvm::SmallVector<mlir::Value> targetShapeVals;     // runtime values
-  llvm::SmallVector<int64_t>     targetShapeStatic;   // static shape (kDynamic)
+  llvm::SmallVector<mlir::OpFoldResult> dstShapeOFR;
+  llvm::SmallVector<int64_t> dstShapeStatic;
 
   for (mlir::OpFoldResult ofr : sizes) {
     if (auto attr = ofr.dyn_cast<mlir::Attribute>()) {
       auto intAttr = attr.cast<mlir::IntegerAttr>();
       int64_t dim = intAttr.getInt();
-
-      targetShapeStatic.push_back(dim);
-      targetShapeVals.push_back(
-          builder.create<mlir::arith::ConstantIndexOp>(loc, dim));
-
+      dstShapeStatic.push_back(dim);
+      dstShapeOFR.push_back(builder.getIndexAttr(dim));
     } else if (auto val = ofr.dyn_cast<mlir::Value>()) {
-      targetShapeStatic.push_back(mlir::ShapedType::kDynamic);
-      targetShapeVals.push_back(val);
-
+      dstShapeStatic.push_back(mlir::ShapedType::kDynamic);
+      dstShapeOFR.push_back(val);
     } else {
       llvm_unreachable("Invalid OpFoldResult in sizes");
     }
   }
 
-  if (auto rankedTy = srcTensorTy.dyn_cast<mlir::RankedTensorType>()) {
-    if (rankedTy.getRank() == (int64_t)targetShapeStatic.size()) {
-      bool same = true;
-      for (int i = 0; i < rankedTy.getRank(); ++i) {
-        int64_t s0 = rankedTy.getDimSize(i);
-        int64_t s1 = targetShapeStatic[i];
-        if (s0 != s1) {
-          if (mlir::ShapedType::isDynamic(s0) ||
-              mlir::ShapedType::isDynamic(s1)) {
-            same = false;
-            break;
-          }
-          same = false;
-          break;
-        }
+  int64_t dstRank = (int64_t)dstShapeStatic.size();
+
+  // Check if shapes are already the same
+  if (srcRank == dstRank) {
+    bool same = true;
+    for (int i = 0; i < srcRank; ++i) {
+      if (srcShape[i] != dstShapeStatic[i]) {
+        same = false;
+        break;
       }
-      if (same) return src;
     }
+    if (same) return src;
   }
 
-  auto targetTensorTy = mlir::RankedTensorType::get(
-      targetShapeStatic,
-      srcTensorTy.getElementType());
+  auto dstTensorTy = mlir::RankedTensorType::get(
+      dstShapeStatic, srcTensorTy.getElementType());
 
-  mlir::Value shapeTensor;
-  {
-    auto shapeTensorTy = mlir::RankedTensorType::get(
-        {static_cast<int64_t>(targetShapeVals.size())},
-        builder.getIndexType());
-
-    shapeTensor = builder.create<mlir::tensor::FromElementsOp>(
-        loc, shapeTensorTy, targetShapeVals);
+  if (srcRank < dstRank) {
+    // Try expand_shape: [M, N] -> [1, 1, M, N]
+    llvm::SmallVector<mlir::ReassociationIndices> reassoc;
+    int64_t extraDims = dstRank - srcRank;
+    
+    for (int64_t srcIdx = 0; srcIdx < srcRank; ++srcIdx) {
+      mlir::ReassociationIndices group;
+      if (srcIdx == 0) {
+        // First src dimension gets all the leading extra dimensions
+        for (int64_t i = 0; i <= extraDims; ++i) {
+          group.push_back(i);
+        }
+      } else {
+        // Other dimensions map 1-to-1
+        group.push_back(extraDims + srcIdx);
+      }
+      reassoc.push_back(group);
+    }
+    
+    return builder.create<mlir::tensor::ExpandShapeOp>(
+        loc, dstTensorTy, src, reassoc, dstShapeOFR);
+  }
+  
+  if (srcRank > dstRank) {
+    // Try collapse_shape: [1, 1, M, N] -> [M, N]
+    llvm::SmallVector<mlir::ReassociationIndices> reassoc;
+    int64_t extraDims = srcRank - dstRank;
+    
+    for (int64_t dstIdx = 0; dstIdx < dstRank; ++dstIdx) {
+      mlir::ReassociationIndices group;
+      if (dstIdx == 0) {
+        // First dst dimension absorbs all the leading extra dimensions
+        for (int64_t i = 0; i <= extraDims; ++i) {
+          group.push_back(i);
+        }
+      } else {
+        // Other dimensions map 1-to-1
+        group.push_back(extraDims + dstIdx);
+      }
+      reassoc.push_back(group);
+    }
+    
+    return builder.create<mlir::tensor::CollapseShapeOp>(
+        loc, dstTensorTy, src, reassoc);
   }
 
-  auto reshaped = builder.create<mlir::tensor::ReshapeOp>(
-      loc,
-      targetTensorTy,
-      src,
-      shapeTensor);
+  // srcRank == dstRank but shapes differ: fallback to collapse + expand
+  llvm::SmallVector<mlir::ReassociationIndices> collapseReassoc;
+  if (srcRank > 0) {
+    mlir::ReassociationIndices allDims;
+    for (int64_t i = 0; i < srcRank; ++i) {
+      allDims.push_back(i);
+    }
+    collapseReassoc.push_back(allDims);
+  }
 
-  return reshaped;
+  int64_t totalStaticSize = 1;
+  bool hasDynamic = false;
+  for (int64_t dim : srcShape) {
+    if (mlir::ShapedType::isDynamic(dim)) {
+      hasDynamic = true;
+      break;
+    }
+    totalStaticSize *= dim;
+  }
+
+  int64_t collapsed1DSize = hasDynamic ? mlir::ShapedType::kDynamic : totalStaticSize;
+  auto collapsed1DTy = mlir::RankedTensorType::get(
+      {collapsed1DSize}, srcTensorTy.getElementType());
+
+  mlir::Value collapsed = builder.create<mlir::tensor::CollapseShapeOp>(
+      loc, collapsed1DTy, src, collapseReassoc);
+
+  llvm::SmallVector<mlir::ReassociationIndices> expandReassoc;
+  if (dstRank > 0) {
+    mlir::ReassociationIndices allDims;
+    for (int64_t i = 0; i < dstRank; ++i) {
+      allDims.push_back(i);
+    }
+    expandReassoc.push_back(allDims);
+  }
+
+  return builder.create<mlir::tensor::ExpandShapeOp>(
+      loc, dstTensorTy, collapsed, expandReassoc, dstShapeOFR);
 }
 
 // Converts a TileLang range/region descriptor into {offs, sizes, strides}.
@@ -1365,11 +1493,11 @@ void CodeGenTileLangNPUIRDEV::EmitCopyMemrefToTensor(
   mlir::Value loaded_tensor = builder.create<mlir::bufferization::ToTensorOp>(
       loc, ub_view, /*restrict=*/true, /*writable=*/false);
 
-  // 7) Reshape to dst_slice if needed
-  // mlir::Value reshaped_tensor = MaybeReshapeTensorByDstSize(loaded_tensor, dstR.sizes);
+  // 7) Reshape to dst_slice if needed (using smart collapse/expand)
+  mlir::Value reshaped_tensor = MaybeReshapeTensorByDstSize(loaded_tensor, dstR.sizes);
 
   // 8) Type Cast
-  mlir::Value casted_tensor = CreateCastIfTypeMismatch(loaded_tensor, dst);
+  mlir::Value casted_tensor = CreateCastIfTypeMismatch(reshaped_tensor, dst);
 
   // 9) InsertSlice (keep your existing InsertSlice signature/behavior)
   mlir::Value result = InsertSlice(
@@ -2078,8 +2206,8 @@ void CodeGenTileLangNPUIRDEV::DotCodegen(const CallNode *op) {
 
   mlir::Location unknown_loc = builder.getUnknownLoc();
   mlir::IndexType idx_ty = builder.getIndexType();
-  mlir::Value a = GetVarValue(npuirop.src0);
-  mlir::Value b = GetVarValue(npuirop.src1);
+  mlir::Value a = GenExtractSliceFromRegion(op->args[0].as<CallNode>());
+  mlir::Value b = GenExtractSliceFromRegion(op->args[1].as<CallNode>());
   mlir::Value c = GetVarValue(npuirop.dst);
   mlir::Type c_type = c.getType();
   mlir::TypeRange result_tensors(&c_type, 1);

--- a/src/target/codegen_npuir_dev.h
+++ b/src/target/codegen_npuir_dev.h
@@ -282,6 +282,9 @@ private:
 
   // === helpers for ascend_copy lowering (member-functionized) ===
   mlir::Value CreateCastIfTypeMismatch(mlir::Value src_value, mlir::Value dst_value);
+  mlir::Value ReshapeTensorImpl(mlir::Value src,
+                                llvm::ArrayRef<int64_t> dstShapeStatic,
+                                llvm::ArrayRef<mlir::OpFoldResult> dstShapeOFR);
   mlir::Value MaybeReshapeTensor(mlir::Value src_tensor, mlir::Value dst_tensor);
   mlir::Value MaybeReshapeTensorByDstSize(mlir::Value src, llvm::ArrayRef<mlir::OpFoldResult> sizes);
   std::tuple<SmallVector<mlir::OpFoldResult>, 


### PR DESCRIPTION
feat: Copy reshape only using expand_shape & collapse_shape
Note: 
- Supports collapse/expand as: [1, 1, M, N] <-> [M, N], [1, 1, 1, M, N] <-> [1, M, N]
- Supports same-rank reshape as: [16] <-> [4, 4] or [1, 1, 16] <-> [1, 4, 4]
- Does not support strided reshape as: [M, 1, N, 1] <-> [M, N] yet.
- Does not support rank-mismatch reshape as: [1, 1, 16] → [4, 4] yet.