### PR TITLE
[Add] Add copy_l1_to_l0a/b transpose Function and example.

### DIFF
--- a/examples/gemm/example_gemm_transpose_l1.py
+++ b/examples/gemm/example_gemm_transpose_l1.py
@@ -1,0 +1,90 @@
+import argparse
+
+import tilelang
+import tilelang.language as T
+import torch
+from tilelang.intrinsics import make_zn_layout, make_nz_layout
+
+tilelang.cache.clear_cache()
+
+parser = argparse.ArgumentParser(description="NPU Kernel Compilation")
+parser.add_argument("--m", type=int, default=512, help="Matrix M dimension")
+parser.add_argument("--n", type=int, default=256, help="Matrix N dimension")
+parser.add_argument("--k", type=int, default=1024, help="Matrix K dimension")
+args = parser.parse_args()
+
+M = args.m
+N = args.n
+K = args.k
+
+
+@tilelang.jit(out_idx=[-1])
+def matmul(M, N, K, block_M, block_N, K_L1, dtype="float16", accum_dtype="float"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, K), dtype),
+            B: T.Tensor((N, K), dtype),
+            C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+
+            A_L1 = T.alloc_L1((block_M, K_L1), dtype)
+            B_L1 = T.alloc_L1((block_N, K_L1), dtype)
+
+            T.annotate_layout(
+                {
+                    A_L1: make_zn_layout(A_L1),
+                    B_L1: make_nz_layout(B_L1),  # Zn
+                }
+            )
+            A_L0 = T.alloc_L0A((block_M, K_L1), dtype)
+            B_L0 = T.alloc_L0B((K_L1, block_N), dtype)
+            C_L0 = T.alloc_L0C((block_M, block_N), accum_dtype)
+
+            with T.Scope("C"):
+                loop_k = T.ceildiv(K, K_L1)
+                for k in T.serial(loop_k):
+                    T.copy(A[bx * block_M : (bx + 1) * block_M, 
+                    k * K_L1 : (k + 1) * K_L1], A_L1)
+                    T.copy(B[by * block_N : (by + 1) * block_N,
+                    k * K_L1 : (k + 1) * K_L1], B_L1)
+
+
+                    T.barrier_all()
+
+                    # T.gemm_v0(A_L1, B_L1, C_L0, init=(k == 0), transpose_B=True)
+                    # copy L1
+                    T.copy(A_L1, A_L0)
+                    T.copy(B_L1, B_L0, transpose=True)
+                    T.barrier_all()
+                    T.mma(A_L0, B_L0, C_L0, init=(k == 0))
+
+                    T.barrier_all()
+
+                T.copy(C_L0, C[bx * block_M : (bx + 1) * block_M, 
+                    by * block_N : (by + 1) * block_N])
+
+    return main
+
+
+func = matmul(M, N, K, 256, 128, 64)
+
+torch.manual_seed(0)
+
+a = torch.randn(M, K).half().npu()
+b = torch.randn(N, K).half().npu()
+c = torch.empty(M, N).half().npu()
+print("init successful!")
+
+c = func(a, b)
+
+ref_c = a @ b.T
+
+torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
+print("Kernel Output Match!")
+# print(func.get_kernel_source())

--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -45,6 +45,9 @@ AscendCopy::AscendCopy(Array<PrimExpr> args, BufferMap vmap) : args_(args) {
   if (args.size() >= 2) {
     enRelu = args[2].as<Bool>().value();
   }
+  if (args.size() >= 4) {
+    transposeL1 = args[3].as<Bool>().value();
+  }
   std::tie(this->src, this->dst) = std::tie(bf[0], bf[1]);
   std::tie(this->src_range, this->dst_range) = std::tie(rgs[0], rgs[1]);
   std::tie(this->src_extents, this->dst_extents) = std::tie(ets[0], ets[1]);
@@ -121,7 +124,7 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     bool needs_strideN = false;
     bool l0c2gm = false;
     bool gm2l1 = false;
-    // bool l12l0 = false;
+    bool l12l0 = false;
     bool print_gm_layout = false;
     bool print_src_layout = false;
     bool print_dst_layout = false;
@@ -140,13 +143,13 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     config.gm2l1 = true;
   } else if (src.scope() == "shared.dyn" && dst.scope() == "wmma.matrix_a") {
     ss << "copy_l1_to_l0a";
-    config.print_src_layout = true;
-    // config.l12l0 = true;
+    // config.print_src_layout = true;
+    config.l12l0 = true;
     config.l0_dst_split = true;
   } else if (src.scope() == "shared.dyn" && dst.scope() == "wmma.matrix_b") {
     ss << "copy_l1_to_l0b";
-    config.print_src_layout = true;
-    // config.l12l0 = true;
+    // config.print_src_layout = true;
+    config.l12l0 = true;
     config.l0_dst_split = true;
   } else if (src.scope() == "wmma.accumulator" && dst.scope() == "global") {
     ss << "copy_l0c_to_gm";
@@ -227,7 +230,10 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     } else if (src.scope() == "global") {
       ss << dst->shape[dst_ndim - 2] << ", " << dst->shape[dst_ndim - 1] << ">";
     } else {
-      ss << src->shape[src_ndim - 2] << ", " << src->shape[src_ndim - 1] << ">";
+      ss << src->shape[src_ndim - 2] << ", " << src->shape[src_ndim - 1];
+      if (config.l12l0) {
+        transposeL1 == 0 ? ss << ", false" << ">" : ss << ", true" << ">";
+      }
       // ss << src->shape[src_ndim - 2] << ", " << src->shape[src_ndim - 1] << ", "
       //    << dst->shape[dst_ndim - 2] << ", " << dst->shape[dst_ndim - 1] << ">";
     }

--- a/src/op/ascend.h
+++ b/src/op/ascend.h
@@ -33,6 +33,7 @@ private:
   Array<PrimExpr> src_extents, dst_extents;
   int srcN;
   bool enRelu;
+  bool transposeL1;
 };
 
 TVM_DLL const Op &ascend_add();

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -25,6 +25,7 @@ using LayoutGM = layout::RowMajor;
 using LayoutL0A = layout::zZ;
 using LayoutL0B = layout::nZ;
 using LayoutL1 = layout::zN;
+using LayoutL1T = layout::nZ;
 
 constexpr int64_t UB_HALF_SIZE = 64;
 
@@ -45,16 +46,18 @@ CATLASS_DEVICE void copy_gm_to_l1(LocalTensor<T> dstTensor,
   tileCopier(dst, src);
 }
 
-template <typename T, typename LayoutL1, uint32_t srcM, uint32_t srcN>
+template <typename T, uint32_t srcM, uint32_t srcN, bool transpose = false>
 CATLASS_DEVICE void copy_l1_to_l0a(LocalTensor<T> dstTensor,
                                    LocalTensor<T> srcTensor,
                                    uint32_t dstM, uint32_t dstN) {
-  using LayoutL1_ = Catlass::detail::TagToLayout_t<T, LayoutL1>;
-  constexpr auto layout = tla::MakeLayout<T, LayoutL1_>(srcM, srcN);
+  using LayoutL1_ = std::conditional_t<transpose,
+                                      Catlass::detail::TagToLayout_t<T, LayoutL1T>,
+                                      Catlass::detail::TagToLayout_t<T, LayoutL1>>;
+  constexpr auto layout = transpose ? 
+  tla::MakeLayout<T, LayoutL1_>(srcN, srcM) : tla::MakeLayout<T, LayoutL1_>(srcM, srcN);
   auto src_LAYOUT = MakeLayoutTile(layout, tla::MakeShape(dstM, dstN));
-
   auto src = MakeTensor<decltype(srcTensor), decltype(src_LAYOUT),
-                        AscendC::TPosition::A1>(srcTensor, src_LAYOUT);
+                      AscendC::TPosition::A1>(srcTensor, src_LAYOUT);
 
   using LayoutL0A_ = Catlass::detail::TagToLayout_t<T, LayoutL0A>;
   auto layoutAInL0 = tla::MakeLayout<T, LayoutL0A_>(dstM, dstN);
@@ -65,17 +68,18 @@ CATLASS_DEVICE void copy_l1_to_l0a(LocalTensor<T> dstTensor,
   tileCopier(dst, src);
 }
 
-template <typename T, typename LayoutL1, uint32_t srcM, uint32_t srcN>
+template <typename T, uint32_t srcM, uint32_t srcN, bool transpose = false>
 CATLASS_DEVICE void copy_l1_to_l0b(LocalTensor<T> dstTensor,
                                    LocalTensor<T> srcTensor,
                                    uint32_t dstM, uint32_t dstN) {
-  using LayoutL1_ = Catlass::detail::TagToLayout_t<T, LayoutL1>;
-  constexpr auto LAYOUT = tla::MakeLayout<T, LayoutL1_>(srcM, srcN);
-  auto src_LAYOUT = MakeLayoutTile(LAYOUT, tla::MakeShape(dstM, dstN));
-  ;
-
+  using LayoutL1_ = std::conditional_t<transpose,
+                                      Catlass::detail::TagToLayout_t<T, LayoutL1T>,
+                                      Catlass::detail::TagToLayout_t<T, LayoutL1>>;
+  constexpr auto layout = transpose ? 
+  tla::MakeLayout<T, LayoutL1_>(srcN, srcM) : tla::MakeLayout<T, LayoutL1_>(srcM, srcN);
+  auto src_LAYOUT = MakeLayoutTile(layout, tla::MakeShape(dstM, dstN));
   auto src = MakeTensor<decltype(srcTensor), decltype(src_LAYOUT),
-                        AscendC::TPosition::A1>(srcTensor, src_LAYOUT);
+                      AscendC::TPosition::A1>(srcTensor, src_LAYOUT);
 
   using LayoutL0B_ = Catlass::detail::TagToLayout_t<T, LayoutL0B>;
   auto layoutBInL0 = tla::MakeLayout<T, LayoutL0B_>(dstM, dstN);
@@ -373,18 +377,18 @@ gemm_v0(LocalTensor<T1> const &A, LocalTensor<T1> const &B,
     uint32_t l0b_base = pp * (N * kL0Size);
 
     WaitFlag<HardEvent::M_MTE1>(L0AB_EVENT + pp);
-    if constexpr (!transpose_A) {
-      tl::ascend::copy_l1_to_l0a<T1, layout::zN, M, K>(
+if constexpr (!transpose_A) {
+      tl::ascend::copy_l1_to_l0a<T1, M, K>(
         l0a[l0a_base], A[kL0Idx * M * kL0Size], M, kSize);
     } else {
-      tl::ascend::copy_l1_to_l0a<T1, layout::nZ, M, K>(
+      tl::ascend::copy_l1_to_l0a<T1, K, M, true>(
         l0a[l0a_base], A[kL0Idx * 16 * kL0Size], M, kSize);
     }
     if constexpr (!transpose_B) {
-      tl::ascend::copy_l1_to_l0b<T1, layout::zN, K, N>(
+      tl::ascend::copy_l1_to_l0b<T1, K, N>(
         l0b[l0b_base], B[kL0Idx * 16 * kL0Size], kSize, N);
     } else {
-      tl::ascend::copy_l1_to_l0b<T1, layout::nZ, K, N>(
+      tl::ascend::copy_l1_to_l0b<T1, N, K, true>(
         l0b[l0b_base], B[kL0Idx * N * kL0Size], kSize, N);
     }
     SetFlag<HardEvent::MTE1_M>(L0AB_EVENT + pp);
@@ -542,18 +546,18 @@ gemm_v1(LocalTensor<T1> const &A, LocalTensor<T1> const &B,
   AscendC::PipeBarrier<PIPE_ALL>();
 
   if constexpr (!transpose_A) {
-    tl::ascend::copy_l1_to_l0a<half, layout::zN, L1_block_M, L1_block_K>
+    tl::ascend::copy_l1_to_l0a<half, L1_block_M, L1_block_K>
                                (l0a, A, BLOCK_M, BLOCK_K);
   } else {
-    tl::ascend::copy_l1_to_l0a<half, layout::nZ, L1_block_M, L1_block_K>
+    tl::ascend::copy_l1_to_l0a<half, L1_block_K, L1_block_M, true>
                                (l0a, A, BLOCK_M, BLOCK_K);
   }
 
   if constexpr (!transpose_B) {
-    tl::ascend::copy_l1_to_l0b<half, layout::zN, L1_block_K, L1_block_N>
+    tl::ascend::copy_l1_to_l0b<half, L1_block_K, L1_block_N>
                                (l0b, B, BLOCK_K, BLOCK_N);
   } else {
-    tl::ascend::copy_l1_to_l0b<half, layout::nZ, L1_block_K, L1_block_N>
+    tl::ascend::copy_l1_to_l0b<half, L1_block_N, L1_block_K, true>
                                (l0b, B, BLOCK_K, BLOCK_N);
   }
 
@@ -582,11 +586,10 @@ CATLASS_DEVICE void gemmL1(LocalTensor<T1> A, LocalTensor<T1> B,
     AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(0);
     AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(0);
 
-    copy_l1_to_l0a<T1, LayOutL1, M, K, baseM, baseK>(A2, A[loopM * baseM * 16]);
+    copy_l1_to_l0a<T1, M, K, baseM, baseK>(A2, A[loopM * baseM * 16]);
 
     for (uint32_t loopN = 0; loopN < N / baseN; loopN++) {
-      copy_l1_to_l0b<T1, LayOutL1, K, N, baseK, baseN>(B2,
-                                                       B[loopN * baseN * K]);
+      copy_l1_to_l0b<T1, K, N, baseK, baseN>(B2, B[loopN * baseN * K]);
 
       AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(0);
       AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(0);

--- a/tilelang/language/copy.py
+++ b/tilelang/language/copy.py
@@ -270,7 +270,7 @@ def npu_copy_v2(src: Union[tir.Buffer, tir.BufferLoad, tir.BufferRegion],
     src = _to_region(src, "r")
     dst = _to_region(dst, "w")
 
-    if transpose is not False:
+    if transpose is True:
             return tir.call_intrin("handle", tir.op.Op.get("tl.ascend_copy"), src, dst, enable_relu, transpose)
     else:
         return tir.call_intrin("handle", tir.op.Op.get("tl.ascend_copy"), src, dst, enable_relu)

--- a/tilelang/language/copy.py
+++ b/tilelang/language/copy.py
@@ -198,7 +198,9 @@ def c2d_im2col(
 
 def npu_copy_v2(src: Union[tir.Buffer, tir.BufferLoad, tir.BufferRegion],
                 dst: Union[tir.Buffer, tir.BufferLoad],
-                enable_relu: bool = False):
+                enable_relu: bool = False,
+                transpose: Optional[bool] = False,  # for copy_l1_to_l0 param: tranpose l1
+                ):
     """Copy data between memory regions.
 
     Args:
@@ -213,7 +215,8 @@ def npu_copy_v2(src: Union[tir.Buffer, tir.BufferLoad, tir.BufferRegion],
         tir.Call: A handle to the copy operation
     """
     if isinstance(src, tir.Buffer) and isinstance(dst, tir.Buffer):
-        ir.assert_structural_equal(src.shape, dst.shape)
+            if not transpose:
+                ir.assert_structural_equal(src.shape, dst.shape)
 
     src_shape = src.shape if isinstance(src, tir.Buffer) else src.buffer.shape
 
@@ -267,4 +270,7 @@ def npu_copy_v2(src: Union[tir.Buffer, tir.BufferLoad, tir.BufferRegion],
     src = _to_region(src, "r")
     dst = _to_region(dst, "w")
 
-    return tir.call_intrin("handle", tir.op.Op.get("tl.ascend_copy"), src, dst, enable_relu)
+    if transpose is not False:
+            return tir.call_intrin("handle", tir.op.Op.get("tl.ascend_copy"), src, dst, enable_relu, transpose)
+    else:
+        return tir.call_intrin("handle", tir.op.Op.get("tl.ascend_copy"), src, dst, enable_relu)

--- a/tilelang/language/copy.py
+++ b/tilelang/language/copy.py
@@ -270,7 +270,7 @@ def npu_copy_v2(src: Union[tir.Buffer, tir.BufferLoad, tir.BufferRegion],
     src = _to_region(src, "r")
     dst = _to_region(dst, "w")
 
-    if transpose is True:
+    if transpose:
             return tir.call_intrin("handle", tir.op.Op.get("tl.ascend_copy"), src, dst, enable_relu, transpose)
     else:
         return tir.call_intrin("handle", tir.op.Op.get("tl.ascend_copy"), src, dst, enable_relu)


### PR DESCRIPTION
Add copy_l1_to_l0a/b transpose Function and example.
The copyshape restriction has been removed; the copy_l1_to_l0ab interface has been refactored, removing layout and adding the transpose option.