### PR TITLE
v pipeline reform

### DIFF
--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -498,6 +498,27 @@ private:
         num_versions--;
       }
     }
+
+    // Special handling for output buffers. If a buffer is written in the last 
+    // stage and not read by any later stage, we can keep one more version to avoid unnecessary synchronization
+    if (num_versions == 1 && buffer_info.use == max_stage_) {
+      // Check if this buffer is written in the last stage
+      for (const auto& pair: pipeline_info_) {
+        const Block &block = pair.first;
+        const auto &info = pair.second;
+        if (info.stage == max_stage_) {
+          auto it = std::find_if(block->writes.begin(), block->writes.end(),
+                                  [&](const BufferRegion &buffer_region) {
+                                    return buffer_region->buffer.same_as(buffer);
+                                  });
+          if (it != block->writes.end()) {
+            num_versions = max_stage_;
+            break;
+          }
+        }
+      }
+    }
+
     return num_versions;
   }
 

--- a/src/transform/pipeline_planning.cc
+++ b/src/transform/pipeline_planning.cc
@@ -443,11 +443,18 @@ private:
           }
         }
         for (const BufferRegion &write : pipeline_stage_infos[i].writes) {
-          if (std::find_if(pinfo.writes.begin(), pinfo.writes.end(),
+          auto it = std::find_if(pinfo.writes.begin(), pinfo.writes.end(),
                            [&](const BufferRegion &r) {
                              return r->buffer == write->buffer &&
                                     MayConflict(r->region, write->region);
-                           }) != pinfo.writes.end()) {
+                           });
+          if (it != pinfo.writes.end()) {
+            bool exact_match = is_zero((*it)->region[0]->extent - write->region[0]->extent)
+                               && is_zero((*it)->region[0]->min - write->region[0]->min);
+            if (exact_match) {
+              // two write are exactly the same region
+              continue;
+            }
             LOG(FATAL) << "Pipeline planning error: Multiple writes to "
                           "overlapping buffer regions detected. "
                        << "Stage " << pinfo.original_order << " and stage " << i


### PR DESCRIPTION
v pipeline reform: 
1. output addr open double buffer. 
2. fix gen IR error when output addr is same with input.