### PR TITLE
[AscendNPU-IR][Expert] Supprt slicing in fixpipe and nd2dz using T.copy

### DIFF
--- a/src/target/codegen_npuir_api.cc
+++ b/src/target/codegen_npuir_api.cc
@@ -952,12 +952,9 @@ mlir::Value CodeGenTileLangNPUIRAPI::GenRankReducedSubviewFromRegion(
   }
   const VarNode *v = buffer_data->data.get();
   mlir::Value v_value = GetVarValue(v);
-
-  // Fast path: when Region exactly matches the buffer with zero offsets we can
-  // return the original memref directly (no subview).
-  if (IsEqual(buffer_data->shape, region_shape) && AllZero(region_indices)) {
-    return v_value;
-  }
+  // Full-region marker used for fast path after rank-reduction shape is known.
+  const bool is_full_region =
+      IsEqual(buffer_data->shape, region_shape) && AllZero(region_indices);
 
   SmallVector<OpFoldResult> offsets;
   SmallVector<OpFoldResult> sizes;
@@ -1020,6 +1017,14 @@ mlir::Value CodeGenTileLangNPUIRAPI::GenRankReducedSubviewFromRegion(
   // Fallback: if all dims are static-1 and min_rank <= 1, keep one dim=1
   if (projectedReducedShape.empty()) {
     projectedReducedShape.push_back(1);
+  }
+
+  // Fast path: only reuse the original memref when no rank reduction is needed.
+  // For full-region slices like [1, 1, 32], we must still build a rank-reduced
+  // subview (e.g. 1x32) so Cube nd2nz/fixpipe keep the expected operand rank.
+  if (is_full_region &&
+      static_cast<int64_t>(projectedReducedShape.size()) == baseTy.getRank()) {
+    return v_value;
   }
 
   // Infer the rank-reduced memref type and create the SubViewOp.
@@ -1156,10 +1161,75 @@ mlir::Value CodeGenTileLangNPUIRAPI::BinaryOpCodegen(const PrimExprNode *op,
 ///   T.copy(T.region(A[bx, by], 1, 128, 256), T.region(A_VEC[0, 0],
 ///   2, 128, 256))
 /// after:
-///   memref.reinterpret_cast; memref.subview; memref.subview;
+///   (default) memref.reinterpret_cast; memref.subview; memref.subview;
 ///   memref.copy
+///   (expert cube path)
+///     - GM -> L1  : hivm.hir.nd2nz
+///     - L0C -> GM : hivm.hir.fixpipe (enable_nz2nd=true)
 void CodeGenTileLangNPUIRAPI::AscendCopyCodegen(const CallNode *op) {
   tvm::tl::AscendCopy npuirop(op->args, this->vmap);
+
+  const std::string src_scope = GetPtrStorageScope(npuirop.src->data);
+  const std::string dst_scope = GetPtrStorageScope(npuirop.dst->data);
+
+  // Expert mode extension:
+  //   T.copy(GM, L1) => nd2nz
+  // Keep GM min_rank=2 to maintain consistent GM rank across calls.
+  if (src_scope == "global" && dst_scope == "shared.dyn") {
+    mlir::Value src = GenRankReducedSubviewFromRegion(
+        npuirop.src, npuirop.src_range, /*min_rank=*/2);
+    mlir::Value dst =
+        GenRankReducedSubviewFromRegion(npuirop.dst, npuirop.dst_range);
+    mlir::UnitAttr dst_continuous = builder.getUnitAttr();
+    builder.create<mlir::hivm::ND2NZOp>(builder.getUnknownLoc(),
+                                        mlir::TypeRange{}, src, dst,
+                                        dst_continuous);
+    return;
+  }
+
+  // Expert mode extension:
+  //   T.copy(L0C, GM) => fixpipe
+  // Defaults match migration intent from explicit npuir_store_fixpipe:
+  //   enable_nz2nd=true, channel_split=false, pre_relu_mode=no_relu.
+  // Keep GM min_rank=2 to maintain consistent GM rank across calls.
+  if (src_scope == "wmma.accumulator" && dst_scope == "global") {
+    mlir::Value src =
+        GenRankReducedSubviewFromRegion(npuirop.src, npuirop.src_range);
+    mlir::Value dst = GenRankReducedSubviewFromRegion(
+        npuirop.dst, npuirop.dst_range, /*min_rank=*/2);
+
+    mlir::UnitAttr enable_nz2nd = builder.getUnitAttr();
+    mlir::hivm::FixpipePreReluMode pre_relu_mode = fixpipe_pre_relu_mode[0];
+    auto src_dtype = npuirop.src->dtype;
+    auto dst_dtype = npuirop.dst->dtype;
+    mlir::hivm::FixpipePreQuantMode pre_quant_mode =
+        mlir::hivm::FixpipePreQuantMode::NO_QUANT;
+    if (src_dtype != dst_dtype) {
+      if (src_dtype == DataType::Float(32) && dst_dtype == DataType::Float(16)) {
+        pre_quant_mode = mlir::hivm::FixpipePreQuantMode::F322F16;
+      } else if (src_dtype == DataType::Float(32) &&
+                 dst_dtype == DataType::BFloat(16)) {
+        pre_quant_mode = mlir::hivm::FixpipePreQuantMode::F322BF16;
+      } else if (src_dtype == DataType::Int(32) &&
+                 dst_dtype == DataType::Int(8)) {
+        pre_quant_mode = mlir::hivm::FixpipePreQuantMode::S322I8;
+      } else {
+        LOG(FATAL) << "Unexpected pre-quant mode in T.copy(L0C, GM).";
+      }
+    }
+    mlir::hivm::FixpipePreQuantModeAttr pre_quant =
+        mlir::hivm::FixpipePreQuantModeAttr::get(builder.getContext(),
+                                                 pre_quant_mode);
+    mlir::hivm::FixpipePreReluModeAttr pre_relu =
+        mlir::hivm::FixpipePreReluModeAttr::get(builder.getContext(),
+                                                pre_relu_mode);
+    mlir::BoolAttr channel_split = builder.getBoolAttr(false);
+    builder.create<mlir::hivm::FixpipeOp>(
+        builder.getUnknownLoc(), mlir::TypeRange{}, src, dst, enable_nz2nd,
+        pre_quant, pre_relu, channel_split);
+    return;
+  }
+
   mlir::Value src_sub_view =
       GenSubviewFromRegion(npuirop.src, npuirop.src_range);
   mlir::Value dst_sub_view =

--- a/testing/npuir/test_copy_shape_dynamic_cube.py
+++ b/testing/npuir/test_copy_shape_dynamic_cube.py
@@ -55,13 +55,14 @@ def cube_copy_shape_1d_2d(M, N, block_M, block_N):
             l0_c = T.alloc_L0C((1, block_N), "float32")
 
             with T.Scope("Cube"):
-                for i in T.Parallel(block_M):
+                for i in T.serial(block_M):
                     bx = blockx * block_M + i
                     t0 = shape_N - by
                     tile_size_N = T.min(block_N, t0)
 
-                    T.npuir_load_nd2nz(A[bx, by], l1_a, size=[1, tile_size_N])
-                    T.npuir_load_nd2nz(Id[0, 0], l1_b, size=[tile_size_N, tile_size_N])
+                    T.copy(A[bx:bx + 1, by:by + tile_size_N], l1_a[0:1, 0:tile_size_N])
+                    T.copy(Id[0:tile_size_N, 0:tile_size_N],
+                           l1_b[0:tile_size_N, 0:tile_size_N])
 
                     T.npuir_dot(
                         l1_a, l1_b, l0_c,
@@ -70,11 +71,7 @@ def cube_copy_shape_1d_2d(M, N, block_M, block_N):
                     )
 
                     with T.rs("PIPE_FIX"):
-                        T.npuir_store_fixpipe(
-                            l0_c, B[bx, by],
-                            size=[1, tile_size_N],
-                            enable_nz2nd=True,
-                        )
+                        T.copy(l0_c[0:1, 0:tile_size_N], B[bx:bx + 1, by:by + tile_size_N])
 
     return copyShapeCube
 
@@ -102,13 +99,14 @@ def cube_copy_shape_2d_3d(M, N, block_M, block_N):
             l0_c = T.alloc_L0C((1, block_N), "float32")
 
             with T.Scope("Cube"):
-                for i in T.Parallel(block_M):
+                for i in T.serial(block_M):
                     bx = blockx * block_M + i
                     t0 = shape_N - by
                     tile_size_N = T.min(block_N, t0)
 
-                    T.npuir_load_nd2nz(A[0, bx, by], l1_a, size=[1, 1, tile_size_N])
-                    T.npuir_load_nd2nz(Id[0, 0], l1_b, size=[tile_size_N, tile_size_N])
+                    T.copy(A[0, bx:bx + 1, by:by + tile_size_N], l1_a[0:1, 0:tile_size_N])
+                    T.copy(Id[0:tile_size_N, 0:tile_size_N],
+                           l1_b[0:tile_size_N, 0:tile_size_N])
 
                     T.npuir_dot(
                         l1_a, l1_b, l0_c,
@@ -117,11 +115,7 @@ def cube_copy_shape_2d_3d(M, N, block_M, block_N):
                     )
 
                     with T.rs("PIPE_FIX"):
-                        T.npuir_store_fixpipe(
-                            l0_c, B[0, bx, by],
-                            size=[1, 1, tile_size_N],
-                            enable_nz2nd=True,
-                        )
+                        T.copy(l0_c[0:1, 0:tile_size_N], B[0, bx:bx + 1, by:by + tile_size_N])
 
     return copyShapeCube2D3D
 
@@ -149,13 +143,14 @@ def cube_copy_shape_3d_4d(M, N, block_M, block_N):
             l0_c = T.alloc_L0C((1, block_N), "float32")
 
             with T.Scope("Cube"):
-                for i in T.Parallel(block_M):
+                for i in T.serial(block_M):
                     bx = blockx * block_M + i
                     t0 = shape_N - by
                     tile_size_N = T.min(block_N, t0)
 
-                    T.npuir_load_nd2nz(A[0, 0, bx, by], l1_a, size=[1, 1, 1, tile_size_N])
-                    T.npuir_load_nd2nz(Id[0, 0], l1_b, size=[tile_size_N, tile_size_N])
+                    T.copy(A[0, 0, bx:bx + 1, by:by + tile_size_N], l1_a[0:1, 0:tile_size_N])
+                    T.copy(Id[0:tile_size_N, 0:tile_size_N],
+                           l1_b[0:tile_size_N, 0:tile_size_N])
 
                     T.npuir_dot(
                         l1_a, l1_b, l0_c,
@@ -164,11 +159,8 @@ def cube_copy_shape_3d_4d(M, N, block_M, block_N):
                     )
 
                     with T.rs("PIPE_FIX"):
-                        T.npuir_store_fixpipe(
-                            l0_c, B[0, 0, bx, by],
-                            size=[1, 1, 1, tile_size_N],
-                            enable_nz2nd=True,
-                        )
+                        T.copy(l0_c[0:1, 0:tile_size_N],
+                               B[0, 0, bx:bx + 1, by:by + tile_size_N])
 
     return copyShapeCube3D4D
 

--- a/testing/npuir/test_copy_simple_dev.py
+++ b/testing/npuir/test_copy_simple_dev.py
@@ -7,7 +7,7 @@ import tilelang.language as T
 torch.npu.set_device(0)
 tilelang.cache.clear_cache()
 
-@tilelang.jit(out_idx=[-1], target="npuir")
+@tilelang.jit(target="npuir")
 def simple_copy_1d(L, block_L, dtype="float16", accum_dtype="float32"):
     @T.prim_func
     def main(
@@ -35,7 +35,7 @@ def simple_copy_1d(L, block_L, dtype="float16", accum_dtype="float32"):
 
     return main
 
-@tilelang.jit(out_idx=[-1], target="npuir")
+@tilelang.jit(target="npuir")
 def simple_copy_2d(M, N, block_M, block_N, dtype="float16", accum_dtype="float32"):
     @T.prim_func
     def main(
@@ -63,7 +63,7 @@ def simple_copy_2d(M, N, block_M, block_N, dtype="float16", accum_dtype="float32
 
     return main
 
-@tilelang.jit(out_idx=[-1], target="npuir")
+@tilelang.jit(target="npuir")
 def simple_copy_3d(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="float32"):
     @T.prim_func
     def main(

--- a/testing/npuir/test_copy_sliced_cube.py
+++ b/testing/npuir/test_copy_sliced_cube.py
@@ -26,7 +26,7 @@ tilelang.cache.clear_cache()
 # Kernel builders
 # ---------------------------------------------------------------------------
 
-@tilelang.jit(out_idx=[-1], target="npuir")
+@tilelang.jit(target="npuir")
 def cube_sliced_copy_2d(M, N, idx, dtype="float16", accum_dtype="float32"):
     @T.prim_func
     def main(
@@ -44,8 +44,8 @@ def cube_sliced_copy_2d(M, N, idx, dtype="float16", accum_dtype="float32"):
                 tail_n = N
                 tail_k = N
 
-                T.npuir_load_nd2nz(A_in[idx, 0], l1_a, size=[tail_m, tail_k])
-                T.npuir_load_nd2nz(B_in[0, 0], l1_b, size=[tail_n, tail_k])
+                T.copy(A_in[idx:idx + tail_m, 0:tail_k], l1_a[0:tail_m, 0:tail_k])
+                T.copy(B_in[0:tail_n, 0:tail_k], l1_b[0:tail_n, 0:tail_k])
 
                 T.npuir_dot(
                     l1_a, l1_b, l0_c,
@@ -54,16 +54,12 @@ def cube_sliced_copy_2d(M, N, idx, dtype="float16", accum_dtype="float32"):
                 )
 
                 with T.rs("PIPE_FIX"):
-                    T.npuir_store_fixpipe(
-                        l0_c, Out[idx, 0],
-                        size=[tail_m, tail_n],
-                        enable_nz2nd=True,
-                    )
+                    T.copy(l0_c[0:tail_m, 0:tail_n], Out[idx:idx + tail_m, 0:tail_n])
 
     return main
 
 
-@tilelang.jit(out_idx=[-1], target="npuir")
+@tilelang.jit(target="npuir")
 def cube_sliced_copy_3d(B, M, N, b_idx, m_idx, dtype="float16", accum_dtype="float32"):
     @T.prim_func
     def main(
@@ -81,8 +77,8 @@ def cube_sliced_copy_3d(B, M, N, b_idx, m_idx, dtype="float16", accum_dtype="flo
                 tail_n = N
                 tail_k = N
 
-                T.npuir_load_nd2nz(A_in[b_idx, m_idx, 0], l1_a, size=[1, tail_m, tail_k])
-                T.npuir_load_nd2nz(B_in[0, 0], l1_b, size=[tail_n, tail_k])
+                T.copy(A_in[b_idx, m_idx:m_idx + tail_m, 0:tail_k], l1_a[0:tail_m, 0:tail_k])
+                T.copy(B_in[0:tail_n, 0:tail_k], l1_b[0:tail_n, 0:tail_k])
 
                 T.npuir_dot(
                     l1_a, l1_b, l0_c,
@@ -91,16 +87,12 @@ def cube_sliced_copy_3d(B, M, N, b_idx, m_idx, dtype="float16", accum_dtype="flo
                 )
 
                 with T.rs("PIPE_FIX"):
-                    T.npuir_store_fixpipe(
-                        l0_c, Out[b_idx, m_idx, 0],
-                        size=[1, tail_m, tail_n],
-                        enable_nz2nd=True,
-                    )
+                    T.copy(l0_c[0:tail_m, 0:tail_n], Out[b_idx, m_idx:m_idx + tail_m, 0:tail_n])
 
     return main
 
 
-@tilelang.jit(out_idx=[-1], target="npuir")
+@tilelang.jit(target="npuir")
 def cube_sliced_copy_4d(B, H, M, N, b_idx, h_idx, m_idx, dtype="float16", accum_dtype="float32"):
     @T.prim_func
     def main(
@@ -118,8 +110,8 @@ def cube_sliced_copy_4d(B, H, M, N, b_idx, h_idx, m_idx, dtype="float16", accum_
                 tail_n = N
                 tail_k = N
 
-                T.npuir_load_nd2nz(A_in[b_idx, h_idx, m_idx, 0], l1_a, size=[1, 1, tail_m, tail_k])
-                T.npuir_load_nd2nz(B_in[0, 0], l1_b, size=[tail_n, tail_k])
+                T.copy(A_in[b_idx, h_idx, m_idx:m_idx + tail_m, 0:tail_k], l1_a[0:tail_m, 0:tail_k])
+                T.copy(B_in[0:tail_n, 0:tail_k], l1_b[0:tail_n, 0:tail_k])
 
                 T.npuir_dot(
                     l1_a, l1_b, l0_c,
@@ -128,11 +120,8 @@ def cube_sliced_copy_4d(B, H, M, N, b_idx, h_idx, m_idx, dtype="float16", accum_
                 )
 
                 with T.rs("PIPE_FIX"):
-                    T.npuir_store_fixpipe(
-                        l0_c, Out[b_idx, h_idx, m_idx, 0],
-                        size=[1, 1, tail_m, tail_n],
-                        enable_nz2nd=True,
-                    )
+                    T.copy(l0_c[0:tail_m, 0:tail_n],
+                           Out[b_idx, h_idx, m_idx:m_idx + tail_m, 0:tail_n])
 
     return main
 

--- a/testing/npuir/test_copy_sliced_dev.py
+++ b/testing/npuir/test_copy_sliced_dev.py
@@ -10,7 +10,7 @@ tilelang.cache.clear_cache()
 # ==========================================
 # 2D Kernel & Test
 # ==========================================
-@tilelang.jit(out_idx=[-1], target="npuir")
+@tilelang.jit(target="npuir")
 def test_slice_copy_2d(block_M, block_N, idx, idx2, dtype="float16"):
     @T.prim_func
     def main(
@@ -116,7 +116,7 @@ def test_2d():
 # ==========================================
 # 3D Kernel & Test
 # ==========================================
-@tilelang.jit(out_idx=[-1], target="npuir")
+@tilelang.jit(target="npuir")
 def test_slice_copy_3d(B, M, N, idx, idx2, dtype="float16"):
     @T.prim_func
     def main(
@@ -211,7 +211,7 @@ def test_3d():
 # ==========================================
 # 4D Kernel & Test
 # ==========================================
-@tilelang.jit(out_idx=[-1], target="npuir")
+@tilelang.jit(target="npuir")
 def test_slice_copy_4d(B, H, M, N, idx_b, idx_h, idx_b2, idx_h2, dtype="float16"):
     @T.prim_func
     def main(

--- a/testing/npuir/test_copy_sliced_extended_dev.py
+++ b/testing/npuir/test_copy_sliced_extended_dev.py
@@ -11,7 +11,7 @@ tilelang.cache.clear_cache()
 # 4D Strided Kernel & Test (FIXED)
 # Pattern: [Scalar, Slice, Scalar, Slice]
 # ==========================================
-@tilelang.jit(out_idx=[-1], target="npuir")
+@tilelang.jit(target="npuir")
 def test_strided_copy_4d_kernel(
     B, S, H, D,        # Shape (Constants)
     S_blk, D_blk,      # Block Sizes (Constants)
@@ -89,7 +89,7 @@ def test_4d_strided():
 # Pattern: [Scalar, Scalar, Slice, Scalar, Slice]
 # Optimization: Merge idx_0 and idx_1 to avoid 16-arg limit
 # ==========================================
-@tilelang.jit(out_idx=[-1], target="npuir")
+@tilelang.jit(target="npuir")
 def test_strided_copy_5d_kernel(
     D0, D1, D2, D3, D4, # Shape (Constants)
     Blk_2, Blk_4,       # Block Sizes (Constants)

--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -1301,6 +1301,19 @@ class compiler_npu:
             except Exception as e:
                 print(f"error: {str(e)}")
                 sys.exit(1)
+
+            if not Path(bin_path).exists():
+                err_lines = [
+                    "AscendNPU IR compile reported success but output object was not generated.",
+                    f"Expected output: {bin_path}",
+                    f"cmd: {' '.join(cmd_list)}",
+                ]
+                if ret.stdout:
+                    err_lines.append(f"stdout:\n{ret.stdout}")
+                if ret.stderr:
+                    err_lines.append(f"stderr:\n{ret.stderr}")
+                raise RuntimeError("\n".join(err_lines))
+
             return Path(bin_path).read_bytes()
 
     def make_npu_launcher_stub(self, name: str, source: Union[str, os.PathLike], debug=False):


### PR DESCRIPTION
1. Add nd2nz and fixpipe support in copycodegen
2. replace 'fixpipe' and 'nd2nz' with 'size' in copy_*_cube .py tests with sliced 'T.copy'
3. remove out_index in copy tests
4. add Path(bin_path).exists() in jit_npu for better error debug