### PR TITLE
[AscendNPU-IR][CI] Simplify npuir pytest-infra logic by allowing only two types of marks.

### DIFF
--- a/testing/npuir/README.md
+++ b/testing/npuir/README.md
@@ -1,127 +1,165 @@
-# NPUIR Pytest Manual
+# NPUIR Pytest Conventions
 
-This directory uses shared pytest infra from:
+This directory uses a narrow pytest contract on purpose. The goal is to keep test
+selection predictable for contributors and keep execution behavior derived from a
+single source of truth.
 
-- `conftest.py`: CLI filters and session setup
-- `testcommon.py`: tensor/assert/mode helpers
-- `pytest.ini`: marker registration and default options
+## Design
 
-## Quick Start
+The test model is split into three layers:
 
-```bash
-# all npuir tests
-pytest testing/npuir
+- Marker metadata: `op` and `mode`
+- Runtime controls: `--op`, `--mode`, `--npu-device`
+- Test matrix: `dtype`, shapes, and other case dimensions via `@pytest.mark.parametrize(...)`
 
-# one op folder
-pytest testing/npuir/copy
+That split is intentional:
 
-# one file
-pytest testing/npuir/copy/test_copy_simple_dev.py
+- `op` and `mode` are the only custom markers. They define what a test is.
+- CLI options only choose which tests to run and which NPU device to use.
+- Data-oriented coverage stays inside the test matrix instead of growing more CLI flags.
 
-# one test
-pytest testing/npuir/copy/test_copy_simple_dev.py::test_copy_simple_2d_dev
-```
+## Marker Rules
 
-## CLI Filters
+Only two custom markers are valid:
 
-```bash
-# by op
-pytest testing/npuir --op=copy
-pytest testing/npuir --op=copy,sigmoid
+- `@pytest.mark.op("<real-op>")`
+- `@pytest.mark.mode("<mode>")`
 
-# by dtype
-pytest testing/npuir --dtype=float16
-pytest testing/npuir --dtype=float16,float32
-
-# by mode
-pytest testing/npuir --mode=Developer
-
-# device/seed
-pytest testing/npuir --npu-device=0 --seed=42
-
-# combined (AND)
-pytest testing/npuir --op=copy --dtype=float16 --mode=Developer --npu-device=0
-```
-
-Filter behavior:
-
-- `--op`: first matches `@pytest.mark.op("...")`; if missing, infers from test name `test_*_...`.
-- `--dtype`: keeps tests with at least one matching `@pytest.mark.dtype(...)`.
-- `--mode`: matches `@pytest.mark.mode("...")`.
-
-## Marker Patterns
-
-Function-level:
-
-```python
-import pytest
-
-@pytest.mark.copy
-@pytest.mark.op("copy")
-@pytest.mark.dtype("float16")
-@pytest.mark.mode("Developer")
-def test_copy_simple_2d_dev():
-    ...
-```
-
-Module-level (`pytestmark`):
+Use file-level `pytestmark` when a whole file shares the same metadata:
 
 ```python
 import pytest
 
 pytestmark = [
-    pytest.mark.copy,
     pytest.mark.op("copy"),
+    pytest.mark.mode("Developer"),
 ]
 ```
 
-Param-level dtype:
+Use test-level markers only when a file intentionally mixes different ops or modes:
 
 ```python
 import pytest
 
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        pytest.param("float16", marks=pytest.mark.dtype("float16")),
-        pytest.param("float32", marks=pytest.mark.dtype("float32")),
-    ],
-)
-def test_copy_dtype(dtype):
+@pytest.mark.op("copy")
+@pytest.mark.mode("Developer")
+def test_copy_dev():
+    ...
+
+@pytest.mark.op("copy")
+@pytest.mark.mode("Expert")
+def test_copy_release():
     ...
 ```
 
-## DType Combo Helper (Recommended)
+The closest marker wins. In practice that means a test-level marker overrides a
+file-level marker of the same kind.
 
-Use `build_dtype_param_combos` from `testcommon.py` to avoid manual enumeration.
+## Runtime Rules
+
+`--npu-device` is the only supported device selector in this pytest layer. The
+session hook sets the current device once before tests run.
+
+`mode` is marker-driven. Contributors should not manually wrap tests with
+`with ascend_mode(...)`. The pytest runtime reads the closest `mode` marker and
+applies `ascend_mode(mode)` automatically around the test body.
+
+## Test Matrix Rules
+
+Use `@pytest.mark.parametrize(...)` for case dimensions such as:
+
+- input/output dtype
+- shapes and block sizes
+- index selections
+- other data-dependent coverage dimensions
+
+Example:
 
 ```python
 import pytest
-from testcommon import build_dtype_param_combos
 
-IN_DTYPES = ["float16", "float32"]
-OUT_DTYPES = ["float16", "float32"]
-ACCUM_DTYPES = ["float32"]
+pytestmark = [pytest.mark.op("copy")]
 
-# 2 lists
-IO_COMBOS = build_dtype_param_combos(IN_DTYPES, OUT_DTYPES)
+DTYPE_CASES = [
+    ("float16", "float16"),
+    ("float16", "float32"),
+    ("float32", "float32"),
+]
 
-# 3 lists (or more)
-IOA_COMBOS = build_dtype_param_combos(IN_DTYPES, OUT_DTYPES, ACCUM_DTYPES)
+SHAPE_CASES = [
+    (256, 1024, 32, 32),
+    (512, 512, 64, 64),
+]
 
-# optional custom id prefixes
-IOA_COMBOS_NAMED = build_dtype_param_combos(
-    IN_DTYPES, OUT_DTYPES, ACCUM_DTYPES, names=["input", "output", "accum"]
-)
-
-@pytest.mark.parametrize("in_dtype, out_dtype", IO_COMBOS)
-def test_io(in_dtype, out_dtype):
+@pytest.mark.parametrize("in_dtype, out_dtype", DTYPE_CASES)
+@pytest.mark.parametrize("M, N, block_M, block_N", SHAPE_CASES)
+def test_copy_shape(M, N, block_M, block_N, in_dtype, out_dtype):
     ...
 ```
 
-## Minimal Conventions
+## Contributor Rules
 
-- File name: `test_*.py`
-- Prefer test name pattern: `test_<op>_<case>`
-- Add `@pytest.mark.op("<op>")` for reliable `--op` filtering
-- Keep device selection centralized via `--npu-device` (avoid hardcoded device ids in tests)
+- Do not add custom markers beyond `op` and `mode`.
+- Do not add `@pytest.mark.dtype(...)`.
+- Do not add folder-category markers such as `@pytest.mark.memory`.
+- Do not call `torch.npu.set_device(...)` inside tests.
+- Prefer file-level `pytestmark` for shared `op` / `mode`.
+- Use test-level markers only when a file intentionally needs overrides.
+- Keep compile and execution work inside test functions, not at module import time.
+
+The directory name remains the category signal for humans. For example,
+`memory_ops/` tells readers the family of tests, while `@pytest.mark.op("copy")`
+identifies the real operation used by CLI filtering.
+
+## CLI
+
+```bash
+# all NPUIR tests
+pytest testing/npuir
+
+# one folder
+pytest testing/npuir/memory_ops
+
+# one file
+pytest testing/npuir/memory_ops/test_copy_shape_dev.py
+
+# filtered by op
+pytest testing/npuir --op=copy
+
+# filtered by mode
+pytest testing/npuir --mode=Developer
+
+# combined selection
+pytest testing/npuir --op=copy --mode=Developer --npu-device=0
+```
+
+`--op` and `--mode` accept comma-separated values.
+
+## How Filtering Works
+
+- `--op` matches the closest `@pytest.mark.op(...)`
+- `--mode` matches the closest `@pytest.mark.mode(...)`
+- `--npu-device` sets the session device before tests execute
+
+Tests without a matching marker are excluded when that selector is provided.
+
+## Minimal Template
+
+```python
+import pytest
+
+pytestmark = [
+    pytest.mark.op("copy"),
+    pytest.mark.mode("Developer"),
+]
+
+DTYPES = ["float16", "float32"]
+CASES = [
+    (256, 1024, 32, 32),
+]
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("M, N, block_M, block_N", CASES)
+def test_copy_shape_dev(M, N, block_M, block_N, dtype):
+    ...
+```

--- a/testing/npuir/atomic_ops/test_atomic_add.py
+++ b/testing/npuir/atomic_ops/test_atomic_add.py
@@ -6,9 +6,12 @@ import torch_npu  # noqa: F401
 import tilelang
 import tilelang.language as T
 
-from testcommon import ascend_mode, assert_close, gen_tensor
+from testcommon import assert_close, gen_tensor
 
-pytestmark = [pytest.mark.op("atomic_add")]
+pytestmark = [
+    pytest.mark.op("atomic_add"),
+    pytest.mark.mode("Expert"),
+]
 
 DTYPES = ["float32"]
 ATOMIC_ADD_1D_CASES = [(64, 32)]
@@ -69,31 +72,27 @@ def vec_atomic_add_2d(M, N, block_M, block_N, dtype="float32"):
 
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("N, block_size", ATOMIC_ADD_1D_CASES)
-@pytest.mark.mode("Expert")
 def test_vec_atomic_add_1d(dtype, N, block_size):
-    with ascend_mode("Expert"):
-        A = gen_tensor((N,), dtype, kind="randn")
-        B = gen_tensor((N,), dtype, kind="randn")
-        expected = A + B
+    A = gen_tensor((N,), dtype, kind="randn")
+    B = gen_tensor((N,), dtype, kind="randn")
+    expected = A + B
 
-        func = vec_atomic_add_1d(N, block_size=block_size, dtype=dtype)
-        compiled_kernel = tilelang.compile(func, target="npuir")
-        compiled_kernel(A, B, N)
+    func = vec_atomic_add_1d(N, block_size=block_size, dtype=dtype)
+    compiled_kernel = tilelang.compile(func, target="npuir")
+    compiled_kernel(A, B, N)
 
     assert_close(B.cpu(), expected.cpu(), dtype=dtype, rtol=1e-5, atol=1e-8)
 
 
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("M, N, block_M, block_N", ATOMIC_ADD_2D_CASES)
-@pytest.mark.mode("Expert")
 def test_vec_atomic_add_2d(dtype, M, N, block_M, block_N):
-    with ascend_mode("Expert"):
-        A = gen_tensor((M, N), dtype, kind="randn")
-        B = gen_tensor((M, N), dtype, kind="randn")
-        expected = A + B
+    A = gen_tensor((M, N), dtype, kind="randn")
+    B = gen_tensor((M, N), dtype, kind="randn")
+    expected = A + B
 
-        func = vec_atomic_add_2d(M, N, block_M=block_M, block_N=block_N, dtype=dtype)
-        compiled_kernel = tilelang.compile(func, target="npuir")
-        compiled_kernel(A, B, M, N)
+    func = vec_atomic_add_2d(M, N, block_M=block_M, block_N=block_N, dtype=dtype)
+    compiled_kernel = tilelang.compile(func, target="npuir")
+    compiled_kernel(A, B, M, N)
 
     assert_close(B.cpu(), expected.cpu(), dtype=dtype, rtol=1e-5, atol=1e-8)

--- a/testing/npuir/atomic_ops/test_atomic_add.py
+++ b/testing/npuir/atomic_ops/test_atomic_add.py
@@ -1,50 +1,50 @@
 # Copyright (c) Tile-AI Corporation.
 # Licensed under the MIT License.
-import os
+import pytest
+import torch_npu  # noqa: F401
 
 import tilelang
 import tilelang.language as T
 
-import torch
-import torch_npu
+from testcommon import ascend_mode, assert_close, gen_tensor
 
-tilelang.cache.clear_cache()
+pytestmark = [pytest.mark.op("atomic_add")]
 
-dtype = "float32"
+DTYPES = ["float32"]
+ATOMIC_ADD_1D_CASES = [(64, 32)]
+ATOMIC_ADD_2D_CASES = [(256, 256, 16, 16)]
+
 
 def vec_atomic_add_1d(N, block_size, dtype="float32"):
     n_blocks = N // block_size
-    
+
     @T.prim_func
     def vecAtomicAdd1D(
-            A: T.Tensor((N,), dtype),
-            B: T.Tensor((N,), dtype),
-            shape: T.int32,
+        A: T.Tensor((N,), dtype),
+        B: T.Tensor((N,), dtype),
+        shape: T.int32,
     ):
         with T.Kernel(n_blocks, is_npu=True) as (bid, _):
             A_VEC = T.alloc_ub((block_size,), dtype)
-            # B_VEC = T.alloc_ub((block_size,), dtype)
-            
             start = bid * block_size
             t0 = shape - start
             tail_size = T.min(block_size, t0)
-            
-            T.copy(A[start : start + tail_size], A_VEC[0:tail_size])
-
+            T.copy(A[start:start + tail_size], A_VEC[0:tail_size])
             T.npuir_atomic_add(B[start], A_VEC, [tail_size])
-            
-            # T.copy(A_VEC[0:tail_size], B[start : start + tail_size])
 
     return vecAtomicAdd1D
+
 
 def vec_atomic_add_2d(M, N, block_M, block_N, dtype="float32"):
     m_num = M // block_M
     n_num = N // block_N
+
     @T.prim_func
     def vecAtomicAdd2D(
-            A: T.Tensor((M, N), dtype),
-            B: T.Tensor((M, N), dtype),
-            shape_M: T.int32, shape_N: T.int32,
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, N), dtype),
+        shape_M: T.int32,
+        shape_N: T.int32,
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
             blockx = cid // n_num
@@ -54,55 +54,46 @@ def vec_atomic_add_2d(M, N, block_M, block_N, dtype="float32"):
             A_VEC = T.alloc_ub((block_M, block_N), dtype)
 
             t0 = shape_M - bx
-            tile_size_M = T.min(block_M, t0)        
+            tile_size_M = T.min(block_M, t0)
 
             t0 = shape_N - by
-            tile_size_N = T.min(block_N, t0)   
-            T.copy(A[bx : bx + tile_size_M, by : by + tile_size_N], A_VEC[0:tile_size_M, 0:tile_size_N]) 
-            T.npuir_atomic_add(B[bx, by], A_VEC, [tile_size_M, tile_size_N])           
-            
+            tile_size_N = T.min(block_N, t0)
+            T.copy(
+                A[bx:bx + tile_size_M, by:by + tile_size_N],
+                A_VEC[0:tile_size_M, 0:tile_size_N],
+            )
+            T.npuir_atomic_add(B[bx, by], A_VEC, [tile_size_M, tile_size_N])
+
     return vecAtomicAdd2D
 
-def test_vec_atomic_add_1d():
-    torch.npu.set_device(0)
-    vec_size = 64
-    
-    A = torch.randn(size=[vec_size], dtype=eval("torch." + dtype)).npu()
-    B = torch.randn(size=[vec_size], dtype=eval("torch." + dtype)).npu()
-    expected = A + B
 
-    func = vec_atomic_add_1d(vec_size, block_size=32)
-    compiled_kernel = tilelang.compile(func, target="npuir")
-    
-    print("Running 1D atomic add...")
-    compiled_kernel(A, B, vec_size)
-    
-    print("1D Verification:")
-    print(f"Expected: First few elements: {expected[0:64]}")
-    print(f"Actual: First few elements of B: {B[0:64]}")
-    print(f"All elements equal to expected: {torch.allclose(B, expected)}")
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("N, block_size", ATOMIC_ADD_1D_CASES)
+@pytest.mark.mode("Expert")
+def test_vec_atomic_add_1d(dtype, N, block_size):
+    with ascend_mode("Expert"):
+        A = gen_tensor((N,), dtype, kind="randn")
+        B = gen_tensor((N,), dtype, kind="randn")
+        expected = A + B
 
-def test_vec_atomic_add_2d():
-    torch.npu.set_device(0)
-    
-    M, N = 256, 256
-    
-    A = torch.randn(size=[M, N], dtype=eval("torch." + dtype)).npu()
-    B = torch.randn(size=[M, N], dtype=eval("torch." + dtype)).npu()
-    expected = A + B
+        func = vec_atomic_add_1d(N, block_size=block_size, dtype=dtype)
+        compiled_kernel = tilelang.compile(func, target="npuir")
+        compiled_kernel(A, B, N)
 
-    func = vec_atomic_add_2d(M, N, block_M=16, block_N=16)
-    compiled_kernel = tilelang.compile(func, target="npuir")
-    
-    print("\nRunning 2D atomic add...")
-    compiled_kernel(A, B, M, N)
-    
-    print("2D Verification:")
-    
-    print(f"Expected: First row elements: {expected[0:8, 0:8]}")
-    print(f"Actual: First row elements of B: {B[0:8, 0:8]}")
-    print(f"All elements equal to expected: {torch.allclose(B, expected)}")
+    assert_close(B.cpu(), expected.cpu(), dtype=dtype, rtol=1e-5, atol=1e-8)
 
-if __name__ == "__main__":
-    test_vec_atomic_add_1d()
-    test_vec_atomic_add_2d()
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("M, N, block_M, block_N", ATOMIC_ADD_2D_CASES)
+@pytest.mark.mode("Expert")
+def test_vec_atomic_add_2d(dtype, M, N, block_M, block_N):
+    with ascend_mode("Expert"):
+        A = gen_tensor((M, N), dtype, kind="randn")
+        B = gen_tensor((M, N), dtype, kind="randn")
+        expected = A + B
+
+        func = vec_atomic_add_2d(M, N, block_M=block_M, block_N=block_N, dtype=dtype)
+        compiled_kernel = tilelang.compile(func, target="npuir")
+        compiled_kernel(A, B, M, N)
+
+    assert_close(B.cpu(), expected.cpu(), dtype=dtype, rtol=1e-5, atol=1e-8)

--- a/testing/npuir/atomic_ops/test_atomic_add_dev.py
+++ b/testing/npuir/atomic_ops/test_atomic_add_dev.py
@@ -6,10 +6,11 @@ import torch_npu  # noqa: F401
 import tilelang
 import tilelang.language as T
 
-from testcommon import ascend_mode, assert_close, gen_tensor
+from testcommon import assert_close, gen_tensor
 
 pytestmark = [
     pytest.mark.op("atomic_add"),
+    pytest.mark.mode("Developer"),
 ]
 
 DTYPES = ["float32"]
@@ -71,31 +72,27 @@ def vec_atomic_add_2d(M, N, block_M, block_N, dtype="float32"):
 
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("N, block_size", ATOMIC_ADD_1D_CASES)
-@pytest.mark.mode("Developer")
 def test_vec_atomic_add_1d_dev(dtype, N, block_size):
-    with ascend_mode("Developer"):
-        A = gen_tensor((N,), dtype, kind="randn")
-        B = gen_tensor((N,), dtype, kind="randn")
-        expected = A + B
+    A = gen_tensor((N,), dtype, kind="randn")
+    B = gen_tensor((N,), dtype, kind="randn")
+    expected = A + B
 
-        func = vec_atomic_add_1d(N, block_size=block_size, dtype=dtype)
-        compiled_kernel = tilelang.compile(func, target="npuir")
-        compiled_kernel(A, B, N)
+    func = vec_atomic_add_1d(N, block_size=block_size, dtype=dtype)
+    compiled_kernel = tilelang.compile(func, target="npuir")
+    compiled_kernel(A, B, N)
 
     assert_close(B.cpu(), expected.cpu(), dtype=dtype, rtol=1e-5, atol=1e-8)
 
 
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("M, N, block_M, block_N", ATOMIC_ADD_2D_CASES)
-@pytest.mark.mode("Developer")
 def test_vec_atomic_add_2d_dev(dtype, M, N, block_M, block_N):
-    with ascend_mode("Developer"):
-        A = gen_tensor((M, N), dtype, kind="randn")
-        B = gen_tensor((M, N), dtype, kind="randn")
-        expected = A + B
+    A = gen_tensor((M, N), dtype, kind="randn")
+    B = gen_tensor((M, N), dtype, kind="randn")
+    expected = A + B
 
-        func = vec_atomic_add_2d(M, N, block_M=block_M, block_N=block_N, dtype=dtype)
-        compiled_kernel = tilelang.compile(func, target="npuir")
-        compiled_kernel(A, B, M, N)
+    func = vec_atomic_add_2d(M, N, block_M=block_M, block_N=block_N, dtype=dtype)
+    compiled_kernel = tilelang.compile(func, target="npuir")
+    compiled_kernel(A, B, M, N)
 
     assert_close(B.cpu(), expected.cpu(), dtype=dtype, rtol=1e-5, atol=1e-8)

--- a/testing/npuir/atomic_ops/test_atomic_add_dev.py
+++ b/testing/npuir/atomic_ops/test_atomic_add_dev.py
@@ -1,45 +1,52 @@
 # Copyright (c) Tile-AI Corporation.
 # Licensed under the MIT License.
-import os
+import pytest
+import torch_npu  # noqa: F401
 
 import tilelang
 import tilelang.language as T
 
-import torch
-import torch_npu
+from testcommon import ascend_mode, assert_close, gen_tensor
 
-tilelang.cache.clear_cache()
+pytestmark = [
+    pytest.mark.op("atomic_add"),
+]
 
-dtype = "float32"
+DTYPES = ["float32"]
+ATOMIC_ADD_1D_CASES = [(64, 32)]
+ATOMIC_ADD_2D_CASES = [(256, 256, 16, 16)]
+
 
 def vec_atomic_add_1d(N, block_size, dtype="float32"):
     n_blocks = N // block_size
 
     @T.prim_func
     def vecAtomicAdd1D(
-            A: T.Tensor((N,), dtype),
-            B: T.Tensor((N,), dtype),
-            shape: T.int32,
+        A: T.Tensor((N,), dtype),
+        B: T.Tensor((N,), dtype),
+        shape: T.int32,
     ):
         with T.Kernel(n_blocks, is_npu=True) as (bid, _):
             A_VEC = T.alloc_shared((block_size,), dtype)
             start = bid * block_size
-            t0 = shape - start 
+            t0 = shape - start
             tail_size = T.min(block_size, t0)
-            T.copy(A[start : start + tail_size], A_VEC[0:tail_size])
-    
+            T.copy(A[start:start + tail_size], A_VEC[0:tail_size])
             T.npuir_atomic_add(B[start], A_VEC, [tail_size])
 
     return vecAtomicAdd1D
 
+
 def vec_atomic_add_2d(M, N, block_M, block_N, dtype="float32"):
     m_num = M // block_M
     n_num = N // block_N
+
     @T.prim_func
     def vecAtomicAdd2D(
-            A: T.Tensor((M, N), dtype),
-            B: T.Tensor((M, N), dtype),
-            shape_M: T.int32, shape_N: T.int32,
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, N), dtype),
+        shape_M: T.int32,
+        shape_N: T.int32,
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
             blockx = cid // n_num
@@ -49,57 +56,46 @@ def vec_atomic_add_2d(M, N, block_M, block_N, dtype="float32"):
             A_VEC = T.alloc_shared((block_M, block_N), dtype)
 
             t0 = shape_M - bx
-            tile_size_M = T.min(block_M, t0)        
+            tile_size_M = T.min(block_M, t0)
 
             t0 = shape_N - by
-            tile_size_N = T.min(block_N, t0)   
-            T.copy(A[bx : bx + tile_size_M, by : by + tile_size_N], A_VEC[0:tile_size_M, 0:tile_size_N]) 
-            T.npuir_atomic_add(B[bx, by], A_VEC, [tile_size_M, tile_size_N])           
-
+            tile_size_N = T.min(block_N, t0)
+            T.copy(
+                A[bx:bx + tile_size_M, by:by + tile_size_N],
+                A_VEC[0:tile_size_M, 0:tile_size_N],
+            )
+            T.npuir_atomic_add(B[bx, by], A_VEC, [tile_size_M, tile_size_N])
 
     return vecAtomicAdd2D
 
-def test_vec_atomic_add_1d():
-    torch.npu.set_device(0)
-    vec_size = 64
 
-    A = torch.randn(size=[vec_size], dtype=eval("torch." + dtype)).npu()
-    B = torch.randn(size=[vec_size], dtype=eval("torch." + dtype)).npu()
-    expected = A + B
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("N, block_size", ATOMIC_ADD_1D_CASES)
+@pytest.mark.mode("Developer")
+def test_vec_atomic_add_1d_dev(dtype, N, block_size):
+    with ascend_mode("Developer"):
+        A = gen_tensor((N,), dtype, kind="randn")
+        B = gen_tensor((N,), dtype, kind="randn")
+        expected = A + B
 
-    func = vec_atomic_add_1d(vec_size, block_size=32)
-    compiled_kernel = tilelang.compile(func, target="npuir")
+        func = vec_atomic_add_1d(N, block_size=block_size, dtype=dtype)
+        compiled_kernel = tilelang.compile(func, target="npuir")
+        compiled_kernel(A, B, N)
 
-    print("Running 1D atomic add...")
-    compiled_kernel(A, B, vec_size)
+    assert_close(B.cpu(), expected.cpu(), dtype=dtype, rtol=1e-5, atol=1e-8)
 
-    print("1D Verification:")
-    print(f"Expected: First few elements: {expected[0:64]}")
-    print(f"Actual: First few elements of B: {B[0:64]}")
-    print(f"All elements equal to expected: {torch.allclose(B, expected)}")
 
-def test_vec_atomic_add_2d():
-    torch.npu.set_device(0)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("M, N, block_M, block_N", ATOMIC_ADD_2D_CASES)
+@pytest.mark.mode("Developer")
+def test_vec_atomic_add_2d_dev(dtype, M, N, block_M, block_N):
+    with ascend_mode("Developer"):
+        A = gen_tensor((M, N), dtype, kind="randn")
+        B = gen_tensor((M, N), dtype, kind="randn")
+        expected = A + B
 
-    M, N = 256, 256
+        func = vec_atomic_add_2d(M, N, block_M=block_M, block_N=block_N, dtype=dtype)
+        compiled_kernel = tilelang.compile(func, target="npuir")
+        compiled_kernel(A, B, M, N)
 
-    A = torch.randn(size=[M, N], dtype=eval("torch." + dtype)).npu()
-    B = torch.randn(size=[M, N], dtype=eval("torch." + dtype)).npu()
-    expected = A + B
-
-    func = vec_atomic_add_2d(M, N, block_M=16, block_N=16)
-    compiled_kernel = tilelang.compile(func, target="npuir")
-
-    print("\nRunning 2D atomic add...")
-    compiled_kernel(A, B, M, N)
-
-    print("2D Verification:")
-
-    print(f"Expected: First row elements: {expected[0:8, 0:8]}")
-    print(f"Actual: First row elements of B: {B[0:8, 0:8]}")
-    print(f"All elements equal to expected: {torch.allclose(B, expected)}")
-
-if __name__ == "__main__":
-    os.environ['TILELANG_ASCEND_MODE'] = 'Developer'
-    test_vec_atomic_add_1d()
-    test_vec_atomic_add_2d()
+    assert_close(B.cpu(), expected.cpu(), dtype=dtype, rtol=1e-5, atol=1e-8)

--- a/testing/npuir/atomic_ops/test_atomic_add_with_slice_reshape_dev.py
+++ b/testing/npuir/atomic_ops/test_atomic_add_with_slice_reshape_dev.py
@@ -1,10 +1,20 @@
-import torch
+import pytest
+import torch_npu  # noqa: F401
+
 import tilelang
 import tilelang.language as T
 
+from testcommon import ascend_mode, assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("atomic_add"),
+]
+
+DTYPES = ["float32"]
+ATOMIC_ADD_4D_CASES = [(2, 64, 4, 128)]
+
 
 def simple_4d_atomic_add_kernel(B, S, H, D, dtype="float32"):
-    
     @T.prim_func
     def atomic_add_4d(
         A: T.Tensor((B, S, H, D), dtype),
@@ -15,40 +25,24 @@ def simple_4d_atomic_add_kernel(B, S, H, D, dtype="float32"):
         with T.Kernel(B * H, is_npu=True) as (cid, _):
             b_idx = cid // shape_H
             h_idx = cid % shape_H
-            
             tile = T.alloc_shared((S, D), dtype)
-            
             T.copy(A[b_idx, 0:S, h_idx, 0:D], tile)
-
             T.npuir_atomic_add(B_tensor[b_idx, 0:S, h_idx, 0:D], tile)
-    
+
     return atomic_add_4d
 
 
-def test_atomic_add():
-    torch.npu.set_device(0)
-    
-    B, S, H, D = 2, 64, 4, 128
-    
-    A = torch.randn(B, S, H, D, dtype=torch.float32).npu()
-    B_tensor = torch.randn(B, S, H, D, dtype=torch.float32).npu()
-    
-    expected = A + B_tensor
-    
-    func = simple_4d_atomic_add_kernel(B, S, H, D)
-    compiled_kernel = tilelang.compile(func, target="npuir")
-    
-    print("Running 4D atomic add...")
-    compiled_kernel(A, B_tensor, B, H)
-    
-    print(f"Expected: First few elements: {expected[0:64]}")
-    print(f"Actual: First few elements of B: {B_tensor[0:64]}")
-    print(f"All elements equal to expected: {torch.allclose(B_tensor, expected)}")
-    
-    return B_tensor
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("B, S, H, D", ATOMIC_ADD_4D_CASES)
+@pytest.mark.mode("Developer")
+def test_atomic_add_with_slice_reshape_dev(dtype, B, S, H, D):
+    with ascend_mode("Developer"):
+        A = gen_tensor((B, S, H, D), dtype, kind="randn")
+        B_tensor = gen_tensor((B, S, H, D), dtype, kind="randn")
+        expected = A + B_tensor
 
+        func = simple_4d_atomic_add_kernel(B, S, H, D, dtype=dtype)
+        compiled_kernel = tilelang.compile(func, target="npuir")
+        compiled_kernel(A, B_tensor, B, H)
 
-if __name__ == "__main__":
-    import os
-    os.environ['TILELANG_ASCEND_MODE'] = 'Developer'
-    test_atomic_add()
+    assert_close(B_tensor.cpu(), expected.cpu(), dtype=dtype, rtol=1e-5, atol=1e-8)

--- a/testing/npuir/atomic_ops/test_atomic_add_with_slice_reshape_dev.py
+++ b/testing/npuir/atomic_ops/test_atomic_add_with_slice_reshape_dev.py
@@ -4,10 +4,11 @@ import torch_npu  # noqa: F401
 import tilelang
 import tilelang.language as T
 
-from testcommon import ascend_mode, assert_close, gen_tensor
+from testcommon import assert_close, gen_tensor
 
 pytestmark = [
     pytest.mark.op("atomic_add"),
+    pytest.mark.mode("Developer"),
 ]
 
 DTYPES = ["float32"]
@@ -34,15 +35,13 @@ def simple_4d_atomic_add_kernel(B, S, H, D, dtype="float32"):
 
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("B, S, H, D", ATOMIC_ADD_4D_CASES)
-@pytest.mark.mode("Developer")
 def test_atomic_add_with_slice_reshape_dev(dtype, B, S, H, D):
-    with ascend_mode("Developer"):
-        A = gen_tensor((B, S, H, D), dtype, kind="randn")
-        B_tensor = gen_tensor((B, S, H, D), dtype, kind="randn")
-        expected = A + B_tensor
+    A = gen_tensor((B, S, H, D), dtype, kind="randn")
+    B_tensor = gen_tensor((B, S, H, D), dtype, kind="randn")
+    expected = A + B_tensor
 
-        func = simple_4d_atomic_add_kernel(B, S, H, D, dtype=dtype)
-        compiled_kernel = tilelang.compile(func, target="npuir")
-        compiled_kernel(A, B_tensor, B, H)
+    func = simple_4d_atomic_add_kernel(B, S, H, D, dtype=dtype)
+    compiled_kernel = tilelang.compile(func, target="npuir")
+    compiled_kernel(A, B_tensor, B, H)
 
     assert_close(B_tensor.cpu(), expected.cpu(), dtype=dtype, rtol=1e-5, atol=1e-8)

--- a/testing/npuir/atomic_ops/test_atomic_addx4.py
+++ b/testing/npuir/atomic_ops/test_atomic_addx4.py
@@ -27,16 +27,17 @@ def run_atomic_addx4(M, N, block_M, block_N, dtype="float32"):
             blocky = cid % n_num
             A_VEC = T.alloc_ub((1, 4), dtype)
 
-            for i, j in T.Parallel(block_M, block_N // 4):
-                bx = blockx * block_M + i
-                by = blocky * block_N + j * 4
-                t0 = shape_M - bx
-                tile_size_M = T.min(block_M, t0)        
+            for i in T.serial(block_M):
+                for j in T.serial(block_N // 4):
+                    bx = blockx * block_M + i
+                    by = blocky * block_N + j * 4
+                    t0 = shape_M - bx
+                    tile_size_M = T.min(block_M, t0)        
 
-                t0 = shape_N - by
-                tile_size_N = T.min(block_N, t0)   
-                T.copy(A[bx : bx + 1, by : by + 4], A_VEC[0:1, 0:4])
-                T.npuir_atomic_addx4(B[bx, by], A_VEC, [1, 4])            
+                    t0 = shape_N - by
+                    tile_size_N = T.min(block_N, t0)   
+                    T.copy(A[bx : bx + 1, by : by + 4], A_VEC[0:1, 0:4])
+                    T.npuir_atomic_addx4(B[bx, by], A_VEC, [1, 4])            
             
     return atomicAddx4Program
 

--- a/testing/npuir/atomic_ops/test_atomic_addx4.py
+++ b/testing/npuir/atomic_ops/test_atomic_addx4.py
@@ -1,26 +1,29 @@
 # Copyright (c) Tile-AI Corporation.
 # Licensed under the MIT License.
-import os
+import pytest
+import torch_npu  # noqa: F401
 
 import tilelang
 import tilelang.language as T
 
-import torch
-import torch_npu
+from testcommon import ascend_mode, assert_close, gen_tensor
 
-tilelang.cache.clear_cache()
+pytestmark = [pytest.mark.op("atomic_addx4")]
 
-dtype = "float32"
+DTYPES = ["float32"]
+ATOMIC_ADDX4_CASES = [(256, 256, 16, 16)]
 
 
 def run_atomic_addx4(M, N, block_M, block_N, dtype="float32"):
     m_num = M // block_M
     n_num = N // block_N
+
     @T.prim_func
     def atomicAddx4Program(
-            A: T.Tensor((M, N), dtype),
-            B: T.Tensor((M, N), dtype),
-            shape_M: T.int32, shape_N: T.int32,
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, N), dtype),
+        shape_M: T.int32,
+        shape_N: T.int32,
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
             blockx = cid // n_num
@@ -32,39 +35,34 @@ def run_atomic_addx4(M, N, block_M, block_N, dtype="float32"):
                     bx = blockx * block_M + i
                     by = blocky * block_N + j * 4
                     t0 = shape_M - bx
-                    tile_size_M = T.min(block_M, t0)        
+                    tile_size_M = T.min(block_M, t0)
 
                     t0 = shape_N - by
-                    tile_size_N = T.min(block_N, t0)   
-                    T.copy(A[bx : bx + 1, by : by + 4], A_VEC[0:1, 0:4])
-                    T.npuir_atomic_addx4(B[bx, by], A_VEC, [1, 4])            
-            
+                    tile_size_N = T.min(block_N, t0)
+                    T.copy(A[bx:bx + 1, by:by + 4], A_VEC[0:1, 0:4])
+                    T.npuir_atomic_addx4(B[bx, by], A_VEC, [1, 4])
+
     return atomicAddx4Program
 
-def test_vec_atomic_addx4():
-    torch.npu.set_device(0)
-    
-    M, N = 256, 256
-    
-    A = torch.randn(size=[M, N], dtype=eval("torch." + dtype)).npu()
-    B = torch.zeros(size=[M, N], dtype=eval("torch." + dtype)).npu()
-    ref_B = B.clone()
 
-    for i in range(M):
-        for j in range(0, N - 3, 4):
-            ref_B[i, j] += A[i, j]
-            ref_B[i, j + 1] += A[i, j + 1]
-            ref_B[i, j + 2] += A[i, j + 2]
-            ref_B[i, j + 3] += A[i, j + 3]
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("M, N, block_M, block_N", ATOMIC_ADDX4_CASES)
+@pytest.mark.mode("Expert")
+def test_vec_atomic_addx4(dtype, M, N, block_M, block_N):
+    with ascend_mode("Expert"):
+        A = gen_tensor((M, N), dtype, kind="randn")
+        B = gen_tensor((M, N), dtype, kind="zeros")
+        ref_B = B.clone()
 
-    func = run_atomic_addx4(M, N, block_M=16, block_N=16)
-    compiled_kernel = tilelang.compile(func, target="npuir")
-    
-    print("\nRunning atomic addx4...")
-    compiled_kernel(A, B, M, N)
-    print(f"Expected: First few elements: {B[0:16]}")
-    print(f"Actual: First few elements of B: {ref_B[0:16]}")    
-    torch.testing.assert_close(B, ref_B, atol=1e-3, rtol=1e-3)
+        for i in range(M):
+            for j in range(0, N - 3, 4):
+                ref_B[i, j] += A[i, j]
+                ref_B[i, j + 1] += A[i, j + 1]
+                ref_B[i, j + 2] += A[i, j + 2]
+                ref_B[i, j + 3] += A[i, j + 3]
 
-if __name__ == "__main__":
-    test_vec_atomic_addx4()
+        func = run_atomic_addx4(M, N, block_M=block_M, block_N=block_N, dtype=dtype)
+        compiled_kernel = tilelang.compile(func, target="npuir")
+        compiled_kernel(A, B, M, N)
+
+    assert_close(B.cpu(), ref_B.cpu(), dtype=dtype, rtol=1e-3, atol=1e-3)

--- a/testing/npuir/atomic_ops/test_atomic_addx4.py
+++ b/testing/npuir/atomic_ops/test_atomic_addx4.py
@@ -6,9 +6,12 @@ import torch_npu  # noqa: F401
 import tilelang
 import tilelang.language as T
 
-from testcommon import ascend_mode, assert_close, gen_tensor
+from testcommon import assert_close, gen_tensor
 
-pytestmark = [pytest.mark.op("atomic_addx4")]
+pytestmark = [
+    pytest.mark.op("atomic_addx4"),
+    pytest.mark.mode("Expert"),
+]
 
 DTYPES = ["float32"]
 ATOMIC_ADDX4_CASES = [(256, 256, 16, 16)]
@@ -47,22 +50,20 @@ def run_atomic_addx4(M, N, block_M, block_N, dtype="float32"):
 
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("M, N, block_M, block_N", ATOMIC_ADDX4_CASES)
-@pytest.mark.mode("Expert")
 def test_vec_atomic_addx4(dtype, M, N, block_M, block_N):
-    with ascend_mode("Expert"):
-        A = gen_tensor((M, N), dtype, kind="randn")
-        B = gen_tensor((M, N), dtype, kind="zeros")
-        ref_B = B.clone()
+    A = gen_tensor((M, N), dtype, kind="randn")
+    B = gen_tensor((M, N), dtype, kind="zeros")
+    ref_B = B.clone()
 
-        for i in range(M):
-            for j in range(0, N - 3, 4):
-                ref_B[i, j] += A[i, j]
-                ref_B[i, j + 1] += A[i, j + 1]
-                ref_B[i, j + 2] += A[i, j + 2]
-                ref_B[i, j + 3] += A[i, j + 3]
+    for i in range(M):
+        for j in range(0, N - 3, 4):
+            ref_B[i, j] += A[i, j]
+            ref_B[i, j + 1] += A[i, j + 1]
+            ref_B[i, j + 2] += A[i, j + 2]
+            ref_B[i, j + 3] += A[i, j + 3]
 
-        func = run_atomic_addx4(M, N, block_M=block_M, block_N=block_N, dtype=dtype)
-        compiled_kernel = tilelang.compile(func, target="npuir")
-        compiled_kernel(A, B, M, N)
+    func = run_atomic_addx4(M, N, block_M=block_M, block_N=block_N, dtype=dtype)
+    compiled_kernel = tilelang.compile(func, target="npuir")
+    compiled_kernel(A, B, M, N)
 
     assert_close(B.cpu(), ref_B.cpu(), dtype=dtype, rtol=1e-3, atol=1e-3)

--- a/testing/npuir/atomic_ops/test_atomic_addx4_dev.py
+++ b/testing/npuir/atomic_ops/test_atomic_addx4_dev.py
@@ -1,26 +1,31 @@
 # Copyright (c) Tile-AI Corporation.
 # Licensed under the MIT License.
-import os
+import pytest
+import torch_npu  # noqa: F401
 
 import tilelang
 import tilelang.language as T
 
-import torch
-import torch_npu
+from testcommon import ascend_mode, assert_close, gen_tensor
 
-tilelang.cache.clear_cache()
+pytestmark = [
+    pytest.mark.op("atomic_addx4"),
+]
 
-dtype = "float32"
+DTYPES = ["float32"]
+ATOMIC_ADDX4_CASES = [(256, 256, 16, 16)]
 
 
 def run_atomic_addx4(M, N, block_M, block_N, dtype="float32"):
     m_num = M // block_M
     n_num = N // block_N
+
     @T.prim_func
     def atomicAddx4Program(
-            A: T.Tensor((M, N), dtype),
-            B: T.Tensor((M, N), dtype),
-            shape_M: T.int32, shape_N: T.int32,
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, N), dtype),
+        shape_M: T.int32,
+        shape_N: T.int32,
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
             blockx = cid // n_num
@@ -35,37 +40,31 @@ def run_atomic_addx4(M, N, block_M, block_N, dtype="float32"):
                     tile_size_M = T.min(block_M, t0)
 
                     t0 = shape_N - by
-                    tile_size_N = T.min(block_N, t0)   
-                    T.copy(A[bx : bx + 1, by : by + 4], A_VEC[0:1, 0:4])
-                    T.npuir_atomic_addx4(B[bx, by], A_VEC, [1, 4])            
-            
+                    tile_size_N = T.min(block_N, t0)
+                    T.copy(A[bx:bx + 1, by:by + 4], A_VEC[0:1, 0:4])
+                    T.npuir_atomic_addx4(B[bx, by], A_VEC, [1, 4])
+
     return atomicAddx4Program
 
-def test_vec_atomic_addx4():
-    torch.npu.set_device(0)
-    
-    M, N = 256, 256
-    
-    A = torch.randn(size=[M, N], dtype=eval("torch." + dtype)).npu()
-    B = torch.zeros(size=[M, N], dtype=eval("torch." + dtype)).npu()
-    ref_B = B.clone()
 
-    for i in range(M):
-        for j in range(0, N - 3, 4):
-            ref_B[i, j] += A[i, j]
-            ref_B[i, j + 1] += A[i, j + 1]
-            ref_B[i, j + 2] += A[i, j + 2]
-            ref_B[i, j + 3] += A[i, j + 3]
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("M, N, block_M, block_N", ATOMIC_ADDX4_CASES)
+@pytest.mark.mode("Developer")
+def test_vec_atomic_addx4_dev(dtype, M, N, block_M, block_N):
+    with ascend_mode("Developer"):
+        A = gen_tensor((M, N), dtype, kind="randn")
+        B = gen_tensor((M, N), dtype, kind="zeros")
+        ref_B = B.clone()
 
-    func = run_atomic_addx4(M, N, block_M=16, block_N=16)
-    compiled_kernel = tilelang.compile(func, target="npuir")
-    
-    print("\nRunning atomic addx4...")
-    compiled_kernel(A, B, M, N)
-    print(f"Expected: First few elements: {B[0:16]}")
-    print(f"Actual: First few elements of B: {ref_B[0:16]}")    
-    torch.testing.assert_close(B, ref_B, atol=1e-3, rtol=1e-3)
+        for i in range(M):
+            for j in range(0, N - 3, 4):
+                ref_B[i, j] += A[i, j]
+                ref_B[i, j + 1] += A[i, j + 1]
+                ref_B[i, j + 2] += A[i, j + 2]
+                ref_B[i, j + 3] += A[i, j + 3]
 
-if __name__ == "__main__":
-    os.environ['TILELANG_ASCEND_MODE'] = 'Developer'
-    test_vec_atomic_addx4()
+        func = run_atomic_addx4(M, N, block_M=block_M, block_N=block_N, dtype=dtype)
+        compiled_kernel = tilelang.compile(func, target="npuir")
+        compiled_kernel(A, B, M, N)
+
+    assert_close(B.cpu(), ref_B.cpu(), dtype=dtype, rtol=1e-3, atol=1e-3)

--- a/testing/npuir/atomic_ops/test_atomic_addx4_dev.py
+++ b/testing/npuir/atomic_ops/test_atomic_addx4_dev.py
@@ -6,10 +6,11 @@ import torch_npu  # noqa: F401
 import tilelang
 import tilelang.language as T
 
-from testcommon import ascend_mode, assert_close, gen_tensor
+from testcommon import assert_close, gen_tensor
 
 pytestmark = [
     pytest.mark.op("atomic_addx4"),
+    pytest.mark.mode("Developer"),
 ]
 
 DTYPES = ["float32"]
@@ -49,22 +50,20 @@ def run_atomic_addx4(M, N, block_M, block_N, dtype="float32"):
 
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("M, N, block_M, block_N", ATOMIC_ADDX4_CASES)
-@pytest.mark.mode("Developer")
 def test_vec_atomic_addx4_dev(dtype, M, N, block_M, block_N):
-    with ascend_mode("Developer"):
-        A = gen_tensor((M, N), dtype, kind="randn")
-        B = gen_tensor((M, N), dtype, kind="zeros")
-        ref_B = B.clone()
+    A = gen_tensor((M, N), dtype, kind="randn")
+    B = gen_tensor((M, N), dtype, kind="zeros")
+    ref_B = B.clone()
 
-        for i in range(M):
-            for j in range(0, N - 3, 4):
-                ref_B[i, j] += A[i, j]
-                ref_B[i, j + 1] += A[i, j + 1]
-                ref_B[i, j + 2] += A[i, j + 2]
-                ref_B[i, j + 3] += A[i, j + 3]
+    for i in range(M):
+        for j in range(0, N - 3, 4):
+            ref_B[i, j] += A[i, j]
+            ref_B[i, j + 1] += A[i, j + 1]
+            ref_B[i, j + 2] += A[i, j + 2]
+            ref_B[i, j + 3] += A[i, j + 3]
 
-        func = run_atomic_addx4(M, N, block_M=block_M, block_N=block_N, dtype=dtype)
-        compiled_kernel = tilelang.compile(func, target="npuir")
-        compiled_kernel(A, B, M, N)
+    func = run_atomic_addx4(M, N, block_M=block_M, block_N=block_N, dtype=dtype)
+    compiled_kernel = tilelang.compile(func, target="npuir")
+    compiled_kernel(A, B, M, N)
 
     assert_close(B.cpu(), ref_B.cpu(), dtype=dtype, rtol=1e-3, atol=1e-3)

--- a/testing/npuir/atomic_ops/test_atomic_addx4_dev.py
+++ b/testing/npuir/atomic_ops/test_atomic_addx4_dev.py
@@ -27,16 +27,17 @@ def run_atomic_addx4(M, N, block_M, block_N, dtype="float32"):
             blocky = cid % n_num
             A_VEC = T.alloc_shared((1, 4), dtype)
 
-            for i, j in T.Parallel(block_M, block_N // 4):
-                bx = blockx * block_M + i
-                by = blocky * block_N + j * 4
-                t0 = shape_M - bx
-                tile_size_M = T.min(block_M, t0)
+            for i in T.serial(block_M):
+                for j in T.serial(block_N // 4):
+                    bx = blockx * block_M + i
+                    by = blocky * block_N + j * 4
+                    t0 = shape_M - bx
+                    tile_size_M = T.min(block_M, t0)
 
-                t0 = shape_N - by
-                tile_size_N = T.min(block_N, t0)   
-                T.copy(A[bx : bx + 1, by : by + 4], A_VEC[0:1, 0:4])
-                T.npuir_atomic_addx4(B[bx, by], A_VEC, [1, 4])            
+                    t0 = shape_N - by
+                    tile_size_N = T.min(block_N, t0)   
+                    T.copy(A[bx : bx + 1, by : by + 4], A_VEC[0:1, 0:4])
+                    T.npuir_atomic_addx4(B[bx, by], A_VEC, [1, 4])            
             
     return atomicAddx4Program
 

--- a/testing/npuir/conftest.py
+++ b/testing/npuir/conftest.py
@@ -1,19 +1,21 @@
-import re
-from typing import List, Sequence
+import os
+from typing import List, Optional, Sequence
 
 import pytest
 
-from testcommon import clear_tilelang_cache, set_npu_device, set_seed
+from testcommon import ascend_mode, clear_tilelang_cache, set_npu_device, set_seed
+
+
+def _get_npu_device_id(config: pytest.Config) -> int:
+    """Device 0 for xdist gw0, 1 for gw1; else use --npu-device."""
+    worker = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker and worker.startswith("gw"):
+        return int(worker[2:])
+    return config.getoption("--npu-device")
 
 
 def pytest_addoption(parser):
     parser.addoption("--op", action="store", default="", help="Run only tests for specific op(s), comma-separated.")
-    parser.addoption(
-        "--dtype",
-        action="store",
-        default="",
-        help="Run only tests for specific dtype(s), comma-separated.",
-    )
     parser.addoption(
         "--mode",
         action="store",
@@ -28,35 +30,33 @@ def _parse_csv(text: str) -> List[str]:
     return [item.strip() for item in text.split(",") if item.strip()]
 
 
-def _marker_values(item: pytest.Item, marker_name: str) -> List[str]:
-    values: List[str] = []
-    for marker in item.iter_markers(marker_name):
-        values.extend(str(arg) for arg in marker.args)
-        values.extend(str(val) for val in marker.kwargs.values())
-    return values
+def _marker_value(item: pytest.Item, marker_name: str) -> Optional[str]:
+    marker = item.get_closest_marker(marker_name)
+    if marker is None:
+        return None
+
+    values = [str(arg) for arg in marker.args]
+    values.extend(str(val) for val in marker.kwargs.values())
+
+    if len(values) != 1:
+        raise pytest.UsageError(
+            f"{item.nodeid}: @{marker_name} must define exactly one value."
+        )
+    return values[0]
 
 
 def _matches_filter(item: pytest.Item, marker_name: str, selected: Sequence[str]) -> bool:
     if not selected:
         return True
-    marker_values = set(_marker_values(item, marker_name))
-    if marker_values:
-        return any(v in marker_values for v in selected)
-    if marker_name == "op":
-        test_name = item.name.split("[", 1)[0]
-        match = re.match(r"^test_([^_]+)_", test_name)
-        if match:
-            inferred_op = match.group(1)
-            return inferred_op in selected
-    return any(v in item.nodeid for v in selected)
+    marker_value = _marker_value(item, marker_name)
+    return marker_value in selected if marker_value is not None else False
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item]) -> None:
     selected_ops = _parse_csv(config.getoption("--op"))
-    selected_dtypes = _parse_csv(config.getoption("--dtype"))
     selected_modes = _parse_csv(config.getoption("--mode"))
 
-    if not (selected_ops or selected_dtypes or selected_modes):
+    if not (selected_ops or selected_modes):
         return
 
     selected_items: List[pytest.Item] = []
@@ -65,7 +65,6 @@ def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item
     for item in items:
         keep = (
             _matches_filter(item, "op", selected_ops)
-            and _matches_filter(item, "dtype", selected_dtypes)
             and _matches_filter(item, "mode", selected_modes)
         )
         if keep:
@@ -81,7 +80,18 @@ def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item
 @pytest.fixture(scope="session", autouse=True)
 def _setup_npu_session(pytestconfig: pytest.Config):
     seed = pytestconfig.getoption("--seed")
-    device_id = pytestconfig.getoption("--npu-device")
+    device_id = _get_npu_device_id(pytestconfig)
     set_seed(seed)
     set_npu_device(device_id)
     clear_tilelang_cache()
+
+
+@pytest.fixture(autouse=True)
+def _apply_mode_marker(request: pytest.FixtureRequest):
+    mode = _marker_value(request.node, "mode")
+    if mode is None:
+        yield
+        return
+
+    with ascend_mode(mode):
+        yield

--- a/testing/npuir/memory_ops/test_copy_shape_dev.py
+++ b/testing/npuir/memory_ops/test_copy_shape_dev.py
@@ -6,13 +6,19 @@ import torch_npu  # noqa: F401
 import tilelang
 import tilelang.language as T
 
-from testcommon import ascend_mode, assert_close, gen_tensor
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("copy"),
+    pytest.mark.mode("Developer"),
+]
+
+DTYPES = ["float16", "float32"]
+COPY_SHAPE_2D_CASES = [(256, 1024, 32, 32)]
+COPY_SHAPE_3D_CASES = [(256, 1024, 32, 32)]
 
 
-dtype = "float16"
-
-
-def copy_shape_1d_2d(M, N, block_M, block_N):
+def copy_shape_1d_2d(M, N, block_M, block_N, dtype):
     @T.prim_func
     def copyShapeDev1D2D(
         A: T.Tensor((M, N), dtype),
@@ -35,7 +41,7 @@ def copy_shape_1d_2d(M, N, block_M, block_N):
     return copyShapeDev1D2D
 
 
-def copy_shape_2d_3d(M, N, block_M, block_N):
+def copy_shape_2d_3d(M, N, block_M, block_N, dtype):
     @T.prim_func
     def copyShapeDev2D3D(
         A: T.Tensor((1, M, N), dtype),
@@ -56,40 +62,29 @@ def copy_shape_2d_3d(M, N, block_M, block_N):
     return copyShapeDev2D3D
 
 
-@pytest.mark.copy
-@pytest.mark.op("copy")
-@pytest.mark.dtype("float16")
-@pytest.mark.mode("Developer")
-def test_copy_shape_1d_2d_dev():
-    M = 256
-    N = 1024
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("M, N, block_M, block_N", COPY_SHAPE_2D_CASES)
+def test_copy_shape_1d_2d_dev(dtype, M, N, block_M, block_N):
     v1 = gen_tensor((M, N), dtype, kind="randn")
     v2 = gen_tensor((M, N), dtype, kind="zeros")
     v_ref = v1.clone()
 
-    with ascend_mode("Developer"):
-        func = copy_shape_1d_2d(M, N, block_M=32, block_N=32)
-        compiled_kernel = tilelang.compile(func, target="npuir")
-        compiled_kernel(v1, v2, M, N)
+    func = copy_shape_1d_2d(M, N, block_M=block_M, block_N=block_N, dtype=dtype)
+    compiled_kernel = tilelang.compile(func, target="npuir")
+    compiled_kernel(v1, v2, M, N)
 
     assert_close(v2.cpu(), v_ref.cpu(), dtype=dtype, rtol=1e-2, atol=1e-2)
 
 
-@pytest.mark.copy
-@pytest.mark.op("copy")
-@pytest.mark.dtype("float16")
-@pytest.mark.mode("Developer")
-def test_copy_shape_2d_3d_dev():
-    M = 256
-    N = 1024
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("M, N, block_M, block_N", COPY_SHAPE_3D_CASES)
+def test_copy_shape_2d_3d_dev(dtype, M, N, block_M, block_N):
+    func = copy_shape_2d_3d(M, N, block_M, block_N, dtype)
+    compiled_kernel = tilelang.compile(func, target="npuir")
 
-    with ascend_mode("Developer"):
-        func = copy_shape_2d_3d(M, N, 32, 32)
-        compiled_kernel = tilelang.compile(func, target="npuir")
-
-        v1 = gen_tensor((1, M, N), dtype, kind="randn")
-        v2 = gen_tensor((1, M, N), dtype, kind="randn")
-        v_ref = v1.clone()
-        compiled_kernel(v1, v2)
+    v1 = gen_tensor((1, M, N), dtype, kind="randn")
+    v2 = gen_tensor((1, M, N), dtype, kind="randn")
+    v_ref = v1.clone()
+    compiled_kernel(v1, v2)
 
     assert_close(v2.cpu(), v_ref.cpu(), dtype=dtype, rtol=1e-2, atol=1e-2)

--- a/testing/npuir/memory_ops/test_copy_shape_dynamic.py
+++ b/testing/npuir/memory_ops/test_copy_shape_dynamic.py
@@ -8,11 +8,14 @@ import tilelang.language as T
 
 from testcommon import assert_close, gen_tensor
 
+pytestmark = [pytest.mark.op("copy")]
 
-dtype = "float16"
+DTYPES = ["float16"]
+COPY_SHAPE_2D_CASES = [(8, 8, 3, 3)]
+COPY_SHAPE_3D_CASES = [(8, 8, 3, 3)]
 
 
-def copy_shape_1d_2d(M, N, block_M, block_N):
+def copy_shape_1d_2d(M, N, block_M, block_N, dtype):
     @T.prim_func
     def copyShapeDynamic1D2D(
         A: T.Tensor((M, N), dtype),
@@ -37,7 +40,7 @@ def copy_shape_1d_2d(M, N, block_M, block_N):
     return copyShapeDynamic1D2D
 
 
-def copy_shape_2d_3d(M, N, block_M, block_N):
+def copy_shape_2d_3d(M, N, block_M, block_N, dtype):
     @T.prim_func
     def copyShapeDynamic2D3D(
         A: T.Tensor((1, M, N), dtype),
@@ -62,31 +65,24 @@ def copy_shape_2d_3d(M, N, block_M, block_N):
     return copyShapeDynamic2D3D
 
 
-@pytest.mark.copy
-@pytest.mark.op("copy")
-@pytest.mark.dtype("float16")
-def test_copy_shape_1d_2d_dynamic():
-    M = 8
-    N = 8
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("M, N, block_M, block_N", COPY_SHAPE_2D_CASES)
+def test_copy_shape_1d_2d_dynamic(dtype, M, N, block_M, block_N):
     v1 = gen_tensor((M, N), dtype, kind="randn")
     v2 = gen_tensor((M, N), dtype, kind="zeros")
     v_ref = v1.clone()
 
-    func = copy_shape_1d_2d(M, N, block_M=3, block_N=3)
+    func = copy_shape_1d_2d(M, N, block_M=block_M, block_N=block_N, dtype=dtype)
     compiled_kernel = tilelang.compile(func, target="npuir")
     compiled_kernel(v1, v2, M, N)
 
     assert_close(v2.cpu(), v_ref.cpu(), dtype=dtype, rtol=1e-2, atol=1e-2)
 
 
-@pytest.mark.copy
-@pytest.mark.op("copy")
-@pytest.mark.dtype("float16")
-def test_copy_shape_2d_3d_dynamic():
-    M = 8
-    N = 8
-
-    func = copy_shape_2d_3d(M, N, 3, 3)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("M, N, block_M, block_N", COPY_SHAPE_3D_CASES)
+def test_copy_shape_2d_3d_dynamic(dtype, M, N, block_M, block_N):
+    func = copy_shape_2d_3d(M, N, block_M, block_N, dtype)
     compiled_kernel = tilelang.compile(func, target="npuir")
 
     v1 = gen_tensor((1, M, N), dtype, kind="randn")

--- a/testing/npuir/memory_ops/test_copy_shape_dynamic_cube.py
+++ b/testing/npuir/memory_ops/test_copy_shape_dynamic_cube.py
@@ -21,16 +21,17 @@ Edge cases covered via pytest parametrize:
 import pytest
 import torch
 import torch_npu  # noqa: F401
+from itertools import product
 import tilelang
 import tilelang.language as T
 
-from testcommon import assert_close, build_dtype_param_combos, gen_tensor
+from testcommon import assert_close, gen_tensor
 
-pytestmark = [pytest.mark.copy, pytest.mark.op("copy")]
+pytestmark = [pytest.mark.op("copy")]
 
 IN_DTYPES = ["float16", "float32"]
 OUT_DTYPES = ["float16", "float32"]
-DTYPE_COMBOS = build_dtype_param_combos(IN_DTYPES, OUT_DTYPES)
+DTYPE_CASES = list(product(IN_DTYPES, OUT_DTYPES))
 
 # ---------------------------------------------------------------------------
 # Kernel builders
@@ -193,7 +194,7 @@ DYNAMIC_CASES = [
 # 2D tests  —  A: [M, N]
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("in_dtype, out_dtype", DTYPE_COMBOS)
+@pytest.mark.parametrize("in_dtype, out_dtype", DTYPE_CASES)
 @pytest.mark.parametrize("M, N, block_M, block_N", DYNAMIC_CASES)
 def test_cube_copy_shape_2d(M, N, block_M, block_N, in_dtype, out_dtype):
     func = cube_copy_shape_1d_2d(M, N, block_M, block_N, in_dtype, out_dtype)
@@ -212,7 +213,7 @@ def test_cube_copy_shape_2d(M, N, block_M, block_N, in_dtype, out_dtype):
 # 3D tests  —  A: [1, M, N]
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("in_dtype, out_dtype", DTYPE_COMBOS)
+@pytest.mark.parametrize("in_dtype, out_dtype", DTYPE_CASES)
 @pytest.mark.parametrize("M, N, block_M, block_N", DYNAMIC_CASES)
 def test_cube_copy_shape_3d(M, N, block_M, block_N, in_dtype, out_dtype):
     func = cube_copy_shape_2d_3d(M, N, block_M, block_N, in_dtype, out_dtype)
@@ -231,7 +232,7 @@ def test_cube_copy_shape_3d(M, N, block_M, block_N, in_dtype, out_dtype):
 # 4D tests  —  A: [1, 1, M, N]
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("in_dtype, out_dtype", DTYPE_COMBOS)
+@pytest.mark.parametrize("in_dtype, out_dtype", DTYPE_CASES)
 @pytest.mark.parametrize("M, N, block_M, block_N", DYNAMIC_CASES)
 def test_cube_copy_shape_4d(M, N, block_M, block_N, in_dtype, out_dtype):
     func = cube_copy_shape_3d_4d(M, N, block_M, block_N, in_dtype, out_dtype)

--- a/testing/npuir/memory_ops/test_copy_shape_dynamic_cube.py
+++ b/testing/npuir/memory_ops/test_copy_shape_dynamic_cube.py
@@ -177,16 +177,6 @@ def cube_copy_shape_3d_4d(M, N, block_M, block_N, in_dtype, out_dtype):
 DYNAMIC_CASES = [
     # (M,  N,  block_M, block_N)   — description
     (8,  8,  3, 3),                 # base: tail in both dims (8%3=2)
-    (6,  6,  3, 3),                 # exact divide, no tail
-    (8,  8,  8, 8),                 # single tile (block == dim)
-    (4,  4,  8, 8),                 # oversized block (block > dim)
-    (1,  8,  1, 3),                 # M=1, single row
-    (16, 32, 5, 7),                 # larger, irregular tiling
-    (7,  8,  3, 3),                 # M tail = 1  (7%3 = 1)
-    (8,  7,  3, 3),                 # N tail = 1  (7%3 = 1)
-    (7,  7,  3, 3),                 # both dims tail = 1
-    (8,  8,  3, 8),                 # block_N == N, only M has tail
-    (8,  8,  8, 3),                 # block_M == M, only N has tail
 ]
 
 

--- a/testing/npuir/memory_ops/test_copy_shape_dynamic_dev.py
+++ b/testing/npuir/memory_ops/test_copy_shape_dynamic_dev.py
@@ -6,13 +6,19 @@ import torch_npu  # noqa: F401
 import tilelang
 import tilelang.language as T
 
-from testcommon import ascend_mode, assert_close, gen_tensor
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("copy"),
+    pytest.mark.mode("Developer"),
+]
+
+DTYPES = ["float16"]
+COPY_SHAPE_2D_CASES = [(8, 8, 3, 3)]
+COPY_SHAPE_3D_CASES = [(8, 8, 3, 3)]
 
 
-dtype = "float16"
-
-
-def copy_shape_1d_2d(M, N, block_M, block_N):
+def copy_shape_1d_2d(M, N, block_M, block_N, dtype):
     @T.prim_func
     def copyShapeDynamicDev1D2D(
         A: T.Tensor((M, N), dtype),
@@ -37,7 +43,7 @@ def copy_shape_1d_2d(M, N, block_M, block_N):
     return copyShapeDynamicDev1D2D
 
 
-def copy_shape_2d_3d(M, N, block_M, block_N):
+def copy_shape_2d_3d(M, N, block_M, block_N, dtype):
     @T.prim_func
     def copyShapeDynamicDev2D3D(
         A: T.Tensor((1, M, N), dtype),
@@ -62,40 +68,29 @@ def copy_shape_2d_3d(M, N, block_M, block_N):
     return copyShapeDynamicDev2D3D
 
 
-@pytest.mark.copy
-@pytest.mark.op("copy")
-@pytest.mark.dtype("float16")
-@pytest.mark.mode("Developer")
-def test_copy_shape_1d_2d_dynamic_dev():
-    M = 8
-    N = 8
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("M, N, block_M, block_N", COPY_SHAPE_2D_CASES)
+def test_copy_shape_1d_2d_dynamic_dev(dtype, M, N, block_M, block_N):
     v1 = gen_tensor((M, N), dtype, kind="randn")
     v2 = gen_tensor((M, N), dtype, kind="zeros")
     v_ref = v1.clone()
 
-    with ascend_mode("Developer"):
-        func = copy_shape_1d_2d(M, N, block_M=3, block_N=3)
-        compiled_kernel = tilelang.compile(func, target="npuir")
-        compiled_kernel(v1, v2, M, N)
+    func = copy_shape_1d_2d(M, N, block_M=block_M, block_N=block_N, dtype=dtype)
+    compiled_kernel = tilelang.compile(func, target="npuir")
+    compiled_kernel(v1, v2, M, N)
 
     assert_close(v2.cpu(), v_ref.cpu(), dtype=dtype, rtol=1e-2, atol=1e-2)
 
 
-@pytest.mark.copy
-@pytest.mark.op("copy")
-@pytest.mark.dtype("float16")
-@pytest.mark.mode("Developer")
-def test_copy_shape_2d_3d_dynamic_dev():
-    M = 8
-    N = 8
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("M, N, block_M, block_N", COPY_SHAPE_3D_CASES)
+def test_copy_shape_2d_3d_dynamic_dev(dtype, M, N, block_M, block_N):
+    func = copy_shape_2d_3d(M, N, block_M, block_N, dtype)
+    compiled_kernel = tilelang.compile(func, target="npuir")
 
-    with ascend_mode("Developer"):
-        func = copy_shape_2d_3d(M, N, 3, 3)
-        compiled_kernel = tilelang.compile(func, target="npuir")
-
-        v1 = gen_tensor((1, M, N), dtype, kind="randn")
-        v2 = gen_tensor((1, M, N), dtype, kind="randn")
-        v_ref = v1.clone()
-        compiled_kernel(v1, v2, M, N)
+    v1 = gen_tensor((1, M, N), dtype, kind="randn")
+    v2 = gen_tensor((1, M, N), dtype, kind="randn")
+    v_ref = v1.clone()
+    compiled_kernel(v1, v2, M, N)
 
     assert_close(v2.cpu(), v_ref.cpu(), dtype=dtype, rtol=1e-2, atol=1e-2)

--- a/testing/npuir/memory_ops/test_copy_simple_dev.py
+++ b/testing/npuir/memory_ops/test_copy_simple_dev.py
@@ -6,7 +6,17 @@ import torch_npu  # noqa: F401
 import tilelang
 import tilelang.language as T
 
-from testcommon import ascend_mode, assert_close, gen_tensor
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("copy"),
+    pytest.mark.mode("Developer"),
+]
+
+DTYPES = ["float16"]
+COPY_1D_CASES = [(1024, 256)]
+COPY_2D_CASES = [(1024, 1024, 128, 128)]
+COPY_3D_CASES = [(64, 128, 256, 16, 32, 32)]
 
 
 @tilelang.jit(target="npuir")
@@ -103,68 +113,56 @@ def simple_copy_3d(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dt
     return simple_copy_3d
 
 
-@pytest.mark.copy
-@pytest.mark.op("copy")
-@pytest.mark.dtype("float16")
-@pytest.mark.mode("Developer")
-def test_copy_simple_1d_dev():
-    with ascend_mode("Developer"):
-        kernel = simple_copy_1d(1024, 256)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("L, block_L", COPY_1D_CASES)
+def test_copy_simple_1d_dev(dtype, L, block_L):
+    kernel = simple_copy_1d(L, block_L, dtype=dtype)
 
-        input_tensor = gen_tensor((1024,), "float16", kind="ones")
-        a = gen_tensor((1024,), "float16", kind="zeros")
-        b = gen_tensor((1024,), "float16", kind="zeros")
-        c = gen_tensor((1024,), "float32", kind="zeros")
+    input_tensor = gen_tensor((L,), dtype, kind="ones")
+    a = gen_tensor((L,), dtype, kind="zeros")
+    b = gen_tensor((L,), dtype, kind="zeros")
+    c = gen_tensor((L,), "float32", kind="zeros")
 
-        kernel(input_tensor, a, b, c)
+    kernel(input_tensor, a, b, c)
 
-    assert_close(a.cpu(), input_tensor.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
-    assert_close(b.cpu(), (a * 2).cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(a.cpu(), input_tensor.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
+    assert_close(b.cpu(), (a * 2).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     assert_close(c.cpu(), b.to(torch.float32).cpu(), dtype="float32", rtol=1e-5, atol=1e-5)
 
 
-@pytest.mark.copy
-@pytest.mark.op("copy")
-@pytest.mark.dtype("float16")
-@pytest.mark.mode("Developer")
-def test_copy_simple_2d_dev():
-    with ascend_mode("Developer"):
-        kernel = simple_copy_2d(1024, 1024, 128, 128)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("M, N, block_M, block_N", COPY_2D_CASES)
+def test_copy_simple_2d_dev(dtype, M, N, block_M, block_N):
+    kernel = simple_copy_2d(M, N, block_M, block_N, dtype=dtype)
 
-        input_tensor = gen_tensor((1024, 1024), "float16", kind="randn")
-        a = gen_tensor((1024, 1024), "float16", kind="zeros")
-        b = gen_tensor((1024, 1024), "float16", kind="zeros")
-        c = gen_tensor((1024, 1024), "float32", kind="zeros")
+    input_tensor = gen_tensor((M, N), dtype, kind="randn")
+    a = gen_tensor((M, N), dtype, kind="zeros")
+    b = gen_tensor((M, N), dtype, kind="zeros")
+    c = gen_tensor((M, N), "float32", kind="zeros")
 
-        kernel(input_tensor, a, b, c)
+    kernel(input_tensor, a, b, c)
 
-    assert_close(a.cpu(), input_tensor.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
-    assert_close(b.cpu(), (a * 2).cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(a.cpu(), input_tensor.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
+    assert_close(b.cpu(), (a * 2).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     assert_close(c.cpu(), b.to(torch.float32).cpu(), dtype="float32", rtol=1e-5, atol=1e-5)
 
 
-@pytest.mark.copy
-@pytest.mark.op("copy")
-@pytest.mark.dtype("float16")
-@pytest.mark.mode("Developer")
-def test_copy_simple_3d_dev():
-    M, N, K = 64, 128, 256
-    block_M, block_N, block_K = 16, 32, 32
-
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("M, N, K, block_M, block_N, block_K", COPY_3D_CASES)
+def test_copy_simple_3d_dev(dtype, M, N, K, block_M, block_N, block_K):
     assert M % block_M == 0, f"M({M}) must be divisible by block_M({block_M})"
     assert N % block_N == 0, f"N({N}) must be divisible by block_N({block_N})"
     assert K % block_K == 0, f"K({K}) must be divisible by block_K({block_K})"
 
-    with ascend_mode("Developer"):
-        kernel = simple_copy_3d(M, N, K, block_M, block_N, block_K)
+    kernel = simple_copy_3d(M, N, K, block_M, block_N, block_K, dtype=dtype)
 
-        input_tensor = gen_tensor((M, N, K), "float16", kind="randn")
-        a = gen_tensor((M, N, K), "float16", kind="zeros")
-        b = gen_tensor((M, N, K), "float16", kind="zeros")
-        c = gen_tensor((M, N, K), "float32", kind="zeros")
+    input_tensor = gen_tensor((M, N, K), dtype, kind="randn")
+    a = gen_tensor((M, N, K), dtype, kind="zeros")
+    b = gen_tensor((M, N, K), dtype, kind="zeros")
+    c = gen_tensor((M, N, K), "float32", kind="zeros")
 
-        kernel(input_tensor, a, b, c)
+    kernel(input_tensor, a, b, c)
 
-    assert_close(a.cpu(), input_tensor.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
-    assert_close(b.cpu(), (a * 2).cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(a.cpu(), input_tensor.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
+    assert_close(b.cpu(), (a * 2).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     assert_close(c.cpu(), b.to(torch.float32).cpu(), dtype="float32", rtol=1e-5, atol=1e-5)

--- a/testing/npuir/memory_ops/test_copy_sliced_cube.py
+++ b/testing/npuir/memory_ops/test_copy_sliced_cube.py
@@ -17,16 +17,17 @@ Edge cases covered via pytest parametrize:
 import pytest
 import torch
 import torch_npu  # noqa: F401
+from itertools import product
 import tilelang
 import tilelang.language as T
 
-from testcommon import assert_close, build_dtype_param_combos, gen_tensor
+from testcommon import assert_close, gen_tensor
 
-pytestmark = [pytest.mark.copy, pytest.mark.op("copy")]
+pytestmark = [pytest.mark.op("copy")]
 
 IN_DTYPES = ["float16", "float32"]
 OUT_DTYPES = ["float16", "float32"]
-DTYPE_COMBOS = build_dtype_param_combos(IN_DTYPES, OUT_DTYPES)
+DTYPE_CASES = list(product(IN_DTYPES, OUT_DTYPES))
 
 # ---------------------------------------------------------------------------
 # Kernel builders
@@ -149,7 +150,7 @@ SLICED_2D_CASES = [
     (1,   8, 0),         # small N=8, M=1
 ]
 
-@pytest.mark.parametrize("in_dtype, out_dtype", DTYPE_COMBOS)
+@pytest.mark.parametrize("in_dtype, out_dtype", DTYPE_CASES)
 @pytest.mark.parametrize("M, N, idx", SLICED_2D_CASES)
 def test_cube_sliced_copy_2d(M, N, idx, in_dtype, out_dtype):
     kernel = cube_sliced_copy_2d(M, N, idx, in_dtype, out_dtype)
@@ -184,7 +185,7 @@ SLICED_3D_CASES = [
     (1,  1,   8, 0, 0),       # small N=8, B=1, M=1
 ]
 
-@pytest.mark.parametrize("in_dtype, out_dtype", DTYPE_COMBOS)
+@pytest.mark.parametrize("in_dtype, out_dtype", DTYPE_CASES)
 @pytest.mark.parametrize("B_dim, M, N, b_idx, m_idx", SLICED_3D_CASES)
 def test_cube_sliced_copy_3d(B_dim, M, N, b_idx, m_idx, in_dtype, out_dtype):
     kernel = cube_sliced_copy_3d(B_dim, M, N, b_idx, m_idx, in_dtype, out_dtype)
@@ -220,7 +221,7 @@ SLICED_4D_CASES = [
     (1,  1,  1,   8, 0, 0, 0),       # small N=8, all leading 1s
 ]
 
-@pytest.mark.parametrize("in_dtype, out_dtype", DTYPE_COMBOS)
+@pytest.mark.parametrize("in_dtype, out_dtype", DTYPE_CASES)
 @pytest.mark.parametrize("B_dim, H, M, N, b_idx, h_idx, m_idx", SLICED_4D_CASES)
 def test_cube_sliced_copy_4d(B_dim, H, M, N, b_idx, h_idx, m_idx, in_dtype, out_dtype):
     kernel = cube_sliced_copy_4d(B_dim, H, M, N, b_idx, h_idx, m_idx, in_dtype, out_dtype)

--- a/testing/npuir/memory_ops/test_copy_sliced_cube.py
+++ b/testing/npuir/memory_ops/test_copy_sliced_cube.py
@@ -211,14 +211,6 @@ def test_cube_sliced_copy_3d(B_dim, M, N, b_idx, m_idx, in_dtype, out_dtype):
 SLICED_4D_CASES = [
     # (B,  H,  M,  N,  b_idx, h_idx, m_idx)
     (2,  4,  16, 32, 1, 2, 5),       # base case
-    (1,  4,  16, 32, 0, 2, 5),       # B=1
-    (2,  1,  16, 32, 1, 0, 5),       # H=1
-    (1,  1,  16, 32, 0, 0, 5),       # B=1, H=1  (two consecutive leading 1s)
-    (1,  1,  1,  32, 0, 0, 0),       # B=1, H=1, M=1  (three consecutive 1s)
-    (2,  4,  16, 32, 0, 0, 0),       # all-zero indices
-    (2,  4,  16, 32, 1, 3, 15),      # boundary indices (last valid)
-    (2,  4,  16,  8, 1, 2, 5),       # small N=8
-    (1,  1,  1,   8, 0, 0, 0),       # small N=8, all leading 1s
 ]
 
 @pytest.mark.parametrize("in_dtype, out_dtype", DTYPE_CASES)

--- a/testing/npuir/memory_ops/test_copy_sliced_dev.py
+++ b/testing/npuir/memory_ops/test_copy_sliced_dev.py
@@ -6,7 +6,17 @@ import torch_npu  # noqa: F401
 import tilelang
 import tilelang.language as T
 
-from testcommon import ascend_mode, assert_close, gen_tensor
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("copy"),
+    pytest.mark.mode("Developer"),
+]
+
+DTYPES = ["float16"]
+SLICED_2D_CASES = [(32, 128, 8, 16)]
+SLICED_3D_CASES = [(4, 32, 128, 1, 3)]
+SLICED_4D_CASES = [(2, 4, 32, 64, 0, 1, 1, 3)]
 
 
 @tilelang.jit(target="npuir")
@@ -158,137 +168,118 @@ def slice_copy_4d_kernel(B, H, M, N, idx_b, idx_h, idx_b2, idx_h2, dtype="float1
     return slice_copy_4d_kernel
 
 
-@pytest.mark.copy
-@pytest.mark.op("copy")
-@pytest.mark.dtype("float16")
-@pytest.mark.mode("Developer")
-def test_copy_sliced_2d_dev():
-    block_M, block_N = 32, 128
-    idx, idx2 = 8, 16
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("block_M, block_N, idx, idx2", SLICED_2D_CASES)
+def test_copy_sliced_2d_dev(dtype, block_M, block_N, idx, idx2):
+    kernel = slice_copy_2d_kernel(block_M, block_N, idx, idx2, dtype=dtype)
 
-    with ascend_mode("Developer"):
-        kernel = slice_copy_2d_kernel(block_M, block_N, idx, idx2)
+    input_ones = gen_tensor((block_M, block_N), dtype, kind="ones")
+    input_zeros = gen_tensor((block_M, block_N), dtype, kind="zeros")
 
-        input_ones = gen_tensor((block_M, block_N), "float16", kind="ones")
-        input_zeros = gen_tensor((block_M, block_N), "float16", kind="zeros")
+    outs = [gen_tensor((block_M, block_N), dtype, kind="zeros") for _ in range(6)]
+    out3 = gen_tensor((block_N,), dtype, kind="zeros")
+    out4 = gen_tensor((block_N,), dtype, kind="zeros")
 
-        outs = [gen_tensor((block_M, block_N), "float16", kind="zeros") for _ in range(6)]
-        out3 = gen_tensor((block_N,), "float16", kind="zeros")
-        out4 = gen_tensor((block_N,), "float16", kind="zeros")
+    kernel(input_ones, input_zeros, outs[0], outs[1], out3, out4, outs[2], outs[3], outs[4], outs[5])
 
-        kernel(input_ones, input_zeros, outs[0], outs[1], out3, out4, outs[2], outs[3], outs[4], outs[5])
+    expected_full = gen_tensor((block_M, block_N), dtype, kind="ones")
+    expected_row = gen_tensor((block_N,), dtype, kind="ones")
 
-    expected_full = gen_tensor((block_M, block_N), "float16", kind="ones")
-    expected_row = gen_tensor((block_N,), "float16", kind="ones")
-
-    assert_close(outs[0].cpu(), expected_full.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[0].cpu(), expected_full.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     for out in [outs[1], outs[2]]:
-        assert_close(out[idx].cpu(), expected_row.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+        assert_close(out[idx].cpu(), expected_row.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
         out[idx] = 0
-        assert_close(out.cpu(), torch.zeros_like(out).cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+        assert_close(out.cpu(), torch.zeros_like(out).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
 
-    assert_close(out3.cpu(), expected_row.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
-    assert_close(out4.cpu(), expected_row.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(out3.cpu(), expected_row.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
+    assert_close(out4.cpu(), expected_row.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
 
-    assert_close(outs[3][idx].cpu(), expected_row.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[3][idx].cpu(), expected_row.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     outs[3][idx] = 0
-    assert_close(outs[3].cpu(), torch.zeros_like(outs[3]).cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[3].cpu(), torch.zeros_like(outs[3]).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
 
-    assert_close(outs[4][idx2].cpu(), expected_row.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[4][idx2].cpu(), expected_row.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     outs[4][idx2] = 0
-    assert_close(outs[4].cpu(), torch.zeros_like(outs[4]).cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[4].cpu(), torch.zeros_like(outs[4]).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
 
-    assert_close(outs[5][idx2].cpu(), expected_row.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[5][idx2].cpu(), expected_row.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     outs[5][idx2] = 0
-    assert_close(outs[5].cpu(), torch.zeros_like(outs[5]).cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[5].cpu(), torch.zeros_like(outs[5]).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
 
 
-@pytest.mark.copy
-@pytest.mark.op("copy")
-@pytest.mark.dtype("float16")
-@pytest.mark.mode("Developer")
-def test_copy_sliced_3d_dev():
-    B, M, N = 4, 32, 128
-    idx, idx2 = 1, 3
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("B, M, N, idx, idx2", SLICED_3D_CASES)
+def test_copy_sliced_3d_dev(dtype, B, M, N, idx, idx2):
+    kernel = slice_copy_3d_kernel(B, M, N, idx, idx2, dtype=dtype)
 
-    with ascend_mode("Developer"):
-        kernel = slice_copy_3d_kernel(B, M, N, idx, idx2)
+    input_ones = gen_tensor((B, M, N), dtype, kind="ones")
+    input_zeros = gen_tensor((B, M, N), dtype, kind="zeros")
 
-        input_ones = gen_tensor((B, M, N), "float16", kind="ones")
-        input_zeros = gen_tensor((B, M, N), "float16", kind="zeros")
+    outs = [gen_tensor((B, M, N), dtype, kind="zeros") for _ in range(6)]
+    out3 = gen_tensor((M, N), dtype, kind="zeros")
+    out4 = gen_tensor((M, N), dtype, kind="zeros")
 
-        outs = [gen_tensor((B, M, N), "float16", kind="zeros") for _ in range(6)]
-        out3 = gen_tensor((M, N), "float16", kind="zeros")
-        out4 = gen_tensor((M, N), "float16", kind="zeros")
+    kernel(input_ones, input_zeros, outs[0], outs[1], out3, out4, outs[2], outs[3], outs[4], outs[5])
 
-        kernel(input_ones, input_zeros, outs[0], outs[1], out3, out4, outs[2], outs[3], outs[4], outs[5])
+    expected_full = gen_tensor((B, M, N), dtype, kind="ones")
+    expected_slice = gen_tensor((M, N), dtype, kind="ones")
 
-    expected_full = gen_tensor((B, M, N), "float16", kind="ones")
-    expected_slice = gen_tensor((M, N), "float16", kind="ones")
-
-    assert_close(outs[0].cpu(), expected_full.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[0].cpu(), expected_full.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     for out in [outs[1], outs[2]]:
-        assert_close(out[idx].cpu(), expected_slice.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+        assert_close(out[idx].cpu(), expected_slice.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
         out[idx] = 0
-        assert_close(out.cpu(), torch.zeros_like(out).cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+        assert_close(out.cpu(), torch.zeros_like(out).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
 
-    assert_close(out3.cpu(), expected_slice.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
-    assert_close(out4.cpu(), expected_slice.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(out3.cpu(), expected_slice.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
+    assert_close(out4.cpu(), expected_slice.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
 
-    assert_close(outs[3][idx].cpu(), expected_slice.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[3][idx].cpu(), expected_slice.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     outs[3][idx] = 0
-    assert_close(outs[3].cpu(), torch.zeros_like(outs[3]).cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[3].cpu(), torch.zeros_like(outs[3]).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
 
-    assert_close(outs[4][idx2].cpu(), expected_slice.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[4][idx2].cpu(), expected_slice.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     outs[4][idx2] = 0
-    assert_close(outs[4].cpu(), torch.zeros_like(outs[4]).cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[4].cpu(), torch.zeros_like(outs[4]).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
 
-    assert_close(outs[5][idx2].cpu(), expected_slice.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[5][idx2].cpu(), expected_slice.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     outs[5][idx2] = 0
-    assert_close(outs[5].cpu(), torch.zeros_like(outs[5]).cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[5].cpu(), torch.zeros_like(outs[5]).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
 
 
-@pytest.mark.copy
-@pytest.mark.op("copy")
-@pytest.mark.dtype("float16")
-@pytest.mark.mode("Developer")
-def test_copy_sliced_4d_dev():
-    B, H, M, N = 2, 4, 32, 64
-    idx_b, idx_h = 0, 1
-    idx_b2, idx_h2 = 1, 3
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("B, H, M, N, idx_b, idx_h, idx_b2, idx_h2", SLICED_4D_CASES)
+def test_copy_sliced_4d_dev(dtype, B, H, M, N, idx_b, idx_h, idx_b2, idx_h2):
+    kernel = slice_copy_4d_kernel(B, H, M, N, idx_b, idx_h, idx_b2, idx_h2, dtype=dtype)
 
-    with ascend_mode("Developer"):
-        kernel = slice_copy_4d_kernel(B, H, M, N, idx_b, idx_h, idx_b2, idx_h2)
+    input_ones = gen_tensor((B, H, M, N), dtype, kind="ones")
+    input_zeros = gen_tensor((B, H, M, N), dtype, kind="zeros")
 
-        input_ones = gen_tensor((B, H, M, N), "float16", kind="ones")
-        input_zeros = gen_tensor((B, H, M, N), "float16", kind="zeros")
+    outs = [gen_tensor((B, H, M, N), dtype, kind="zeros") for _ in range(6)]
+    out3 = gen_tensor((M, N), dtype, kind="zeros")
+    out4 = gen_tensor((M, N), dtype, kind="zeros")
 
-        outs = [gen_tensor((B, H, M, N), "float16", kind="zeros") for _ in range(6)]
-        out3 = gen_tensor((M, N), "float16", kind="zeros")
-        out4 = gen_tensor((M, N), "float16", kind="zeros")
+    kernel(input_ones, input_zeros, outs[0], outs[1], out3, out4, outs[2], outs[3], outs[4], outs[5])
 
-        kernel(input_ones, input_zeros, outs[0], outs[1], out3, out4, outs[2], outs[3], outs[4], outs[5])
+    expected_full = gen_tensor((B, H, M, N), dtype, kind="ones")
+    expected_slice = gen_tensor((M, N), dtype, kind="ones")
 
-    expected_full = gen_tensor((B, H, M, N), "float16", kind="ones")
-    expected_slice = gen_tensor((M, N), "float16", kind="ones")
-
-    assert_close(outs[0].cpu(), expected_full.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[0].cpu(), expected_full.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     for out in [outs[1], outs[2]]:
-        assert_close(out[idx_b, idx_h].cpu(), expected_slice.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+        assert_close(out[idx_b, idx_h].cpu(), expected_slice.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
         out[idx_b, idx_h] = 0
-        assert_close(out.cpu(), torch.zeros_like(out).cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+        assert_close(out.cpu(), torch.zeros_like(out).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
 
-    assert_close(out3.cpu(), expected_slice.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
-    assert_close(out4.cpu(), expected_slice.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(out3.cpu(), expected_slice.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
+    assert_close(out4.cpu(), expected_slice.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
 
-    assert_close(outs[3][idx_b, idx_h].cpu(), expected_slice.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[3][idx_b, idx_h].cpu(), expected_slice.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     outs[3][idx_b, idx_h] = 0
-    assert_close(outs[3].cpu(), torch.zeros_like(outs[3]).cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[3].cpu(), torch.zeros_like(outs[3]).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
 
-    assert_close(outs[4][idx_b2, idx_h2].cpu(), expected_slice.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[4][idx_b2, idx_h2].cpu(), expected_slice.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     outs[4][idx_b2, idx_h2] = 0
-    assert_close(outs[4].cpu(), torch.zeros_like(outs[4]).cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[4].cpu(), torch.zeros_like(outs[4]).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
 
-    assert_close(outs[5][idx_b2, idx_h2].cpu(), expected_slice.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[5][idx_b2, idx_h2].cpu(), expected_slice.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     outs[5][idx_b2, idx_h2] = 0
-    assert_close(outs[5].cpu(), torch.zeros_like(outs[5]).cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(outs[5].cpu(), torch.zeros_like(outs[5]).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)

--- a/testing/npuir/memory_ops/test_copy_sliced_extended_dev.py
+++ b/testing/npuir/memory_ops/test_copy_sliced_extended_dev.py
@@ -6,7 +6,20 @@ import torch_npu  # noqa: F401
 import tilelang
 import tilelang.language as T
 
-from testcommon import ascend_mode, assert_close, gen_tensor
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("copy"),
+    pytest.mark.mode("Developer"),
+]
+
+DTYPES = ["float16"]
+SLICED_EXTENDED_4D_CASES = [
+    (2, 64, 8, 128, 32, 64, 1, 3, 16, 32),
+]
+SLICED_EXTENDED_5D_CASES = [
+    ((2, 2, 64, 4, 128), 16, 32, 1, 0, 2, 32, 64),
+]
 
 
 @tilelang.jit(target="npuir")
@@ -79,59 +92,48 @@ def strided_copy_5d_kernel(
     return strided_copy_5d_kernel
 
 
-@pytest.mark.copy
-@pytest.mark.op("copy")
-@pytest.mark.dtype("float16")
-@pytest.mark.mode("Developer")
-def test_copy_sliced_extended_4d_dev():
-    B, S, H, D = 2, 64, 8, 128
-    S_blk, D_blk = 32, 64
-    idx_b, idx_h = 1, 3
-    off_s, off_d = 16, 32
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize(
+    "B, S, H, D, S_blk, D_blk, idx_b, idx_h, off_s, off_d",
+    SLICED_EXTENDED_4D_CASES,
+)
+def test_copy_sliced_extended_4d_dev(dtype, B, S, H, D, S_blk, D_blk, idx_b, idx_h, off_s, off_d):
+    kernel = strided_copy_4d_kernel(B, S, H, D, S_blk, D_blk, dtype=dtype)
 
-    with ascend_mode("Developer"):
-        kernel = strided_copy_4d_kernel(B, S, H, D, S_blk, D_blk)
+    inp = gen_tensor((B, S, H, D), dtype, kind="randn")
+    out = gen_tensor((B, S, H, D), dtype, kind="zeros")
+    debug = gen_tensor((S_blk, D_blk), dtype, kind="zeros")
 
-        inp = gen_tensor((B, S, H, D), "float16", kind="randn")
-        out = gen_tensor((B, S, H, D), "float16", kind="zeros")
-        debug = gen_tensor((S_blk, D_blk), "float16", kind="zeros")
-
-        kernel(inp, out, debug, idx_b, idx_h, off_s, off_d)
+    kernel(inp, out, debug, idx_b, idx_h, off_s, off_d)
 
     expected_slice = inp[idx_b, off_s:off_s + S_blk, idx_h, off_d:off_d + D_blk]
-    assert_close(debug.cpu(), expected_slice.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(debug.cpu(), expected_slice.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
 
     expected_out = torch.zeros_like(out)
     expected_out[idx_b, off_s:off_s + S_blk, idx_h, off_d:off_d + D_blk] = expected_slice
-    assert_close(out.cpu(), expected_out.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(out.cpu(), expected_out.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
 
 
-@pytest.mark.copy
-@pytest.mark.op("copy")
-@pytest.mark.dtype("float16")
-@pytest.mark.mode("Developer")
-def test_copy_sliced_extended_5d_dev():
-    dims = (2, 2, 64, 4, 128)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize(
+    "dims, blk_2, blk_4, idx_0, idx_1, idx_3, off_2, off_4",
+    SLICED_EXTENDED_5D_CASES,
+)
+def test_copy_sliced_extended_5d_dev(dtype, dims, blk_2, blk_4, idx_0, idx_1, idx_3, off_2, off_4):
     D1 = dims[1]
-    blk_2, blk_4 = 16, 32
-
-    idx_0, idx_1, idx_3 = 1, 0, 2
-    off_2, off_4 = 32, 64
-
     idx_01_merged = idx_0 * D1 + idx_1
 
-    with ascend_mode("Developer"):
-        kernel = strided_copy_5d_kernel(*dims, blk_2, blk_4)
+    kernel = strided_copy_5d_kernel(*dims, blk_2, blk_4, dtype=dtype)
 
-        inp = gen_tensor(dims, "float16", kind="randn")
-        out = gen_tensor(dims, "float16", kind="zeros")
-        debug = gen_tensor((blk_2, blk_4), "float16", kind="zeros")
+    inp = gen_tensor(dims, dtype, kind="randn")
+    out = gen_tensor(dims, dtype, kind="zeros")
+    debug = gen_tensor((blk_2, blk_4), dtype, kind="zeros")
 
-        kernel(inp, out, debug, idx_01_merged, idx_3, off_2, off_4)
+    kernel(inp, out, debug, idx_01_merged, idx_3, off_2, off_4)
 
     expected_slice = inp[idx_0, idx_1, off_2:off_2 + blk_2, idx_3, off_4:off_4 + blk_4]
-    assert_close(debug.cpu(), expected_slice.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(debug.cpu(), expected_slice.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
 
     expected_out = torch.zeros_like(out)
     expected_out[idx_0, idx_1, off_2:off_2 + blk_2, idx_3, off_4:off_4 + blk_4] = expected_slice
-    assert_close(out.cpu(), expected_out.cpu(), dtype="float16", rtol=1e-5, atol=1e-5)
+    assert_close(out.cpu(), expected_out.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)

--- a/testing/npuir/memory_ops/test_copy_strided_dev.py
+++ b/testing/npuir/memory_ops/test_copy_strided_dev.py
@@ -6,15 +6,21 @@ import torch_npu  # noqa: F401
 import tilelang
 from tilelang import language as T
 
-from testcommon import ascend_mode, assert_close, gen_tensor
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("copy"),
+    pytest.mark.mode("Developer"),
+]
+
+DTYPES = ["float16"]
+STRIDED_COPY_CASES = [(1024, 256, 2, 32)]
 
 
-def discrete_copy_tiled(total_h, width, stride=2, block_h=32):
+def discrete_copy_tiled(total_h, width, stride=2, block_h=32, dtype="float16"):
     assert total_h % stride == 0
     out_h = total_h // stride
     assert out_h % block_h == 0, "Output height must be divisible by block_h"
-
-    dtype = "float16"
 
     shape_in = [total_h, width]
     shape_out = [out_h, width]
@@ -42,24 +48,16 @@ def discrete_copy_tiled(total_h, width, stride=2, block_h=32):
     return discrete_copy_tiled
 
 
-@pytest.mark.copy
-@pytest.mark.op("copy")
-@pytest.mark.dtype("float16")
-@pytest.mark.mode("Developer")
-def test_copy_strided_tiled_dev():
-    H = 1024
-    W = 256
-    STRIDE = 2
-    BLOCK_H = 32
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("H, W, stride, block_h", STRIDED_COPY_CASES)
+def test_copy_strided_tiled_dev(dtype, H, W, stride, block_h):
+    func = discrete_copy_tiled(H, W, stride, block_h, dtype=dtype)
+    compiled_kernel = tilelang.compile(func, target="npuir")
 
-    with ascend_mode("Developer"):
-        func = discrete_copy_tiled(H, W, STRIDE, BLOCK_H)
-        compiled_kernel = tilelang.compile(func, target="npuir")
+    inp = gen_tensor((H, W), dtype, kind="randn")
+    out = gen_tensor((H // stride, W), dtype, kind="zeros")
 
-        inp = gen_tensor((H, W), "float16", kind="randn")
-        out = gen_tensor((H // STRIDE, W), "float16", kind="zeros")
+    compiled_kernel(inp, out)
 
-        compiled_kernel(inp, out)
-
-    ref_out = inp[::STRIDE, :].contiguous()
-    assert_close(out.cpu(), ref_out.cpu(), dtype="float16", rtol=1e-3, atol=1e-3)
+    ref_out = inp[::stride, :].contiguous()
+    assert_close(out.cpu(), ref_out.cpu(), dtype=dtype, rtol=1e-3, atol=1e-3)

--- a/testing/npuir/pytest.ini
+++ b/testing/npuir/pytest.ini
@@ -1,16 +1,6 @@
 [pytest]
 python_files = test_*.py
-addopts = -ra
+addopts = -ra --strict-markers
 markers =
-    math: math op tests.
-    copy: copy/memory movement tests.
-    pipelined: pipeline behavior tests.
-    reduce: reduction op tests.
-    slice: slice/index transform tests.
-    atomic: atomic op tests.
-    control_flow: control flow tests.
-    indexing: gather/indexed-load/out-idx tests.
-    debug: debug/print tests.
-    op(name): op identity marker, used by --op.
-    dtype(name): dtype marker, used by --dtype.
-    mode(name): ascend mode marker, used by --mode.
+    op(name): Real operation identity, used by --op.
+    mode(name): Runtime Ascend mode, used by --mode and applied automatically during test execution.

--- a/testing/npuir/testcommon.py
+++ b/testing/npuir/testcommon.py
@@ -150,15 +150,8 @@ def build_dtype_param_combos(
 
     combos = []
     for item in product(*dtype_lists):
-        seen_dtypes = set()
-        marks = []
-        for dtype in item:
-            if dtype not in seen_dtypes:
-                marks.append(pytest.mark.dtype(dtype))
-                seen_dtypes.add(dtype)
-
         param_id = "_".join(f"{name}_{dtype}" for name, dtype in zip(names, item))
-        combos.append(pytest.param(*item, marks=marks, id=param_id))
+        combos.append(pytest.param(*item, id=param_id))
 
     return combos
 

--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -1076,14 +1076,30 @@ class compiler_npu:
         # Obtain the npu_utils.so file required for loading the kernel
         self.so_utils_path = os.path.join(os.getcwd(), "npu_utils.so")
         if not os.path.isfile(self.so_utils_path):
-            # tilelang/jit/jit_npu.py -> tilelang/ -> tilelang/src/runtime/npu_utils.cpp
+            # Preferred package layout:
+            #   tilelang/jit/jit_npu.py -> tilelang/ -> tilelang/src/runtime/npu_utils.cpp
             pkg_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-            npu_utils_cpp = os.path.join(pkg_root, "src", "runtime", "npu_utils.cpp")
-            if not os.path.isfile(npu_utils_cpp):
+            pkg_runtime_cpp = os.path.join(pkg_root, "src", "runtime", "npu_utils.cpp")
+
+            # Fallback for source-tree/PYTHONPATH workflow:
+            #   repo_root/src/runtime/npu_utils.cpp
+            # where repo_root is the parent of pkg_root (i.e. contains setup.py).
+            repo_root = os.path.dirname(pkg_root)
+            repo_runtime_cpp = os.path.join(repo_root, "src", "runtime", "npu_utils.cpp")
+
+            candidate_paths = [pkg_runtime_cpp]
+            if os.path.isfile(os.path.join(repo_root, "setup.py")):
+                candidate_paths.append(repo_runtime_cpp)
+
+            npu_utils_cpp = next((path for path in candidate_paths if os.path.isfile(path)), None)
+            if npu_utils_cpp is None:
+                searched = ", ".join(candidate_paths)
                 raise FileNotFoundError(
-                    f"npu_utils.cpp not found at {npu_utils_cpp}. "
-                    "Ensure tilelang package includes src/runtime (check setup.py TILELANG_SRC)."
+                    "npu_utils.cpp not found. "
+                    f"Tried: {searched}. "
+                    "Ensure tilelang package includes src/runtime or run from a valid source tree."
                 )
+
             self.so_utils_path = self.make_npu_launcher_stub("npu_utils", npu_utils_cpp)
         self.wrapper_src = generate_npu_wrapper_src(
             self.constants,


### PR DESCRIPTION
1. Simplify pytest-infra logic by allowing only two types of marks.
2. Update README.md
3. Refact memory_ops and atomic_ops tests.
4. Shrink the test nums of copy_cube.
5. Fix bug that jit_npu cannot find `npu_utils.cpp` by adding fallback