### PR TITLE
[AscendNPU-IR][Developer] Support slice Operation for reduce and copy Op

### DIFF
--- a/testing/npuir/test_reduce_slice.py
+++ b/testing/npuir/test_reduce_slice.py
@@ -1,0 +1,85 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025.
+import torch
+import os
+import tilelang
+import tilelang.language as T
+
+torch.npu.set_device(0)
+tilelang.cache.clear_cache()
+
+@tilelang.jit(target="npuir")
+def slice_reduce(block_M, block_N, dtype = "float16"):
+    M = T.symbolic("M")
+    N = T.symbolic("N")
+    BLOCK_SIZE = 1
+    @T.prim_func
+    def reduce(
+        Input: T.Tensor((M, N), dtype),
+        Output: T.Tensor((1, N), dtype)
+    ):
+        with T.Kernel(BLOCK_SIZE, is_npu=True) as (cid, _):
+            src = T.alloc_shared([block_M, block_N], dtype=dtype)
+            dst = T.alloc_shared([1, block_N], dtype=dtype)
+
+            for i in T.serial(T.ceildiv(N, block_N)):
+                offset_n = i * block_N
+                remain_n = T.min(block_N, N - offset_n)
+                value_zero = 0
+                T.npuir_brc(value_zero, dst)
+                for j in T.serial(T.ceildiv(M, block_M)):
+                    offset_m = j * block_M
+                    remain_m = T.min(block_M, M - offset_m)
+                    T.copy(Input[offset_m, offset_n], src, size=[remain_m, remain_n]) # support size specification form
+                    # support both size spec and slice form
+                    T.npuir_reduce(src[:remain_m, :], dst, dims=0, reduce_mode="abssum", clear=False)
+                T.copy(dst[0, :remain_n], Output[0, offset_n:offset_n + remain_n]) # support slice form
+
+    return reduce
+
+def test_slice_add():
+    kernel = slice_reduce(32, 32)
+    torch.manual_seed(42)
+
+    # case 1
+    M, N = 17, 256
+    input = torch.randn([M, N], dtype=torch.float16).npu()
+    output = torch.randn([1, N], dtype=torch.float16).npu()
+    kernel(input, output)
+    ref_output = torch.abs(input).sum(dim=0, keepdim=True)
+
+    print("output")
+    print(output)
+    print("ref_output")
+    print(ref_output)
+    torch.testing.assert_close(output, ref_output, rtol=1e-2, atol=1e-2)
+
+    # case 2
+    M, N = 39, 466
+    input = torch.randn([M, N], dtype=torch.float16).npu()
+    output = torch.randn([1, N], dtype=torch.float16).npu()
+    kernel(input, output)
+    ref_output = torch.abs(input).sum(dim=0, keepdim=True)
+
+    print("output")
+    print(output)
+    print("ref_output")
+    print(ref_output)
+    torch.testing.assert_close(output, ref_output, rtol=1e-2, atol=1e-2)
+
+    # case 3
+    M, N = 77, 283
+    input = torch.randn([M, N], dtype=torch.float16).npu()
+    output = torch.randn([1, N], dtype=torch.float16).npu()
+    kernel(input, output)
+    ref_output = torch.abs(input).sum(dim=0, keepdim=True)
+
+    print("output")
+    print(output)
+    print("ref_output")
+    print(ref_output)
+    torch.testing.assert_close(output, ref_output, rtol=1e-2, atol=1e-2)
+    print("\033[92mAll check passed!\033[0m")
+
+if __name__ == "__main__":
+    os.environ['TILELANG_ASCEND_MODE'] = 'Developer'
+    test_slice_add()

--- a/tilelang/language/customize_npuir.py
+++ b/tilelang/language/customize_npuir.py
@@ -576,6 +576,8 @@ def _get_tmp_buffer_dev(data):
         return T.alloc_shared(data.shape, data.dtype)
     elif isinstance(data, tir.BufferLoad):
         return T.alloc_shared(data.buffer.shape, data.dtype)
+    elif isinstance(data, tir.BufferRegion):
+        return T.alloc_shared(data.buffer.shape, data.buffer.dtype)
     else:
         raise TypeError(f"Unsupported dst type: {type(data)}")
 


### PR DESCRIPTION
Reduce Op and copy Op are now support both slice form and size specification form, and I think it's reasonable to keep both.
take this copy for example:
- T.copy(Input[offset_m, offset_n], src, size=[remain_m, remain_n])

if we convert it into slice form, it would be:
- T.copy(Input[offset_m: offset_m + remain_m, offset_n: offset_n + remain_n], src)

it would be too long