### PR TITLE
[bugfix]prevent L1 buffer scope demotion when using dump_tensordc dump tensor

### DIFF
--- a/src/transform/ascend_infer_buffer_scope.cc
+++ b/src/transform/ascend_infer_buffer_scope.cc
@@ -3,21 +3,21 @@
 
 #include <tvm/ir/op.h>
 
-#include <tvm/tir/transform.h>
-#include <tvm/tir/stmt_functor.h>
-#include <tvm/tir/analysis.h>
 #include <tvm/arith/analyzer.h>
 #include <tvm/runtime/registry.h>
+#include <tvm/tir/analysis.h>
 #include <tvm/tir/builtin.h>
 #include <tvm/tir/op.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
 
+#include <iostream>
+#include <regex>
+#include <set>
 #include <string>
 #include <unordered_map>
-#include <vector>
-#include <set>
 #include <utility>
-#include <regex>
-#include <iostream>
+#include <vector>
 namespace tvm {
 namespace tir {
 
@@ -35,7 +35,7 @@ public:
 
     auto new_body = this->operator()(func->body);
 
-    PrimFuncNode* fptr = func.CopyOnWrite();
+    PrimFuncNode *fptr = func.CopyOnWrite();
     fptr->body = new_body;
 
     // PrintDebugInfo();
@@ -49,12 +49,12 @@ private:
     bool used_in_vector = false;
     std::set<int> gemm_positions;
     std::set<std::string> func_names;
-    std::vector<const CallNode*> call_sites;
+    std::vector<const CallNode *> call_sites;
   };
 
   struct BufferAllocationInfo {
-    const AllocateNode* alloc_node = nullptr;
-    const VarNode* handle_var = nullptr;
+    const AllocateNode *alloc_node = nullptr;
+    const VarNode *handle_var = nullptr;
     std::string original_scope;
     std::string corrected_scope;
     bool is_data_bound = false;
@@ -63,17 +63,19 @@ private:
   struct AscendCopyPositionInfo {
     bool is_first_in_at_least_one = false;
     bool is_second_in_at_least_one = false;
-    std::vector<std::pair<const VarNode*, const VarNode*>> first_second_pairs;
-    std::vector<std::pair<const VarNode*, const VarNode*>> second_first_pairs;
+    std::vector<std::pair<const VarNode *, const VarNode *>> first_second_pairs;
+    std::vector<std::pair<const VarNode *, const VarNode *>> second_first_pairs;
   };
 
   class BufferUseCollector : public StmtExprVisitor {
-   public:
-    std::unordered_map<const VarNode*, AscendCopyPositionInfo> ascend_copy_position_info;
-    std::vector<std::pair<const VarNode*, const VarNode*>> ascend_copy_buffer_pairs_;
-    std::unordered_map<const VarNode*, BufferUseInfo> buffer_use_info;
-    std::unordered_map<const VarNode*, BufferAllocationInfo> alloc_info;
-    std::unordered_map<const VarNode*, const AllocateNode*> handle_to_alloc;
+  public:
+    std::unordered_map<const VarNode *, AscendCopyPositionInfo>
+        ascend_copy_position_info;
+    std::vector<std::pair<const VarNode *, const VarNode *>>
+        ascend_copy_buffer_pairs_;
+    std::unordered_map<const VarNode *, BufferUseInfo> buffer_use_info;
+    std::unordered_map<const VarNode *, BufferAllocationInfo> alloc_info;
+    std::unordered_map<const VarNode *, const AllocateNode *> handle_to_alloc;
 
     static bool IsGEMMFunction(const std::string &func_name) {
       return IsGEMMInternal(ToLower(func_name));
@@ -91,25 +93,26 @@ private:
     }
 
     static std::string GetPtrStorageScope(Var buffer_var) {
-      if (auto* ptr_type = buffer_var->type_annotation.as<PointerTypeNode>()) {
+      if (auto *ptr_type = buffer_var->type_annotation.as<PointerTypeNode>()) {
         return ptr_type->storage_scope;
       }
       return "";
     }
 
-    void BuildHandleAllocMapping(const Stmt& stmt) {
+    void BuildHandleAllocMapping(const Stmt &stmt) {
       class MappingBuilder : public StmtExprVisitor {
-       public:
-        MappingBuilder(BufferUseCollector* parent) : parent_(parent) {}
+      public:
+        MappingBuilder(BufferUseCollector *parent) : parent_(parent) {}
 
-        void VisitStmt_(const BlockNode* op) override {
-          for (const Buffer& buffer : op->alloc_buffers) {
-            const VarNode* handle_var = buffer->data.get();
+        void VisitStmt_(const BlockNode *op) override {
+          for (const Buffer &buffer : op->alloc_buffers) {
+            const VarNode *handle_var = buffer->data.get();
 
             BufferAllocationInfo info;
             info.alloc_node = nullptr;
             info.handle_var = handle_var;
-            info.original_scope = BufferUseCollector::GetPtrStorageScope(buffer->data);
+            info.original_scope =
+                BufferUseCollector::GetPtrStorageScope(buffer->data);
             info.is_data_bound = false;
             info.from_block_alloc = true;
 
@@ -120,14 +123,15 @@ private:
           StmtExprVisitor::VisitStmt_(op);
         }
 
-        void VisitStmt_(const AllocateNode* op) override {
+        void VisitStmt_(const AllocateNode *op) override {
 
-          const VarNode* handle_var = op->buffer_var.get();
+          const VarNode *handle_var = op->buffer_var.get();
 
           BufferAllocationInfo info;
           info.alloc_node = op;
           info.handle_var = handle_var;
-          info.original_scope = BufferUseCollector::GetPtrStorageScope(op->buffer_var);
+          info.original_scope =
+              BufferUseCollector::GetPtrStorageScope(op->buffer_var);
           info.is_data_bound = false;
           info.from_block_alloc = false;
 
@@ -137,19 +141,20 @@ private:
           StmtExprVisitor::VisitStmt_(op);
         }
 
-       private:
-        BufferUseCollector* parent_;
+      private:
+        BufferUseCollector *parent_;
       };
 
       MappingBuilder builder(this);
       builder.operator()(stmt);
     }
 
-    void VisitStmt_(const AllocateNode* op) override {
+    void VisitStmt_(const AllocateNode *op) override {
 
       if (alloc_info.find(op->buffer_var.get()) == alloc_info.end()) {
-        std::string scope = op->buffer_var->type_annotation.defined() ?
-                           GetPtrStorageScope(op->buffer_var) : "";
+        std::string scope = op->buffer_var->type_annotation.defined()
+                                ? GetPtrStorageScope(op->buffer_var)
+                                : "";
 
         BufferAllocationInfo info;
         info.alloc_node = op;
@@ -164,14 +169,15 @@ private:
       StmtExprVisitor::VisitStmt_(op);
     }
 
-    void VisitStmt_(const BlockNode* op) override {
+    void VisitStmt_(const BlockNode *op) override {
 
-      for (const Buffer& buffer : op->alloc_buffers) {
-        const VarNode* handle_var = buffer->data.get();
+      for (const Buffer &buffer : op->alloc_buffers) {
+        const VarNode *handle_var = buffer->data.get();
 
         if (alloc_info.find(handle_var) == alloc_info.end()) {
-          std::string scope = buffer->data->type_annotation.defined() ?
-                             GetPtrStorageScope(buffer->data) : "";
+          std::string scope = buffer->data->type_annotation.defined()
+                                  ? GetPtrStorageScope(buffer->data)
+                                  : "";
 
           BufferAllocationInfo info;
           info.alloc_node = nullptr;
@@ -181,16 +187,15 @@ private:
           info.from_block_alloc = true;
           alloc_info[handle_var] = info;
           handle_to_alloc[handle_var] = nullptr;
-
         }
       }
 
       StmtExprVisitor::VisitStmt_(op);
     }
 
-    void VisitExpr_(const CallNode* op) override {
+    void VisitExpr_(const CallNode *op) override {
       std::string op_name = "";
-      if (const OpNode* tl_op = op->op.as<OpNode>()) {
+      if (const OpNode *tl_op = op->op.as<OpNode>()) {
         op_name = tl_op->name;
         if (tl_op->name == "tl.ascend_copy") {
 
@@ -198,42 +203,51 @@ private:
             return;
           }
 
-          const VarNode* first_buf_handle = nullptr;
-          const CallNode* first_region = op->args[0].as<CallNode>();
-          if (first_region && !first_region->args.empty() && first_region->args[0].as<BufferLoadNode>()) {
-            const BufferLoadNode* first_buf_load = first_region->args[0].as<BufferLoadNode>();
+          const VarNode *first_buf_handle = nullptr;
+          const CallNode *first_region = op->args[0].as<CallNode>();
+          if (first_region && !first_region->args.empty() &&
+              first_region->args[0].as<BufferLoadNode>()) {
+            const BufferLoadNode *first_buf_load =
+                first_region->args[0].as<BufferLoadNode>();
             first_buf_handle = first_buf_load->buffer->data.get();
           }
 
-          const VarNode* second_buf_handle = nullptr;
-          const CallNode* second_region = op->args[1].as<CallNode>();
-          if (second_region && !second_region->args.empty() && second_region->args[0].as<BufferLoadNode>()) {
-            const BufferLoadNode* second_buf_load = second_region->args[0].as<BufferLoadNode>();
+          const VarNode *second_buf_handle = nullptr;
+          const CallNode *second_region = op->args[1].as<CallNode>();
+          if (second_region && !second_region->args.empty() &&
+              second_region->args[0].as<BufferLoadNode>()) {
+            const BufferLoadNode *second_buf_load =
+                second_region->args[0].as<BufferLoadNode>();
             second_buf_handle = second_buf_load->buffer->data.get();
           }
 
           if (first_buf_handle && second_buf_handle) {
             std::string first_name = first_buf_handle->name_hint;
             std::string second_name = second_buf_handle->name_hint;
-            ascend_copy_buffer_pairs_.emplace_back(first_buf_handle, second_buf_handle);
-            AscendCopyPositionInfo& first_info = ascend_copy_position_info[first_buf_handle];
-            AscendCopyPositionInfo& second_info = ascend_copy_position_info[second_buf_handle];
+            ascend_copy_buffer_pairs_.emplace_back(first_buf_handle,
+                                                   second_buf_handle);
+            AscendCopyPositionInfo &first_info =
+                ascend_copy_position_info[first_buf_handle];
+            AscendCopyPositionInfo &second_info =
+                ascend_copy_position_info[second_buf_handle];
 
             first_info.is_first_in_at_least_one = true;
-            first_info.first_second_pairs.emplace_back(first_buf_handle, second_buf_handle);
+            first_info.first_second_pairs.emplace_back(first_buf_handle,
+                                                       second_buf_handle);
 
             second_info.is_second_in_at_least_one = true;
-            second_info.second_first_pairs.emplace_back(second_buf_handle, first_buf_handle);
+            second_info.second_first_pairs.emplace_back(second_buf_handle,
+                                                        first_buf_handle);
           }
 
           if (first_buf_handle) {
-            BufferUseInfo& info = buffer_use_info[first_buf_handle];
+            BufferUseInfo &info = buffer_use_info[first_buf_handle];
             info.func_names.insert("tl.ascend_copy");
             info.call_sites.push_back(op);
           }
 
           if (second_buf_handle) {
-            BufferUseInfo& info = buffer_use_info[second_buf_handle];
+            BufferUseInfo &info = buffer_use_info[second_buf_handle];
             info.func_names.insert("tl.ascend_copy");
             info.call_sites.push_back(op);
           }
@@ -242,7 +256,7 @@ private:
 
       if (op->op.same_as(builtin::call_extern())) {
         if (op->args.size() > 0) {
-          if (auto* func_name = op->args[0].as<StringImmNode>()) {
+          if (auto *func_name = op->args[0].as<StringImmNode>()) {
             std::string name = func_name->value;
 
             for (size_t i = 1; i < op->args.size(); ++i) {
@@ -250,28 +264,27 @@ private:
             }
           }
         }
-      }
-      else {
-        if (!op_name.empty()){
+      } else {
+        if (!op_name.empty()) {
           for (size_t i = 0; i < op->args.size(); ++i) {
-              AnalyzeBufferInCall(op, i, op_name);
+            AnalyzeBufferInCall(op, i, op_name);
           }
         }
       }
       StmtExprVisitor::VisitExpr_(op);
     }
 
-    void AnalyzeBufferInCall(const CallNode* call, size_t arg_idx,
-                            const std::string& func_name) {
-      auto* arg = call->args[arg_idx].as<CallNode>();
+    void AnalyzeBufferInCall(const CallNode *call, size_t arg_idx,
+                             const std::string &func_name) {
+      auto *arg = call->args[arg_idx].as<CallNode>();
       if (!arg || !arg->op.same_as(builtin::tvm_access_ptr())) {
         return;
       }
 
       if (arg->args.size() > 1) {
-        if (auto* var = arg->args[1].as<VarNode>()) {
+        if (auto *var = arg->args[1].as<VarNode>()) {
 
-          BufferUseInfo& info = buffer_use_info[var];
+          BufferUseInfo &info = buffer_use_info[var];
           info.func_names.insert(func_name);
           info.call_sites.push_back(call);
 
@@ -291,11 +304,11 @@ private:
       }
     }
 
-    int DetermineGEMMPosition(const CallNode* call, size_t arg_idx,
-                             const std::string& func_name) {
+    int DetermineGEMMPosition(const CallNode *call, size_t arg_idx,
+                              const std::string &func_name) {
       int access_ptr_count = 0;
       for (size_t i = 1; i < arg_idx; ++i) {
-        if (auto* prev_arg = call->args[i].as<CallNode>()) {
+        if (auto *prev_arg = call->args[i].as<CallNode>()) {
           if (prev_arg->op.same_as(builtin::tvm_access_ptr())) {
             access_ptr_count++;
           }
@@ -303,25 +316,28 @@ private:
       }
       if (func_name.find("gemm") != std::string::npos ||
           func_name.find("mma") != std::string::npos) {
-        if (access_ptr_count == 0) return 0; // A -> L0A
-        if (access_ptr_count == 1) return 1; // B -> L0B
-        if (access_ptr_count == 2) return 2; // C -> L0C
+        if (access_ptr_count == 0)
+          return 0; // A -> L0A
+        if (access_ptr_count == 1)
+          return 1; // B -> L0B
+        if (access_ptr_count == 2)
+          return 2; // C -> L0C
       }
 
       return -1;
     }
 
-    const AllocateNode* GetAllocForHandle(const VarNode* handle) const {
+    const AllocateNode *GetAllocForHandle(const VarNode *handle) const {
       auto it = handle_to_alloc.find(handle);
       return it != handle_to_alloc.end() ? it->second : nullptr;
     }
 
-    BufferAllocationInfo* GetAllocInfo(const VarNode* handle) {
+    BufferAllocationInfo *GetAllocInfo(const VarNode *handle) {
       auto it = alloc_info.find(handle);
       return it != alloc_info.end() ? &it->second : nullptr;
     }
 
-    BufferUseInfo* GetUseInfo(const VarNode* handle) {
+    BufferUseInfo *GetUseInfo(const VarNode *handle) {
       auto it = buffer_use_info.find(handle);
       return it != buffer_use_info.end() ? &it->second : nullptr;
     }
@@ -352,12 +368,13 @@ private:
   };
 
   void InferCorrectScopes() {
-    for (const auto& kv : collector_->alloc_info) {
-      const VarNode* handle = kv.first;
-      BufferAllocationInfo* alloc_info = collector_->GetAllocInfo(handle);
-      if (!alloc_info) continue;
+    for (const auto &kv : collector_->alloc_info) {
+      const VarNode *handle = kv.first;
+      BufferAllocationInfo *alloc_info = collector_->GetAllocInfo(handle);
+      if (!alloc_info)
+        continue;
 
-      BufferUseInfo* use_info = collector_->GetUseInfo(handle);
+      BufferUseInfo *use_info = collector_->GetUseInfo(handle);
 
       std::string original_scope = alloc_info->original_scope;
       std::string corrected_scope = original_scope;
@@ -365,11 +382,11 @@ private:
       if (original_scope == "local.fragment") {
         if (use_info && !use_info->gemm_positions.empty()) {
           if (use_info->gemm_positions.count(0) > 0) {
-            corrected_scope = "wmma.matrix_a";  // L0A
+            corrected_scope = "wmma.matrix_a"; // L0A
           } else if (use_info->gemm_positions.count(1) > 0) {
-            corrected_scope = "wmma.matrix_b";  // L0B
+            corrected_scope = "wmma.matrix_b"; // L0B
           } else if (use_info->gemm_positions.count(2) > 0) {
-            corrected_scope = "wmma.accumulator";  // L0C
+            corrected_scope = "wmma.accumulator"; // L0C
           } else {
             corrected_scope = "wmma.accumulator";
           }
@@ -405,17 +422,16 @@ private:
         }
 
         handle_scope_corrections_[handle] = corrected_scope;
-
       }
 
-      for (const auto& kv : collector_->alloc_info) {
-        const VarNode* handle = kv.first;
-        BufferAllocationInfo* alloc_info = collector_->GetAllocInfo(handle);
+      for (const auto &kv : collector_->alloc_info) {
+        const VarNode *handle = kv.first;
+        BufferAllocationInfo *alloc_info = collector_->GetAllocInfo(handle);
         if (!alloc_info || alloc_info->original_scope != "shared.dyn") {
           continue;
-    }
+        }
 
-        BufferUseInfo* use_info = collector_->GetUseInfo(handle);
+        BufferUseInfo *use_info = collector_->GetUseInfo(handle);
         if (!use_info) {
           continue;
         }
@@ -423,8 +439,9 @@ private:
         bool only_in_ascend_copy = false;
         if (!use_info->used_in_cube) {
           bool only_valid_funcs = true;
-          for (const auto& func_name : use_info->func_names) {
-            if (func_name != "tl.ascend_copy" && func_name != "tl.ascend_dump_tensor") {
+          for (const auto &func_name : use_info->func_names) {
+            if (func_name != "tl.ascend_copy" &&
+                func_name != "tl.ascend_dump_tensor") {
               only_valid_funcs = false;
               break;
             }
@@ -442,13 +459,14 @@ private:
           continue;
         }
 
-        const AscendCopyPositionInfo& pos_info = pos_info_it->second;
+        const AscendCopyPositionInfo &pos_info = pos_info_it->second;
 
         bool found_qualified_copy = false;
 
-        for (const auto& pair : pos_info.first_second_pairs) {
-          const VarNode* second_handle = pair.second;
-          BufferAllocationInfo* second_alloc = collector_->GetAllocInfo(second_handle);
+        for (const auto &pair : pos_info.first_second_pairs) {
+          const VarNode *second_handle = pair.second;
+          BufferAllocationInfo *second_alloc =
+              collector_->GetAllocInfo(second_handle);
           if (!second_alloc) {
             continue;
           }
@@ -458,7 +476,8 @@ private:
             second_scope = second_alloc->original_scope;
           }
 
-          if (second_scope == "wmma.matrix_a" || second_scope == "wmma.matrix_b") {
+          if (second_scope == "wmma.matrix_a" ||
+              second_scope == "wmma.matrix_b") {
             found_qualified_copy = true;
             break;
           }
@@ -468,10 +487,10 @@ private:
         } else {
           alloc_info->corrected_scope = "shared";
         }
-        
+
         bool has_dump_tensor = false;
         if (use_info) {
-          for (const auto& func : use_info->func_names) {
+          for (const auto &func : use_info->func_names) {
             if (func == "tl.ascend_dump_tensor" || func == "tl.dump_tensor") {
               has_dump_tensor = true;
               break;
@@ -486,9 +505,10 @@ private:
           should_apply = true;
         }
 
-        if (should_apply) {        
+        if (should_apply) {
           if (alloc_info->alloc_node) {
-            scope_corrections_[alloc_info->alloc_node] = alloc_info->corrected_scope;
+            scope_corrections_[alloc_info->alloc_node] =
+                alloc_info->corrected_scope;
           }
           handle_scope_corrections_[handle] = alloc_info->corrected_scope;
         }
@@ -496,19 +516,21 @@ private:
     }
     const std::string UB_SCOPE = "shared";
 
-    for (const auto& buf_pair : collector_->ascend_copy_buffer_pairs_) {
-      const VarNode* first_buf_handle = buf_pair.first;
-      const VarNode* second_buf_handle = buf_pair.second;
+    for (const auto &buf_pair : collector_->ascend_copy_buffer_pairs_) {
+      const VarNode *first_buf_handle = buf_pair.first;
+      const VarNode *second_buf_handle = buf_pair.second;
 
-      BufferAllocationInfo* first_alloc_info = collector_->GetAllocInfo(first_buf_handle);
-      BufferAllocationInfo* second_alloc_info = collector_->GetAllocInfo(second_buf_handle);
+      BufferAllocationInfo *first_alloc_info =
+          collector_->GetAllocInfo(first_buf_handle);
+      BufferAllocationInfo *second_alloc_info =
+          collector_->GetAllocInfo(second_buf_handle);
       if (!first_alloc_info || !second_alloc_info) {
         continue;
       }
 
       std::string first_buf_scope = first_alloc_info->corrected_scope.empty()
-                                    ? first_alloc_info->original_scope
-                                    : first_alloc_info->corrected_scope;
+                                        ? first_alloc_info->original_scope
+                                        : first_alloc_info->corrected_scope;
       bool first_is_ub = (first_buf_scope == UB_SCOPE);
       std::string first_name = first_buf_handle->name_hint;
       std::string second_name = second_buf_handle->name_hint;
@@ -517,12 +539,14 @@ private:
         continue;
       }
 
-      BufferUseInfo* second_use_info = collector_->GetUseInfo(second_buf_handle);
+      BufferUseInfo *second_use_info =
+          collector_->GetUseInfo(second_buf_handle);
       bool second_no_cube_vector = false;
       if (second_use_info == nullptr) {
         second_no_cube_vector = true;
       } else {
-        if (!second_use_info->used_in_cube && !second_use_info->used_in_vector) {
+        if (!second_use_info->used_in_cube &&
+            !second_use_info->used_in_vector) {
           second_no_cube_vector = true;
         }
       }
@@ -532,8 +556,8 @@ private:
       }
 
       std::string second_old_scope = second_alloc_info->corrected_scope.empty()
-                                      ? second_alloc_info->original_scope
-                                      : second_alloc_info->corrected_scope;
+                                         ? second_alloc_info->original_scope
+                                         : second_alloc_info->corrected_scope;
 
       second_alloc_info->corrected_scope = UB_SCOPE;
       handle_scope_corrections_[second_buf_handle] = UB_SCOPE;
@@ -543,17 +567,17 @@ private:
     }
   }
 
-  bool CheckSharedBufferConflict(const BufferUseInfo* use_info) {
+  bool CheckSharedBufferConflict(const BufferUseInfo *use_info) {
     return false;
   }
 
   void PrintDebugInfo() {
     LOG(INFO) << "=== Scope Correction Results ===";
-    for (const auto& kv : collector_->alloc_info) {
-      const VarNode* handle = kv.first;
-      const BufferAllocationInfo& info = kv.second;
+    for (const auto &kv : collector_->alloc_info) {
+      const VarNode *handle = kv.first;
+      const BufferAllocationInfo &info = kv.second;
 
-      BufferUseInfo* use_info = collector_->GetUseInfo(handle);
+      BufferUseInfo *use_info = collector_->GetUseInfo(handle);
 
       LOG(INFO) << "Buffer: " << handle->name_hint;
       LOG(INFO) << "  Original scope: " << info.original_scope;
@@ -562,7 +586,7 @@ private:
       if (use_info) {
         if (!use_info->func_names.empty()) {
           LOG(INFO) << "  Used in functions:";
-          for (const auto& func : use_info->func_names) {
+          for (const auto &func : use_info->func_names) {
             LOG(INFO) << "    - " << func;
           }
         }
@@ -570,10 +594,13 @@ private:
         if (!use_info->gemm_positions.empty()) {
           LOG(INFO) << "  GEMM positions:";
           for (int pos : use_info->gemm_positions) {
-            const char* role = "Unknown";
-            if (pos == 0) role = "A (L0A)";
-            else if (pos == 1) role = "B (L0B)";
-            else if (pos == 2) role = "C (L0C)";
+            const char *role = "Unknown";
+            if (pos == 0)
+              role = "A (L0A)";
+            else if (pos == 1)
+              role = "B (L0B)";
+            else if (pos == 2)
+              role = "C (L0C)";
             LOG(INFO) << "    - Position " << pos << ": " << role;
           }
         }
@@ -585,20 +612,21 @@ private:
     }
   }
 
-  std::unordered_map<const AllocateNode*, std::string> scope_corrections_;
-  std::unordered_map<const VarNode*, std::string> handle_scope_corrections_;
-  std::unordered_map<const VarNode*, Var> var_replacements_;
+  std::unordered_map<const AllocateNode *, std::string> scope_corrections_;
+  std::unordered_map<const VarNode *, std::string> handle_scope_corrections_;
+  std::unordered_map<const VarNode *, Var> var_replacements_;
   std::unique_ptr<BufferUseCollector> collector_;
-  std::unordered_map<const VarNode*, Buffer> buffer_replacements_;
+  std::unordered_map<const VarNode *, Buffer> buffer_replacements_;
 
   static std::string GetPtrStorageScope(Var buffer_var) {
-    if (auto* ptr_type = buffer_var->type_annotation.as<PointerTypeNode>()) {
+    if (auto *ptr_type = buffer_var->type_annotation.as<PointerTypeNode>()) {
       return ptr_type->storage_scope;
     }
     return "";
   }
 
-  Var CreateVarWithCorrectScope(const Var& old_var, const std::string& new_scope) {
+  Var CreateVarWithCorrectScope(const Var &old_var,
+                                const std::string &new_scope) {
     auto it = var_replacements_.find(old_var.get());
     if (it != var_replacements_.end()) {
       return it->second;
@@ -633,7 +661,7 @@ private:
       return true;
     }
 
-    // Construct the new buffer 
+    // Construct the new buffer
     Var new_data =
         CreateVarWithCorrectScope(old_buffer->data, scope_it->second);
     *new_buffer = Buffer(new_data, old_buffer->dtype, old_buffer->shape,
@@ -643,7 +671,7 @@ private:
     return true;
   }
 
-  Stmt VisitStmt_(const AllocateNode* op) override {
+  Stmt VisitStmt_(const AllocateNode *op) override {
     auto it = scope_corrections_.find(op);
     if (it != scope_corrections_.end()) {
       std::string new_scope = it->second;
@@ -651,21 +679,22 @@ private:
       Var new_buffer_var = op->buffer_var;
       auto handle_it = handle_scope_corrections_.find(op->buffer_var.get());
       if (handle_it != handle_scope_corrections_.end()) {
-        new_buffer_var = CreateVarWithCorrectScope(op->buffer_var, handle_it->second);
+        new_buffer_var =
+            CreateVarWithCorrectScope(op->buffer_var, handle_it->second);
       }
 
-      return Allocate(new_buffer_var, op->dtype, op->extents,
-                      op->condition, VisitStmt(op->body));
+      return Allocate(new_buffer_var, op->dtype, op->extents, op->condition,
+                      VisitStmt(op->body));
     }
 
     return StmtExprMutator::VisitStmt_(op);
   }
 
-  Stmt VisitStmt_(const BlockNode* op) override {
+  Stmt VisitStmt_(const BlockNode *op) override {
     Array<Buffer> new_alloc_buffers;
 
-    for (const Buffer& buffer : op->alloc_buffers) {
-      const VarNode* handle = buffer->data.get();
+    for (const Buffer &buffer : op->alloc_buffers) {
+      const VarNode *handle = buffer->data.get();
       auto it = handle_scope_corrections_.find(handle);
 
       if (it != handle_scope_corrections_.end()) {
@@ -674,10 +703,10 @@ private:
         Var new_data = CreateVarWithCorrectScope(buffer->data, new_scope);
         var_replacements_[handle] = new_data;
 
-        auto new_buffer = Buffer(new_data, buffer->dtype, buffer->shape,
-                                buffer->strides, buffer->elem_offset,
-                                buffer->name, buffer->data_alignment,
-                                buffer->offset_factor, buffer->buffer_type);
+        auto new_buffer =
+            Buffer(new_data, buffer->dtype, buffer->shape, buffer->strides,
+                   buffer->elem_offset, buffer->name, buffer->data_alignment,
+                   buffer->offset_factor, buffer->buffer_type);
 
         new_alloc_buffers.push_back(new_buffer);
         buffer_replacements_[handle] = new_buffer;
@@ -687,20 +716,14 @@ private:
     }
 
     auto new_body = VisitStmt(op->body);
-    auto new_block = Block(op->iter_vars,
-                          op->reads,
-                          op->writes,
-                          op->name_hint,
-                          new_body,
-                          op->init,
-                          new_alloc_buffers,
-                          op->match_buffers,
-                          op->annotations);
+    auto new_block =
+        Block(op->iter_vars, op->reads, op->writes, op->name_hint, new_body,
+              op->init, new_alloc_buffers, op->match_buffers, op->annotations);
 
     return new_block;
   }
 
-  PrimExpr VisitExpr_(const VarNode* op) override {
+  PrimExpr VisitExpr_(const VarNode *op) override {
     auto it = handle_scope_corrections_.find(op);
     if (it != handle_scope_corrections_.end()) {
       Var old_var = GetRef<Var>(op);
@@ -750,17 +773,18 @@ private:
     return BufferStore(new_buffer, value, indices);
   }
 
-  PrimExpr VisitExpr_(const CallNode* op) override {
+  PrimExpr VisitExpr_(const CallNode *op) override {
     if (op->op.same_as(builtin::tvm_access_ptr())) {
 
       if (op->args.size() > 1) {
-        if (auto* var = op->args[1].as<VarNode>()) {
+        if (auto *var = op->args[1].as<VarNode>()) {
           auto it = handle_scope_corrections_.find(var);
           if (it != handle_scope_corrections_.end()) {
 
             Array<PrimExpr> new_args;
-            new_args.push_back(op->args[0]);  // type annotation
-            new_args.push_back(CreateVarWithCorrectScope(GetRef<Var>(var), it->second));
+            new_args.push_back(op->args[0]); // type annotation
+            new_args.push_back(
+                CreateVarWithCorrectScope(GetRef<Var>(var), it->second));
 
             for (size_t i = 2; i < op->args.size(); ++i) {
               new_args.push_back(VisitExpr(op->args[i]));
@@ -781,12 +805,11 @@ transform::Pass InferAllocScope() {
     ScopeCorrector corrector;
     return corrector.Correct(std::move(f));
   };
-  return transform::CreatePrimFuncPass(pass_func, 0,
-                                      "tl.InferAllocScope", {});
+  return transform::CreatePrimFuncPass(pass_func, 0, "tl.InferAllocScope", {});
 }
 
 TVM_REGISTER_GLOBAL("tl.transform.InferAllocScope")
     .set_body_typed(InferAllocScope);
 
-}  // namespace tir
-}  // namespace tvm
+} // namespace tir
+} // namespace tvm

--- a/src/transform/ascend_infer_buffer_scope.cc
+++ b/src/transform/ascend_infer_buffer_scope.cc
@@ -421,13 +421,16 @@ private:
         }
 
         bool only_in_ascend_copy = false;
-        if (!use_info->used_in_cube && !use_info->used_in_vector) {
-          only_in_ascend_copy = true;
+        if (!use_info->used_in_cube) {
+          bool only_valid_funcs = true;
           for (const auto& func_name : use_info->func_names) {
-            if (func_name != "tl.ascend_copy") {
-              only_in_ascend_copy = false;
+            if (func_name != "tl.ascend_copy" && func_name != "tl.ascend_dump_tensor") {
+              only_valid_funcs = false;
               break;
             }
+          }
+          if (only_valid_funcs) {
+            only_in_ascend_copy = true;
           }
         }
 
@@ -465,8 +468,25 @@ private:
         } else {
           alloc_info->corrected_scope = "shared";
         }
+        
+        bool has_dump_tensor = false;
+        if (use_info) {
+          for (const auto& func : use_info->func_names) {
+            if (func == "tl.ascend_dump_tensor" || func == "tl.dump_tensor") {
+              has_dump_tensor = true;
+              break;
+            }
+          }
+        }
 
-        if (alloc_info->corrected_scope != alloc_info->original_scope) {
+        bool should_apply = false;
+        if (has_dump_tensor && alloc_info->corrected_scope == "shared.dyn") {
+          should_apply = true;
+        } else if (alloc_info->corrected_scope != alloc_info->original_scope) {
+          should_apply = true;
+        }
+
+        if (should_apply) {        
           if (alloc_info->alloc_node) {
             scope_corrections_[alloc_info->alloc_node] = alloc_info->corrected_scope;
           }


### PR DESCRIPTION
Summary:
Previously, buffers like A_L1 were incorrectly demoted from 'shared.dyn'
to 'shared' when 'tl.ascend_dump_tensor' was used. This occurred because
the debug operator was flagged as a Vector use, triggering a redundant
and overly strict logic check that bypassed the L1 promotion path.

Changes:

- Unified the 'only_in_ascend_copy' logic to allow debug operators
  (tl.ascend_dump_tensor, tl.dump_tensor) as valid functional uses.
- Removed redundant logic checks that relied on 'used_in_vector' flags.
- Forced scope re-application in the IR mutator for buffers containing
   debug instructions to ensure correct memory placement.