### PR TITLE
[AscendNPU-IR][Developer] Control Loop Sequence

### DIFF
--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -435,7 +435,7 @@ void CodeGenTileLangNPUIRDEV::VisitStmt_(const tir::ForNode *op) {
 
   // Collect all variables defined in the loop body,
   // which may need to be carried as loop values
-  std::set<const tir::VarNode*> loop_carried_vars;
+  std::vector<const tir::VarNode*> loop_carried_vars;
   std::vector<mlir::Value> init_values;
 
   // Traverse the body of the for loop body, and generate
@@ -527,7 +527,7 @@ void CodeGenTileLangNPUIRDEV::VisitStmt_(const tir::IfThenElseNode *op) {
 
 void CodeGenTileLangNPUIRDEV::CollectVarsUsedInBodyButDefinedOutside(
     const tir::ForNode *op, 
-    std::set<const VarNode*>& loop_carried_vars) {
+    std::vector<const VarNode*>& loop_carried_vars) {
   LoopCarriedVarCollector collector(this, loop_carried_vars);
   collector.VisitStmt(op->body);
 }
@@ -3162,8 +3162,10 @@ void CodeGenTileLangNPUIRDEV::VisitStmt_(const DeclBufferNode *op) {
 void CodeGenTileLangNPUIRDEV::LoopCarriedVarCollector::VisitExpr_(
     const tir::CallNode *call) {
   auto check_var = [&](const tir::VarNode *var_node) {
-    if (var_node && outer_->GetVarValue(var_node) != mlir::Value{}) {
-      loop_carried_vars_.insert(var_node);
+    if (var_node && outer_->GetVarValue(var_node) != mlir::Value{} &&
+        vars_set_.find(var_node) == vars_set_.end()) {
+      vars_set_.insert(var_node);
+      loop_carried_vars_.push_back(var_node);
     }
   };
   auto process_call_arg = [&](int arg_index) {
@@ -3204,9 +3206,11 @@ void CodeGenTileLangNPUIRDEV::LoopCarriedVarCollector::VisitExpr_(
 }
 
 void CodeGenTileLangNPUIRDEV::LoopCarriedVarCollector::VisitStmt_(const tir::BufferStoreNode* op) {
-  auto check_var = [&](const tir::VarNode* var_node) {
-    if (var_node && outer_->GetVarValue(var_node) != mlir::Value{}) {
-      loop_carried_vars_.insert(var_node);
+  auto check_var = [&](const tir::VarNode *var_node) {
+    if (var_node && outer_->GetVarValue(var_node) != mlir::Value{} &&
+        vars_set_.find(var_node) == vars_set_.end()) {
+      vars_set_.insert(var_node);
+      loop_carried_vars_.push_back(var_node);
     }
   };
 

--- a/src/target/codegen_npuir_dev.h
+++ b/src/target/codegen_npuir_dev.h
@@ -225,7 +225,7 @@ protected:
   std::vector<int64_t> GetStrideFromShapeAPI(Array<tvm::PrimExpr> shape);
   // Collect all variables defined outside the loop body
   void CollectVarsUsedInBodyButDefinedOutside(const ForNode *op, 
-      std::set<const VarNode*>& loop_carried_vars);
+      std::vector<const VarNode*>& loop_carried_vars);
 
 private:
   mlir::Value GetEventID(PrimExpr id);
@@ -360,11 +360,12 @@ private:
       : public tir::StmtExprVisitor {
   private:
     CodeGenTileLangNPUIRDEV* outer_;
-    std::set<const VarNode*>& loop_carried_vars_;
+    std::vector<const VarNode*>& loop_carried_vars_;
+    std::unordered_set<const VarNode *> vars_set_;
     
   public:
     LoopCarriedVarCollector(CodeGenTileLangNPUIRDEV* outer, 
-                            std::set<const VarNode*>& loop_carried_vars)
+                            std::vector<const VarNode*>& loop_carried_vars)
         : outer_(outer), loop_carried_vars_(loop_carried_vars) {}
     
     using tir::StmtExprVisitor::VisitStmt;


### PR DESCRIPTION
When the set function is used, the initialization parameter sequence of scf::for varies on different servers. The initialization parameter sequence is changed to be the same as that used in the for loop.