### PR TITLE
[bugfix]Modify the kv_group adaptation in the sparse_flash_attn_gqa_pipeline.py test case to PTO

### DIFF
--- a/examples/pipeline/sparse_flash_attn_gqa_pipeline.py
+++ b/examples/pipeline/sparse_flash_attn_gqa_pipeline.py
@@ -216,7 +216,7 @@ func = sparse_attention_fwd(
     tail_dim=0,
     topk=2048,
     kv_stride=1,
-    kv_group=8,
+    kv_group=4,
 )
 
 
@@ -274,7 +274,7 @@ def ref_sparse_attention_fwd_interface_gqa(q,
     return o.to(torch.float16)
 
 
-B, S, SKV, H_Q, H_KV, DIM, topk = 2, 273, 44444, 64, 8, 128, 2048
+B, S, SKV, H_Q, H_KV, DIM, topk = 2, 273, 44444, 64, 4, 128, 2048
 kv_group = H_Q // H_KV
 dtype = torch.float16
 


### PR DESCRIPTION
Modify the kv_group adaptation in the sparse_flash_attn_gqa_pipeline.py test case to PTO.Due to the limitation of a minimum classification of 16 for L0 and L1 at the bottom level of PTO, the classification of L0 and L1 in the current use case is 8. When running PTO, an error occurs during compilation. Therefore, it is necessary to first modify the kv_group of the use case to adapt to the minimum classification limitation of PTO. We will adapt the scene through PASS in the future.