### PR TITLE
[Refactor] Refactor tilelang.language _dtype functoin, unify into one.

### DIFF
--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -2,6 +2,7 @@ import tilelang.language as T
 from tvm.tir import PrimExpr, Buffer, BufferRegion, BufferLoad, Call
 from typing import List, Union, Tuple
 from tvm import tir
+from tilelang.language.ascend import _dtype
 
 import math
 
@@ -38,26 +39,6 @@ def _get_buffer_info(
         return ptr, size
     else:
         raise TypeError(f"Unsupported type: {type(br)}")
-
-
-def _dtype(buf):
-    type_map = {
-        "float16": "half",
-        "float32": "float",
-        "int32": "int",
-        "uint32": "uint32_t",
-        "bfloat16": "bfloat16_t",
-        "uint16": "uint16_t",
-        "uint8": "uint8_t",
-		"int4": "int4b_t",
-        "int8": "int8_t",
-        "int16": "int16_t",
-        "int64": "int64_t",
-        "uint64": "uint64_t",
-    }
-    if isinstance(buf, BufferRegion):
-        buf = buf.buffer
-    return type_map[buf.dtype]
 
 
 def fill(buffer: Union[Buffer, BufferRegion], value: PrimExpr):

--- a/tilelang/language/customize.py
+++ b/tilelang/language/customize.py
@@ -6,6 +6,8 @@ import tilelang.language as T
 from tvm.tir import PrimExpr, Buffer, BufferRegion, Var
 from typing import List, Union
 from tvm import tir
+from tilelang.language.ascend import _dtype
+
 
 
 def atomic_add(dst: Buffer, value: PrimExpr) -> PrimExpr:
@@ -108,26 +110,6 @@ def view(src: Buffer,
     if dtype is None:
         dtype = src.dtype
     return T.Buffer(shape, dtype, src.data)
-
-
-def _dtype(buf):
-    type_map = {
-        "float16": "half",
-        "float32": "float",
-        "int32": "int",
-        "uint32": "uint32_t",
-        "bfloat16": "bfloat16_t",
-        "uint16": "uint16_t",
-        "uint8": "uint8_t",
-		"int4": "int4b_t",
-        "int8": "int8_t",
-        "int16": "int16_t",
-        "int64": "int64_t",
-        "uint64": "uint64_t",
-    }
-    if isinstance(buf, BufferRegion):
-        buf = buf.buffer
-    return type_map[buf.dtype]
 
 
 def npu_gemm(A, B, C, init=False):


### PR DESCRIPTION
Refactor tilelang.language _dtype functoin, unify into one.
Use the same data type to retrieve the interface makes maintenance and modification easier.