### PR TITLE
[AscendNPU-IR][Dev] Support sliced input and output for unary Op

### DIFF
--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -9,6 +9,7 @@
 #include "../op/ascend.h"
 #include "../op/builtin.h"
 #include "arith/pattern_match.h"
+#include <algorithm>
 #include <atomic>
 #include <cmath>
 #include <cstddef>
@@ -392,6 +393,19 @@ CodeGenTileLangNPUIRDEV::GetShape(Array<PrimExpr> shape_in) {
     } else {
       // Dynamic dimension "?x";
       shape.push_back(-1);
+    }
+  }
+  return shape;
+}
+
+inline Array<PrimExpr>
+CodeGenTileLangNPUIRDEV::GetShape(const Array<Range> &ranges) {
+  Array<PrimExpr> shape;
+  for (const auto &range : ranges) {
+    if (as_const_int(range->extent)) {
+      shape.push_back(range->extent);
+    } else {
+      shape.push_back(1);
     }
   }
   return shape;
@@ -2019,20 +2033,51 @@ mlir::Value CodeGenTileLangNPUIRDEV::BinaryOpCodegen(const PrimExprNode *op,
 template <typename T, typename U>
 void CodeGenTileLangNPUIRDEV::UnaryVecOpCodegen(const CallNode *op) {
   T npuirop(op->args, this->vmap);
-  auto in_data_name = GetVarValue(npuirop.src);
-  auto out_data_name = GetVarValue(npuirop.dst);
-  auto dims = getBroadcastDim(npuirop.src->shape, npuirop.dst->shape);
-  mlir::Type dst_type = out_data_name.getType();
-  mlir::TypeRange result_tensors(&dst_type, 1);
+  bool is_dynamic =
+      std::any_of(npuirop.src_range.begin(), npuirop.src_range.end(),
+                  [](const Range &r) { return !as_const_int(r->extent); });
+  if (is_dynamic) {
+    auto srcVal = GetVarValue(npuirop.src);
+    auto dstVal = GetVarValue(npuirop.dst);
+    auto dims = getBroadcastDim(npuirop.src->shape, npuirop.dst->shape);
+    mlir::Type dst_type = dstVal.getType();
+    mlir::TypeRange dst_tensors(&dst_type, 1);
+    // Create HIVM Op
+    auto newOp =
+        builder.create<U>(builder.getUnknownLoc(),
+                          dst_tensors,                       // result type
+                          srcVal,                            // in
+                          dstVal,                            // out
+                          builder.getDenseI64ArrayAttr({}),  // transpose
+                          builder.getDenseI64ArrayAttr(dims) // broadcast
+        );
+    SetVarValue(npuirop.dst, newOp->getResult(0));
+    return;
+  }
+  // src process
+  mlir::Value src = GenExtractSliceFromRegion(npuirop.src, npuirop.src_range);
+  // dst process
+  const auto &dst_range = npuirop.dst_range;
+  mlir::Value insertBase = NeedGenInsertSlice(npuirop.dst, dst_range, src);
+  bool needInsertSlice = (insertBase != GetVarValue(npuirop.dst));
+  // Create broadcast dim
+  Array<PrimExpr> src_shape = GetShape(npuirop.src_range);
+  Array<PrimExpr> dst_shape = GetShape(npuirop.dst_range);
+  llvm::SmallVector<int64_t> dims = getBroadcastDim(src_shape, dst_shape);
   // Create HIVM Op
   auto newOp = builder.create<U>(builder.getUnknownLoc(),
-                                 result_tensors, // result type
-                                 in_data_name,   // in
-                                 out_data_name,  // out
+                                 insertBase.getType(), // result type
+                                 src,                  // in
+                                 insertBase,           // out
                                  builder.getDenseI64ArrayAttr({}),  // transpose
                                  builder.getDenseI64ArrayAttr(dims) // broadcast
   );
-  SetVarValue(npuirop.dst, newOp->getResult(0));
+  mlir::Value newOpValue = newOp->getResult(0);
+  mlir::Value result =
+      needInsertSlice ? ReshapeCastAndInsertSlice(
+                            newOpValue, GetVarValue(npuirop.dst), dst_range)
+                      : newOpValue;
+  SetVarValue(npuirop.dst, result);
 }
 
 void CodeGenTileLangNPUIRDEV::BarrierCodegen(const CallNode *op) {
@@ -2078,14 +2123,13 @@ mlir::Value CodeGenTileLangNPUIRDEV::NeedGenInsertSlice(Buffer buffer_data,
     strides_val.push_back(builder.getI64IntegerAttr(1));
   }
 
-  auto srcTensorTy = src.getType().cast<mlir::TensorType>();
-  auto dstTensorTy =
-      GetVarValue(buffer_data).getType().cast<mlir::TensorType>();
-  auto elemTy = dstTensorTy.getElementType();
-  auto srcShape = srcTensorTy.getShape();
+  auto srcType = src.getType().cast<mlir::TensorType>();
+  auto dstType = GetVarValue(buffer_data).getType().cast<mlir::TensorType>();
+  auto elemType = dstType.getElementType();
+  auto srcShape = srcType.getShape();
 
   auto emptyTensor = builder.create<mlir::tensor::EmptyOp>(
-      builder.getUnknownLoc(), srcShape, elemTy);
+      builder.getUnknownLoc(), srcShape, elemType);
 
   return emptyTensor.getResult();
 }

--- a/src/target/codegen_npuir_dev.h
+++ b/src/target/codegen_npuir_dev.h
@@ -279,6 +279,7 @@ private:
   // returns HIVM address space against given address space
   mlir::hivm::AddressSpace GetHIVMAddressSpace(String address_space);
   std::vector<long int> GetShape(Array<PrimExpr> extents);
+  Array<PrimExpr> GetShape(const Array<Range> &ranges);
 
   friend void PrintConst(const FloatImmNode *op, CodeGenTileLangNPUIRDEV *p);
 

--- a/testing/npuir/arith_ops/test_slice_vexp_dev.py
+++ b/testing/npuir/arith_ops/test_slice_vexp_dev.py
@@ -1,0 +1,105 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+
+import tilelang
+import tilelang.language as T
+
+import torch
+
+import pytest
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [pytest.mark.mode("Developer")]
+
+DTYPES = ["float32", "float16"]
+
+
+@tilelang.jit(target="npuir")
+def vec_unary_op(block_M, block_N, dtype="float32"):
+    M = T.symbolic("M")
+    N = T.symbolic("N")
+
+    @T.prim_func
+    def vexp_slice(A: T.Tensor((M, N), dtype), C: T.Tensor((M, N), dtype)):
+        with T.Kernel(T.ceildiv(N, block_N) * T.ceildiv(M, block_M), is_npu=True) as (
+            cid,
+            _,
+        ):
+            blockx = cid % T.ceildiv(N, block_N)
+            bx = blockx * block_M
+            blocky = cid // T.ceildiv(N, block_N)
+            by = blocky * block_N
+
+            A_VEC = T.alloc_shared([block_M // 2, block_N], dtype)
+            C_VEC = T.alloc_shared([block_M, block_N], dtype)
+
+            T.copy(A[bx : bx + block_M // 2, by : by + block_N], A_VEC)
+            T.vexp(A_VEC, C_VEC[block_M // 2 : block_M, :])
+
+            T.copy(C_VEC[:block_M, :block_N], C[bx : bx + block_M, by : by + block_N])
+
+    return vexp_slice
+
+
+@pytest.mark.op("vexp_slice")
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_unary_op(dtype):
+
+    M, N = 32, 32
+
+    A = gen_tensor([M, N], dtype, kind="randn")
+    C = gen_tensor([M, N], dtype, kind="zeros")
+    expected = torch.exp(A)
+
+    func = vec_unary_op(32, 32, dtype)
+
+    func(A, C)
+
+    exp_slice = expected.cpu()[:16, :]
+    c_slice = C.cpu()[16:, :]
+
+    assert_close(c_slice, exp_slice, dtype=dtype)
+
+
+@tilelang.jit(target="npuir")
+def unary_op_broadcast(block_M, block_N, dtype="float32"):
+    M = T.symbolic("M")
+    N = T.symbolic("N")
+
+    @T.prim_func
+    def vexp_broadcast(A: T.Tensor((M, N), dtype), C: T.Tensor((M, N), dtype)):
+        with T.Kernel(T.ceildiv(N, block_N) * T.ceildiv(M, block_M), is_npu=True) as (
+            cid,
+            _,
+        ):
+            blockx = cid % T.ceildiv(N, block_N)
+            bx = blockx * block_M
+            blocky = cid // T.ceildiv(N, block_N)
+            by = blocky * block_N
+
+            A_VEC = T.alloc_shared([block_M, block_N], dtype)
+            C_VEC = T.alloc_shared([block_M, block_N], dtype)
+
+            T.copy(A[bx : bx + block_M, by : by + block_N], A_VEC)
+            T.vexp(A_VEC[0:1, :], C_VEC)
+
+            T.copy(C_VEC, C[bx : bx + block_M, by : by + block_N])
+
+    return vexp_broadcast
+
+
+@pytest.mark.op("vexp_broadcast")
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_unary_op_broadcast(dtype):
+
+    M, N = 32, 32
+
+    A = gen_tensor([M, N], dtype, kind="ones")
+    C = gen_tensor([M, N], dtype, kind="zeros")
+    expected = torch.exp(A[0, :].expand(M, N))
+
+    func = unary_op_broadcast(32, 32, dtype)
+
+    func(A, C)
+
+    assert_close(C.cpu(), expected.cpu(), dtype=dtype)


### PR DESCRIPTION
Support sliced input and output for unary Op
- Add extract slice operation for sliced source tensor
- Add insert slice operation for sliced destination tensor
- Delete broadcast op, the shape of the src and dst slice size should be the same, in stead of being broadcasted