### PR TITLE
[AscendNPU-IR] Replace T.Parallel with T.serial in copy_shape tests

### DIFF
--- a/testing/npuir/test_copy_shape_dev.py
+++ b/testing/npuir/test_copy_shape_dev.py
@@ -23,10 +23,10 @@ def copy_shape_1d_2d(M, N, block_M, block_N):
 
             A_BUF = T.alloc_shared((block_N), dtype)
 
-            for i in T.Parallel(block_M):
+            for i in T.serial(block_M):
                 bx = blockx * block_M + i
-                T.copy(A[bx, by], A_BUF) 
-                T.copy(A_BUF, B[bx, by])
+                T.copy(A[bx, by:by+block_N], A_BUF)
+                T.copy(A_BUF, B[bx, by:by+block_N])
 
     return copyShape
 
@@ -46,10 +46,10 @@ def copy_shape_2d_3d(M, N, block_M, block_N):
 
             A_BUF = T.alloc_shared((1, block_N), dtype)
 
-            for i in T.Parallel(block_M):
+            for i in T.serial(block_M):
                 bx = blockx * block_M + i  
-                T.copy(A[0, bx, by], A_BUF)  
-                T.copy(A_BUF, B[0, bx, by])       
+                T.copy(A[0, bx, by:by+block_N], A_BUF)
+                T.copy(A_BUF, B[0, bx, by:by+block_N])
                 
     return copyShape2D3D
 

--- a/testing/npuir/test_copy_shape_dynamic.py
+++ b/testing/npuir/test_copy_shape_dynamic.py
@@ -23,7 +23,7 @@ def copy_shape_1d_2d(M, N, block_M, block_N):
 
             A_BUF = T.alloc_ub((block_N), dtype)
 
-            for i in T.Parallel(block_M):
+            for i in T.serial(block_M):
                 bx = blockx * block_M + i 
                 t0 = shape_N - by
                 tile_size_N = T.min(block_N, t0) 
@@ -49,7 +49,7 @@ def copy_shape_2d_3d(M, N, block_M, block_N):
 
             A_BUF = T.alloc_ub((1, block_N), dtype)
 
-            for i in T.Parallel(block_M):
+            for i in T.serial(block_M):
                 bx = blockx * block_M + i
                 t0 = shape_N - by
                 tile_size_N = T.min(block_N, t0) 

--- a/testing/npuir/test_copy_shape_dynamic_dev.py
+++ b/testing/npuir/test_copy_shape_dynamic_dev.py
@@ -23,7 +23,7 @@ def copy_shape_1d_2d(M, N, block_M, block_N):
 
             A_BUF = T.alloc_shared((block_N), dtype)
 
-            for i in T.Parallel(block_M):
+            for i in T.serial(block_M):
                 bx = blockx * block_M + i 
                 t0 = shape_N - by
                 tile_size_N = T.min(block_N, t0) 
@@ -49,7 +49,7 @@ def copy_shape_2d_3d(M, N, block_M, block_N):
 
             A_BUF = T.alloc_shared((1, block_N), dtype)
 
-            for i in T.Parallel(block_M):
+            for i in T.serial(block_M):
                 bx = blockx * block_M + i
                 t0 = shape_N - by
                 tile_size_N = T.min(block_N, t0) 


### PR DESCRIPTION
We should not use the same BUF in T.Parallel for copy. This is semantically incorrect. This PR:
1. replace T.Parallel with T.serial
2. use slicing in test_copy_shape_dev

Note: dynamic shape doesn't support slicing yet, so size is kept. This will be fixed in the future.