### PR TITLE
[AscendNPU-IR] Support out_idx in jit-npu

### DIFF
--- a/testing/npuir/test_out_idx.py
+++ b/testing/npuir/test_out_idx.py
@@ -1,0 +1,139 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025.
+import os
+import torch
+import tilelang
+import tilelang.language as T
+
+torch.npu.set_device(0)
+tilelang.cache.clear_cache()
+
+@tilelang.jit(out_idx=[-1], target="npuir")
+def matmul(block_M, block_N, K_L1, dtype="float16", accum_dtype="float32"):
+    M = T.symbolic("M")
+    N = T.symbolic("N")
+    K = T.symbolic("K")
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), dtype),
+        B: T.Tensor((K, N), dtype),
+        C: T.Tensor((M, N), dtype)
+    ):
+        with T.Kernel(T.ceildiv(M, block_M) * T.ceildiv(N, block_N), is_npu=True) as (cid, _):
+            with T.Scope("Cube"):
+                bx = cid // T.ceildiv(N, block_N) * block_M
+                by = cid % T.ceildiv(N, block_N) * block_N
+                A_BUF = T.alloc_L1([block_M, K_L1], dtype)
+                B_BUF = T.alloc_L1([K_L1, block_N], dtype)
+                C_BUF = T.alloc_L0C([block_M, block_N], accum_dtype)
+
+                remain_M = T.min(M - bx, block_M)
+                remain_N = T.min(N - by, block_N)
+
+                for i in T.serial(T.ceildiv(K, K_L1)):
+                    remain_K = T.min(K - i * K_L1, K_L1)
+                    T.npuir_load_nd2nz(A[bx, i * K_L1], A_BUF, [remain_M, remain_K])
+                    T.npuir_load_nd2nz(B[i * K_L1, by], B_BUF, [remain_K, remain_N])
+
+                    if i == 0:
+                        T.npuir_dot(A_BUF, B_BUF, C_BUF, initC=True, b_transpose=False,
+                            size=[remain_M, remain_K, remain_N])
+                    else:
+                        T.npuir_dot(A_BUF, B_BUF, C_BUF, initC=False, b_transpose=False,
+                            size=[remain_M, remain_K, remain_N])
+
+                    T.npuir_store_fixpipe(C_BUF, C[bx, by],
+                        size=[remain_M, remain_N], enable_nz2nd=True)
+
+    return main
+
+
+def test_mat_mul():
+    
+    func = matmul(128, 256, 16)
+    # shape 1
+    M, N, K = 1024, 512, 2048
+    a = torch.randn(M, K).half().npu()
+    b = torch.randn(K, N).half().npu()
+    
+    c = func(a, b)
+    print(c)
+    ref_c = a @ b
+    print(ref_c)
+    torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
+
+    # shape 2
+    M, N, K = 512, 1024, 512
+    a = torch.randn(M, K).half().npu()
+    b = torch.randn(K, N).half().npu()
+    
+    c = func(a, b)
+    print(c)
+    ref_c = a @ b
+    print(ref_c)
+    torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
+    print("\033[92mAll check passed!\033[0m")
+
+@tilelang.jit(out_idx=[-2, -1], target="npuir")
+def minicv(M, N, K, block_M, block_N, dtype="float16", inner_dtype="float32"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @T.prim_func
+    def minicv(
+            A: T.Tensor((M, K), dtype),
+            B: T.Tensor((K, N), dtype),
+            C: T.Tensor((M, N), inner_dtype),
+            D: T.Tensor((M, N), inner_dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            blockx = cid // n_num
+            bx = blockx * block_M
+            blocky = cid % n_num
+            by = blocky * block_N
+
+            A_BUF = T.alloc_shared((block_M, K), dtype)
+            B_BUF = T.alloc_shared((K, block_N), dtype)
+            C_BUF = T.alloc_fragment((block_M, block_N), inner_dtype)
+            D_BUF = T.alloc_fragment((block_M, block_N), inner_dtype)
+
+            T.copy(A[bx, 0], A_BUF, [block_M, K])
+            T.copy(B[0, by], B_BUF, [K, block_N])
+
+            T.gemm(A_BUF, B_BUF, C_BUF, [block_M, K, block_N], initC = True)
+            T.vexp(C_BUF, D_BUF)
+
+            T.copy(C_BUF, C[bx, by], [block_M, block_N])
+            T.copy(D_BUF, D[bx, by], [block_M, block_N])
+
+    return minicv
+
+def test_minicv():
+    M = 1024
+    N = 1024
+    K = 512
+    dtype="float16"
+    inner_dtype="float32"
+
+    os.environ['TILELANG_ASCEND_WORKSPACE_SIZE'] = str(M * N)
+    func = minicv(M, N, K, 128, 256)
+
+    v1 = torch.randn(size=[M, K], dtype=eval("torch." + dtype)).npu()
+    v2 = torch.randn(size=[K, N], dtype=eval("torch." + dtype)).npu()
+
+    y_ref = torch.exp(v1.to(torch.float32) @ v2.to(torch.float32))
+    v3, v4 = func(v1, v2)
+
+    print(y_ref)
+    print(v4)
+    torch.testing.assert_close(v4, y_ref, rtol=1e-2, atol=1e-2)
+    print("\033[92mAll check passed!\033[0m")
+
+if __name__ == "__main__":
+    # test dynamic shape
+    os.environ['TILELANG_ASCEND_MODE'] = 'Expert'
+    test_mat_mul()
+    # test multi out_idxs
+    os.environ['TILELANG_ASCEND_MODE'] = 'Developer'
+    test_minicv()
+ 

--- a/tilelang/jit/__init__.py
+++ b/tilelang/jit/__init__.py
@@ -70,7 +70,7 @@ def compile(
     """
     if target == 'npuir':
         compile_npuir = compiler_npu()
-        return compile_npuir.compile(func)
+        return compile_npuir.compile(func, out_idx)
     return cached(
         func=func,
         out_idx=out_idx,

--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -954,7 +954,9 @@ class NPUUtils(object):
         return self.get_device_properties("npu")["num_vectorcore"]
 
 class JitKernel_NPU:
-    def __init__(self, metadata: dict) -> None:
+    def __init__(self, metadata: dict, out_idx=None) -> None:
+        self.out_idx = out_idx  
+        self.param_info = metadata.get('param_info', [])
         # 1 launch path
         self.so_launcher_path = f"{metadata['kernel_name']}.so"
         self.utils_name = f"{metadata['name']}"
@@ -1039,6 +1041,84 @@ class JitKernel_NPU:
             raise ValueError(f"Failed to evaluate grid expression '{result}': {e}")
 
     def __call__(self, *args: Any) -> Any:
+        # calculate the input params：total_params - out_params
+        total_params = len(self.param_info)
+        num_inputs = total_params - (len(self.out_idx) if self.out_idx is not None else 0)
+        
+        if len(args) != num_inputs:
+            raise ValueError(f"Expected {num_inputs} input tensors (total_params={total_params}, out_idx={self.out_idx}), got {len(args)}")
+        
+        self._calcu_grid(*args)
+        
+        # build the mapping from original inputs to the args position
+        orig_to_input = {}
+        input_pos = 0
+        for i, info in enumerate(self.param_info):
+            if not info['is_output']:
+                orig_to_input[i] = input_pos
+                input_pos += 1
+        
+        # build the symbolic var names to extra_args indices
+        sym_name_to_extra_idx = {}
+        if hasattr(self, 'symbolic') and self.symbolic:
+            for idx, sym_var in enumerate(self.symbolic.keys()):
+                sym_name_to_extra_idx[sym_var.name] = idx
+        
+        full_args = [None] * total_params
+        input_ptr = 0
+        output_created = []
+        
+        for i, info in enumerate(self.param_info):
+            if info['is_output']:
+                # create output tensor
+                dtype = info['dtype']
+                
+                # analyze the shape, replace the symbolic variables with actual values
+                shape = []
+                for dim in info['shape']:
+                    if isinstance(dim, tir.Var):
+                        var_name = dim.name
+                        
+                        # try to get the shape from input tensors
+                        if var_name in self.symbolic:
+                            tensor_idx, dim_idx = self.symbolic[var_name]
+                            if tensor_idx in orig_to_input:
+                                input_arg = args[orig_to_input[tensor_idx]]
+                                actual_dim = input_arg.shape[dim_idx]
+                                shape.append(actual_dim)
+                                continue
+                        
+                        # get the shape from extra_args
+                        if var_name in sym_name_to_extra_idx:
+                            extra_idx = sym_name_to_extra_idx[var_name]
+                            if extra_idx < len(self.extra_args):
+                                shape.append(self.extra_args[extra_idx])
+                            else:
+                                raise ValueError(f"Symbolic variable {var_name} not found in extra_args")
+                        else:
+                            raise ValueError(f"Unknown symbolic variable {var_name}")
+                    else:
+                        shape.append(int(dim))
+                
+                # create a 1D tensor if shape is none
+                if not shape:
+                    shape = [1]
+                
+                device = args[0].device if args else torch.device('cpu')
+                
+                # create the output tensor
+                tensor = torch.empty(shape, dtype=dtype, device=device)
+                output_created.append(tensor)
+                full_args[i] = tensor
+            else:
+                # input tensor
+                full_args[i] = args[input_ptr]
+                input_ptr += 1
+        
+        # append extra_args to full_args
+        full_args.extend(self.extra_args)
+        
+        # run kernel
         npu_utils = NPUUtils()
         t_module, t_function, t_n_regs, t_n_spills = npu_utils.load_binary(
             self.utils_name,
@@ -1047,8 +1127,7 @@ class JitKernel_NPU:
             self.utils_device,
             self.mix_mode,
         )
-        self._calcu_grid(*args)
-        return self.launch_npu(
+        self.launch_npu(
             self.launch_grid[0],
             self.launch_grid[1],
             self.launch_grid[2],
@@ -1058,17 +1137,32 @@ class JitKernel_NPU:
             self.launch_metadata,
             self.launch_enter_hook,
             self.launch_exit_hook,
-            *args,
-            *self.extra_args
+            *full_args  
         )
+        
+        if self.out_idx is None:
+            return None
+        if len(self.out_idx) == 1:
+            return full_args[self.out_idx[0]]
+        else:
+            return [full_args[i] for i in self.out_idx]
 
 
 class compiler_npu:
     def __init__(self) -> None:
         pass
 
-    def compile(self, mod: PrimFunc) -> JitKernel_NPU:
+    def compile(self, mod: PrimFunc, out_idx=None) -> JitKernel_NPU:
+        self.original_mod = mod
+        # extract_param_info
+        param_info = self._extract_param_info(mod, out_idx)
+        # process negative out_idx
+        if out_idx is not None:
+            total_params = len(param_info)
+            out_idx = [i if i >= 0 else total_params + i for i in out_idx]
         self.metadata = {}
+        self.metadata["out_idx"] = out_idx
+        self.metadata["param_info"] = param_info
         self.mod, self.metadata["symbolic"] = _symbolic_var_promoter_pass(mod)
         # get grid message
         self._parse_grid()
@@ -1108,7 +1202,64 @@ class compiler_npu:
         self.so_launcher_path = self.make_npu_launcher_stub(
             self.metadata["kernel_name"], self.wrapper_src
         )
-        return JitKernel_NPU(metadata=self.metadata)
+        
+        return JitKernel_NPU(metadata=self.metadata, out_idx=out_idx)
+
+    def _extract_param_info(self, func: PrimFunc, out_idx):
+        """
+        Extract parameter information from PrimFunc.
+        
+        Returns a list of dicts, each containing:
+            - dtype: torch.dtype of the parameter
+            - shape: list of dimensions (may contain tir.Var for dynamic shapes)
+            - is_output: bool indicating if this parameter is an output tensor
+        """
+        buffer_map = func.buffer_map
+        params = func.params
+        info_list = []
+
+        # Convert out_idx to positive indices
+        total_params = len(params)
+        pos_out_idx = None
+        if out_idx is not None:
+            pos_out_idx = {i if i >= 0 else total_params + i for i in out_idx}
+        for i, param in enumerate(params):
+            if param in buffer_map:
+                # Tensor parameter (has buffer)
+                buffer = buffer_map[param]
+                dtype_str = str(buffer.dtype)
+                torch_dtype = self._tvm_dtype_to_torch(dtype_str)
+                shape_expr = list(buffer.shape)
+                is_output = (pos_out_idx is not None and i in pos_out_idx)
+                info_list.append({
+                    'dtype': torch_dtype,
+                    'shape': shape_expr,
+                    'is_output': is_output
+                })
+            else:
+                # scalar param
+                torch_dtype = torch.float32  
+                if hasattr(self, 'signature') and i in self.signature:
+                    dtype_str = self.signature[i]
+                    torch_dtype = self._tvm_dtype_to_torch(dtype_str)
+                    info_list.append({
+                        'dtype': torch_dtype,
+                        'shape': [],
+                        'is_output': False
+                    })
+        return info_list
+
+    def _tvm_dtype_to_torch(self, dtype_str):
+        mapping = {
+            'float16': torch.float16,
+            'float32': torch.float32,
+            'int8': torch.int8,
+            'int16': torch.int16,
+            'int32': torch.int32,
+            'int64': torch.int64,
+            'bool': torch.bool,
+        }
+        return mapping.get(dtype_str, torch.float32)
 
     def _parse_grid(self):
         launcher = LaunchThreadExtractor()


### PR DESCRIPTION
This PR enhances the NPU JIT kernel adapter to automatically create output tensors based on out_idx, enabling the intuitive syntax o, lse = flashattn_fwd(q, k, v) instead of requiring explicit output tensor passing o, lse = flashattn_fwd(q, k, v, o, lse)

Key Changes
1. Parameter Information Extraction (_extract_param_info)
2. Automatic Output Tensor Creation in JitKernel_NPU.__call__  based on param_info and out_idx
3. Symbolic Variable Resolution through mapping between symbolic variables and their values from inputs/extra_args