### PR TITLE
[AscendNPU-IR][Developer] Fix dynamic slice input case for T.copy

### DIFF
--- a/testing/npuir/test_copy_shape_dynamic_dev.py
+++ b/testing/npuir/test_copy_shape_dynamic_dev.py
@@ -58,6 +58,23 @@ def copy_shape_2d_3d(M, N, block_M, block_N):
                 
     return copyShape2D3D
 
+
+def copy_dynamic_insert_slice_2d(M, K, block_M):
+    @T.prim_func
+    def copyDynamicInsertSlice2d(
+            A: T.Tensor((M, K), dtype),
+            B: T.Tensor((M, K), dtype),
+            shape_N: T.int32,
+    ):
+        with T.Kernel(T.ceildiv(M, block_M), is_npu=True) as (cid, _):
+            buf = T.alloc_shared((block_M, K), dtype)
+            BLOCK = T.min(block_M, shape_N - cid * block_M)
+            T.copy(A[cid * block_M, 0], buf, size=[BLOCK, K])
+            T.copy(buf, B[cid * block_M, 0], size=[BLOCK, K])
+
+    return copyDynamicInsertSlice2d
+
+
 def test_copy_shape_1d_2d():
     # In the futrue, Developer mode and Expert Mode will transition smoothly without
     # requiring explicit declarations.
@@ -95,10 +112,25 @@ def test_copy_shape_2d_3d():
     torch.testing.assert_close(v2, v_ref, rtol=1e-2, atol=1e-2)
     print("\033[92mAll check passed!\033[0m")
 
+
+def test_copy_dynamic_insert_slice_2d():
+    M, K, block_M = 32, 4, 16
+    shape_n = 27
+    v1 = torch.randn(size=[M, K], dtype=eval("torch." + dtype)).npu()
+    v2 = torch.zeros(size=[M, K], dtype=eval("torch." + dtype)).npu()
+    v_ref = v1.clone()
+    func = copy_dynamic_insert_slice_2d(M, K, block_M)
+    compiled_kernel = tilelang.compile(func, target="npuir")
+    compiled_kernel(v1, v2, shape_n)
+    torch.testing.assert_close(v2[:shape_n, :], v_ref[:shape_n, :], rtol=1e-2, atol=1e-2)
+    print("\033[92mcopy_dynamic_insert_slice_2d check passed!\033[0m")
+
+
 if __name__ == "__main__":
 
     os.environ['TILELANG_ASCEND_MODE'] = 'Developer'
 
     test_copy_shape_1d_2d()
     test_copy_shape_2d_3d()
+    test_copy_dynamic_insert_slice_2d()
 

--- a/tilelang/language/copy.py
+++ b/tilelang/language/copy.py
@@ -144,31 +144,37 @@ def copy(
         extent = list(size)
     else:
         assert src_extent or dst_extent, "Can't deduce copy extents from args"
-        # When one side is BufferLoad (extent=None), use the other side's extent
-        # for block copy.
-        if src_extent is None and dst_extent is not None:
-            extent = list(dst_extent)
-        elif dst_extent is None and src_extent is not None:
-            extent = list(src_extent)
-        else:
-            extent = []
-            for se, de in zip(src_extent, dst_extent):
-                if isinstance(se, tir.IntImm) and isinstance(de, tir.IntImm):
-                    extent.append(se if se.value >= de.value else de)
-                elif isinstance(se, tir.IntImm):
-                    extent.append(de)
-                else:
-                    extent.append(se)
+        max_len = max(len(src_extent or []), len(dst_extent or []))
+        src_extent = [1] * (max_len - len(src_extent)) + list(src_extent) if src_extent else [1] * max_len
+        dst_extent = [1] * (max_len - len(dst_extent)) + list(dst_extent) if dst_extent else [1] * max_len
+        extent = []
+        for se, de in zip(src_extent, dst_extent):
+            sv = getattr(se, "value", se)
+            dv = getattr(de, "value", de)
+            if isinstance(sv, int) and isinstance(dv, int):
+                extent.append(se if sv >= dv else de)
+            elif isinstance(sv, int) and sv == 1:
+                extent.append(de)
+            elif isinstance(dv, int) and dv == 1:
+                extent.append(se)
+            else:
+                extent.append(se)
 
     def _to_region(data, access_type):
         if isinstance(data, tir.Var) and T.has_let_value(data):
             data = T.get_let_value(data)
         if isinstance(data, tir.Buffer):
-            return buffer_to_tile_region(data, access_type)
+            ndim = len(data.shape)
+            trailing = extent[-ndim:] if len(extent) >= ndim else extent
+            return buffer_load_to_tile_region(
+                T.BufferLoad(data, [0] * ndim), access_type, trailing)
         elif isinstance(data, tir.BufferRegion):
-            return buffer_region_to_tile_region(data, access_type, extent)
+            return buffer_region_to_tile_region(
+                data, access_type, [x.extent for x in data.region])
         else:
-            return buffer_load_to_tile_region(data, access_type, extent)
+            ndim = len(data.buffer.shape)
+            trailing = extent[-ndim:] if len(extent) >= ndim else extent
+            return buffer_load_to_tile_region(data, access_type, trailing)
 
     src = _to_region(src, "r")
     dst = _to_region(dst, "w")


### PR DESCRIPTION
Fix T.copy(BufferLoad, Buffer, size=dynamic_value) where the Buffer side ignored the size parameter and always used its static shape as the region extent.