### PR TITLE
[AscendNPU-IR][developer] Fix reduce issue

### DIFF
--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1802,7 +1802,8 @@ void CodeGenTileLangNPUIRDEV::VcastCodegen(const CallNode *op) {
 void CodeGenTileLangNPUIRDEV::VreduceCodegen(const CallNode *op) {
   tvm::tl::NpuirReduce npuirop(op->args, this->vmap);
   Value src = GenExtractSliceFromRegion(npuirop.src, npuirop.src_range);
-  Value dst = GetVarValue(npuirop.dst);
+  Value dst_ori = GetVarValue(npuirop.dst);
+  Value dst = GenExtractSliceFromRegion(npuirop.dst, npuirop.dst_range);
   auto reduce_mode = npuirop.reduce_mode;
   mlir::hivm::ReduceOpAttr mode =
       mlir::hivm::ReduceOpAttr::get(&context, NPUIR_STR_REDUCEOP[reduce_mode]);
@@ -1811,7 +1812,8 @@ void CodeGenTileLangNPUIRDEV::VreduceCodegen(const CallNode *op) {
   auto reduceOp = builder.create<mlir::hivm::VReduceOp>(
       builder.getUnknownLoc(), result_tensors, src, dst, mode,
       builder.getDenseI64ArrayAttr(npuirop.reduce_dims));
-  SetVarValue(npuirop.dst, reduceOp->getResult(0));
+  auto insertSliceOp = ReshapeCastAndInsertSlice(reduceOp.getResult()[0], dst_ori, npuirop.dst_range);
+  SetVarValue(npuirop.dst, insertSliceOp);
 }
 
 void CodeGenTileLangNPUIRDEV::VcumsumCodegen(const CallNode *op) {


### PR DESCRIPTION
After merging with Baber's NPUIR update, HC encountered reduce-related issues in developer mode. Specifically, the new version of hivm.hir.vreduce does not support inconsistencies in non-reduce dimensions. The solution is to insert extract_slice and insert_slice before and after vreduce respectively to ensure consistency in non-reduce axis dimensions during vreduce.