### PR TITLE
[AscendNPU-IR][Developer][Expert] fix vector-scalar arithemic operations

### DIFF
--- a/src/target/codegen_npuir_api.cc
+++ b/src/target/codegen_npuir_api.cc
@@ -1464,7 +1464,7 @@ void CodeGenTileLangNPUIRAPI::CreateHIVMBinaryVectorOp(const CallNode *op) {
   auto processImm = [&](mlir::Value &src, int arg_id,
                         Array<PrimExpr> &buffer_shape) {
     if (op->args[arg_id].as<IntImm>() || op->args[arg_id].as<FloatImm>() || 
-        op->args[arg_id].as<tir::VarNode>() || op->args[arg_id].as<tir::BufferLoadNode>()) {
+        op->args[arg_id].as<tir::VarNode>()) {
       // Scalar case
       const CallNode *region_node = op->args[1 - arg_id].as<CallNode>();
       const BufferLoadNode *buffer_load_node =
@@ -1490,8 +1490,10 @@ void CodeGenTileLangNPUIRAPI::CreateHIVMBinaryVectorOp(const CallNode *op) {
       }
       const IntImmNode* int_imm = region_node->args[2].as<IntImmNode>();
       // If load only one element, do not use memref.subview, use memref.load as a scalar
-      if(is_scalar_load) {
+      if(is_scalar_load && arg_id == 1) {
         src = GenMemrefLoadFromRegion(buffer_node);
+        // clear buffer_shape to unable broadcast
+        buffer_shape.clear();
       } else {
         src = GenSubviewFromRegion(region_node);
       }

--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -2193,7 +2193,7 @@ void CodeGenTileLangNPUIRDEV::CreateHIVMBinaryVectorOp(const CallNode *op) {
   auto processImm = [&](mlir::Value &src, int arg_id,
                         Array<PrimExpr> &buffer_shape) {
     if (op->args[arg_id].as<IntImm>() || op->args[arg_id].as<FloatImm>() || 
-        op->args[arg_id].as<tir::VarNode>() || op->args[arg_id].as<tir::BufferLoadNode>()) {
+        op->args[arg_id].as<tir::VarNode>()) {
       // Scalar case
       const CallNode *region_node = op->args[1 - arg_id].as<CallNode>();
       const BufferLoadNode *buffer_load_node =

--- a/testing/npuir/test_vec_add_2d_scalar.py
+++ b/testing/npuir/test_vec_add_2d_scalar.py
@@ -41,8 +41,69 @@ def vec_add(block_M, block_N):
 
     return main
 
+def vec_add_2(block_M, block_N):
+    M = T.symbolic("M")
+    N = T.symbolic("N")
+    m_num = M // block_M
+    n_num = N // block_N
+    dtype = "float16"
+    BLOCK_SIZE = 20
+
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, N), dtype),
+            B: T.Tensor((M, N), dtype),
+            C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(BLOCK_SIZE, is_npu=True) as (cid, _):
+            A_VEC = T.alloc_ub((block_M, block_N), dtype)
+            B_VEC = T.alloc_ub((block_M, block_N), dtype)
+            C_VEC = T.alloc_ub((block_M, block_N), dtype)
+            for i in T.serial(T.ceildiv(m_num*n_num, BLOCK_SIZE)):
+                block_id = i * BLOCK_SIZE + cid
+                if block_id < m_num * n_num:
+                    block_id_m = block_id // n_num
+                    block_id_n = block_id % n_num
+                    bx = block_id_m * block_M
+                    by = block_id_n * block_N
+                    T.copy(A[bx, by], A_VEC)
+                    T.copy(B[0, 0], B_VEC)
+                    T.npuir_add(A_VEC, B_VEC[0, 0], C_VEC)
+                    T.copy(C_VEC, C[bx, by])
+
+    return main
+
+def vec_add_3(block_M, N):
+    M = T.symbolic("M")
+    m_num = M // block_M
+    n_num = 1
+    dtype = "float16"
+    BLOCK_SIZE = 20
+
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, N), dtype),
+            B: T.Tensor((M, N), dtype),
+            C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num*n_num, is_npu=True) as (cid, _):
+            A_VEC = T.alloc_ub((block_M, N), dtype)
+            B_VEC = T.alloc_ub((block_M, N), dtype)
+            C_VEC = T.alloc_ub((block_M, N), dtype)
+            bx = cid * block_M
+            T.copy(A[bx, 0], A_VEC)
+            T.copy(B[bx, 0], B_VEC)
+            j = 0 # to avoid 32byte alignment error
+            for i in T.serial(block_M):
+                T.npuir_add(A_VEC[i, j], B_VEC[i, j], C_VEC[i, j])
+            T.copy(C_VEC[:, 0], C[bx, 0])
+
+    return main
+
 def run_test():
     M, N = 128, 256
+
+    # case 1 VEC_A + VEC_B[0]
     func = vec_add(32, 32)
     compiled_kernel = tilelang.compile(func, target='npuir')
 
@@ -50,7 +111,7 @@ def run_test():
     b = torch.randn(N).half().npu()
     c = torch.randn(M, N).half().npu()
 
-    torch.manual_seed(88888888)  # set the random seed for torch
+    torch.manual_seed(88888888)  
     dtype = "float16"
 
     ref_output = a + b[0]
@@ -59,7 +120,47 @@ def run_test():
     print(c)
     print("Expected Result:")
     print(ref_output)
-    torch.testing.assert_close(c, ref_output, rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(c, ref_output, rtol=1e-3, atol=1e-3)
+    print("\033[92mAll check passed!\033[0m")
+
+    # case 2 VEC_A + VEC_B[0, 0]
+    func = vec_add_2(32, N)
+    compiled_kernel = tilelang.compile(func, target='npuir')
+
+    a = torch.randn(M, N).half().npu()
+    b = torch.randn(M, N).half().npu()
+    c = torch.randn(M, N).half().npu()
+
+    torch.manual_seed(88888888)  
+    dtype = "float16"
+
+    ref_output = a + b[0, 0]
+    compiled_kernel(a, b, c)
+    print("Actual Result:")
+    print(c)
+    print("Expected Result:")
+    print(ref_output)
+    torch.testing.assert_close(c, ref_output, rtol=1e-3, atol=1e-3)
+    print("\033[92mAll check passed!\033[0m")
+
+    # case 3 VEC_A[i, j] + VEC_B[i, j]
+    func = vec_add_3(32, 32)
+    compiled_kernel = tilelang.compile(func, target='npuir')
+
+    a = torch.randn(M, N).half().npu()
+    b = torch.randn(M, N).half().npu()
+    c = torch.randn(M, N).half().npu()
+    ref_output = c.clone()
+    torch.manual_seed(88888888)  
+    dtype = "float16"
+
+    ref_output[:, 0:1] = a[:, 0:1] + b[:, 0:1]
+    compiled_kernel(a, b, c)
+    print("Actual Result:")
+    print(c)
+    print("Expected Result:")
+    print(ref_output)
+    torch.testing.assert_close(c, ref_output, rtol=1e-3, atol=1e-3)
     print("\033[92mAll check passed!\033[0m")
 
 if __name__ == "__main__":

--- a/tilelang/language/customize_npuir.py
+++ b/tilelang/language/customize_npuir.py
@@ -116,72 +116,64 @@ class AscendBinaryOp(object):
         self.__dst = dst
     def buildTirCall(self):
         src0 = _to_region(self.__src0, "r", _get_extent(self.__src0))
-        src1 = _to_region(self.__src1, "r", _get_extent(self.__src1))
+        src1 = tir.const(self.__src1, self.__dst.dtype) if isinstance(self.__src1,(int,float)) else _to_region(self.__src1, "r", _get_extent(self.__src1))
         dst = _to_region(self.__dst, "w", _get_extent(self.__dst))
         return tir.call_intrin("handle", tir.op.Op.get("tl.npuir_" + self.__opName), src0, src1, dst)
 
 """npuir add at tile-level."""
 def npuir_add(A, B, C):
     """Element-wise addition: C = A + B.
-    
+
     Args:
         A: First input tensor
         B: Second input tensor or scalar value
         C: Output tensor
-    
+
     Returns:
         tir.Call: The TIR call for the addition operation
     """
-    if isinstance(B,(int,float)):
-        B = tir.const(B, C.dtype)
     return AscendBinaryOp("add", A, B, C).buildTirCall()
 
 """npuir sub at tile-level."""
 def npuir_sub(A, B, C):
     """Element-wise subtraction: C = A - B.
-    
+
     Args:
         A: First input tensor
         B: Second input tensor or scalar value
         C: Output tensor
-    
+
     Returns:
         tir.Call: The TIR call for the subtraction operation
     """
-    if isinstance(B,(int,float)):
-        B = tir.const(B, C.dtype)
     return AscendBinaryOp("sub", A, B, C).buildTirCall()
 
 """npuir mul at tile-level."""
 def npuir_mul(A, B, C):
     """Element-wise multiplication: C = A * B.
-    
+
     Args:
         A: First input tensor
         B: Second input tensor or scalar value
         C: Output tensor
-    
+
     Returns:
         tir.Call: The TIR call for the multiplication operation
     """
-    if isinstance(B,(int,float)):
-        B = tir.const(B, C.dtype)
     return AscendBinaryOp("mul", A, B, C).buildTirCall()
 
 """npuir div at tile-level."""
 def npuir_div(A, B, C):
     """Element-wise division: C = A / B.
-    
+
     Args:
         A: First input tensor
         B: Second input tensor or scalar value
         C: Output tensor
-    
+
     Returns:
         tir.Call: The TIR call for the division operation
     """
-    if isinstance(B,(int,float)):
-        B = tir.const(B, C.dtype)
     return AscendBinaryOp("div", A, B, C).buildTirCall()
 
 """npuir max at tile-level."""


### PR DESCRIPTION
Process the condition of BufferLoad scalar: B[0], B[i], B[0,0], B[i,j]
Based on the new MR of transferring BufferLoad to Bufferegion, Now BufferLoad like B[0] will be transferred into a Bufferregion with size 1(T.region(B[0],1,1). To make getBroadcastDim function correctly, it requires to clear the buffershape in codegen so that the buffershape will be 0 like const scalar cases.

Main changes:
1. delete the BufferLoad type when checking the scalar case in codegen(CreateHIVMBinaryVectorOp)
2. clear bufferload.shape if it is the case of 'is_scalar_load'.
3. add another test case.