### PR TITLE
[Add] pipeline && allocate 3d buffer && slice buffer in broadcast

### DIFF
--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -850,9 +850,18 @@ void CodeGenTileLangAscendPto::CallExternCodegen(const CallNode *op) {
         }
         if (api_name == "TLOAD" && prefetch_n_stages_map_.count(dst_var_id) &&
             prefetch_n_stages_map_[dst_var_id].first > 0) {
-
-          auto buffer_k = op->args[2].as<CallNode>()->args[2] /
-                          op->args[2].as<CallNode>()->args[3];
+          PrimExpr element_count;
+          auto shape = buffer_shapess_[GetRef<tir::Var>(dst_var)];
+          if (shape.size() == 3) {
+            element_count = shape[1] * shape[2];
+          } else if (shape.size() == 2) {
+            element_count = shape[0] * shape[1];
+          } else {
+            ICHECK(false)
+                << "An error occurred. Please check prefetch_n_stages_map_, "
+                   "buffer_shapes_, and buffer_versions_.";
+          }
+          auto buffer_k = op->args[2].as<CallNode>()->args[2] / element_count;
           tvm::arith::Analyzer analyzer;
           PrimExpr simplified_k = analyzer.Simplify(buffer_k);
           this->stream << ", " << dst_var_id << "[" << simplified_k << "]"
@@ -1049,8 +1058,8 @@ void CodeGenTileLangAscendPto::SetAndWaitFlagCodegen(const CallNode *op, const s
   std::string dst = Downcast<StringImm>(op->args[1])->value;
   std::string event_id = PrintExpr(op->args[2]);
   this->PrintIndent();
-  this->stream << op_name << "(PIPE_" << src << ", " << "PIPE_" <<
-  dst << ", " << "EVENT_ID" << event_id << ");\n";
+  this->stream << kAscendPtoScope << op_name << "_pipeline<PIPE_" << src << ", " << "PIPE_" <<
+  dst << "> (" << event_id << ");\n";
 }
 
 void CodeGenTileLangAscendPto::HandleA5Flag(const std::string &op,
@@ -1259,22 +1268,76 @@ void CodeGenTileLangAscendPto::BinaryVecOpCodegen(const CallNode *op,
     auto var_name = PrintBufferOffset(op->args[i].as<CallNode>());
     var_names.push_back(var_name);
   }
-  if (prefetch_n_stages_map_[var_names[1]].first > 0) {
-    auto buffer_k = op->args[1].as<CallNode>()->args[2] / op->args[1].as<CallNode>()->args[3];
-    tvm::arith::Analyzer analyzer;
-    PrimExpr simplified_buffer_k = analyzer.Simplify(buffer_k);
+  if (!(src0_offset != "0" || src1_offset != "0" || dst_offset != "0")) {
     this->PrintIndent();
     this->stream << op_name << "(";
-    for (int i = 0; i < var_names.size(); i++) {
-      this->stream << var_names[i];
-      if (i != 0) {
-        this->stream << "[" << simplified_buffer_k << "]";
+
+    if (prefetch_n_stages_map_[var_names[0]].first > 0) {
+      PrimExpr element_count_dst;
+      auto shape_dst = buffer_shapess_[GetRef<tir::Var>(
+          op->args[0].as<CallNode>()->args[1].as<VarNode>())];
+      if (shape_dst.size() == 3) {
+        element_count_dst = shape_dst[1] * shape_dst[2];
+      } else if (shape_dst.size() == 2) {
+        element_count_dst = shape_dst[0] * shape_dst[1];
+      } else {
+        ICHECK(false)
+            << "An error occurred. Please check prefetch_n_stages_map_, "
+               "buffer_shapes_, and buffer_versions_.";
       }
-      if (i != var_names.size() - 1) {
-        this->stream << ", ";
-      }
+      auto buffer_k_dst =
+          op->args[0].as<CallNode>()->args[2] / element_count_dst;
+      tvm::arith::Analyzer analyzer;
+      PrimExpr simplified_buffer_k_dst = analyzer.Simplify(buffer_k_dst);
+      this->stream << var_names[0] << "[" << simplified_buffer_k_dst << "], ";
+    } else {
+      this->stream << var_names[0] << ", ";
     }
-    this->stream << ");\n";
+
+    if (prefetch_n_stages_map_[var_names[1]].first > 0) {
+      PrimExpr element_count_src0;
+      auto shape_src0 = buffer_shapess_[GetRef<tir::Var>(
+          op->args[1].as<CallNode>()->args[1].as<VarNode>())];
+      if (shape_src0.size() == 3) {
+        element_count_src0 = shape_src0[1] * shape_src0[2];
+      } else if (shape_src0.size() == 2) {
+        element_count_src0 = shape_src0[0] * shape_src0[1];
+      } else {
+        ICHECK(false)
+            << "An error occurred. Please check prefetch_n_stages_map_, "
+               "buffer_shapes_, and buffer_versions_.";
+      }
+      auto buffer_k_src0 =
+          op->args[1].as<CallNode>()->args[2] / element_count_src0;
+      tvm::arith::Analyzer analyzer;
+      PrimExpr simplified_buffer_k_src0 = analyzer.Simplify(buffer_k_src0);
+      this->stream << var_names[1] << "[" << simplified_buffer_k_src0 << "], ";
+    } else {
+      this->stream << var_names[1] << ", ";
+    }
+
+    if (prefetch_n_stages_map_[var_names[2]].first > 0) {
+      PrimExpr element_count_src1;
+      auto shape_src1 = buffer_shapess_[GetRef<tir::Var>(
+          op->args[2].as<CallNode>()->args[1].as<VarNode>())];
+      if (shape_src1.size() == 3) {
+        element_count_src1 = shape_src1[1] * shape_src1[2];
+      } else if (shape_src1.size() == 2) {
+        element_count_src1 = shape_src1[0] * shape_src1[1];
+      } else {
+        ICHECK(false)
+            << "An error occurred. Please check prefetch_n_stages_map_, "
+               "buffer_shapes_, and buffer_versions_.";
+      }
+      auto buffer_k_src1 =
+          op->args[2].as<CallNode>()->args[2] / element_count_src1;
+      tvm::arith::Analyzer analyzer;
+      PrimExpr simplified_buffer_k_src1 = analyzer.Simplify(buffer_k_src1);
+      this->stream << var_names[2] << "[" << simplified_buffer_k_src1 << "]);\n";
+    } else {
+      this->stream << var_names[2] << ");\n";
+    }
+
   } else if (src0_offset != "0" || src1_offset != "0" || dst_offset != "0") {
     this->PrintIndent();
     this->stream << kAscendPtoScope << "binary_tile" << "<" << kAscendPtoScope << "BinaryOp::" << op_name << ", " << ub_type << ", " << shape << ">" << "("
@@ -1322,6 +1385,48 @@ void CodeGenTileLangAscendPto::BroadcastOpCodegen(const CallNode *op) {
   std::string src_name = PrintExpr(op->args[2].as<CallNode>()->args[1]);
   std::string dst_name = PrintExpr(op->args[1].as<CallNode>()->args[1]);
 
+  std::string src_offset = PrintExpr(op->args[2].as<CallNode>()->args[2]);
+  std::string dst_offset = PrintExpr(op->args[1].as<CallNode>()->args[2]);
+
+  auto src_element_count = op->args[2].as<CallNode>()->args[3];
+  auto dst_element_count = op->args[1].as<CallNode>()->args[3];
+
+  bool is_slice = false;
+  auto src_shape = buffer_shapess_[GetRef<tir::Var>(
+      op->args[2].as<CallNode>()->args[1].as<VarNode>())];
+  auto dst_shape = buffer_shapess_[GetRef<tir::Var>(
+      op->args[1].as<CallNode>()->args[1].as<VarNode>())];
+
+  // auto src_type = op->args[2].as<CallNode>()->args[0].as<CallNode>()->dtype;
+  // auto dst_type = op->args[1].as<CallNode>()->args[0].as<CallNode>()->dtype;
+
+  auto dst_type = ub_data_map_[dst_name][0];
+  auto src_type = ub_data_map_[src_name][0];
+
+  auto check_equal = [&](const PrimExpr &a, const PrimExpr &b) -> bool {
+    tvm::arith::Analyzer analyzer;
+    PrimExpr simplified = analyzer.Simplify(a == b);
+    if (auto imm = simplified.as<tir::IntImmNode>())
+      return imm->value != 0;
+    return false;
+  };
+
+  if (src_shape.size() > 2 || src_shape.size() == 0) {
+    ICHECK(false) << "check src_shape in broadcast.";
+  } else if (src_shape.size() == 2) {
+    tvm::arith::Analyzer analyzer;
+    PrimExpr cond0 = (src_shape[0] != 1);
+    PrimExpr cond1 = (src_shape[1] != 1);
+    PrimExpr both_cond = analyzer.Simplify(cond0 && cond1);
+    auto imm = both_cond.as<tir::IntImmNode>();
+     if (imm->value != 0) {
+      ICHECK(false) << "check src_shape in broadcast.";
+    }
+    is_slice = !check_equal(src_element_count, src_shape[0] * src_shape[1]);
+  } else if (src_shape.size() == 1) {
+    is_slice = !check_equal(src_element_count, src_shape[0]);
+  }
+
   std::vector<std::string> ub_data_vector = ub_data_map_[src_name];
   std::string ub_data_type = ub_data_vector[0];
   std::string row = ub_data_vector[2];
@@ -1331,14 +1436,29 @@ void CodeGenTileLangAscendPto::BroadcastOpCodegen(const CallNode *op) {
   std::string axis = extractBroadCastAxis(template_args);
   if (axis == "1") {
     this->PrintIndent();
-    this->stream << kAscendPtoScope << "TileUbDataDN <" << ub_data_type << ", " << row << ", " << col << ", " 
-    << row << ", " << col << "> " << src_name << "_DN_ROWEXPAND;\n";
+    this->stream << kAscendPtoScope << "TileUbDataDN <" << ub_data_type << ", "
+                 << row << ", " << col << ", " << row << ", " << col << "> "
+                 << src_name << "_DN_ROWEXPAND;\n";
     this->PrintIndent();
     this->stream << "TASSIGN(" << src_name << "_DN_ROWEXPAND, " << address << ");\n";
     this->PrintIndent();
     this->stream << "pipe_barrier(PIPE_V);\n";
     this->PrintIndent();
-    this->stream << "TROWEXPAND" << "(" << dst_name << ", " << src_name << "_DN_ROWEXPAND" << ");\n";
+    if (!is_slice) {
+      this->stream << "TROWEXPAND" << "(" << dst_name << ", " << src_name
+                   << "_DN_ROWEXPAND" << ");\n";
+    } else {
+      std::string src_offset = PrintExpr(op->args[2].as<CallNode>()->args[2]);
+      auto src_type_len = std::to_string(GetTypeLen(src_type));
+      this->stream << kAscendPtoScope << "TROWEXPAND_with_slice_buffer <"
+                   << dst_type << ", " << dst_shape[0] << ", " << dst_shape[1]
+                   << ", " << dst_shape[0] << ", " << dst_shape[1] << ", "
+                   << src_type << ", " << src_shape[0] << ", " << src_shape[1]
+                   << ", " << src_shape[0] << ", " << src_shape[1] << ", "
+                   << src_element_count << "> (" << dst_name << ", " << src_name
+                   << "_DN_ROWEXPAND, " << address << ", (" << src_offset
+                   << ") * " << src_type_len << ");\n";
+    }
     this->PrintIndent();
     this->stream << "pipe_barrier(PIPE_V);\n";
     this->PrintIndent();
@@ -1849,32 +1969,47 @@ bool CodeGenTileLangAscendPto::ValidLayoutEnabled(const AllocateNode *op) {
   bool valid = false;
   std::string type = getType(op->dtype);
   int8_t typeSize = GetTypeLen(type);
-  if (shape.size() == 2 && !buffer_versions_.count(op->buffer_var)) {
-    if (tvm::tir::is_zero(tvm::truncmod(shape[1] * typeSize, 32))) {
-      valid = false;
+  bool has_buffer_version = buffer_versions_.count(
+      op->buffer_var); // Check if multiple buffers are enabled/configured in
+                       // the T.pipeline.
+  if (!has_buffer_version) {
+    if (shape.size() == 3) {
+      if (tvm::tir::is_zero(tvm::truncmod(shape[2] * typeSize, 32))) {
+        valid = false;
+      } else {
+        valid = true;
+      }
+    } else if (shape.size() == 2) {
+      if (tvm::tir::is_zero(tvm::truncmod(shape[1] * typeSize, 32))) {
+        valid = false;
+      } else {
+        valid = true;
+      }
+    } else if (shape.size() == 1) {
+      if (tvm::tir::is_zero(tvm::truncmod(shape[0] * typeSize, 32))) {
+        valid = false;
+      } else {
+        valid = true;
+      }
     } else {
-      valid = true;
-    }
-  } else if (shape.size() == 2 && buffer_versions_.count(op->buffer_var)) {
-    if (tvm::tir::is_zero(tvm::truncmod(shape[0] * typeSize, 32))) {
-      valid = false;
-    } else {
-      valid = true;
-    }
-  } else if (shape.size() == 3 && buffer_versions_.count(op->buffer_var)) {
-    if (tvm::tir::is_zero(tvm::truncmod(shape[2] * typeSize, 32))) {
-      valid = false;
-    } else {
-      valid = true;
-    }
-  } else if (shape.size() == 1 && !buffer_versions_.count(op->buffer_var)) {
-    if (tvm::tir::is_zero(tvm::truncmod(shape[0] * typeSize, 32))) {
-      valid = false;
-    } else {
-      valid = true;
+      ICHECK(false) << "ValidLayoutEnabled Error";
     }
   } else {
-    ICHECK(false) << "ValidLayoutEnabled Error";
+    if (shape.size() == 2) {
+      if (tvm::tir::is_zero(tvm::truncmod(shape[0] * typeSize, 32))) {
+        valid = false;
+      } else {
+        valid = true;
+      }
+    } else if (shape.size() == 3) {
+      if (tvm::tir::is_zero(tvm::truncmod(shape[2] * typeSize, 32))) {
+        valid = false;
+      } else {
+        valid = true;
+      }
+    } else {
+      ICHECK(false) << "ValidLayoutEnabled Error";
+    }
   }
   return valid;
 }
@@ -1912,6 +2047,22 @@ void CodeGenTileLangAscendPto::VisitStmt_(const AllocateNode *op) {
       }
     }
     this->PrintIndent();
+
+    // Recording the count of buffer allocations in the pipeline.
+    bool buffer_in_pipeline = false;
+    if (buffer_versions_.count(op->buffer_var)) {
+      if (!is_one(buffer_versions_[op->buffer_var])) {
+        int8_t bufferNum =
+            Downcast<Integer>(buffer_versions_[op->buffer_var])->value;
+        prefetch_n_stages_map_[vid] = std::pair<int, int>{bufferNum, 0};
+        buffer_in_pipeline = true;
+      }
+    } else if (shape.size() == 3) {
+      auto bufferNum = shape[0].as<IntImmNode>()->value;
+      prefetch_n_stages_map_[vid] = std::pair<int, int>{static_cast<int>(bufferNum), 0};
+      buffer_in_pipeline = true;
+    }
+
     // Allocate buffer
     if (found_by_name) {
       if (pos == kAscendPtoScope + "TileUbData") {
@@ -1958,11 +2109,10 @@ void CodeGenTileLangAscendPto::VisitStmt_(const AllocateNode *op) {
           ub_data[2] = PrintExpr(padded_shape2);
         }
 
-        if (buffer_versions_.count(op->buffer_var)) {
-          // Recording the count of buffer allocations in the pipeline.
-          int8_t bufferNum =
-              Downcast<Integer>(buffer_versions_[op->buffer_var])->value;
-          prefetch_n_stages_map_[vid] = std::pair<int, int>{bufferNum, 0};
+        if (buffer_in_pipeline) {
+          // // Recording the count of buffer allocations in the pipeline.
+          auto bufferNum = prefetch_n_stages_map_[vid].first;
+          // prefetch_n_stages_map_[vid] = std::pair<int, int>{bufferNum, 0};
 
           // Output the valid shape.
           stream << pos << "ND<" << type << ", " << ub_data[1] << ", "
@@ -1987,7 +2137,7 @@ void CodeGenTileLangAscendPto::VisitStmt_(const AllocateNode *op) {
         ub_data_map_[vid] = ub_data;
 
       } else {
-        if (!(pos == kAscendPtoScope + "TileMatL1" && shape.size() == 3)) {
+        if (!buffer_in_pipeline) {
           int dtype_bytes = op->dtype.bytes();
           std::vector<PrimExpr> valid_shapes;
           valid_shapes.reserve(2);
@@ -2014,8 +2164,8 @@ void CodeGenTileLangAscendPto::VisitStmt_(const AllocateNode *op) {
           stream << "TASSIGN(" << vid << ", "
                  << PrintExpr(target_expr) << ");\n";
         } else {
-          int8_t bufferNum = shape[0].as<IntImmNode>()->value;
-          prefetch_n_stages_map_[vid] = std::pair<int, int>{bufferNum, 0};
+          auto bufferNum = prefetch_n_stages_map_[vid].first;
+          // prefetch_n_stages_map_[vid] = std::pair<int, int>{bufferNum, 0};
           int dtype_bytes = op->dtype.bytes();
           std::vector<PrimExpr> valid_shapes;
           valid_shapes.reserve(shape.size() - 1);
@@ -2104,11 +2254,10 @@ void CodeGenTileLangAscendPto::VisitStmt_(const AllocateNode *op) {
           ub_data[2] = PrintExpr(padded_shape2);
         }
 
-        if (buffer_versions_.count(op->buffer_var)) {
-          // Recording the count of buffer allocations in the pipeline.
-          int8_t bufferNum =
-              Downcast<Integer>(buffer_versions_[op->buffer_var])->value;
-          prefetch_n_stages_map_[vid] = std::pair<int, int>{bufferNum, 0};
+        if (buffer_in_pipeline) {
+          // // Recording the count of buffer allocations in the pipeline.
+          auto bufferNum = prefetch_n_stages_map_[vid].first;
+          // prefetch_n_stages_map_[vid] = std::pair<int, int>{bufferNum, 0};
 
           // Output the valid shape.
           stream << pos << "ND<" << type << ", " << ub_data[1] << ", "
@@ -2121,6 +2270,12 @@ void CodeGenTileLangAscendPto::VisitStmt_(const AllocateNode *op) {
             stream << "TASSIGN(" << vid << "[" << i << "], "
                    << PrintExpr(address_offset_[String(pos)])
                    << ");\n";
+            ub_data[3] = PrintExpr(address_offset_[String(pos)]);
+            ub_data_map_[vid] = ub_data;
+            address_offset_.Set(String(pos),
+                                PrimExpr(int(op->ConstantAllocationSize() *
+                                             op->dtype.bytes())) +
+                                    address_offset_[String(pos)]);
           }
         } else {
           stream << pos << "ND<" << type << ", " << ub_data[1] << ", "
@@ -2130,16 +2285,16 @@ void CodeGenTileLangAscendPto::VisitStmt_(const AllocateNode *op) {
           stream << "TASSIGN(" << vid << ", "
                  << PrintExpr(address_offset_[String(pos)])
                  << ");\n";
+          ub_data[3] = PrintExpr(address_offset_[String(pos)]);
+          ub_data_map_[vid] = ub_data;
+          address_offset_.Set(
+              String(pos),
+              PrimExpr(int(op->ConstantAllocationSize() * op->dtype.bytes())) +
+                  address_offset_[String(pos)]);
         }
-        ub_data[3] = PrintExpr(address_offset_[String(pos)]);
-        ub_data_map_[vid] = ub_data;
-        address_offset_.Set(
-            String(pos),
-            PrimExpr(int(op->ConstantAllocationSize() * op->dtype.bytes())) +
-                address_offset_[String(pos)]);
 
       } else {
-        if (!(pos == kAscendPtoScope + "TileMatL1" && shape.size() == 3)) {
+        if (!buffer_in_pipeline) {
           int dtype_bytes = op->dtype.bytes();
           std::vector<PrimExpr> valid_shapes;
           valid_shapes.reserve(2);
@@ -2171,8 +2326,8 @@ void CodeGenTileLangAscendPto::VisitStmt_(const AllocateNode *op) {
               PrimExpr(int(op->ConstantAllocationSize() * op->dtype.bytes())) +
                   address_offset_[String(pos)]);
         } else {
-          int8_t bufferNum = shape[0].as<IntImmNode>()->value;
-          prefetch_n_stages_map_[vid] = std::pair<int, int>{bufferNum, 0};
+          auto bufferNum = prefetch_n_stages_map_[vid].first;
+          // prefetch_n_stages_map_[vid] = std::pair<int, int>{bufferNum, 0};
           int dtype_bytes = op->dtype.bytes();
           std::vector<PrimExpr> valid_shapes;
           valid_shapes.reserve(shape.size() - 1);

--- a/src/target/codegen_ascend_pto.h
+++ b/src/target/codegen_ascend_pto.h
@@ -175,6 +175,19 @@ private:
   std::map<std::string, std::string> for_num_map_;
   std::map<std::string, std::pair<int, int>> prefetch_n_stages_map_;
 
+  std::unordered_map<std::string, std::string> dtype_map = {
+        {"int8", "char"},
+        {"int32", "int"},
+        {"int8x4", "int32_t"},
+        {"int32x4", "int32x4"},
+        {"float16", "half"},
+        {"float32", "float"},
+        {"float64", "double"},
+        {"float16x4", "float16x4"},
+        {"bfloat16x4", "bfloat16x4"},
+        {"float32x4", "float32x4"},
+        {"float32x16", "float32x16"}};
+  
   struct global_tensor{
     String shape_type;
     String dtype;

--- a/src/tl_templates/pto/common.h
+++ b/src/tl_templates/pto/common.h
@@ -432,4 +432,48 @@ AICORE PTO_INLINE void pow(
     TMUL(dst, src0, src1);
     TEXP(dst, dst);
 }
+
+template<pipe_t pipe, pipe_t tpipe> AICORE PTO_INLINE void set_flag_pipeline(int32_t pipeID) {
+    switch (pipeID) {
+        case 0: set_flag(pipe, tpipe, EVENT_ID0); break;
+        case 1: set_flag(pipe, tpipe, EVENT_ID1); break;
+        case 2: set_flag(pipe, tpipe, EVENT_ID2); break;
+        case 3: set_flag(pipe, tpipe, EVENT_ID3); break;
+        case 4: set_flag(pipe, tpipe, EVENT_ID4); break;
+        case 5: set_flag(pipe, tpipe, EVENT_ID5); break;
+        case 6: set_flag(pipe, tpipe, EVENT_ID6); break;
+        case 7: set_flag(pipe, tpipe, EVENT_ID7); break;
+        default:break;
+    }
+}
+
+template<pipe_t pipe, pipe_t tpipe> AICORE PTO_INLINE void wait_flag_pipeline(int32_t pipeID) {
+    switch (pipeID) {
+        case 0: wait_flag(pipe, tpipe, EVENT_ID0); break;
+        case 1: wait_flag(pipe, tpipe, EVENT_ID1); break;
+        case 2: wait_flag(pipe, tpipe, EVENT_ID2); break;
+        case 3: wait_flag(pipe, tpipe, EVENT_ID3); break;
+        case 4: wait_flag(pipe, tpipe, EVENT_ID4); break;
+        case 5: wait_flag(pipe, tpipe, EVENT_ID5); break;
+        case 6: wait_flag(pipe, tpipe, EVENT_ID6); break;
+        case 7: wait_flag(pipe, tpipe, EVENT_ID7); break;
+        default:break;
+    }
+}
+
+template <typename dstT, int32_t dstRow, int32_t dstCol, 
+          int32_t dstRowValid, int32_t dstColValid, 
+          typename srcT, int32_t srcRow, int32_t srcCol,
+          int32_t srcRowValid, int32_t srcColValid,
+          int32_t src_element_count>
+AICORE PTO_INLINE void TROWEXPAND_with_slice_buffer(
+    TileUbDataND<dstT, dstRow, dstCol, dstRow, dstCol> dst,
+    TileUbDataDN<srcT, srcRow, srcCol, srcRow, srcCol> src,
+    int32_t src_addr, int32_t src_offset) {
+  TileUbDataDN<srcT, src_element_count, srcCol, src_element_count, srcColValid>
+      src_temp_ub;
+  pto::TASSIGN(src_temp_ub, src_addr + src_offset);
+
+  pto::TROWEXPAND(dst, src_temp_ub);
+}
 }


### PR DESCRIPTION
This update focuses on pipeline scenario adaptation (setflag/waitflag), 3D buffer allocation optimization, supplementing broadcast slicing operations, auto-padding to meet 32-byte alignment requirements, and dtype acquisition enhancements.

1. Pipeline scenario adaptation for setflag/waitflag

2. Optimization of 3D buffer allocation

3. Supplementation of broadcast slicing operations

4. Auto-padding to meet 32-byte alignment when allocation does not satisfy the requirement

5. Optimization of dtype acquisition