### PR TITLE
fix: support src slicing for ub_to_ub copy

### DIFF
--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -183,7 +183,7 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
       ss << ">";
     } else {
       PrimExpr len = 1;
-      for (auto &shape : src->shape) {
+      for (auto &shape : dst_extents) {
         len *= shape;
       }
       ss << "copy_ub_to_ub<" << get_dtype(dst) << ", "


### PR DESCRIPTION
Switched from `src->shape` to `dst_extents` to calculate the total length. This allows copying a slice from the source tensor to a full destination tensor.