### PR TITLE
[bugfix]prevent L1 buffer scope demotion when using dump_tensor&& Robust Buffer-to-Layout Mapping with Rebinding Support

### DIFF
--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -1678,7 +1678,6 @@ void CodeGenTileLangAscend::BroadcastOpCodegen(const CallNode *op) {
 
 void CodeGenTileLangAscend::SetCrossFlagCodegen(const CallNode *op) {
   std::string pipe = Downcast<StringImm>(op->args[0])->value;
-  int flagId = op->args[1].as<IntImmNode>()->value;
   int mode = op->args[2].as<IntImmNode>()->value;
   std::string op_name = "AscendC::CrossCoreSetFlag<0x";
   op_name.append(std::to_string(mode));

--- a/src/transform/ascend_infer_buffer_scope.cc
+++ b/src/transform/ascend_infer_buffer_scope.cc
@@ -421,13 +421,16 @@ private:
         }
 
         bool only_in_ascend_copy = false;
-        if (!use_info->used_in_cube && !use_info->used_in_vector) {
-          only_in_ascend_copy = true;
+        if (!use_info->used_in_cube) {
+          bool only_valid_funcs = true;
           for (const auto& func_name : use_info->func_names) {
-            if (func_name != "tl.ascend_copy") {
-              only_in_ascend_copy = false;
+            if (func_name != "tl.ascend_copy" && func_name != "tl.ascend_dump_tensor") {
+              only_valid_funcs = false;
               break;
             }
+          }
+          if (only_valid_funcs) {
+            only_in_ascend_copy = true;
           }
         }
 
@@ -465,8 +468,25 @@ private:
         } else {
           alloc_info->corrected_scope = "shared";
         }
+        
+        bool has_dump_tensor = false;
+        if (use_info) {
+          for (const auto& func : use_info->func_names) {
+            if (func == "tl.ascend_dump_tensor" || func == "tl.dump_tensor") {
+              has_dump_tensor = true;
+              break;
+            }
+          }
+        }
 
-        if (alloc_info->corrected_scope != alloc_info->original_scope) {
+        bool should_apply = false;
+        if (has_dump_tensor && alloc_info->corrected_scope == "shared.dyn") {
+          should_apply = true;
+        } else if (alloc_info->corrected_scope != alloc_info->original_scope) {
+          should_apply = true;
+        }
+
+        if (should_apply) {        
           if (alloc_info->alloc_node) {
             scope_corrections_[alloc_info->alloc_node] = alloc_info->corrected_scope;
           }

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -481,12 +481,28 @@ private:
     if (op->annotations.count(attr::kLayoutMap)) {
       auto map =
           op->annotations.Get(attr::kLayoutMap).as<Map<Var, Layout>>().value();
-      for (const auto &[var, layout] : map) {
-        ICHECK(buffer_data_to_buffer_.count(var))
-            << "buffer " << var << " is not found in the block";
-        auto buffer = buffer_data_to_buffer_[var];
-        ICHECK(StructuralEqual()(layout->InputShape(), buffer->shape));
-        annotated_layout_map_.Set(buffer, layout);
+      for (auto it : map) {
+          Var target_var = it.first;
+          Layout target_layout = it.second;
+          Buffer found_buffer;
+          if (buffer_data_to_buffer_.count(target_var)) {
+              found_buffer = buffer_data_to_buffer_[target_var];
+          } else {
+              for (auto const& kv : buffer_data_to_buffer_) {
+                  Var current_var = kv.first;
+                  Buffer current_buf = kv.second;
+                  if (current_var->name_hint == target_var->name_hint &&
+                      StructuralEqual()(current_buf->shape, target_layout->InputShape()) &&
+                      current_var->dtype == target_var->dtype) {
+                      found_buffer = current_buf;
+                      break;
+                  }
+              }
+          }
+          if (!found_buffer.defined()) {
+              ICHECK(false) << "Buffer " << target_var->name_hint << " has no matching definition in this scope.";
+          }
+          annotated_layout_map_.Set(found_buffer, target_layout);
       }
     }
     IRVisitorWithAnalyzer::VisitStmt_(op);


### PR DESCRIPTION
Summary:
Previously, buffers like A_L1 were incorrectly demoted from 'shared.dyn' 
to 'shared' when 'tl.ascend_dump_tensor' was used. This occurred because 
the debug operator was flagged as a Vector use, triggering a redundant 
and overly strict logic check that bypassed the L1 promotion path.

Changes:
- Unified the 'only_in_ascend_copy' logic to allow debug operators 
  (tl.ascend_dump_tensor, tl.dump_tensor) as valid functional uses.
- Removed redundant logic checks that relied on 'used_in_vector' flags.
- Forced scope re-application in the IR mutator for buffers containing 
  debug instructions to ensure correct memory placement.
- Ensures correct mapping between Var handles and their corresponding Layout objects, even when the original Var pointers have been invalidated or re-created (re-bound) during IR transformations.

This fix ensures that debugging does not interfere with memory scope 
inference and maintains performance/accuracy for Ascend NPUs.