### PR TITLE
[AscendNPU-IR][Expert] Support rank-mismatch and dynamic shape in nd2nz and fixpipe

### DIFF
--- a/src/target/codegen_npuir_api.cc
+++ b/src/target/codegen_npuir_api.cc
@@ -1457,13 +1457,8 @@ void CodeGenTileLangNPUIRAPI::Nz2NdCodegen(const CallNode *op) {
   // Generate hivm.hir.nz2nd for tl.npuir_store_nz2nd.
   tvm::tl::NpuirNz2nd npuirop(op->args, this->vmap);
   // gen memref.subview
-  // src is cc: no min_rank needed.
-  mlir::Value src =
-      GenRankReducedSubviewFromRegion(npuirop.src, npuirop.src_range);
-  // dst is GM: ensure min_rank=2 to maintain consistent GM rank across all
-  // nz2nd calls in the same function, preventing callee signature mismatches.
-  mlir::Value dst =
-      GenRankReducedSubviewFromRegion(npuirop.dst, npuirop.dst_range, /*min_rank=*/2);
+  mlir::Value src = GenSubviewFromRegion(npuirop.src, npuirop.src_range);
+  mlir::Value dst = GenSubviewFromRegion(npuirop.dst, npuirop.dst_range);
 
   // gen hivm.hir.nz2nd
   builder.create<mlir::hivm::NZ2NDOp>(builder.getUnknownLoc(),

--- a/src/target/codegen_npuir_api.cc
+++ b/src/target/codegen_npuir_api.cc
@@ -9,6 +9,7 @@
 #include "../op/ascend.h"
 #include "../op/builtin.h"
 #include "arith/pattern_match.h"
+#include <algorithm>
 #include <atomic>
 #include <cmath>
 #include <cstddef>
@@ -880,6 +881,115 @@ CodeGenTileLangNPUIRAPI::GenSubviewFromRegion(const CallNode *region_node) {
   return GenSubviewFromRegion(regionop.GetBuffer(), regionop.GetRanges());
 }
 
+// Helper to check if an OpFoldResult is a static integer equal to `value`.
+static bool IsStaticIntOFR(mlir::OpFoldResult ofr, int64_t value) {
+  if (auto attr = ofr.dyn_cast<mlir::Attribute>()) {
+    if (auto intAttr = attr.dyn_cast<mlir::IntegerAttr>()) {
+      return intAttr.getInt() == value;
+    }
+  }
+  return false;
+}
+
+// Generate a rank-reduced memref.subview from a Buffer+Region, by dropping
+// static-1 dimensions from the Region extents. This mirrors the developer-mode
+// rank-reduction used by AscendCopy, and is needed so that 3D Region slices
+// like 1xMxN can be safely consumed by 2D Cube nd2nz/fixpipe kernels.
+mlir::Value CodeGenTileLangNPUIRAPI::GenRankReducedSubviewFromRegion(
+    Buffer buffer_data, Array<Range> range, int min_rank) {
+  /*
+  range stores region details
+    extent stores the shape or size of region
+    min stores the offset of the region
+  */
+  Array<PrimExpr> region_shape, region_indices;
+  for (Range r : range) {
+    region_shape.push_back(r.get()->extent);
+    region_indices.push_back(r.get()->min);
+  }
+  const VarNode *v = buffer_data->data.get();
+  mlir::Value v_value = GetVarValue(v);
+
+  // Fast path: when Region exactly matches the buffer with zero offsets we can
+  // return the original memref directly (no subview).
+  if (IsEqual(buffer_data->shape, region_shape) && AllZero(region_indices)) {
+    return v_value;
+  }
+
+  SmallVector<OpFoldResult> offsets;
+  SmallVector<OpFoldResult> sizes;
+  SmallVector<OpFoldResult> strides;
+
+  for (Range r : range) {
+    // Offsets
+    if (auto s_int = as_const_int(r.get()->min)) {
+      offsets.push_back(builder.getI64IntegerAttr(*s_int));
+    } else {
+      mlir::Value indexVal = CreateIndexCastOp(MakeValue(r.get()->min));
+      offsets.push_back(indexVal);
+    }
+    // Sizes
+    if (auto s_int = as_const_int(r.get()->extent)) {
+      sizes.push_back(builder.getI64IntegerAttr(*s_int));
+    } else {
+      mlir::Value s_index = CreateIndexCastOp(MakeValue(r.get()->extent));
+      sizes.push_back(s_index);
+    }
+    // Strides (always 1)
+    strides.push_back(builder.getI64IntegerAttr(1));
+  }
+
+  auto baseTy = v_value.getType().cast<mlir::MemRefType>();
+
+  // Build projected reduced shape by dropping static-1 dims from slice sizes.
+  // When min_rank > 0, keep leading static-1 dims as needed to satisfy the
+  // minimum rank requirement. This ensures GM operands for Cube nd2nz/fixpipe
+  // maintain consistent rank (at least 2D) across all calls in the same function,
+  // preventing callee signature mismatches in convert-hivm-to-std.
+  
+  // 1. Count non-static-1 dims
+  int numNonStatic1 = 0;
+  for (auto ofr : sizes) {
+    if (!IsStaticIntOFR(ofr, 1)) numNonStatic1++;
+  }
+  // 2. How many static-1 dims must we keep to satisfy min_rank?
+  int static1ToKeep = std::max(0, min_rank - numNonStatic1);
+
+  // 3. Build projected shape, keeping leading static-1 dims as needed
+  llvm::SmallVector<int64_t> projectedReducedShape;
+  projectedReducedShape.reserve(sizes.size());
+  int static1Kept = 0;
+  for (auto ofr : sizes) {
+    if (IsStaticIntOFR(ofr, 1)) {
+      if (static1Kept < static1ToKeep) {
+        projectedReducedShape.push_back(1);
+        static1Kept++;
+      }
+      continue;  // drop this static-1 dim
+    }
+    // non-static-1 dim: always keep
+    if (auto attr = ofr.dyn_cast<mlir::Attribute>()) {
+      projectedReducedShape.push_back(
+          attr.cast<mlir::IntegerAttr>().getInt());
+    } else {
+      projectedReducedShape.push_back(mlir::ShapedType::kDynamic);
+    }
+  }
+  // Fallback: if all dims are static-1 and min_rank <= 1, keep one dim=1
+  if (projectedReducedShape.empty()) {
+    projectedReducedShape.push_back(1);
+  }
+
+  // Infer the rank-reduced memref type and create the SubViewOp.
+  auto reducedTy =
+      mlir::memref::SubViewOp::inferRankReducedResultType(
+          projectedReducedShape, baseTy, offsets, sizes, strides)
+          .cast<mlir::MemRefType>();
+
+  return builder.create<mlir::memref::SubViewOp>(
+      builder.getUnknownLoc(), reducedTy, v_value, offsets, sizes, strides);
+}
+
 mlir::Value CodeGenTileLangNPUIRAPI::GenSubviewFromRegion(Buffer buffer_data,
                                                           Array<Range> range) {
   /*
@@ -1326,8 +1436,13 @@ void CodeGenTileLangNPUIRAPI::Nd2NzCodegen(const CallNode *op) {
   // Generate hivm.hir.nd2nz for tl.npuir_load_nd2nz.
   tvm::tl::NpuirNd2nz npuirop(op->args, this->vmap);
   // gen memref.subview
-  mlir::Value src = GenSubviewFromRegion(npuirop.src, npuirop.src_range);
-  mlir::Value dst = GenSubviewFromRegion(npuirop.dst, npuirop.dst_range);
+  // src is GM: ensure min_rank=2 to maintain consistent GM rank across all
+  // nd2nz calls in the same function, preventing callee signature mismatches.
+  mlir::Value src =
+      GenRankReducedSubviewFromRegion(npuirop.src, npuirop.src_range, /*min_rank=*/2);
+  // dst is cbuf: downstream will cast to 4D, so no min_rank needed.
+  mlir::Value dst =
+      GenRankReducedSubviewFromRegion(npuirop.dst, npuirop.dst_range);
 
   // gen hivm.hir.nd2nz
   mlir::Location unknown_loc = builder.getUnknownLoc();
@@ -1342,8 +1457,13 @@ void CodeGenTileLangNPUIRAPI::Nz2NdCodegen(const CallNode *op) {
   // Generate hivm.hir.nz2nd for tl.npuir_store_nz2nd.
   tvm::tl::NpuirNz2nd npuirop(op->args, this->vmap);
   // gen memref.subview
-  mlir::Value src = GenSubviewFromRegion(npuirop.src, npuirop.src_range);
-  mlir::Value dst = GenSubviewFromRegion(npuirop.dst, npuirop.dst_range);
+  // src is cc: no min_rank needed.
+  mlir::Value src =
+      GenRankReducedSubviewFromRegion(npuirop.src, npuirop.src_range);
+  // dst is GM: ensure min_rank=2 to maintain consistent GM rank across all
+  // nz2nd calls in the same function, preventing callee signature mismatches.
+  mlir::Value dst =
+      GenRankReducedSubviewFromRegion(npuirop.dst, npuirop.dst_range, /*min_rank=*/2);
 
   // gen hivm.hir.nz2nd
   builder.create<mlir::hivm::NZ2NDOp>(builder.getUnknownLoc(),
@@ -1354,8 +1474,13 @@ void CodeGenTileLangNPUIRAPI::FixpipeCodegen(const CallNode *op) {
   // Generate hivm.hir.fixpipe for tl.npuir_store_fixpipe.
   tvm::tl::NpuirFixpipe npuirop(op->args, this->vmap);
   // gen memref.subview
-  mlir::Value src = GenSubviewFromRegion(npuirop.src, npuirop.src_range);
-  mlir::Value dst = GenSubviewFromRegion(npuirop.dst, npuirop.dst_range);
+  // src is cc: no min_rank needed.
+  mlir::Value src =
+      GenRankReducedSubviewFromRegion(npuirop.src, npuirop.src_range);
+  // dst is GM: ensure min_rank=2 to maintain consistent GM rank across all
+  // fixpipe calls in the same function, preventing callee signature mismatches.
+  mlir::Value dst =
+      GenRankReducedSubviewFromRegion(npuirop.dst, npuirop.dst_range, /*min_rank=*/2);
 
   // gen hivm.hir.fixpipe
   mlir::Location unknown_loc = builder.getUnknownLoc();

--- a/src/target/codegen_npuir_api.cc
+++ b/src/target/codegen_npuir_api.cc
@@ -892,8 +892,7 @@ static bool IsStaticIntOFR(mlir::OpFoldResult ofr, int64_t value) {
 }
 
 // Generate a rank-reduced memref.subview from a Buffer+Region, by dropping
-// static-1 dimensions from the Region extents. This mirrors the developer-mode
-// rank-reduction used by AscendCopy, and is needed so that 3D Region slices
+// static-1 dimensions from the Region extents, so that 3D Region slices
 // like 1xMxN can be safely consumed by 2D Cube nd2nz/fixpipe kernels.
 mlir::Value CodeGenTileLangNPUIRAPI::GenRankReducedSubviewFromRegion(
     Buffer buffer_data, Array<Range> range, int min_rank) {
@@ -944,8 +943,7 @@ mlir::Value CodeGenTileLangNPUIRAPI::GenRankReducedSubviewFromRegion(
   // Build projected reduced shape by dropping static-1 dims from slice sizes.
   // When min_rank > 0, keep leading static-1 dims as needed to satisfy the
   // minimum rank requirement. This ensures GM operands for Cube nd2nz/fixpipe
-  // maintain consistent rank (at least 2D) across all calls in the same function,
-  // preventing callee signature mismatches in convert-hivm-to-std.
+  // maintain consistent rank (2D) across all calls in the same function.
   
   // 1. Count non-static-1 dims
   int numNonStatic1 = 0;

--- a/src/target/codegen_npuir_api.h
+++ b/src/target/codegen_npuir_api.h
@@ -265,11 +265,7 @@ private:
   mlir::Value GenSubviewFromRegion(const CallNode *region_node);
   mlir::Value GenSubviewFromRegion(Buffer buffer_data, Array<Range> range);
   // Similar to GenSubviewFromRegion but performs rank reduction by dropping
-  // static-1 dimensions from the slice sizes (Region extents). This is used to
-  // align src/dst ranks for Cube nd2nz/fixpipe/nz2nd codegen, where Region
-  // slices like 1xMxN conceptually map to 2D Cube tiles MxN.
-  // min_rank: minimum rank to preserve (default 0). When min_rank > 0, keeps
-  // leading static-1 dims as needed to satisfy the minimum rank requirement.
+  // static-1 dimensions from the slice sizes (Region extents).
   mlir::Value GenRankReducedSubviewFromRegion(Buffer buffer_data,
                                               Array<Range> range,
                                               int min_rank = 0);

--- a/src/target/codegen_npuir_api.h
+++ b/src/target/codegen_npuir_api.h
@@ -264,6 +264,15 @@ private:
   mlir::Value GenMemrefLoadFromRegion(const BufferLoadNode *op);
   mlir::Value GenSubviewFromRegion(const CallNode *region_node);
   mlir::Value GenSubviewFromRegion(Buffer buffer_data, Array<Range> range);
+  // Similar to GenSubviewFromRegion but performs rank reduction by dropping
+  // static-1 dimensions from the slice sizes (Region extents). This is used to
+  // align src/dst ranks for Cube nd2nz/fixpipe/nz2nd codegen, where Region
+  // slices like 1xMxN conceptually map to 2D Cube tiles MxN.
+  // min_rank: minimum rank to preserve (default 0). When min_rank > 0, keeps
+  // leading static-1 dims as needed to satisfy the minimum rank requirement.
+  mlir::Value GenRankReducedSubviewFromRegion(Buffer buffer_data,
+                                              Array<Range> range,
+                                              int min_rank = 0);
   mlir::Value CreateIndexCastOp(mlir::Value src);
   std::pair<bool, mlir::Value> CheckMLIRValueMap(mlir::Value val);
   std::pair<bool, mlir::Value> CheckPrimExprMap(const PrimExprNode * op);

--- a/testing/npuir/test_copy_shape_dynamic_cube.py
+++ b/testing/npuir/test_copy_shape_dynamic_cube.py
@@ -1,0 +1,308 @@
+import os
+import torch
+import tilelang
+import tilelang.language as T
+
+
+tilelang.cache.clear_cache()
+dtype = "float16"
+
+
+def cube_copy_shape_1d_2d(M, N, block_M, block_N):
+    """
+    Dynamic tail block copy on Cube core (2D GM -> 2D GM).
+
+    Layout:
+        A: [M, N], B: [M, N], Id: [N, N]
+    We copy row-by-row in tiles of size `block_N`, but the last tile in
+    each row uses a dynamic `tile_size_N = min(block_N, shape_N - by)`.
+    For each tile, we:
+        GM (1 × tile_size_N) -> L1 -> L0C -> GM
+    using:
+        npuir_load_nd2nz + npuir_dot (with identity) + npuir_store_fixpipe.
+    """
+
+    @T.prim_func
+    def copyShapeCube(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, N), dtype),
+        Id: T.Tensor((N, N), dtype),
+        shape_M: T.int32,
+        shape_N: T.int32,
+    ):
+        with T.Kernel(
+            T.ceildiv(M, block_M) * T.ceildiv(N, block_N), is_npu=True
+        ) as (cid, _):
+            blockx = cid // T.ceildiv(N, block_N)
+            blocky = cid % T.ceildiv(N, block_N)
+            by = blocky * block_N
+
+            # L1/L0C buffers for a single row tile.
+            l1_a = T.alloc_L1((1, block_N), dtype)
+            l1_b = T.alloc_L1((block_N, block_N), dtype)
+            l0_c = T.alloc_L0C((1, block_N), "float32")
+
+            with T.Scope("Cube"):
+                for i in T.Parallel(block_M):
+                    bx = blockx * block_M + i
+                    # Dynamic tail size for N dimension.
+                    t0 = shape_N - by
+                    tile_size_N = T.min(block_N, t0)
+
+                    # GM -> L1: load a 1 × tile_size_N slice.
+                    T.npuir_load_nd2nz(
+                        A[bx, by],
+                        l1_a,
+                        size=[1, tile_size_N],
+                    )
+
+                    # GM -> L1: load top-left tile_size_N × tile_size_N part of Id.
+                    T.npuir_load_nd2nz(
+                        Id[0, 0],
+                        l1_b,
+                        size=[tile_size_N, tile_size_N],
+                    )
+
+                    # L1 × L1 -> L0C: multiply by identity, effectively copying.
+                    T.npuir_dot(
+                        l1_a,
+                        l1_b,
+                        l0_c,
+                        initC=True,
+                        b_transpose=True,
+                        size=[1, tile_size_N, tile_size_N],
+                    )
+
+                    # L0C -> GM: write back to B with dynamic tail size.
+                    with T.rs("PIPE_FIX"):
+                        T.npuir_store_fixpipe(
+                            l0_c,
+                            B[bx, by],
+                            size=[1, tile_size_N],
+                            enable_nz2nd=True,
+                        )
+
+    return copyShapeCube
+
+
+def cube_copy_shape_2d_3d(M, N, block_M, block_N):
+    """
+    Dynamic tail block copy on Cube core (3D GM -> 3D GM).
+
+    Layout:
+        A: [1, M, N], B: [1, M, N], Id: [N, N]
+    Similar to `cube_copy_shape_1d_2d`, but with an extra leading batch
+    dimension kept at size 1. We still copy 1 × tile_size_N slices via
+    the Cube pipeline.
+    """
+
+    @T.prim_func
+    def copyShapeCube2D3D(
+        A: T.Tensor((1, M, N), dtype),
+        B: T.Tensor((1, M, N), dtype),
+        Id: T.Tensor((N, N), dtype),
+        shape_M: T.int32,
+        shape_N: T.int32,
+    ):
+        with T.Kernel(
+            T.ceildiv(M, block_M) * T.ceildiv(N, block_N), is_npu=True
+        ) as (cid, _):
+            blockx = cid // T.ceildiv(N, block_N)
+            blocky = cid % T.ceildiv(N, block_N)
+            by = blocky * block_N
+
+            l1_a = T.alloc_L1((1, block_N), dtype)
+            l1_b = T.alloc_L1((block_N, block_N), dtype)
+            l0_c = T.alloc_L0C((1, block_N), "float32")
+
+            with T.Scope("Cube"):
+                for i in T.Parallel(block_M):
+                    bx = blockx * block_M + i
+                    t0 = shape_N - by
+                    tile_size_N = T.min(block_N, t0)
+
+                    # GM -> L1: load slice [0, bx, by:by+tile_size_N].
+                    T.npuir_load_nd2nz(
+                        A[0, bx, by],
+                        l1_a,
+                        size=[1, tile_size_N],
+                    )
+
+                    # GM -> L1: identity tile for N dimension.
+                    T.npuir_load_nd2nz(
+                        Id[0, 0],
+                        l1_b,
+                        size=[tile_size_N, tile_size_N],
+                    )
+
+                    # L1 × L1 -> L0C.
+                    T.npuir_dot(
+                        l1_a,
+                        l1_b,
+                        l0_c,
+                        initC=True,
+                        b_transpose=True,
+                        size=[1, tile_size_N, tile_size_N],
+                    )
+
+                    # L0C -> GM.
+                    with T.rs("PIPE_FIX"):
+                        T.npuir_store_fixpipe(
+                            l0_c,
+                            B[0, bx, by],
+                            size=[1, tile_size_N],
+                            enable_nz2nd=True,
+                        )
+
+    return copyShapeCube2D3D
+
+
+def cube_copy_shape_3d_4d(M, N, block_M, block_N):
+    """
+    Dynamic tail block copy on Cube core (4D GM -> 4D GM).
+
+    Layout:
+        A: [1, 1, M, N], B: [1, 1, M, N], Id: [N, N]
+    This further extends `cube_copy_shape_2d_3d` by adding another leading
+    batch dimension kept at size 1. We still copy 1 × tile_size_N slices via
+    the Cube pipeline.
+    """
+
+    @T.prim_func
+    def copyShapeCube3D4D(
+        A: T.Tensor((1, 1, M, N), dtype),
+        B: T.Tensor((1, 1, M, N), dtype),
+        Id: T.Tensor((N, N), dtype),
+        shape_M: T.int32,
+        shape_N: T.int32,
+    ):
+        with T.Kernel(
+            T.ceildiv(M, block_M) * T.ceildiv(N, block_N), is_npu=True
+        ) as (cid, _):
+            blockx = cid // T.ceildiv(N, block_N)
+            blocky = cid % T.ceildiv(N, block_N)
+            by = blocky * block_N
+
+            l1_a = T.alloc_L1((1, block_N), dtype)
+            l1_b = T.alloc_L1((block_N, block_N), dtype)
+            l0_c = T.alloc_L0C((1, block_N), "float32")
+
+            with T.Scope("Cube"):
+                for i in T.Parallel(block_M):
+                    bx = blockx * block_M + i
+                    t0 = shape_N - by
+                    tile_size_N = T.min(block_N, t0)
+
+                    # GM -> L1: load slice [0, 0, bx, by:by+tile_size_N].
+                    T.npuir_load_nd2nz(
+                        A[0, 0, bx, by],
+                        l1_a,
+                        size=[1, tile_size_N],
+                    )
+
+                    # GM -> L1: identity tile for N dimension.
+                    T.npuir_load_nd2nz(
+                        Id[0, 0],
+                        l1_b,
+                        size=[tile_size_N, tile_size_N],
+                    )
+
+                    # L1 × L1 -> L0C.
+                    T.npuir_dot(
+                        l1_a,
+                        l1_b,
+                        l0_c,
+                        initC=True,
+                        b_transpose=True,
+                        size=[1, tile_size_N, tile_size_N],
+                    )
+
+                    # L0C -> GM.
+                    with T.rs("PIPE_FIX"):
+                        T.npuir_store_fixpipe(
+                            l0_c,
+                            B[0, 0, bx, by],
+                            size=[1, tile_size_N],
+                            enable_nz2nd=True,
+                        )
+
+    return copyShapeCube3D4D
+
+
+def test_cube_copy_shape_1d_2d():
+    # In the future, Developer mode and Expert Mode will transition smoothly
+    # without requiring explicit declarations.
+    torch.npu.set_device(0)
+
+    M = 8
+    N = 8
+    v1 = torch.randn(size=[M, N], dtype=eval("torch." + dtype)).npu()
+    v2 = torch.zeros(size=[M, N], dtype=eval("torch." + dtype)).npu()
+    v_ref = v1.clone()
+
+    func = cube_copy_shape_1d_2d(M, N, block_M=3, block_N=3)
+    compiled_kernel = tilelang.compile(func, target="npuir")
+
+    # Identity matrix for Cube dot.
+    Id = torch.eye(N, dtype=eval("torch." + dtype)).npu()
+
+    compiled_kernel(v1, v2, Id, M, N)
+    print(v_ref)
+    print(v2)
+    torch.testing.assert_close(v2, v_ref, rtol=1e-2, atol=1e-2)
+    print("\033[92mAll Cube 2D dynamic-shape checks passed!\033[0m")
+
+
+def test_cube_copy_shape_2d_3d():
+    # In the future, Developer mode and Expert Mode will transition smoothly
+    # without requiring explicit declarations.
+    torch.npu.set_device(0)
+
+    M = 8
+    N = 8
+    func = cube_copy_shape_2d_3d(M, N, block_M=3, block_N=3)
+    compiled_kernel = tilelang.compile(func, target="npuir")
+
+    v1 = torch.randn(size=[1, M, N], dtype=eval("torch." + dtype)).npu()
+    v2 = torch.zeros(size=[1, M, N], dtype=eval("torch." + dtype)).npu()
+    v_ref = v1.clone()
+
+    Id = torch.eye(N, dtype=eval("torch." + dtype)).npu()
+
+    compiled_kernel(v1, v2, Id, M, N)
+
+    print(v_ref)
+    print(v2)
+    torch.testing.assert_close(v2, v_ref, rtol=1e-2, atol=1e-2)
+    print("\033[92mAll Cube 3D dynamic-shape checks passed!\033[0m")
+
+
+def test_cube_copy_shape_3d_4d():
+    # In the future, Developer mode and Expert Mode will transition smoothly
+    # without requiring explicit declarations.
+    torch.npu.set_device(0)
+
+    M = 8
+    N = 8
+    func = cube_copy_shape_3d_4d(M, N, block_M=3, block_N=3)
+    compiled_kernel = tilelang.compile(func, target="npuir")
+
+    v1 = torch.randn(size=[1, 1, M, N], dtype=eval("torch." + dtype)).npu()
+    v2 = torch.zeros(size=[1, 1, M, N], dtype=eval("torch." + dtype)).npu()
+    v_ref = v1.clone()
+
+    Id = torch.eye(N, dtype=eval("torch." + dtype)).npu()
+
+    compiled_kernel(v1, v2, Id, M, N)
+
+    print(v_ref)
+    print(v2)
+    torch.testing.assert_close(v2, v_ref, rtol=1e-2, atol=1e-2)
+    print("\033[92mAll Cube 4D dynamic-shape checks passed!\033[0m")
+
+
+if __name__ == "__main__":
+    test_cube_copy_shape_1d_2d()
+    test_cube_copy_shape_2d_3d()
+    test_cube_copy_shape_3d_4d()
+

--- a/testing/npuir/test_copy_shape_dynamic_cube.py
+++ b/testing/npuir/test_copy_shape_dynamic_cube.py
@@ -60,8 +60,8 @@ def cube_copy_shape_1d_2d(M, N, block_M, block_N):
                     t0 = shape_N - by
                     tile_size_N = T.min(block_N, t0)
 
-                    T.npuir_load_nd2nz(A[bx:bx+1, by:by+tile_size_N], l1_a)
-                    T.npuir_load_nd2nz(Id[0:tile_size_N, 0:tile_size_N], l1_b)
+                    T.npuir_load_nd2nz(A[bx, by], l1_a, size=[1, tile_size_N])
+                    T.npuir_load_nd2nz(Id[0, 0], l1_b, size=[tile_size_N, tile_size_N])
 
                     T.npuir_dot(
                         l1_a, l1_b, l0_c,
@@ -71,7 +71,8 @@ def cube_copy_shape_1d_2d(M, N, block_M, block_N):
 
                     with T.rs("PIPE_FIX"):
                         T.npuir_store_fixpipe(
-                            l0_c, B[bx:bx+1, by:by+tile_size_N],
+                            l0_c, B[bx, by],
+                            size=[1, tile_size_N],
                             enable_nz2nd=True,
                         )
 
@@ -106,8 +107,8 @@ def cube_copy_shape_2d_3d(M, N, block_M, block_N):
                     t0 = shape_N - by
                     tile_size_N = T.min(block_N, t0)
 
-                    T.npuir_load_nd2nz(A[0:1, bx:bx+1, by:by+tile_size_N], l1_a)
-                    T.npuir_load_nd2nz(Id[0:tile_size_N, 0:tile_size_N], l1_b)
+                    T.npuir_load_nd2nz(A[0, bx, by], l1_a, size=[1, 1, tile_size_N])
+                    T.npuir_load_nd2nz(Id[0, 0], l1_b, size=[tile_size_N, tile_size_N])
 
                     T.npuir_dot(
                         l1_a, l1_b, l0_c,
@@ -117,7 +118,8 @@ def cube_copy_shape_2d_3d(M, N, block_M, block_N):
 
                     with T.rs("PIPE_FIX"):
                         T.npuir_store_fixpipe(
-                            l0_c, B[0:1, bx:bx+1, by:by+tile_size_N],
+                            l0_c, B[0, bx, by],
+                            size=[1, 1, tile_size_N],
                             enable_nz2nd=True,
                         )
 
@@ -152,8 +154,8 @@ def cube_copy_shape_3d_4d(M, N, block_M, block_N):
                     t0 = shape_N - by
                     tile_size_N = T.min(block_N, t0)
 
-                    T.npuir_load_nd2nz(A[0:1, 0:1, bx:bx+1, by:by+tile_size_N], l1_a)
-                    T.npuir_load_nd2nz(Id[0:tile_size_N, 0:tile_size_N], l1_b)
+                    T.npuir_load_nd2nz(A[0, 0, bx, by], l1_a, size=[1, 1, 1, tile_size_N])
+                    T.npuir_load_nd2nz(Id[0, 0], l1_b, size=[tile_size_N, tile_size_N])
 
                     T.npuir_dot(
                         l1_a, l1_b, l0_c,
@@ -163,7 +165,8 @@ def cube_copy_shape_3d_4d(M, N, block_M, block_N):
 
                     with T.rs("PIPE_FIX"):
                         T.npuir_store_fixpipe(
-                            l0_c, B[0:1, 0:1, bx:bx+1, by:by+tile_size_N],
+                            l0_c, B[0, 0, bx, by],
+                            size=[1, 1, 1, tile_size_N],
                             enable_nz2nd=True,
                         )
 

--- a/testing/npuir/test_copy_shape_dynamic_cube.py
+++ b/testing/npuir/test_copy_shape_dynamic_cube.py
@@ -1,26 +1,39 @@
-import os
+# Copyright (c) Huawei Technologies Co., Ltd. 2025.
+"""
+Cube core dynamic-tail-block copy tests (nd2nz → dot → fixpipe).
+
+For each rank (2D / 3D / 4D):
+  1. Tile the M×N region with block_M × block_N tiles.
+  2. The last tile in each dimension uses a dynamic tail:
+       tile_size_N = min(block_N, shape_N - by)
+  3. Each tile goes through: GM → nd2nz → L1 → dot(identity) → L0C → fixpipe → GM
+  4. Verify the output matches the input (identity copy).
+
+Edge cases covered via pytest parametrize:
+  - Exact division (no tail block)
+  - Single tile (block == dim)
+  - Oversized block (block > dim)
+  - M = 1  (single row)
+  - Tail of 1 in M / N / both  (e.g. 7 % 3 = 1)
+  - Larger irregular shapes
+  - Leading dimensions = 1  (3D: [1,M,N], 4D: [1,1,M,N])
+"""
+import pytest
 import torch
 import tilelang
 import tilelang.language as T
 
-
+torch.npu.set_device(0)
 tilelang.cache.clear_cache()
+
 dtype = "float16"
 
+# ---------------------------------------------------------------------------
+# Kernel builders
+# ---------------------------------------------------------------------------
 
 def cube_copy_shape_1d_2d(M, N, block_M, block_N):
-    """
-    Dynamic tail block copy on Cube core (2D GM -> 2D GM).
-
-    Layout:
-        A: [M, N], B: [M, N], Id: [N, N]
-    We copy row-by-row in tiles of size `block_N`, but the last tile in
-    each row uses a dynamic `tile_size_N = min(block_N, shape_N - by)`.
-    For each tile, we:
-        GM (1 × tile_size_N) -> L1 -> L0C -> GM
-    using:
-        npuir_load_nd2nz + npuir_dot (with identity) + npuir_store_fixpipe.
-    """
+    """Dynamic tail block copy: 2D GM [M, N] → 2D GM [M, N]."""
 
     @T.prim_func
     def copyShapeCube(
@@ -37,7 +50,6 @@ def cube_copy_shape_1d_2d(M, N, block_M, block_N):
             blocky = cid % T.ceildiv(N, block_N)
             by = blocky * block_N
 
-            # L1/L0C buffers for a single row tile.
             l1_a = T.alloc_L1((1, block_N), dtype)
             l1_b = T.alloc_L1((block_N, block_N), dtype)
             l0_c = T.alloc_L0C((1, block_N), "float32")
@@ -45,40 +57,21 @@ def cube_copy_shape_1d_2d(M, N, block_M, block_N):
             with T.Scope("Cube"):
                 for i in T.Parallel(block_M):
                     bx = blockx * block_M + i
-                    # Dynamic tail size for N dimension.
                     t0 = shape_N - by
                     tile_size_N = T.min(block_N, t0)
 
-                    # GM -> L1: load a 1 × tile_size_N slice.
-                    T.npuir_load_nd2nz(
-                        A[bx, by],
-                        l1_a,
-                        size=[1, tile_size_N],
-                    )
+                    T.npuir_load_nd2nz(A[bx:bx+1, by:by+tile_size_N], l1_a)
+                    T.npuir_load_nd2nz(Id[0:tile_size_N, 0:tile_size_N], l1_b)
 
-                    # GM -> L1: load top-left tile_size_N × tile_size_N part of Id.
-                    T.npuir_load_nd2nz(
-                        Id[0, 0],
-                        l1_b,
-                        size=[tile_size_N, tile_size_N],
-                    )
-
-                    # L1 × L1 -> L0C: multiply by identity, effectively copying.
                     T.npuir_dot(
-                        l1_a,
-                        l1_b,
-                        l0_c,
-                        initC=True,
-                        b_transpose=True,
+                        l1_a, l1_b, l0_c,
+                        initC=True, b_transpose=True,
                         size=[1, tile_size_N, tile_size_N],
                     )
 
-                    # L0C -> GM: write back to B with dynamic tail size.
                     with T.rs("PIPE_FIX"):
                         T.npuir_store_fixpipe(
-                            l0_c,
-                            B[bx, by],
-                            size=[1, tile_size_N],
+                            l0_c, B[bx:bx+1, by:by+tile_size_N],
                             enable_nz2nd=True,
                         )
 
@@ -86,15 +79,7 @@ def cube_copy_shape_1d_2d(M, N, block_M, block_N):
 
 
 def cube_copy_shape_2d_3d(M, N, block_M, block_N):
-    """
-    Dynamic tail block copy on Cube core (3D GM -> 3D GM).
-
-    Layout:
-        A: [1, M, N], B: [1, M, N], Id: [N, N]
-    Similar to `cube_copy_shape_1d_2d`, but with an extra leading batch
-    dimension kept at size 1. We still copy 1 × tile_size_N slices via
-    the Cube pipeline.
-    """
+    """Dynamic tail block copy: 3D GM [1, M, N] → 3D GM [1, M, N]."""
 
     @T.prim_func
     def copyShapeCube2D3D(
@@ -121,36 +106,18 @@ def cube_copy_shape_2d_3d(M, N, block_M, block_N):
                     t0 = shape_N - by
                     tile_size_N = T.min(block_N, t0)
 
-                    # GM -> L1: load slice [0, bx, by:by+tile_size_N].
-                    T.npuir_load_nd2nz(
-                        A[0, bx, by],
-                        l1_a,
-                        size=[1, tile_size_N],
-                    )
+                    T.npuir_load_nd2nz(A[0:1, bx:bx+1, by:by+tile_size_N], l1_a)
+                    T.npuir_load_nd2nz(Id[0:tile_size_N, 0:tile_size_N], l1_b)
 
-                    # GM -> L1: identity tile for N dimension.
-                    T.npuir_load_nd2nz(
-                        Id[0, 0],
-                        l1_b,
-                        size=[tile_size_N, tile_size_N],
-                    )
-
-                    # L1 × L1 -> L0C.
                     T.npuir_dot(
-                        l1_a,
-                        l1_b,
-                        l0_c,
-                        initC=True,
-                        b_transpose=True,
+                        l1_a, l1_b, l0_c,
+                        initC=True, b_transpose=True,
                         size=[1, tile_size_N, tile_size_N],
                     )
 
-                    # L0C -> GM.
                     with T.rs("PIPE_FIX"):
                         T.npuir_store_fixpipe(
-                            l0_c,
-                            B[0, bx, by],
-                            size=[1, tile_size_N],
+                            l0_c, B[0:1, bx:bx+1, by:by+tile_size_N],
                             enable_nz2nd=True,
                         )
 
@@ -158,15 +125,7 @@ def cube_copy_shape_2d_3d(M, N, block_M, block_N):
 
 
 def cube_copy_shape_3d_4d(M, N, block_M, block_N):
-    """
-    Dynamic tail block copy on Cube core (4D GM -> 4D GM).
-
-    Layout:
-        A: [1, 1, M, N], B: [1, 1, M, N], Id: [N, N]
-    This further extends `cube_copy_shape_2d_3d` by adding another leading
-    batch dimension kept at size 1. We still copy 1 × tile_size_N slices via
-    the Cube pipeline.
-    """
+    """Dynamic tail block copy: 4D GM [1, 1, M, N] → 4D GM [1, 1, M, N]."""
 
     @T.prim_func
     def copyShapeCube3D4D(
@@ -193,105 +152,98 @@ def cube_copy_shape_3d_4d(M, N, block_M, block_N):
                     t0 = shape_N - by
                     tile_size_N = T.min(block_N, t0)
 
-                    # GM -> L1: load slice [0, 0, bx, by:by+tile_size_N].
-                    T.npuir_load_nd2nz(
-                        A[0, 0, bx, by],
-                        l1_a,
-                        size=[1, tile_size_N],
-                    )
+                    T.npuir_load_nd2nz(A[0:1, 0:1, bx:bx+1, by:by+tile_size_N], l1_a)
+                    T.npuir_load_nd2nz(Id[0:tile_size_N, 0:tile_size_N], l1_b)
 
-                    # GM -> L1: identity tile for N dimension.
-                    T.npuir_load_nd2nz(
-                        Id[0, 0],
-                        l1_b,
-                        size=[tile_size_N, tile_size_N],
-                    )
-
-                    # L1 × L1 -> L0C.
                     T.npuir_dot(
-                        l1_a,
-                        l1_b,
-                        l0_c,
-                        initC=True,
-                        b_transpose=True,
+                        l1_a, l1_b, l0_c,
+                        initC=True, b_transpose=True,
                         size=[1, tile_size_N, tile_size_N],
                     )
 
-                    # L0C -> GM.
                     with T.rs("PIPE_FIX"):
                         T.npuir_store_fixpipe(
-                            l0_c,
-                            B[0, 0, bx, by],
-                            size=[1, tile_size_N],
+                            l0_c, B[0:1, 0:1, bx:bx+1, by:by+tile_size_N],
                             enable_nz2nd=True,
                         )
 
     return copyShapeCube3D4D
 
 
-def test_cube_copy_shape_1d_2d():
-    M = 8
-    N = 8
-    v1 = torch.randn(size=[M, N], dtype=eval("torch." + dtype)).npu()
-    v2 = torch.zeros(size=[M, N], dtype=eval("torch." + dtype)).npu()
-    v_ref = v1.clone()
+# ---------------------------------------------------------------------------
+# Test shape configurations
+# ---------------------------------------------------------------------------
 
-    func = cube_copy_shape_1d_2d(M, N, block_M=3, block_N=3)
+DYNAMIC_CASES = [
+    # (M,  N,  block_M, block_N)   — description
+    (8,  8,  3, 3),                 # base: tail in both dims (8%3=2)
+    (6,  6,  3, 3),                 # exact divide, no tail
+    (8,  8,  8, 8),                 # single tile (block == dim)
+    (4,  4,  8, 8),                 # oversized block (block > dim)
+    (1,  8,  1, 3),                 # M=1, single row
+    (16, 32, 5, 7),                 # larger, irregular tiling
+    (7,  8,  3, 3),                 # M tail = 1  (7%3 = 1)
+    (8,  7,  3, 3),                 # N tail = 1  (7%3 = 1)
+    (7,  7,  3, 3),                 # both dims tail = 1
+    (8,  8,  3, 8),                 # block_N == N, only M has tail
+    (8,  8,  8, 3),                 # block_M == M, only N has tail
+]
+
+
+# ---------------------------------------------------------------------------
+# 2D tests  —  A: [M, N]
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("M, N, block_M, block_N", DYNAMIC_CASES)
+def test_cube_copy_shape_2d(M, N, block_M, block_N):
+    func = cube_copy_shape_1d_2d(M, N, block_M, block_N)
     compiled_kernel = tilelang.compile(func, target="npuir")
 
-    # Identity matrix for Cube dot.
-    Id = torch.eye(N, dtype=eval("torch." + dtype)).npu()
+    v1 = torch.randn(M, N, dtype=torch.float16).npu()
+    v2 = torch.zeros(M, N, dtype=torch.float16).npu()
+    v_ref = v1.clone()
+    Id = torch.eye(N, dtype=torch.float16).npu()
 
     compiled_kernel(v1, v2, Id, M, N)
-    print(v_ref)
-    print(v2)
     torch.testing.assert_close(v2, v_ref, rtol=1e-2, atol=1e-2)
-    print("\033[92mAll Cube 2D dynamic-shape checks passed!\033[0m")
 
 
-def test_cube_copy_shape_2d_3d():
-    M = 8
-    N = 8
-    func = cube_copy_shape_2d_3d(M, N, block_M=3, block_N=3)
+# ---------------------------------------------------------------------------
+# 3D tests  —  A: [1, M, N]
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("M, N, block_M, block_N", DYNAMIC_CASES)
+def test_cube_copy_shape_3d(M, N, block_M, block_N):
+    func = cube_copy_shape_2d_3d(M, N, block_M, block_N)
     compiled_kernel = tilelang.compile(func, target="npuir")
 
-    v1 = torch.randn(size=[1, M, N], dtype=eval("torch." + dtype)).npu()
-    v2 = torch.zeros(size=[1, M, N], dtype=eval("torch." + dtype)).npu()
+    v1 = torch.randn(1, M, N, dtype=torch.float16).npu()
+    v2 = torch.zeros(1, M, N, dtype=torch.float16).npu()
     v_ref = v1.clone()
-
-    Id = torch.eye(N, dtype=eval("torch." + dtype)).npu()
+    Id = torch.eye(N, dtype=torch.float16).npu()
 
     compiled_kernel(v1, v2, Id, M, N)
-
-    print(v_ref)
-    print(v2)
     torch.testing.assert_close(v2, v_ref, rtol=1e-2, atol=1e-2)
-    print("\033[92mAll Cube 3D dynamic-shape checks passed!\033[0m")
 
 
-def test_cube_copy_shape_3d_4d():
-    M = 8
-    N = 8
-    func = cube_copy_shape_3d_4d(M, N, block_M=3, block_N=3)
+# ---------------------------------------------------------------------------
+# 4D tests  —  A: [1, 1, M, N]
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("M, N, block_M, block_N", DYNAMIC_CASES)
+def test_cube_copy_shape_4d(M, N, block_M, block_N):
+    func = cube_copy_shape_3d_4d(M, N, block_M, block_N)
     compiled_kernel = tilelang.compile(func, target="npuir")
 
-    v1 = torch.randn(size=[1, 1, M, N], dtype=eval("torch." + dtype)).npu()
-    v2 = torch.zeros(size=[1, 1, M, N], dtype=eval("torch." + dtype)).npu()
+    v1 = torch.randn(1, 1, M, N, dtype=torch.float16).npu()
+    v2 = torch.zeros(1, 1, M, N, dtype=torch.float16).npu()
     v_ref = v1.clone()
-
-    Id = torch.eye(N, dtype=eval("torch." + dtype)).npu()
+    Id = torch.eye(N, dtype=torch.float16).npu()
 
     compiled_kernel(v1, v2, Id, M, N)
-
-    print(v_ref)
-    print(v2)
     torch.testing.assert_close(v2, v_ref, rtol=1e-2, atol=1e-2)
-    print("\033[92mAll Cube 4D dynamic-shape checks passed!\033[0m")
 
 
+# ---------------------------------------------------------------------------
 if __name__ == "__main__":
-    torch.npu.set_device(0)
-    test_cube_copy_shape_1d_2d()
-    test_cube_copy_shape_2d_3d()
-    test_cube_copy_shape_3d_4d()
-
+    pytest.main([__file__, "-v"])

--- a/testing/npuir/test_copy_shape_dynamic_cube.py
+++ b/testing/npuir/test_copy_shape_dynamic_cube.py
@@ -230,10 +230,6 @@ def cube_copy_shape_3d_4d(M, N, block_M, block_N):
 
 
 def test_cube_copy_shape_1d_2d():
-    # In the future, Developer mode and Expert Mode will transition smoothly
-    # without requiring explicit declarations.
-    torch.npu.set_device(0)
-
     M = 8
     N = 8
     v1 = torch.randn(size=[M, N], dtype=eval("torch." + dtype)).npu()
@@ -254,10 +250,6 @@ def test_cube_copy_shape_1d_2d():
 
 
 def test_cube_copy_shape_2d_3d():
-    # In the future, Developer mode and Expert Mode will transition smoothly
-    # without requiring explicit declarations.
-    torch.npu.set_device(0)
-
     M = 8
     N = 8
     func = cube_copy_shape_2d_3d(M, N, block_M=3, block_N=3)
@@ -278,10 +270,6 @@ def test_cube_copy_shape_2d_3d():
 
 
 def test_cube_copy_shape_3d_4d():
-    # In the future, Developer mode and Expert Mode will transition smoothly
-    # without requiring explicit declarations.
-    torch.npu.set_device(0)
-
     M = 8
     N = 8
     func = cube_copy_shape_3d_4d(M, N, block_M=3, block_N=3)
@@ -302,6 +290,7 @@ def test_cube_copy_shape_3d_4d():
 
 
 if __name__ == "__main__":
+    torch.npu.set_device(0)
     test_cube_copy_shape_1d_2d()
     test_cube_copy_shape_2d_3d()
     test_cube_copy_shape_3d_4d()

--- a/testing/npuir/test_copy_sliced_cube.py
+++ b/testing/npuir/test_copy_sliced_cube.py
@@ -1,5 +1,20 @@
 # Copyright (c) Huawei Technologies Co., Ltd. 2025.
-import os
+"""
+Cube core sliced-copy tests (nd2nz → dot → fixpipe) with static shapes.
+
+For each rank (2D / 3D / 4D):
+  1. Construct A with only one row-slice non-zero.
+  2. Construct an N×N identity matrix B.
+  3. The Cube pipeline loads the slice, multiplies by identity, and stores back.
+  4. Verify only the target slice is written; all others remain zero.
+
+Edge cases covered via pytest parametrize:
+  - First / last row index
+  - M = 1 (single row)
+  - Leading dimensions = 1 (rank-reduction boundary)
+  - Consecutive leading 1s (e.g. B=1, H=1, M=1 for 4D)
+"""
+import pytest
 import torch
 import tilelang
 import tilelang.language as T
@@ -7,27 +22,9 @@ import tilelang.language as T
 torch.npu.set_device(0)
 tilelang.cache.clear_cache()
 
-"""
-This file focuses on testing the Cube core sliced path:
-    GM (one row slice) --npuir_load_nd2nz--> L1
-    L1 × L1 (via npuir_dot) --> L0C
-    L0C --npuir_store_fixpipe--> GM (same row position)
-
-Idea for 2D: construct A with shape [M, N], only row `idx` is non-zero;
-construct B with shape [N, N] as an identity matrix.
-In Cube scope we use:
-    T.npuir_load_nd2nz(A[idx, 0], l1_a, [1, N])
-    T.npuir_load_nd2nz(B[0, 0],   l1_b, [N, N])
-    T.npuir_dot(l1_a, l1_b, l0_c, ..., b_transpose=True, size=[1, N, N])
-    T.npuir_store_fixpipe(l0_c, Out[idx, 0], size=[1, N], enable_nz2nd=True)
-Then the `idx`-th row of `Out` should equal the `idx`-th row of `A`, and all
-other rows should remain zero.
-
-We extend this pattern to:
-- 3D: 3D GM (B, M, N) -> 2D L1 / 2D L0C -> 3D GM
-- 4D: 4D GM (B, H, M, N) <-> 2D L1 / 2D L0C
-"""
-
+# ---------------------------------------------------------------------------
+# Kernel builders
+# ---------------------------------------------------------------------------
 
 @tilelang.jit(out_idx=[-1], target="npuir")
 def cube_sliced_copy_2d(M, N, idx, dtype="float16", accum_dtype="float32"):
@@ -38,7 +35,6 @@ def cube_sliced_copy_2d(M, N, idx, dtype="float16", accum_dtype="float32"):
         Out: T.Tensor((M, N), dtype),
     ):
         with T.Kernel(1, is_npu=True) as (cid, subid):
-            # Only one row slice is involved, so L1/L0C shapes are [1, N] or [N, N].
             l1_a = T.alloc_L1([1, N], dtype)
             l1_b = T.alloc_L1([N, N], dtype)
             l0_c = T.alloc_L0C([1, N], accum_dtype)
@@ -48,72 +44,26 @@ def cube_sliced_copy_2d(M, N, idx, dtype="float16", accum_dtype="float32"):
                 tail_n = N
                 tail_k = N
 
-                # GM -> L1: load the `idx`-th row of A and the full B (identity).
-                T.npuir_load_nd2nz(A_in[idx, 0], l1_a, [tail_m, tail_k])
-                T.npuir_load_nd2nz(B_in[0, 0], l1_b, [tail_n, tail_k])
+                T.npuir_load_nd2nz(A_in[idx:idx+tail_m, 0:tail_k], l1_a)
+                T.npuir_load_nd2nz(B_in[0:tail_n, 0:tail_k], l1_b)
 
-                # L1 × L1 -> L0C: run through Cube dot to L0C.
                 T.npuir_dot(
-                    l1_a,
-                    l1_b,
-                    l0_c,
-                    initC=True,
-                    b_transpose=True,
+                    l1_a, l1_b, l0_c,
+                    initC=True, b_transpose=True,
                     size=[tail_m, tail_k, tail_n],
                 )
 
-                # L0C -> GM: use fixpipe to store back to the same row in GM.
                 with T.rs("PIPE_FIX"):
                     T.npuir_store_fixpipe(
-                        l0_c,
-                        Out[idx, 0],
-                        size=[tail_m, tail_n],
+                        l0_c, Out[idx:idx+tail_m, 0:tail_n],
                         enable_nz2nd=True,
                     )
 
     return main
 
 
-def test_cube_sliced_copy_2d():
-    print("=" * 30 + " Running Cube Sliced Copy 2D Test " + "=" * 30)
-
-    M, N = 16, 32
-    idx = 5
-
-    kernel = cube_sliced_copy_2d(M, N, idx)
-
-    # A: only row `idx` is non-zero, others are zeros.
-    A = torch.zeros(M, N).npu().half()
-    row = torch.arange(1, N + 1, dtype=torch.float16).npu()
-    A[idx] = row
-
-    # B: identity matrix, so A[idx] @ B^T == A[idx].
-    B = torch.eye(N, dtype=torch.float16).npu()
-
-    Out = torch.zeros(M, N).npu().half()
-
-    # Run kernel: the Cube pipeline should write back only the `idx`-th row.
-    kernel(A, B, Out)
-
-    expected = torch.zeros(M, N).npu().half()
-    expected[idx] = row
-
-    torch.testing.assert_close(Out, expected, rtol=1e-5, atol=1e-5)
-
-    print("Cube Sliced Copy 2D Test Passed!")
-
-
 @tilelang.jit(out_idx=[-1], target="npuir")
 def cube_sliced_copy_3d(B, M, N, b_idx, m_idx, dtype="float16", accum_dtype="float32"):
-    """
-    3D GM -> 2D L1 / 2D L0C -> 3D GM on Cube.
-
-    A_in: [B, M, N], only slice (b_idx, m_idx, :) is non-zero.
-    B_in: [N, N] identity.
-    We load A_in[b_idx, m_idx, :] to [1, N] L1, run dot with identity,
-    and store the result back to Out[b_idx, m_idx, :].
-    """
-
     @T.prim_func
     def main(
         A_in: T.Tensor((B, M, N), dtype),
@@ -130,71 +80,26 @@ def cube_sliced_copy_3d(B, M, N, b_idx, m_idx, dtype="float16", accum_dtype="flo
                 tail_n = N
                 tail_k = N
 
-                # GM -> L1: 3D slice (b_idx, m_idx, :) to 2D L1.
-                T.npuir_load_nd2nz(A_in[b_idx, m_idx, 0], l1_a, [tail_m, tail_k])
-                T.npuir_load_nd2nz(B_in[0, 0], l1_b, [tail_n, tail_k])
+                T.npuir_load_nd2nz(A_in[b_idx:b_idx+1, m_idx:m_idx+tail_m, 0:tail_k], l1_a)
+                T.npuir_load_nd2nz(B_in[0:tail_n, 0:tail_k], l1_b)
 
-                # L1 × L1 -> L0C.
                 T.npuir_dot(
-                    l1_a,
-                    l1_b,
-                    l0_c,
-                    initC=True,
-                    b_transpose=True,
+                    l1_a, l1_b, l0_c,
+                    initC=True, b_transpose=True,
                     size=[tail_m, tail_k, tail_n],
                 )
 
-                # L0C -> GM: back to the same (b_idx, m_idx, :) slice in 3D GM.
                 with T.rs("PIPE_FIX"):
                     T.npuir_store_fixpipe(
-                        l0_c,
-                        Out[b_idx, m_idx, 0],
-                        size=[tail_m, tail_n],
+                        l0_c, Out[b_idx:b_idx+1, m_idx:m_idx+tail_m, 0:tail_n],
                         enable_nz2nd=True,
                     )
 
     return main
 
 
-def test_cube_sliced_copy_3d():
-    print("\n" + "=" * 30 + " Running Cube Sliced Copy 3D Test " + "=" * 30)
-
-    B_dim, M, N = 4, 16, 32
-    b_idx, m_idx = 1, 7
-
-    kernel = cube_sliced_copy_3d(B_dim, M, N, b_idx, m_idx)
-
-    # A: only slice (b_idx, m_idx, :) is non-zero.
-    A = torch.zeros(B_dim, M, N).npu().half()
-    row = torch.arange(1, N + 1, dtype=torch.float16).npu()
-    A[b_idx, m_idx] = row
-
-    # B: identity matrix on the last dimension.
-    B = torch.eye(N, dtype=torch.float16).npu()
-
-    Out = torch.zeros(B_dim, M, N).npu().half()
-
-    kernel(A, B, Out)
-
-    expected = torch.zeros(B_dim, M, N).npu().half()
-    expected[b_idx, m_idx] = row
-
-    torch.testing.assert_close(Out, expected, rtol=1e-5, atol=1e-5)
-
-    print("Cube Sliced Copy 3D Test Passed!")
-
-
 @tilelang.jit(out_idx=[-1], target="npuir")
 def cube_sliced_copy_4d(B, H, M, N, b_idx, h_idx, m_idx, dtype="float16", accum_dtype="float32"):
-    """
-    4D GM <-> 2D L1 / 2D L0C on Cube.
-
-    A_in: [B, H, M, N], only slice (b_idx, h_idx, m_idx, :) is non-zero.
-    B_in: [N, N] identity.
-    The selected 1×N slice is moved to 2D L1, computed in 2D L0C, and
-    stored back into the same 4D GM position.
-    """
-
     @T.prim_func
     def main(
         A_in: T.Tensor((B, H, M, N), dtype),
@@ -211,65 +116,126 @@ def cube_sliced_copy_4d(B, H, M, N, b_idx, h_idx, m_idx, dtype="float16", accum_
                 tail_n = N
                 tail_k = N
 
-                # GM -> L1: 4D slice (b_idx, h_idx, m_idx, :) to 2D L1.
-                T.npuir_load_nd2nz(A_in[b_idx, h_idx, m_idx, 0], l1_a, [tail_m, tail_k])
-                T.npuir_load_nd2nz(B_in[0, 0], l1_b, [tail_n, tail_k])
+                T.npuir_load_nd2nz(A_in[b_idx:b_idx+1, h_idx:h_idx+1, m_idx:m_idx+tail_m, 0:tail_k], l1_a)
+                T.npuir_load_nd2nz(B_in[0:tail_n, 0:tail_k], l1_b)
 
-                # L1 × L1 -> L0C.
                 T.npuir_dot(
-                    l1_a,
-                    l1_b,
-                    l0_c,
-                    initC=True,
-                    b_transpose=True,
+                    l1_a, l1_b, l0_c,
+                    initC=True, b_transpose=True,
                     size=[tail_m, tail_k, tail_n],
                 )
 
-                # L0C -> GM: back to the same (b_idx, h_idx, m_idx, :) slice in 4D GM.
                 with T.rs("PIPE_FIX"):
                     T.npuir_store_fixpipe(
-                        l0_c,
-                        Out[b_idx, h_idx, m_idx, 0],
-                        size=[tail_m, tail_n],
+                        l0_c, Out[b_idx:b_idx+1, h_idx:h_idx+1, m_idx:m_idx+tail_m, 0:tail_n],
                         enable_nz2nd=True,
                     )
 
     return main
 
 
-def test_cube_sliced_copy_4d():
-    print("\n" + "=" * 30 + " Running Cube Sliced Copy 4D Test " + "=" * 30)
+# ---------------------------------------------------------------------------
+# 2D parametrized tests  —  A: [M, N]
+# ---------------------------------------------------------------------------
 
-    B_dim, H, M, N = 2, 4, 16, 32
-    b_idx, h_idx, m_idx = 1, 2, 5
+SLICED_2D_CASES = [
+    # (M,  N,  idx)
+    (16, 32, 5),         # base case
+    (16, 32, 0),         # first row
+    (16, 32, 15),        # last row
+    (1,  32, 0),         # M=1: single-row tensor
+    (32, 16, 16),        # M > N, higher index
+    (16,  8, 5),         # small N=8
+    (1,   8, 0),         # small N=8, M=1
+]
 
-    kernel = cube_sliced_copy_4d(B_dim, H, M, N, b_idx, h_idx, m_idx)
+@pytest.mark.parametrize("M, N, idx", SLICED_2D_CASES)
+def test_cube_sliced_copy_2d(M, N, idx):
+    kernel = cube_sliced_copy_2d(M, N, idx)
 
-    # A: only slice (b_idx, h_idx, m_idx, :) is non-zero.
-    A = torch.zeros(B_dim, H, M, N).npu().half()
+    A = torch.zeros(M, N, dtype=torch.float16).npu()
     row = torch.arange(1, N + 1, dtype=torch.float16).npu()
-    A[b_idx, h_idx, m_idx] = row
+    A[idx] = row
 
-    # B: identity matrix on the last dimension.
     B = torch.eye(N, dtype=torch.float16).npu()
-
-    Out = torch.zeros(B_dim, H, M, N).npu().half()
+    Out = torch.zeros(M, N, dtype=torch.float16).npu()
 
     kernel(A, B, Out)
 
-    expected = torch.zeros(B_dim, H, M, N).npu().half()
-    expected[b_idx, h_idx, m_idx] = row
-
+    expected = torch.zeros(M, N, dtype=torch.float16).npu()
+    expected[idx] = row
     torch.testing.assert_close(Out, expected, rtol=1e-5, atol=1e-5)
 
-    print("Cube Sliced Copy 4D Test Passed!")
+
+# ---------------------------------------------------------------------------
+# 3D parametrized tests  —  A: [B, M, N]
+# ---------------------------------------------------------------------------
+
+SLICED_3D_CASES = [
+    # (B,  M,  N,  b_idx, m_idx)
+    (4,  16, 32, 1, 7),       # base case
+    (1,  16, 32, 0, 7),       # B=1  (leading-1 rank reduction)
+    (4,  1,  32, 2, 0),       # M=1
+    (1,  1,  32, 0, 0),       # B=1, M=1  (consecutive leading 1s)
+    (4,  16, 32, 3, 15),      # boundary indices (last B, last M)
+    (4,  16, 32, 0, 0),       # all-zero indices
+    (4,  16,  8, 1, 7),       # small N=8
+    (1,  1,   8, 0, 0),       # small N=8, B=1, M=1
+]
+
+@pytest.mark.parametrize("B_dim, M, N, b_idx, m_idx", SLICED_3D_CASES)
+def test_cube_sliced_copy_3d(B_dim, M, N, b_idx, m_idx):
+    kernel = cube_sliced_copy_3d(B_dim, M, N, b_idx, m_idx)
+
+    A = torch.zeros(B_dim, M, N, dtype=torch.float16).npu()
+    row = torch.arange(1, N + 1, dtype=torch.float16).npu()
+    A[b_idx, m_idx] = row
+
+    B = torch.eye(N, dtype=torch.float16).npu()
+    Out = torch.zeros(B_dim, M, N, dtype=torch.float16).npu()
+
+    kernel(A, B, Out)
+
+    expected = torch.zeros(B_dim, M, N, dtype=torch.float16).npu()
+    expected[b_idx, m_idx] = row
+    torch.testing.assert_close(Out, expected, rtol=1e-5, atol=1e-5)
 
 
-def main():
-    test_cube_sliced_copy_2d()
-    test_cube_sliced_copy_3d()
-    test_cube_sliced_copy_4d()
+# ---------------------------------------------------------------------------
+# 4D parametrized tests  —  A: [B, H, M, N]
+# ---------------------------------------------------------------------------
+
+SLICED_4D_CASES = [
+    # (B,  H,  M,  N,  b_idx, h_idx, m_idx)
+    (2,  4,  16, 32, 1, 2, 5),       # base case
+    (1,  4,  16, 32, 0, 2, 5),       # B=1
+    (2,  1,  16, 32, 1, 0, 5),       # H=1
+    (1,  1,  16, 32, 0, 0, 5),       # B=1, H=1  (two consecutive leading 1s)
+    (1,  1,  1,  32, 0, 0, 0),       # B=1, H=1, M=1  (three consecutive 1s)
+    (2,  4,  16, 32, 0, 0, 0),       # all-zero indices
+    (2,  4,  16, 32, 1, 3, 15),      # boundary indices (last valid)
+    (2,  4,  16,  8, 1, 2, 5),       # small N=8
+    (1,  1,  1,   8, 0, 0, 0),       # small N=8, all leading 1s
+]
+
+@pytest.mark.parametrize("B_dim, H, M, N, b_idx, h_idx, m_idx", SLICED_4D_CASES)
+def test_cube_sliced_copy_4d(B_dim, H, M, N, b_idx, h_idx, m_idx):
+    kernel = cube_sliced_copy_4d(B_dim, H, M, N, b_idx, h_idx, m_idx)
+
+    A = torch.zeros(B_dim, H, M, N, dtype=torch.float16).npu()
+    row = torch.arange(1, N + 1, dtype=torch.float16).npu()
+    A[b_idx, h_idx, m_idx] = row
+
+    B = torch.eye(N, dtype=torch.float16).npu()
+    Out = torch.zeros(B_dim, H, M, N, dtype=torch.float16).npu()
+
+    kernel(A, B, Out)
+
+    expected = torch.zeros(B_dim, H, M, N, dtype=torch.float16).npu()
+    expected[b_idx, h_idx, m_idx] = row
+    torch.testing.assert_close(Out, expected, rtol=1e-5, atol=1e-5)
 
 
+# ---------------------------------------------------------------------------
 if __name__ == "__main__":
-    main()
+    pytest.main([__file__, "-v"])

--- a/testing/npuir/test_copy_sliced_cube.py
+++ b/testing/npuir/test_copy_sliced_cube.py
@@ -1,0 +1,275 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025.
+import os
+import torch
+import tilelang
+import tilelang.language as T
+
+torch.npu.set_device(0)
+tilelang.cache.clear_cache()
+
+"""
+This file focuses on testing the Cube core sliced path:
+    GM (one row slice) --npuir_load_nd2nz--> L1
+    L1 × L1 (via npuir_dot) --> L0C
+    L0C --npuir_store_fixpipe--> GM (same row position)
+
+Idea for 2D: construct A with shape [M, N], only row `idx` is non-zero;
+construct B with shape [N, N] as an identity matrix.
+In Cube scope we use:
+    T.npuir_load_nd2nz(A[idx, 0], l1_a, [1, N])
+    T.npuir_load_nd2nz(B[0, 0],   l1_b, [N, N])
+    T.npuir_dot(l1_a, l1_b, l0_c, ..., b_transpose=True, size=[1, N, N])
+    T.npuir_store_fixpipe(l0_c, Out[idx, 0], size=[1, N], enable_nz2nd=True)
+Then the `idx`-th row of `Out` should equal the `idx`-th row of `A`, and all
+other rows should remain zero.
+
+We extend this pattern to:
+- 3D: 3D GM (B, M, N) -> 2D L1 / 2D L0C -> 3D GM
+- 4D: 4D GM (B, H, M, N) <-> 2D L1 / 2D L0C
+"""
+
+
+@tilelang.jit(out_idx=[-1], target="npuir")
+def cube_sliced_copy_2d(M, N, idx, dtype="float16", accum_dtype="float32"):
+    @T.prim_func
+    def main(
+        A_in: T.Tensor((M, N), dtype),
+        B_in: T.Tensor((N, N), dtype),
+        Out: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, subid):
+            # Only one row slice is involved, so L1/L0C shapes are [1, N] or [N, N].
+            l1_a = T.alloc_L1([1, N], dtype)
+            l1_b = T.alloc_L1([N, N], dtype)
+            l0_c = T.alloc_L0C([1, N], accum_dtype)
+
+            with T.Scope("Cube"):
+                tail_m = 1
+                tail_n = N
+                tail_k = N
+
+                # GM -> L1: load the `idx`-th row of A and the full B (identity).
+                T.npuir_load_nd2nz(A_in[idx, 0], l1_a, [tail_m, tail_k])
+                T.npuir_load_nd2nz(B_in[0, 0], l1_b, [tail_n, tail_k])
+
+                # L1 × L1 -> L0C: run through Cube dot to L0C.
+                T.npuir_dot(
+                    l1_a,
+                    l1_b,
+                    l0_c,
+                    initC=True,
+                    b_transpose=True,
+                    size=[tail_m, tail_k, tail_n],
+                )
+
+                # L0C -> GM: use fixpipe to store back to the same row in GM.
+                with T.rs("PIPE_FIX"):
+                    T.npuir_store_fixpipe(
+                        l0_c,
+                        Out[idx, 0],
+                        size=[tail_m, tail_n],
+                        enable_nz2nd=True,
+                    )
+
+    return main
+
+
+def test_cube_sliced_copy_2d():
+    print("=" * 30 + " Running Cube Sliced Copy 2D Test " + "=" * 30)
+
+    M, N = 16, 32
+    idx = 5
+
+    kernel = cube_sliced_copy_2d(M, N, idx)
+
+    # A: only row `idx` is non-zero, others are zeros.
+    A = torch.zeros(M, N).npu().half()
+    row = torch.arange(1, N + 1, dtype=torch.float16).npu()
+    A[idx] = row
+
+    # B: identity matrix, so A[idx] @ B^T == A[idx].
+    B = torch.eye(N, dtype=torch.float16).npu()
+
+    Out = torch.zeros(M, N).npu().half()
+
+    # Run kernel: the Cube pipeline should write back only the `idx`-th row.
+    kernel(A, B, Out)
+
+    expected = torch.zeros(M, N).npu().half()
+    expected[idx] = row
+
+    torch.testing.assert_close(Out, expected, rtol=1e-5, atol=1e-5)
+
+    print("Cube Sliced Copy 2D Test Passed!")
+
+
+@tilelang.jit(out_idx=[-1], target="npuir")
+def cube_sliced_copy_3d(B, M, N, b_idx, m_idx, dtype="float16", accum_dtype="float32"):
+    """
+    3D GM -> 2D L1 / 2D L0C -> 3D GM on Cube.
+
+    A_in: [B, M, N], only slice (b_idx, m_idx, :) is non-zero.
+    B_in: [N, N] identity.
+    We load A_in[b_idx, m_idx, :] to [1, N] L1, run dot with identity,
+    and store the result back to Out[b_idx, m_idx, :].
+    """
+
+    @T.prim_func
+    def main(
+        A_in: T.Tensor((B, M, N), dtype),
+        B_in: T.Tensor((N, N), dtype),
+        Out: T.Tensor((B, M, N), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, subid):
+            l1_a = T.alloc_L1([1, N], dtype)
+            l1_b = T.alloc_L1([N, N], dtype)
+            l0_c = T.alloc_L0C([1, N], accum_dtype)
+
+            with T.Scope("Cube"):
+                tail_m = 1
+                tail_n = N
+                tail_k = N
+
+                # GM -> L1: 3D slice (b_idx, m_idx, :) to 2D L1.
+                T.npuir_load_nd2nz(A_in[b_idx, m_idx, 0], l1_a, [tail_m, tail_k])
+                T.npuir_load_nd2nz(B_in[0, 0], l1_b, [tail_n, tail_k])
+
+                # L1 × L1 -> L0C.
+                T.npuir_dot(
+                    l1_a,
+                    l1_b,
+                    l0_c,
+                    initC=True,
+                    b_transpose=True,
+                    size=[tail_m, tail_k, tail_n],
+                )
+
+                # L0C -> GM: back to the same (b_idx, m_idx, :) slice in 3D GM.
+                with T.rs("PIPE_FIX"):
+                    T.npuir_store_fixpipe(
+                        l0_c,
+                        Out[b_idx, m_idx, 0],
+                        size=[tail_m, tail_n],
+                        enable_nz2nd=True,
+                    )
+
+    return main
+
+
+def test_cube_sliced_copy_3d():
+    print("\n" + "=" * 30 + " Running Cube Sliced Copy 3D Test " + "=" * 30)
+
+    B_dim, M, N = 4, 16, 32
+    b_idx, m_idx = 1, 7
+
+    kernel = cube_sliced_copy_3d(B_dim, M, N, b_idx, m_idx)
+
+    # A: only slice (b_idx, m_idx, :) is non-zero.
+    A = torch.zeros(B_dim, M, N).npu().half()
+    row = torch.arange(1, N + 1, dtype=torch.float16).npu()
+    A[b_idx, m_idx] = row
+
+    # B: identity matrix on the last dimension.
+    B = torch.eye(N, dtype=torch.float16).npu()
+
+    Out = torch.zeros(B_dim, M, N).npu().half()
+
+    kernel(A, B, Out)
+
+    expected = torch.zeros(B_dim, M, N).npu().half()
+    expected[b_idx, m_idx] = row
+
+    torch.testing.assert_close(Out, expected, rtol=1e-5, atol=1e-5)
+
+    print("Cube Sliced Copy 3D Test Passed!")
+
+
+@tilelang.jit(out_idx=[-1], target="npuir")
+def cube_sliced_copy_4d(B, H, M, N, b_idx, h_idx, m_idx, dtype="float16", accum_dtype="float32"):
+    """
+    4D GM <-> 2D L1 / 2D L0C on Cube.
+
+    A_in: [B, H, M, N], only slice (b_idx, h_idx, m_idx, :) is non-zero.
+    B_in: [N, N] identity.
+    The selected 1×N slice is moved to 2D L1, computed in 2D L0C, and
+    stored back into the same 4D GM position.
+    """
+
+    @T.prim_func
+    def main(
+        A_in: T.Tensor((B, H, M, N), dtype),
+        B_in: T.Tensor((N, N), dtype),
+        Out: T.Tensor((B, H, M, N), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, subid):
+            l1_a = T.alloc_L1([1, N], dtype)
+            l1_b = T.alloc_L1([N, N], dtype)
+            l0_c = T.alloc_L0C([1, N], accum_dtype)
+
+            with T.Scope("Cube"):
+                tail_m = 1
+                tail_n = N
+                tail_k = N
+
+                # GM -> L1: 4D slice (b_idx, h_idx, m_idx, :) to 2D L1.
+                T.npuir_load_nd2nz(A_in[b_idx, h_idx, m_idx, 0], l1_a, [tail_m, tail_k])
+                T.npuir_load_nd2nz(B_in[0, 0], l1_b, [tail_n, tail_k])
+
+                # L1 × L1 -> L0C.
+                T.npuir_dot(
+                    l1_a,
+                    l1_b,
+                    l0_c,
+                    initC=True,
+                    b_transpose=True,
+                    size=[tail_m, tail_k, tail_n],
+                )
+
+                # L0C -> GM: back to the same (b_idx, h_idx, m_idx, :) slice in 4D GM.
+                with T.rs("PIPE_FIX"):
+                    T.npuir_store_fixpipe(
+                        l0_c,
+                        Out[b_idx, h_idx, m_idx, 0],
+                        size=[tail_m, tail_n],
+                        enable_nz2nd=True,
+                    )
+
+    return main
+
+
+def test_cube_sliced_copy_4d():
+    print("\n" + "=" * 30 + " Running Cube Sliced Copy 4D Test " + "=" * 30)
+
+    B_dim, H, M, N = 2, 4, 16, 32
+    b_idx, h_idx, m_idx = 1, 2, 5
+
+    kernel = cube_sliced_copy_4d(B_dim, H, M, N, b_idx, h_idx, m_idx)
+
+    # A: only slice (b_idx, h_idx, m_idx, :) is non-zero.
+    A = torch.zeros(B_dim, H, M, N).npu().half()
+    row = torch.arange(1, N + 1, dtype=torch.float16).npu()
+    A[b_idx, h_idx, m_idx] = row
+
+    # B: identity matrix on the last dimension.
+    B = torch.eye(N, dtype=torch.float16).npu()
+
+    Out = torch.zeros(B_dim, H, M, N).npu().half()
+
+    kernel(A, B, Out)
+
+    expected = torch.zeros(B_dim, H, M, N).npu().half()
+    expected[b_idx, h_idx, m_idx] = row
+
+    torch.testing.assert_close(Out, expected, rtol=1e-5, atol=1e-5)
+
+    print("Cube Sliced Copy 4D Test Passed!")
+
+
+def main():
+    test_cube_sliced_copy_2d()
+    test_cube_sliced_copy_3d()
+    test_cube_sliced_copy_4d()
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/npuir/test_copy_sliced_cube.py
+++ b/testing/npuir/test_copy_sliced_cube.py
@@ -44,8 +44,8 @@ def cube_sliced_copy_2d(M, N, idx, dtype="float16", accum_dtype="float32"):
                 tail_n = N
                 tail_k = N
 
-                T.npuir_load_nd2nz(A_in[idx:idx+tail_m, 0:tail_k], l1_a)
-                T.npuir_load_nd2nz(B_in[0:tail_n, 0:tail_k], l1_b)
+                T.npuir_load_nd2nz(A_in[idx, 0], l1_a, size=[tail_m, tail_k])
+                T.npuir_load_nd2nz(B_in[0, 0], l1_b, size=[tail_n, tail_k])
 
                 T.npuir_dot(
                     l1_a, l1_b, l0_c,
@@ -55,7 +55,8 @@ def cube_sliced_copy_2d(M, N, idx, dtype="float16", accum_dtype="float32"):
 
                 with T.rs("PIPE_FIX"):
                     T.npuir_store_fixpipe(
-                        l0_c, Out[idx:idx+tail_m, 0:tail_n],
+                        l0_c, Out[idx, 0],
+                        size=[tail_m, tail_n],
                         enable_nz2nd=True,
                     )
 
@@ -80,8 +81,8 @@ def cube_sliced_copy_3d(B, M, N, b_idx, m_idx, dtype="float16", accum_dtype="flo
                 tail_n = N
                 tail_k = N
 
-                T.npuir_load_nd2nz(A_in[b_idx:b_idx+1, m_idx:m_idx+tail_m, 0:tail_k], l1_a)
-                T.npuir_load_nd2nz(B_in[0:tail_n, 0:tail_k], l1_b)
+                T.npuir_load_nd2nz(A_in[b_idx, m_idx, 0], l1_a, size=[1, tail_m, tail_k])
+                T.npuir_load_nd2nz(B_in[0, 0], l1_b, size=[tail_n, tail_k])
 
                 T.npuir_dot(
                     l1_a, l1_b, l0_c,
@@ -91,7 +92,8 @@ def cube_sliced_copy_3d(B, M, N, b_idx, m_idx, dtype="float16", accum_dtype="flo
 
                 with T.rs("PIPE_FIX"):
                     T.npuir_store_fixpipe(
-                        l0_c, Out[b_idx:b_idx+1, m_idx:m_idx+tail_m, 0:tail_n],
+                        l0_c, Out[b_idx, m_idx, 0],
+                        size=[1, tail_m, tail_n],
                         enable_nz2nd=True,
                     )
 
@@ -116,8 +118,8 @@ def cube_sliced_copy_4d(B, H, M, N, b_idx, h_idx, m_idx, dtype="float16", accum_
                 tail_n = N
                 tail_k = N
 
-                T.npuir_load_nd2nz(A_in[b_idx:b_idx+1, h_idx:h_idx+1, m_idx:m_idx+tail_m, 0:tail_k], l1_a)
-                T.npuir_load_nd2nz(B_in[0:tail_n, 0:tail_k], l1_b)
+                T.npuir_load_nd2nz(A_in[b_idx, h_idx, m_idx, 0], l1_a, size=[1, 1, tail_m, tail_k])
+                T.npuir_load_nd2nz(B_in[0, 0], l1_b, size=[tail_n, tail_k])
 
                 T.npuir_dot(
                     l1_a, l1_b, l0_c,
@@ -127,7 +129,8 @@ def cube_sliced_copy_4d(B, H, M, N, b_idx, h_idx, m_idx, dtype="float16", accum_
 
                 with T.rs("PIPE_FIX"):
                     T.npuir_store_fixpipe(
-                        l0_c, Out[b_idx:b_idx+1, h_idx:h_idx+1, m_idx:m_idx+tail_m, 0:tail_n],
+                        l0_c, Out[b_idx, h_idx, m_idx, 0],
+                        size=[1, 1, tail_m, tail_n],
                         enable_nz2nd=True,
                     )
 


### PR DESCRIPTION
1. Rank reduction for nd2nz / fixpipe GM operands.
Introduce GenRankReducedSubviewFromRegion to drop static-1 dimensions from Region slices, so that higher-dimensional GM shapes (e.g. 1×M×N from a 3D/4D tensor) can be properly consumed by 2D Cube operations.
2. min_rank constraint for consistent callee signatures.
Add a min_rank parameter (default 2 for GM operands) to prevent aggressive rank reduction from collapsing shapes like [1, N] to 1D while other slices remain 2D. 
This ensures all GM operands within the same function share a uniform rank, avoiding type mismatches when convert-hivm-to-std outlines them into a unified callee signature.
3. Test coverage for sliced and dynamic-shape Cube pipelines.
Add test_copy_sliced_cube.py (static sliced copy with 2D/3D/4D GM) and test_copy_shape_dynamic_cube.py (dynamic tail-block copy with 2D/3D/4D GM). 
Each kernel exercises the full nd2nz → dot → fixpipe pipeline.