### PR TITLE
Restructure the slicing functionality of the PTO computation interface, including binaryop, binaryops, and unaryop. Adapt the bufferregion for sigmoid and scalar_op, and add frontend test cases.

### DIFF
--- a/examples/activation/sigmoidv2_slice.py
+++ b/examples/activation/sigmoidv2_slice.py
@@ -1,0 +1,47 @@
+import tilelang
+from tilelang import language as T
+import torch
+
+torch.set_default_device('npu')
+torch.manual_seed(42)
+
+tilelang.disable_cache()
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+@tilelang.jit(out_idx=[1], pass_configs=pass_configs)
+def sigmoidv2():
+    dtype = "float"
+    
+    @T.prim_func
+    def main(input: T.Tensor([4, 8], dtype),
+             output: T.Tensor([4, 8], dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            input_shared = T.alloc_ub((4, 8), dtype)
+            output_shared = T.alloc_ub((4, 8), dtype)
+            tmp_shared = T.alloc_ub((4, 8), "uint8")
+            
+            T.copy(input, input_shared)
+            for i in range(4):
+                T.tile.sigmoid(output_shared[i, :], input_shared[i, :], tmp_shared)
+            T.copy(output_shared, output)
+            
+    return main
+
+dtype = torch.float
+input = torch.randn([4, 8], dtype=dtype)
+func = sigmoidv2()
+print("init successful!")
+output = func(input)
+
+torch.npu.synchronize()
+
+ref_output = torch.sigmoid(input)
+
+torch.testing.assert_close(ref_output, output, rtol=1e-2, atol=1e-2)
+print("Kernel Output Match!")

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -32,6 +32,8 @@ namespace tvm {
 namespace codegen {
   const std::string kAscendPtoScope = "tl::ascend_pto::";
 
+  using ShapeInfo = CodeGenTileLangAscendPto::ShapeInfo;
+
 static std::string getType(const DataType &dtype) {
   if (dtype.is_float16()) {
     return "half";

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -64,8 +64,8 @@ static std::string getType(const DataType &dtype) {
   return "";
 }
 
-int8_t GetTypeLen(std::string type) {
-  int8_t typeSize = 1;
+int32_t GetTypeLen(std::string type) {
+  int32_t typeSize = 1;
   if (type == "float") {
     typeSize = 4;
   } else if (type == "bfloat16_t") {

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -102,6 +102,45 @@ std::string GetTypeLenString(std::string type) {
   return typeSize;
 }
 
+std::string CodeGenTileLangAscendPto::GetTempVarName(const std::string& temp_name) {
+  return temp_name + "_" + std::to_string(counters_[temp_name]++);
+}
+
+void CodeGenTileLangAscendPto::CreateUbVariable(const std::string& temp_name, const ShapeInfo& shape_info) {
+  this->PrintIndent();
+  this->stream << kAscendPtoScope << "TileUbDataND<" << shape_info.type << ", " << shape_info.slice_row << ", " 
+  << shape_info.slice_col  << ", "<< shape_info.slice_row << ", " << shape_info.slice_col << "> " << temp_name << ";\n";
+
+  this->PrintIndent();
+  this->stream << "TASSIGN(" << temp_name << ", " << shape_info.first_addr << " + " 
+  << shape_info.offset << " * " << GetTypeLen(shape_info.type) << ");\n";
+}
+
+ShapeInfo CodeGenTileLangAscendPto::GetSliceInfo(const CallNode *op) {
+  auto shape = buffer_shapess_[GetRef<tir::Var>(op->args[1].as<VarNode>())];
+  int32_t row;
+  int32_t col;
+  if (shape.size() == 1) {
+    row = shape[0].as<IntImmNode>()->value;
+  } else {
+    row = shape[0].as<IntImmNode>()->value;
+    col = shape[1].as<IntImmNode>()->value;
+  }
+  int32_t extent = op->args[3].as<IntImmNode>()->value;
+  int32_t slice_row = (extent / col) > 1 ? (extent / col) : 1;
+  int32_t slice_col = extent > col ? col : extent;
+  auto src_addr = ub_data_map_[PrintExpr(op->args[1])][3];
+  auto offset = PrintExpr(op->args[2]);
+  auto type = ub_data_map_[PrintExpr(op->args[1])][0];
+  bool is_slice;
+  if (shape.size() == 1) {
+    is_slice = extent != row;
+  } else {
+    is_slice = extent != row * col;
+  }
+  return ShapeInfo{row, col, slice_row, slice_col, extent, src_addr, offset, type, is_slice};
+}
+
 CodeGenTileLangAscendPto::CodeGenTileLangAscendPto(std::string platform) {
   // restrict_keyword_ = "__gm__ uint8_t *";
   platform_ = platform;
@@ -1561,28 +1600,25 @@ void CodeGenTileLangAscendPto::SetDeqScaleCodegen(const CallNode *op) {
 
 void CodeGenTileLangAscendPto::BinaryVecOpCodegen(const CallNode *op,
                                                const std::string &op_name) {
+  
+  ShapeInfo src0_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+  ShapeInfo src1_shape_info = GetSliceInfo(op->args[2].as<CallNode>());
+  ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
+
+  std::string src0_offset = src0_shape_info.offset;
+  std::string src1_offset = src1_shape_info.offset;
+  std::string dst_offset = dst_shape_info.offset;
+
+  int32_t src0_extent = src0_shape_info.extent;
+  int32_t src1_extent = src1_shape_info.extent;
+  int32_t dst_extent = dst_shape_info.extent;
+
   std::vector<std::string> var_names;
-  std::string src0_name = PrintExpr(op->args[1].as<CallNode>()->args[1]);
-  std::string src1_name = PrintExpr(op->args[2].as<CallNode>()->args[1]);
-  std::string dst_name = PrintExpr(op->args[0].as<CallNode>()->args[1]);
-
-  std::string src0_offset = PrintExpr(op->args[1].as<CallNode>()->args[2]);
-  std::string src1_offset = PrintExpr(op->args[2].as<CallNode>()->args[2]);
-  std::string dst_offset = PrintExpr(op->args[0].as<CallNode>()->args[2]);
-
-  std::string src0_addr = ub_data_map_[src0_name][3];
-  std::string src1_addr = ub_data_map_[src1_name][3];
-  std::string dst_addr = ub_data_map_[dst_name][3];
-
-  std::string shape = PrintExpr(op->args[3]);
-
-  std::string ub_type = ub_data_map_[dst_name][0];
-  int32_t type_len = GetTypeLen(ub_type);
   for (int i = 0; i < op->args.size() - 1; i++) {
     auto var_name = PrintBufferOffset(op->args[i].as<CallNode>());
     var_names.push_back(var_name);
   }
-  if (!(src0_offset != "0" || src1_offset != "0" || dst_offset != "0")) {
+  if (!(src0_shape_info.is_slice || src1_shape_info.is_slice || dst_shape_info.is_slice)) {
     this->PrintIndent();
     this->stream << op_name << "(";
 
@@ -1594,6 +1630,8 @@ void CodeGenTileLangAscendPto::BinaryVecOpCodegen(const CallNode *op,
         element_count_dst = shape_dst[1] * shape_dst[2];
       } else if (shape_dst.size() == 2) {
         element_count_dst = shape_dst[0] * shape_dst[1];
+      } else if (shape_dst.size() == 1) {
+        element_count_dst = shape_dst[0];
       } else {
         ICHECK(false)
             << "An error occurred. Please check prefetch_n_stages_map_, "
@@ -1603,7 +1641,7 @@ void CodeGenTileLangAscendPto::BinaryVecOpCodegen(const CallNode *op,
           op->args[0].as<CallNode>()->args[2] / element_count_dst;
       tvm::arith::Analyzer analyzer;
       PrimExpr simplified_buffer_k_dst = analyzer.Simplify(buffer_k_dst);
-      this->stream << var_names[0] << "[" << simplified_buffer_k_dst << "], ";
+      this->stream << var_names[0] << "[" << (PrintExpr(simplified_buffer_k_dst)) << "], ";
     } else {
       this->stream << var_names[0] << ", ";
     }
@@ -1616,6 +1654,8 @@ void CodeGenTileLangAscendPto::BinaryVecOpCodegen(const CallNode *op,
         element_count_src0 = shape_src0[1] * shape_src0[2];
       } else if (shape_src0.size() == 2) {
         element_count_src0 = shape_src0[0] * shape_src0[1];
+      } else if (shape_src0.size() == 1) {
+        element_count_src0 = shape_src0[0];
       } else {
         ICHECK(false)
             << "An error occurred. Please check prefetch_n_stages_map_, "
@@ -1625,7 +1665,7 @@ void CodeGenTileLangAscendPto::BinaryVecOpCodegen(const CallNode *op,
           op->args[1].as<CallNode>()->args[2] / element_count_src0;
       tvm::arith::Analyzer analyzer;
       PrimExpr simplified_buffer_k_src0 = analyzer.Simplify(buffer_k_src0);
-      this->stream << var_names[1] << "[" << simplified_buffer_k_src0 << "], ";
+      this->stream << var_names[1] << "[" << PrintExpr(simplified_buffer_k_src0) << "], ";
     } else {
       this->stream << var_names[1] << ", ";
     }
@@ -1634,10 +1674,13 @@ void CodeGenTileLangAscendPto::BinaryVecOpCodegen(const CallNode *op,
       PrimExpr element_count_src1;
       auto shape_src1 = buffer_shapess_[GetRef<tir::Var>(
           op->args[2].as<CallNode>()->args[1].as<VarNode>())];
+      std::cout << "shape_src1: " << shape_src1 << std::endl;
       if (shape_src1.size() == 3) {
         element_count_src1 = shape_src1[1] * shape_src1[2];
       } else if (shape_src1.size() == 2) {
         element_count_src1 = shape_src1[0] * shape_src1[1];
+      } else if (shape_src1.size() == 1) {
+        element_count_src1 = shape_src1[0];
       } else {
         ICHECK(false)
             << "An error occurred. Please check prefetch_n_stages_map_, "
@@ -1647,16 +1690,20 @@ void CodeGenTileLangAscendPto::BinaryVecOpCodegen(const CallNode *op,
           op->args[2].as<CallNode>()->args[2] / element_count_src1;
       tvm::arith::Analyzer analyzer;
       PrimExpr simplified_buffer_k_src1 = analyzer.Simplify(buffer_k_src1);
-      this->stream << var_names[2] << "[" << simplified_buffer_k_src1 << "]);\n";
+      this->stream << var_names[2] << "[" << PrintExpr(simplified_buffer_k_src1) << "]);\n";
     } else {
       this->stream << var_names[2] << ");\n";
     }
 
-  } else if (src0_offset != "0" || src1_offset != "0" || dst_offset != "0") {
+  } else if (src0_shape_info.is_slice || src1_shape_info.is_slice || dst_shape_info.is_slice) {
+    std::string src0_temp_name = GetTempVarName("src0_binary_temp");
+    std::string src1_temp_name = GetTempVarName("src1_binary_temp");
+    std::string dst_temp_name = GetTempVarName("dst_binary_temp");
+    CreateUbVariable(src0_temp_name, src0_shape_info);
+    CreateUbVariable(src1_temp_name, src1_shape_info);
+    CreateUbVariable(dst_temp_name, dst_shape_info);
     this->PrintIndent();
-    this->stream << kAscendPtoScope << "binary_tile" << "<" << kAscendPtoScope << "BinaryOp::" << op_name << ", " << ub_type << ", " << shape << ">" << "("
-    << dst_addr << ", " << src0_addr << ", " << src1_addr << ", " << dst_offset
-    << ", " << src0_offset << ", " << src1_offset << ", " << type_len << ");\n";
+    this->stream << op_name << "(" << dst_temp_name << ", " << src0_temp_name << ", " << src1_temp_name << ");\n";
   } else if (prefetch_n_stages_map_[var_names[1]].first == 0) {
     this->PrintIndent();
     this->stream << op_name << "(";
@@ -1932,33 +1979,18 @@ void CodeGenTileLangAscendPto::BinaryVecOpsCodegen(const CallNode *op,
                             : index;
     }
     std::string scalar_name =
-        is_call ? (PrintBufferOffset(selected_elements_buffer) + "_scalar")
-                : "scalar";
+        is_call ? GetTempVarName(PrintBufferOffset(selected_elements_buffer) + "_scalar")
+                : GetTempVarName("scalar");
     this->PrintIndent();
     this->stream << "set_flag(PIPE_V, PIPE_S, EVENT_ID0);\n";     
     this->PrintIndent();
     this->stream << "wait_flag(PIPE_V, PIPE_S, EVENT_ID0);\n";
     this->PrintIndent();
-    this->stream << "{\n";
-    this->PrintIndent();
     this->stream << "auto " << scalar_name << " = " << scalar_expr << ";\n";
 
-    std::string dst_ub_name = var_names[0];
-    std::string src_ub_name = var_names[1];
+    ShapeInfo src_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+    ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
 
-    std::vector<std::string> dst_vector = ub_data_map_[dst_ub_name];
-    std::vector<std::string> src_vector = ub_data_map_[src_ub_name];
-
-    std::string dst_offset = PrintExpr(op->args[0].as<CallNode>()->args[2]);
-    std::string src_offset = PrintExpr(op->args[1].as<CallNode>()->args[2]);
- 
-    std::string var_name_temp_dst = dst_ub_name + "_temp";
-    std::string var_name_temp_src = src_ub_name + "_temp";
- 
-    std::string dst_addr = dst_vector[3];
-    std::string src_addr = src_vector[3];
- 
-    std::string ub_data_type = dst_vector[0];
     std::string loop_num = getValueOrProcess(for_num_map_, index);
  
     std::string final_op_name = operation;
@@ -1973,41 +2005,15 @@ void CodeGenTileLangAscendPto::BinaryVecOpsCodegen(const CallNode *op,
  
     this->PrintIndent();
     if (loop_num >= "0" && loop_num <= "9") {
-      auto ub_data_temp_col_dst = std::stoi(dst_vector[2]);
-      auto ub_data_temp_col_src = std::stoi(src_vector[2]);
-      if (dst_offset != "0") {
-          ub_data_temp_col_dst = std::stoi(PrintExpr(op->args[op->args.size()-1]));
-        }
-        if (src_offset != "0") {
-          ub_data_temp_col_src = std::stoi(PrintExpr(op->args[op->args.size()-1]));
-      }
-      if (is_call) {
-        this->stream << kAscendPtoScope << "binarys_tile<" << kAscendPtoScope << "BinaryOps::" << final_op_name 
-        << ", " << ub_data_type << ", " << ub_data_temp_col_dst << ", " << ub_data_temp_col_src << ">("
-        << dst_addr << ", " << src_addr << ", " << dst_offset << ", " << src_offset << ", " << GetTypeLenString(ub_data_type) 
-        << ", " << applied_scalar << ");\n";
-      } else {
-        this->PrintIndent();
-        this->stream << kAscendPtoScope << "TileUbDataND<" << ub_data_type << ", 1, "
-        << ub_data_temp_col_dst << ", 1, " << ub_data_temp_col_dst << "> " << var_name_temp_dst << ";\n";
-        this->PrintIndent();
-        this->stream << "TASSIGN(" << var_name_temp_dst << ", " << dst_addr << " + " <<
-        dst_offset << " * " << GetTypeLenString(ub_data_type) << ");\n";
-        if (dst_ub_name != src_ub_name) {
-          this->PrintIndent();
-          this->stream << kAscendPtoScope << "TileUbDataND<" << ub_data_type << ", 1, "
-          << ub_data_temp_col_src << ", 1, " << ub_data_temp_col_src << "> " << var_name_temp_src << ";\n";
-          this->PrintIndent();
-          this->stream << "TASSIGN(" << var_name_temp_src << ", " << src_addr << " + " <<
-          src_offset << " * " << GetTypeLenString(ub_data_type) << ");\n";
-        }
-        this->stream << final_op_name << "(" << var_name_temp_dst << ", " << var_name_temp_src << ", " << applied_scalar << ");\n";
-      } 
+      std::string src_temp_name = GetTempVarName("src_binarys_temp");
+      std::string dst_temp_name = GetTempVarName("dst_binarys_temp");
+      CreateUbVariable(src_temp_name, src_shape_info);
+      CreateUbVariable(dst_temp_name, dst_shape_info);
+      this->PrintIndent();
+      this->stream << final_op_name << "(" << dst_temp_name << ", " << src_temp_name << ", " << applied_scalar << ");\n";
     } else {
         this->stream << operation << "(" << var_names[0] << ", " << var_names[1] << ", " << applied_scalar << ");\n";
     }
-    this->PrintIndent();
-    this->stream << "}\n";
   } else {
     this->PrintIndent();
     this->stream << operation << "(";
@@ -2020,40 +2026,76 @@ void CodeGenTileLangAscendPto::BinaryVecOpsCodegen(const CallNode *op,
 
 void CodeGenTileLangAscendPto::UnaryVecOpCodegen(const CallNode *op, const std::string& op_name) {
   std::vector<std::string> var_names;
-
-  std::string src_name = PrintExpr(op->args[1].as<CallNode>()->args[1]);
-  std::string dst_name = PrintExpr(op->args[0].as<CallNode>()->args[1]);
-
-  std::string src_offset = PrintExpr(op->args[1].as<CallNode>()->args[2]);
-  std::string dst_offset = PrintExpr(op->args[0].as<CallNode>()->args[2]);
-
-  std::string src_addr = ub_data_map_[src_name][3];
-  std::string dst_addr = ub_data_map_[dst_name][3];
-
-  std::string shape = PrintExpr(op->args[2]);
-  std::string ub_type = ub_data_map_[dst_name][0];
-  int32_t type_len = GetTypeLen(ub_type);
   for (int i = 0; i < op->args.size() - 1; i++) {
     auto var_name = PrintBufferOffset(op->args[i].as<CallNode>());
     var_names.push_back(var_name);
   }
 
-  if (src_offset != "0" || dst_offset != "0") {
+  ShapeInfo src_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+  ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
+
+  bool is_src_slice = src_shape_info.extent != src_shape_info.row * src_shape_info.col;
+  bool is_dst_slice = dst_shape_info.extent != dst_shape_info.row * dst_shape_info.col;
+
+  if (src_shape_info.is_slice || dst_shape_info.is_slice) {
+    std::string src_temp_name = GetTempVarName("src_unary_temp");
+    std::string dst_temp_name = GetTempVarName("dst_unary_temp");
+    CreateUbVariable(src_temp_name, src_shape_info);
+    CreateUbVariable(dst_temp_name, dst_shape_info);
     this->PrintIndent();
-    this->stream << kAscendPtoScope << "unary_tile" << "<" << kAscendPtoScope << "UnaryOp::" << op_name << ", " << ub_type << ", " << shape << ">" << "("
-    << dst_addr << ", " << src_addr << ", " << dst_offset
-    << ", " << src_offset << ", "  << type_len << ");\n";
+    this->stream << op_name << "(" << dst_temp_name << ", " << src_temp_name << ");\n";
   } else {
     this->PrintIndent();
     this->stream << op_name << "(";
-    for (int i = 0; i < var_names.size(); i++) {
-      this->stream << var_names[i];
-      if (i != var_names.size() - 1) {
-        this->stream << ", ";
+
+    if (prefetch_n_stages_map_[var_names[0]].first > 0) {
+      PrimExpr element_count_dst;
+      auto shape_dst = buffer_shapess_[GetRef<tir::Var>(
+          op->args[0].as<CallNode>()->args[1].as<VarNode>())];
+      if (shape_dst.size() == 3) {
+        element_count_dst = shape_dst[1] * shape_dst[2];
+      } else if (shape_dst.size() == 2) {
+        element_count_dst = shape_dst[0] * shape_dst[1];
+      } else if (shape_dst.size() == 1) {
+        element_count_dst = shape_dst[0];
+      } else {
+        ICHECK(false)
+            << "An error occurred. Please check prefetch_n_stages_map_, "
+                "buffer_shapes_, and buffer_versions_.";
       }
+      auto buffer_k_dst =
+          op->args[0].as<CallNode>()->args[2] / element_count_dst;
+      tvm::arith::Analyzer analyzer;
+      PrimExpr simplified_buffer_k_dst = analyzer.Simplify(buffer_k_dst);
+      this->stream << var_names[0] << "[" << (PrintExpr(simplified_buffer_k_dst)) << "], ";
+    } else {
+      this->stream << var_names[0] << ", ";
     }
-    this->stream << ");\n";
-  } 
+
+    if (prefetch_n_stages_map_[var_names[1]].first > 0) {
+      PrimExpr element_count_src0;
+      auto shape_src0 = buffer_shapess_[GetRef<tir::Var>(
+          op->args[1].as<CallNode>()->args[1].as<VarNode>())];
+      if (shape_src0.size() == 3) {
+        element_count_src0 = shape_src0[1] * shape_src0[2];
+      } else if (shape_src0.size() == 2) {
+        element_count_src0 = shape_src0[0] * shape_src0[1];
+      } else if (shape_src0.size() == 1) {
+        element_count_src0 = shape_src0[0];
+      } else {
+        ICHECK(false)
+            << "An error occurred. Please check prefetch_n_stages_map_, "
+                "buffer_shapes_, and buffer_versions_.";
+      }
+      auto buffer_k_src0 =
+          op->args[1].as<CallNode>()->args[2] / element_count_src0;
+      tvm::arith::Analyzer analyzer;
+      PrimExpr simplified_buffer_k_src0 = analyzer.Simplify(buffer_k_src0);
+      this->stream << var_names[1] << "[" << PrintExpr(simplified_buffer_k_src0) << "]);\n";
+    } else {
+      this->stream << var_names[1] << ");\n";
+    }
+  }
 }
 
 void CodeGenTileLangAscendPto::ScalarOpCodegen(const CallNode *op, const std::string& op_name) {
@@ -2494,6 +2536,12 @@ bool CodeGenTileLangAscendPto::ValidLayoutEnabled(const AllocateNode *op) {
       } else {
         valid = true;
       }
+    } else if (shape.size() == 1) {
+      if (tvm::tir::is_zero(tvm::truncmod(shape[0] * typeSize, 32))) {
+        valid = false;
+      } else {
+        valid = true;
+      }
     } else {
       ICHECK(false) << "ValidLayoutEnabled Error";
     }
@@ -2689,24 +2737,24 @@ void CodeGenTileLangAscendPto::VisitStmt_(const AllocateNode *op) {
           std::vector<PrimExpr> valid_shapes;
           valid_shapes.reserve(shape.size() - 1);
           stream << pos << "<" << type;
-          int shape_value = shape[1].as<tvm::tir::IntImmNode>()->value;
+          int shape_value = shape[0].as<tvm::tir::IntImmNode>()->value;
           if (shape_value * dtype_bytes % 32 == 0) {
-            valid_shapes.push_back(shape[1]);
+            valid_shapes.push_back(shape[0]);
           } else {
             valid_shapes.push_back(tvm::IntImm(
-                shape[1].dtype(),
+                shape[0].dtype(),
                 shape_value +
                     (32 - shape_value * dtype_bytes % 32) / dtype_bytes));
           }
-          valid_shapes.push_back(shape[2]);
+          valid_shapes.push_back(shape[1]);
           for (size_t i = 0; i < valid_shapes.size(); i++) {
             l_data[i + 1] = PrintExpr(valid_shapes[i]);
             stream << ", " << valid_shapes[i];
           }
-          for (size_t i = 1; i < shape.size(); i++) {
+          for (size_t i = 0; i < shape.size(); i++) {
             stream << ", " << shape[i];
           }
-          stream << "> " << vid << "[" << shape[0] << "];\n";
+          stream << "> " << vid << "[" << bufferNum << "];\n";
           for (size_t j = 0; j < bufferNum; j++) {
             this->PrintIndent();
             stream << "TASSIGN(" << vid << "[" << j << "], "
@@ -2863,24 +2911,24 @@ void CodeGenTileLangAscendPto::VisitStmt_(const AllocateNode *op) {
           std::vector<PrimExpr> valid_shapes;
           valid_shapes.reserve(shape.size() - 1);
           stream << pos << "<" << type;
-          int shape_value = shape[1].as<tvm::tir::IntImmNode>()->value;
+          int shape_value = shape[0].as<tvm::tir::IntImmNode>()->value;
           if (shape_value * dtype_bytes % 32 == 0) {
-            valid_shapes.push_back(shape[1]);
+            valid_shapes.push_back(shape[0]);
           } else {
             valid_shapes.push_back(tvm::IntImm(
-                shape[1].dtype(),
+                shape[0].dtype(),
                 shape_value +
                     (32 - shape_value * dtype_bytes % 32) / dtype_bytes));
           }
-          valid_shapes.push_back(shape[2]);
+          valid_shapes.push_back(shape[1]);
           for (size_t i = 0; i < valid_shapes.size(); i++) {
             l_data[i + 1] = PrintExpr(valid_shapes[i]);
             stream << ", " << valid_shapes[i];
           }
-          for (size_t i = 1; i < shape.size(); i++) {
+          for (size_t i = 0; i < shape.size(); i++) {
             stream << ", " << shape[i];
           }
-          stream << "> " << vid << "[" << shape[0] << "];\n";
+          stream << "> " << vid << "[" << bufferNum << "];\n";
           for (size_t j = 0; j < bufferNum; j++) {
             this->PrintIndent();
             stream << "TASSIGN(" << vid << "[" << j << "], "

--- a/src/target/codegen_ascend_pto.h
+++ b/src/target/codegen_ascend_pto.h
@@ -151,7 +151,7 @@ private:
   std::string PrintBufferOffset(const CallNode *op);
   void UbShapeInputCheck(const AllocateNode *op);
   bool ValidLayoutEnabled(const AllocateNode *op);
-  
+
   std::string GetTempVarName(const std::string& temp_name);
   void CreateUbVariable(const std::string& temp_name, const ShapeInfo& shape_info);
   ShapeInfo GetSliceInfo(const CallNode *op);
@@ -223,6 +223,8 @@ private:
     Array<String> shape_list;
   };
   std::unordered_map<String, global_tensor> global_tensor_template;
+
+  std::unordered_map<std::string, int32_t> counters_;
 
   bool use_swizzle_{false};
 

--- a/src/target/codegen_ascend_pto.h
+++ b/src/target/codegen_ascend_pto.h
@@ -63,6 +63,17 @@ public:
   // Override this as a work around for __grid_constant__ parameter
   void AddFunction(const GlobalVar &gvar, const PrimFunc &f);
 
+  struct ShapeInfo{
+    int32_t row;
+    int32_t col;
+    int32_t slice_row;
+    int32_t slice_col;
+    int32_t extent;
+    std::string first_addr;
+    std::string offset;
+    std::string type;
+    bool is_slice;
+  };
 private:
   void AutoBarrierCodegen (const CallNode *op);
   void AutoFlagOpCodegen (const CallNode *op, std::string op_name);
@@ -140,6 +151,10 @@ private:
   std::string PrintBufferOffset(const CallNode *op);
   void UbShapeInputCheck(const AllocateNode *op);
   bool ValidLayoutEnabled(const AllocateNode *op);
+  
+  std::string GetTempVarName(const std::string& temp_name);
+  void CreateUbVariable(const std::string& temp_name, const ShapeInfo& shape_info);
+  ShapeInfo GetSliceInfo(const CallNode *op);
 
   // Whether global barrier is needed.
   bool need_global_barrier_{false};
@@ -215,7 +230,7 @@ private:
 
   std::string current_resource_scope_ = ""; // 标识是CUBE还是VEC
 
-  int32_t select_num = 0;
+  int32_t select_num = 0; 
 
   int32_t reduce_num = 0;
 };

--- a/src/transform/ascend_pto_save_buffer_shape.cc
+++ b/src/transform/ascend_pto_save_buffer_shape.cc
@@ -78,6 +78,13 @@ class SimpleBufferShapeCollector : public StmtVisitor {
     shape_map_.Set(op->buffer_var, shape);
     StmtVisitor::VisitStmt_(op);
   }
+
+  void VisitStmt_(const BlockNode *op) final {
+    for (const Buffer& buffer : op->alloc_buffers) {
+      shape_map_.Set(buffer->data, buffer->shape);
+    }
+    StmtVisitor::VisitStmt_(op);
+  }
   
   Map<Var, Array<PrimExpr>> shape_map_;
 };

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -29,20 +29,20 @@ static Buffer makeBufferWithLayout(const Buffer &buffer, const Layout &layout,
   const auto *ptr_type =
       TVM_TYPE_AS(buffer->data->type_annotation, PointerTypeNode);
   Type new_type;
+  Var new_var;
   // convert fragments to normal local buffer
   if (ptr_type->storage_scope == "local.fragment") {
     new_type = PointerType(ptr_type->element_type, "local");
+    new_var = Var(buffer->data->name_hint, new_type);
   } else {
-    new_type = buffer->data->type_annotation;
+    new_var = buffer->data;
   }
-  Var new_var;
   if (ptr_type->storage_scope == "global") {
     new_var = buffer->data;
   } else {
     if (var_remap.count(buffer->data)) {
       new_var = var_remap[buffer->data];
     } else {
-      new_var = Var(buffer->data->name_hint, new_type);
       var_remap.Set(buffer->data, new_var);
     }
   }

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -316,6 +316,54 @@ def test_axpy(target, shape):
     M, N = shape
     run_test_axpy(M, N, 128, 256, target)
 
+def axpy_slice(M, N, block_M, block_N, dtype="float"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    VEC_NUM = 2
+
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, N), dtype),
+            B: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            T.tile.fill(b_ub, 0)
+
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+
+            T.tile.axpy(b_ub, a_ub, 2.0)
+
+            T.copy(b_ub, B[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    return main
+
+
+def run_test_axpy_slice(M, N, block_M, block_N, target):
+    func = axpy_slice(M, N, block_M, block_N)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    a = torch.randn(M, N).npu()
+
+    torch.npu.synchronize()
+
+    b = func(a)
+
+    ref_b = a * 2.0
+    torch.testing.assert_close(b, ref_b, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("target", ["ascendc"])
+@pytest.mark.parametrize("shape", [(1024, 1024)])
+def test_axpy_slice(target, shape):
+    M, N = shape
+    run_test_axpy_slice(M, N, 128, 256, target)
+
 
 def bilinear_interpolation(mask, h_repeat, repeat_mode, dst_blk_stride, v_r_offset, v_repeat, src0, src0offset_int,
                            src0offset, src1):

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -61,6 +61,7 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.AscendLowerParallelToVector()(mod)
     # Infer memory layouts for fragments and shared memory
     mod = tilelang.transform.LayoutInference()(mod)
+    mod = tilelang.transform.CollectBufferShapes()(mod)
     # Lower high-level tile operations to low-level operations
     mod = tilelang.transform.LowerTileOp()(mod)
     # Legalize vectorized loops to ensure they are valid
@@ -86,7 +87,6 @@ def OptimizeForTarget(mod: IRModule, target: Target, platform: str) -> IRModule:
     mod = tir.transform.LowerOpaqueBlock()(mod)
     mod = tir.transform.NarrowDataType(32)(mod)
     mod = tilelang.transform.ConfigIndexBitwidth()(mod)
-    mod = tilelang.transform.CollectBufferShapes()(mod)
     mod = tilelang.transform.FlattenBuffer()(mod)
     mod = tir.transform.Simplify()(mod)
     mod = tilelang.transform.VectorizeLoop(enable_vectorize=allow_vectorize(pass_ctx=pass_ctx))(mod)

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -675,13 +675,25 @@ def exp(dst: Buffer, src0: Buffer):
     """
     return unary_op(dst, src0, "exp")
 
-def sigmoid(dst: Buffer, src: Buffer, tmp: Buffer):
-    size = math.prod(dst.shape)
+def sigmoid(dst: Union[Buffer, BufferRegion], src: Union[Buffer, BufferRegion], tmp: Buffer):
+    if isinstance(dst, BufferRegion):
+        print("test1")
+        dst_ptr, buffer_extent = _handle_buffer_region(dst, "w")
+        size = math.prod(buffer_extent)
+        print("test2")
+    else: 
+        dst_ptr = dst.access_ptr("w")
+        size = math.prod(dst.shape)
+
+    if isinstance(src, BufferRegion):
+        src_ptr, _ = _handle_buffer_region(src, "r")
+    else: 
+        src_ptr = src.access_ptr("r")
     return tir.call_intrin(
         "handle",
         tir.op.Op.get(f"tl.ascend_sigmoid"),
-        dst.access_ptr("w"),
-        src.access_ptr("r"),
+        dst_ptr,
+        src_ptr,
         tmp.access_ptr("w"),
         size,
     )
@@ -757,21 +769,32 @@ def bitwise_not(dst: Buffer, src0: Buffer):
 
 
 def scalar_op(
-    dst: Buffer, src0: Buffer, scalar_value: PrimExpr, op_tl: str
+    dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], scalar_value: PrimExpr, op_tl: str
 ):
-    size_0 = math.prod(src0.shape)
-    size_2 = math.prod(dst.shape)
+    if isinstance(dst, BufferRegion):
+        dst_ptr, dst_extent = _handle_buffer_region(dst, "w")
+        size_2 = math.prod(dst_extent)
+    else: 
+        dst_ptr = dst.access_ptr("w")
+        size_2 = math.prod(dst.shape)
 
+    if isinstance(src0, BufferRegion):
+        src0_ptr, src0_extent = _handle_buffer_region(src0, "r")
+        size_0 = math.prod(src0_extent)
+    else: 
+        src0_ptr = src0.access_ptr("r")
+        size_0 = math.prod(src0.shape)
+    
     assert size_0 == size_2, "size must be same"
 
     return tir.call_intrin(
         "handle",
         tir.op.Op.get(f"tl.ascend_{op_tl}"),
-        dst.access_ptr("w"),
-        src0.access_ptr("r"),
+        dst_ptr,
+        src0_ptr,
         scalar_value,
         size_0,
-    )
+)
 
 
 def leaky_relu(dst: Buffer, src0: Buffer, scalar_value: PrimExpr):

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -40,6 +40,14 @@ def _get_buffer_info(
     else:
         raise TypeError(f"Unsupported type: {type(br)}")
 
+def _handle_buffer_region(br: BufferRegion, mask):
+    bf = br.buffer
+    indices = [x.min for x in br.region]
+    offset = bf.offset_of(indices)[0]
+    extent = [x.extent for x in br.region]
+    size_extent = math.prod(extent)
+    return bf.access_ptr(mask, offset=offset, extent = size_extent), extent
+
 
 def fill(buffer: Union[Buffer, BufferRegion], value: PrimExpr):
     """Fill a buffer or buffer region with a specified value.
@@ -51,12 +59,6 @@ def fill(buffer: Union[Buffer, BufferRegion], value: PrimExpr):
     Returns:
         A TVM intrinsic call that performs the fill operation
     """
-    def _handle_buffer_region(br: BufferRegion, mask):
-        bf = br.buffer
-        indices = [x.min for x in br.region]
-        offset = bf.offset_of(indices)[0]
-        extent = [x.extent for x in br.region]
-        return bf.access_ptr(mask, offset=offset), extent
     if isinstance(buffer, BufferRegion):
         buffer_ptr, buffer_extent = _handle_buffer_region(buffer, "w")
         size = math.prod(buffer_extent)
@@ -483,13 +485,6 @@ def binary_op(
     src1: Union[Buffer, BufferRegion, BufferLoad, PrimExpr, float],
     op: str,
 ):
-    def _handle_buffer_region(br: BufferRegion, mask):
-        bf = br.buffer
-        indices = [x.min for x in br.region]
-        offset = bf.offset_of(indices)[0]
-
-        extent = [x.extent for x in br.region]
-        return bf.access_ptr(mask, offset=offset), extent
 
     if isinstance(dst, BufferRegion):
         dst_ptr, dst_extent = _handle_buffer_region(dst, "w")
@@ -633,14 +628,6 @@ def bitwise_or(dst: Buffer, src0: Buffer, src1: Union[Buffer, BufferRegion, Buff
 
 
 def unary_op(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], op: str):
-
-    def _handle_buffer_region(br: BufferRegion, mask):
-        bf = br.buffer
-        indices = [x.min for x in br.region]
-        offset = bf.offset_of(indices)[0]
-
-        extent = [x.extent for x in br.region]
-        return bf.access_ptr(mask, offset=offset), extent
 
     if isinstance(dst, BufferRegion):
         dst_ptr, dst_extent = _handle_buffer_region(dst, "w")
@@ -1518,12 +1505,6 @@ def broadcast(dst: Union[Buffer, BufferRegion],
               The source column is replicated `dst.shape[1]` times.
             - **No Broadcast (Copy)**: If shapes are identical, the axis defaults to 0.
     """
-    def _handle_buffer_region(br: BufferRegion, mask):
-        bf = br.buffer
-        indices = [x.min for x in br.region]
-        offset = bf.offset_of(indices)[0]
-        extent = [x.extent for x in br.region]
-        return bf.access_ptr(mask, offset=offset), extent
     
     if isinstance(dst, BufferRegion):
         dst_ptr, dst_extent = _handle_buffer_region(dst, "w")


### PR DESCRIPTION
Restructure the slicing functionality of the PTO computation interface, including binaryop, binaryops, and unaryop. Adapt the bufferregion for sigmoid and scalar_op, and add frontend test cases.