### PR TITLE
[AscendNPU IR] Partially reconstructed the jit_npu

### DIFF
--- a/src/runtime/npu_utils.cpp
+++ b/src/runtime/npu_utils.cpp
@@ -283,10 +283,26 @@ static PyObject* copyMemory(PyObject* self, PyObject* args) {
   return Py_None;
 }
 
+static PyObject *getDeviceNum(PyObject *self, PyObject *args) {
+  int32_t deviceCount;
+
+  rtError_t rtRet = rtGetDeviceCount(&deviceCount);
+
+  if (rtRet != RT_ERROR_NONE) {
+    printf("rtGetDeviceCount failed, 0x%x", rtRet);
+    return NULL;
+  }
+  if (PyErr_Occurred()) {
+    return NULL;
+  }
+  return Py_BuildValue("I", deviceCount);
+}
+
 static PyMethodDef NpuUtilsMethods[] = {
     {"load_kernel_binary", loadKernelBinary, METH_VARARGS, "Load NPU kernel binary into NPU driver"},
     {"get_arch", getArch, METH_VARARGS, "Get soc version of NPU"},
     {"get_aicore_num", getAiCoreNum, METH_VARARGS, "Get the number of AI core"},
+    {"get_device_num", getDeviceNum, METH_VARARGS, "Get the number of Ascend device"},
     {"create_stream", createStream, METH_VARARGS, "Create a stream"},
     {"read_data_from_file", readDataFromBinaryFileWrapper, METH_VARARGS, "Read binary file into the array already allocated"},
     {"write_data_to_file", writeDataToBinaryFileWrapper, METH_VARARGS, "Write an array to a binary file"},

--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -15,6 +15,7 @@ import torch
 import torch_npu
 import functools
 from ..engine import lower
+from ..utils import NPUUtils
 
 from tvm import tir
 from tvm.tir import PrimFunc
@@ -758,44 +759,6 @@ def read_binary_file(file_path, mode="rb", chunk_size=None, return_type="bytes")
     except IOError as e:
         raise IOError(f"Error occurred while reading the file: {e}")
 
-
-class NPUUtils(object):
-    def __new__(cls):
-        if not hasattr(cls, "instance"):
-            cls.instance = super(NPUUtils, cls).__new__(cls)
-        return cls.instance
-
-    def __init__(self):
-        cache_path = "npu_utils.so"
-        import importlib.util
-
-        spec = importlib.util.spec_from_file_location("npu_utils", cache_path)
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        self.npu_utils_mod = mod
-
-    def load_binary(self, name, kernel, shared, device, mix_mode):
-        return self.npu_utils_mod.load_kernel_binary(
-            name, kernel, shared, device, mix_mode
-        )
-
-    @functools.lru_cache()
-    def get_device_properties(self, device):
-        num_aic = self.get_aicore_num()
-        num_aiv = num_aic * 2
-        return {"num_aicore": num_aic, "num_vectorcore": num_aiv}
-
-    @functools.lru_cache()
-    def get_arch(self):
-        return self.npu_utils_mod.get_arch()
-
-    @functools.lru_cache()
-    def get_aicore_num(self):
-        return self.npu_utils_mod.get_aicore_num()
-
-    @functools.lru_cache()
-    def get_aivector_core_num(self):
-        return self.get_device_properties("npu")["num_vectorcore"]
 
 class JitKernel_NPU:
     def __init__(self, metadata: dict, out_idx=None) -> None:

--- a/tilelang/utils/__init__.py
+++ b/tilelang/utils/__init__.py
@@ -13,3 +13,4 @@ from .language import (
     array_reduce,  # noqa: F401
 )
 from .deprecated import deprecated  # noqa: F401
+from .ascend_npu import NPUUtils  # noqa: F401

--- a/tilelang/utils/ascend_npu.py
+++ b/tilelang/utils/ascend_npu.py
@@ -1,0 +1,49 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+# Copied from bitblas
+import functools
+
+class NPUUtils(object):
+    def __new__(cls):
+        if not hasattr(cls, "instance"):
+            cls.instance = super(NPUUtils, cls).__new__(cls)
+        return cls.instance
+    
+    def __init__(self) -> None:
+        # TODO: change to use cache, non-fixed directory (Finish before 330)
+        fname = "npu_utils.so"
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("npu_utils", fname)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        self.npu_utils_mod = mod
+    
+    def load_binary(self, name, kernel, shared, device, mix_mode):
+        return self.npu_utils_mod.load_kernel_binary(
+            name, kernel, shared, device, mix_mode
+        )
+    
+    @functools.lru_cache()
+    def get_arch(self):
+        # Return Ascend soc version
+        return self.npu_utils_mod.get_arch()
+    
+    @functools.lru_cache()
+    def get_aicore_num(self):
+        # Return Ascend soc aicore number
+        return self.npu_utils_mod.get_aicore_num()
+    
+    @functools.lru_cache()
+    def get_aivector_core_num(self):
+        # Return Ascend soc vector core number
+        return self.get_aicore_num() * 2
+    
+    @functools.lru_cache()
+    def get_aicube_core_num(self):
+        # Return Ascend soc cube core number
+        return self.get_aicore_num()
+    
+    @functools.lru_cache()
+    def get_device_num(self):
+        # Return Ascend device number
+        return self.npu_utils_mod.get_device_num()


### PR DESCRIPTION
1. The number of Ascend devices obtained during runtime is added to prepare for distributed deployment.
2. Partially refactored the jit_npu code and moved the ascend utils to tilelang utils.