### PR TITLE
[bugfix]Robust Buffer-to-Layout Mapping with Rebinding Support

### DIFF
--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -1678,7 +1678,6 @@ void CodeGenTileLangAscend::BroadcastOpCodegen(const CallNode *op) {
 
 void CodeGenTileLangAscend::SetCrossFlagCodegen(const CallNode *op) {
   std::string pipe = Downcast<StringImm>(op->args[0])->value;
-  int flagId = op->args[1].as<IntImmNode>()->value;
   int mode = op->args[2].as<IntImmNode>()->value;
   std::string op_name = "AscendC::CrossCoreSetFlag<0x";
   op_name.append(std::to_string(mode));

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -26,18 +26,17 @@
 namespace tvm {
 namespace codegen {
 
-
 #define ASCEND_A2A3_L0A_SIZE (65536)
 #define ASCEND_A2A3_L0B_SIZE (65536)
-#define ASCEND_A2A3_L1_SIZE  (524032)
+#define ASCEND_A2A3_L1_SIZE (524032)
 #define ASCEND_A2A3_L0C_SIZE (131072)
-#define ASCEND_A2A3_UB_SIZE  (196352)
+#define ASCEND_A2A3_UB_SIZE (196352)
 
 #define ASCEND_A5_L0A_SIZE (ASCEND_A2A3_L0A_SIZE)
 #define ASCEND_A5_L0B_SIZE (ASCEND_A2A3_L0B_SIZE)
-#define ASCEND_A5_L1_SIZE  (ASCEND_A2A3_L1_SIZE)
+#define ASCEND_A5_L1_SIZE (ASCEND_A2A3_L1_SIZE)
 #define ASCEND_A5_L0C_SIZE (262144)
-#define ASCEND_A5_UB_SIZE  (262144)
+#define ASCEND_A5_UB_SIZE (262144)
 
 std::string getType(const DataType &dtype) {
   if (dtype.is_float16()) {
@@ -527,7 +526,7 @@ void CodeGenTileLangAscend::VisitExpr_(const CallNode *op, std::ostream &os) {
   } else if (op->op.same_as(tl::ascend_pow())) {
     PowerOpCodegen(op, "AscendC::Power");
   } else if (op->op.same_as(tl::ascend_bitwise_xor())) {
-    PrintOpCall(op, "AscendC::Xor", {0, op->args.size()-1}, {0, 0});
+    PrintOpCall(op, "AscendC::Xor", {0, op->args.size() - 1}, {0, 0});
   } else if (op->op.same_as(tl::ascend_broadcast())) {
     BroadcastOpCodegen(op);
   } else if (op->op.same_as(tl::ascend_wait_cross_flag())) {
@@ -577,13 +576,13 @@ void CodeGenTileLangAscend::VisitExpr_(const CallNode *op, std::ostream &os) {
   } else if (op->op.same_as(tl::ascend_reinterpretcast())) {
     ReinterpretCastCodegen(op);
   } else if (op->op.same_as(tl::ascend_clamp_max())) {
-      ClampMaxMinCodegen(op);
+    ClampMaxMinCodegen(op);
   } else if (op->op.same_as(tl::ascend_clamp_min())) {
-      ClampMaxMinCodegen(op);
+    ClampMaxMinCodegen(op);
   } else if (op->op.same_as(tl::ascend_clamp())) {
-      ClampCodegen(op);
+    ClampCodegen(op);
   } else if (op->op.same_as(tl::ascend_round())) {
-      RoundCodegen(op, "AscendC::Round");
+    RoundCodegen(op, "AscendC::Round");
   } else if (op->op.same_as(tl::ascend_sub_experiment())) {
     CreateSubExperimentCodegen(op, "AscendC::Sub");
   } else if (op->op.same_as(tl::ascend_abs_experiment())) {
@@ -689,7 +688,7 @@ void CodeGenTileLangAscend::VisitStmt_(const AllocateNode *op) {
     bool found_by_name = false;
     std::string target_var_name = op->buffer_var->name_hint;
 
-    for (const auto& pair : address_map_) {
+    for (const auto &pair : address_map_) {
       Var var_key = pair.first;
       if (var_key->name_hint == target_var_name) {
         target_expr = pair.second;
@@ -809,16 +808,16 @@ void CodeGenTileLangAscend::PreFunctionBody(const PrimFunc &f) {
   if (this->platform_ == "A5") {
     l0a_size = ASCEND_A5_L0A_SIZE;
     l0b_size = ASCEND_A5_L0B_SIZE;
-    l1_size  = ASCEND_A5_L1_SIZE;
+    l1_size = ASCEND_A5_L1_SIZE;
     l0c_size = ASCEND_A5_L0C_SIZE;
-    ub_size  = ASCEND_A5_UB_SIZE;
+    ub_size = ASCEND_A5_UB_SIZE;
   } else {
     // A2 / A3
     l0a_size = ASCEND_A2A3_L0A_SIZE;
     l0b_size = ASCEND_A2A3_L0B_SIZE;
-    l1_size  = ASCEND_A2A3_L1_SIZE;
+    l1_size = ASCEND_A2A3_L1_SIZE;
     l0c_size = ASCEND_A2A3_L0C_SIZE;
-    ub_size  = ASCEND_A2A3_UB_SIZE;
+    ub_size = ASCEND_A2A3_UB_SIZE;
   }
 
   this->PrintIndent();
@@ -832,13 +831,16 @@ void CodeGenTileLangAscend::PreFunctionBody(const PrimFunc &f) {
 
   this->PrintIndent();
   stream << "AscendC::TBuf<AscendC::TPosition::A1> ascend_l1; "
-            "pipe.InitBuffer(ascend_l1, " << l1_size << ");\n";
+            "pipe.InitBuffer(ascend_l1, "
+         << l1_size << ");\n";
   this->PrintIndent();
   stream << "AscendC::TBuf<AscendC::TPosition::CO1> ascend_l0c; "
-            "pipe.InitBuffer(ascend_l0c, " << l0c_size << ");\n";
+            "pipe.InitBuffer(ascend_l0c, "
+         << l0c_size << ");\n";
   this->PrintIndent();
   stream << "AscendC::TBuf<AscendC::TPosition::VECCALC> ascend_ub; "
-            "pipe.InitBuffer(ascend_ub, " << ub_size << ");\n";
+            "pipe.InitBuffer(ascend_ub, "
+         << ub_size << ");\n";
 
   this->PrintIndent();
   stream << "pipe.Destroy();\n";
@@ -950,10 +952,10 @@ void CodeGenTileLangAscend::PrintHostFunc(
     }
     arg_names.push_back(v->name_hint);
     if (v.dtype().is_handle()) {
-    os << "uint8_t* " << v->name_hint;
+      os << "uint8_t* " << v->name_hint;
     } else {
       os << getType(v.dtype()) << " " << v->name_hint;
-  }
+    }
   }
   ProcessHostInput(os, arg_names, shape_vars);
   os << ", aclrtStream stream) {\n  ";
@@ -1095,7 +1097,8 @@ void CodeGenTileLangAscend::AddFunction(const GlobalVar &gvar,
   std::string content = stream.str();
 }
 
-std::string CodeGenTileLangAscend::PrintBufferOffset(const CallNode *call_arg_node,
+std::string
+CodeGenTileLangAscend::PrintBufferOffset(const CallNode *call_arg_node,
                                          bool has_offset) {
   auto _var = call_arg_node->args[1].as<VarNode>();
   auto _var_offset = PrintExpr(call_arg_node->args[2]);
@@ -1212,7 +1215,7 @@ void CodeGenTileLangAscend::SelectCodegen(const CallNode *op,
     auto mask_dtype = Downcast<StringImm>(op->args[8])->value;
 
     op_name_temp += "<" + src0_dtype + ", " + mask_dtype + ">";
-    
+
     auto var_name4 = PrintExpr(op->args[4]);
     var_names.push_back("static_cast<" + src0_dtype + ">(" + var_name4 + ")");
 
@@ -1269,17 +1272,20 @@ void CodeGenTileLangAscend::CreateVecIndexCodegen(const CallNode *op,
 }
 
 void CodeGenTileLangAscend::FillCodegen(const CallNode *op) {
-  std::string op_name = "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   PrintOpCall(op, op_name, {1, 2}, {2, 4});
 }
 
 void CodeGenTileLangAscend::ArithProgressionCodegen(const CallNode *op) {
-  std::string op_name = "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   PrintOpCall(op, op_name, {1, 2}, {2, 5});
 }
 
 void CodeGenTileLangAscend::SortCodegen(const CallNode *op) {
-  std::string op_name = "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   std::vector<std::string> var_names;
   for (int i = 1; i < op->args.size() - 2; i++) {
     auto var_name = PrintBufferOffset(op->args[i].as<CallNode>());
@@ -1303,28 +1309,35 @@ void CodeGenTileLangAscend::SortCodegen(const CallNode *op) {
 }
 
 void CodeGenTileLangAscend::MergeSortCodegen(const CallNode *op) {
-  std::string op_name = "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   int len = op->args.size();
   PrintOpCall(op, op_name, {1, len - 3}, {len - 3, len});
 }
 
 void CodeGenTileLangAscend::TopKCodegen(const CallNode *op) {
-  std::string op_name = "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   int len = op->args.size();
   PrintOpCall(op, op_name, {1, len - 1}, {len - 1, len});
 }
 
 void CodeGenTileLangAscend::ShmemCodegen(const CallNode *op) {
-  std::string op_name = "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   int len = op->args.size();
   PrintOpCall(op, op_name, {1, 3}, {3, len});
 }
 
 void CodeGenTileLangAscend::GatherMaskCodegen(const CallNode *op) {
-  std::string op_name = "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   int len = op->args.size();
   if (op->args[len - 1].as<CallNode>()) {
-    std::string op_name = "tl::ascend::Gather";  // The custom mode of GatherMask is actually implemented using Gather at the underlying level.
+    std::string op_name =
+        "tl::ascend::Gather"; // The custom mode of GatherMask is actually
+                              // implemented using Gather at the underlying
+                              // level.
     PrintOpCall(op, op_name, {1, len}, {0, 0});
   } else {
     std::string src1Pattern = Downcast<StringImm>(op->args[len - 1])->value;
@@ -1357,17 +1370,19 @@ void CodeGenTileLangAscend::GatherMaskCodegen(const CallNode *op) {
         this->stream << ", ";
       }
     }
-    this->stream <<", " <<  pattern << ");\n";
+    this->stream << ", " << pattern << ");\n";
   }
 }
 
 void CodeGenTileLangAscend::GatherbCodegen(const CallNode *op) {
-  std::string op_name = "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   PrintOpCall(op, op_name, {1, 4}, {4, 7});
 }
 
 void CodeGenTileLangAscend::InitSortBufCodegen(const CallNode *op) {
-  std::string op_name = "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   PrintOpCall(op, op_name, {1, 2}, {2, 3});
 }
 
@@ -1419,25 +1434,25 @@ void CodeGenTileLangAscend::SubsOpCodegen(const CallNode *op) {
   if (op->args[2].as<CallNode>()) {
     auto var_name = PrintBufferOffset(op->args[2].as<CallNode>(), false);
 
-        this->PrintIndent();
-        this->stream << "AscendC::PipeBarrier<PIPE_ALL>();\n";
-        this->PrintIndent();
-        this->stream << "auto " << var_name << "_scalar = " << var_name
-                     << ".GetValue(" << PrintExpr(op->args[op->args.size() - 2])
-                     << ");\n";
-        var_names.push_back("-" + var_name + "_scalar");
-      } else {
-        var_names.push_back("-" + PrintExpr(op->args[op->args.size() - 2]));
-      }
-      this->PrintIndent();
-      this->stream << "AscendC::Adds"
-                   << "(";
-      for (int i = 0; i < var_names.size(); i++) {
-        this->stream << var_names[i];
-        if (i != var_names.size() - 1) {
-          this->stream << ", ";
-        }
-      }
+    this->PrintIndent();
+    this->stream << "AscendC::PipeBarrier<PIPE_ALL>();\n";
+    this->PrintIndent();
+    this->stream << "auto " << var_name << "_scalar = " << var_name
+                 << ".GetValue(" << PrintExpr(op->args[op->args.size() - 2])
+                 << ");\n";
+    var_names.push_back("-" + var_name + "_scalar");
+  } else {
+    var_names.push_back("-" + PrintExpr(op->args[op->args.size() - 2]));
+  }
+  this->PrintIndent();
+  this->stream << "AscendC::Adds"
+               << "(";
+  for (int i = 0; i < var_names.size(); i++) {
+    this->stream << var_names[i];
+    if (i != var_names.size() - 1) {
+      this->stream << ", ";
+    }
+  }
 
   this->stream << ", " << PrintExpr(op->args[op->args.size() - 1]) << ");\n";
   this->PrintIndent();
@@ -1572,7 +1587,8 @@ void CodeGenTileLangAscend::GatherCodegen(const CallNode *op,
 }
 
 void CodeGenTileLangAscend::ReduceOpCodegen(const CallNode *op) {
-  std::string op_name = "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
 
   std::vector<std::string> var_names;
   for (int i = 1; i < op->args.size(); i++) {
@@ -1589,9 +1605,9 @@ void CodeGenTileLangAscend::ReduceOpCodegen(const CallNode *op) {
   }
   this->stream << ");\n";
   // this->stream << ", " << PrintExpr(op->args[op->args.size() - 1]) << ");\n";
-      // this->EndScope(func_scope);
-      // this->PrintIndent();
-      // this->stream << "}\n";
+  // this->EndScope(func_scope);
+  // this->PrintIndent();
+  // this->stream << "}\n";
 }
 
 void CodeGenTileLangAscend::BlockReduceOpCodegen(const CallNode *op,
@@ -1657,7 +1673,8 @@ void CodeGenTileLangAscend::PowerOpCodegen(const CallNode *op,
 }
 
 void CodeGenTileLangAscend::BroadcastOpCodegen(const CallNode *op) {
-  std::string op_name = "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   int dim = op->args[4].as<IntImmNode>()->value;
 
   this->PrintIndent();
@@ -1685,7 +1702,7 @@ void CodeGenTileLangAscend::SetCrossFlagCodegen(const CallNode *op) {
   op_name.append(pipe);
   op_name.append(">");
 
-  PrintOpCall(op, op_name, {0, 0}, {1, op->args.size()-1});
+  PrintOpCall(op, op_name, {0, 0}, {1, op->args.size() - 1});
 }
 
 void CodeGenTileLangAscend::FlagOpCodegen(const CallNode *op,
@@ -1706,7 +1723,8 @@ void CodeGenTileLangAscend::PipeBarrierCodegen(const CallNode *op) {
 }
 
 void CodeGenTileLangAscend::GemmOpCodegen(const CallNode *op) {
-  std::string op_name = "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
 
   this->PrintIndent();
   auto a_var = op->args[1].as<CallNode>()->args[1].as<VarNode>();
@@ -1857,7 +1875,8 @@ void CodeGenTileLangAscend::AutoWaitCrossFlagCodegen(const CallNode *op) {
   this->stream << "AscendC::CrossCoreWaitFlag(" << flag_id << ");\n";
 }
 
-void CodeGenTileLangAscend::UseSwizzleCodegen(const CallNode *op, std::ostream &os) {
+void CodeGenTileLangAscend::UseSwizzleCodegen(const CallNode *op,
+                                              std::ostream &os) {
   std::string op_name =
       "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   std::string expr = PrintExpr(op->args[1]);
@@ -1909,8 +1928,7 @@ void CodeGenTileLangAscend::CopyCodegen(const CallNode *op) {
   static const std::unordered_map<std::string, int> kCopyOpExtraArgs = {
       {"copy_l0c_to_gm", 1}, {"copy_gm_to_l1", 1}, {"copy_l1_to_l0a", 2},
       {"copy_l1_to_l0b", 2}, {"copy_gm_to_ub", 1}, {"copy_ub_to_gm", 1},
-      {"copy_ub_to_ub", 0}
-  };
+      {"copy_ub_to_ub", 0}};
 
   bool found = false;
   int extra_args = 0;
@@ -1954,8 +1972,7 @@ void CodeGenTileLangAscend::SigmoidCodegen(const CallNode *op,
       this->stream << ", ";
     }
   }
-  this->stream << ", " << PrintExpr(op->args[op->args.size() - 1])
-               << ");\n";
+  this->stream << ", " << PrintExpr(op->args[op->args.size() - 1]) << ");\n";
 }
 
 void CodeGenTileLangAscend::RoundCodegen(const CallNode *op,
@@ -1964,30 +1981,35 @@ void CodeGenTileLangAscend::RoundCodegen(const CallNode *op,
   auto var_name_0 = PrintBufferOffset(op->args[0].as<CallNode>());
   auto var_name_1 = PrintBufferOffset(op->args[1].as<CallNode>());
   auto var_name_2 = PrintBufferOffset(op->args[2].as<CallNode>());
-  this->stream << op_name << "(" << var_name_0 << ", " << var_name_1 << ", " << var_name_2 << ", "
-               << PrintExpr(op->args[3]) << ");\n";
+  this->stream << op_name << "(" << var_name_0 << ", " << var_name_1 << ", "
+               << var_name_2 << ", " << PrintExpr(op->args[3]) << ");\n";
 }
 
 void CodeGenTileLangAscend::ClampMaxMinCodegen(const CallNode *op) {
-  std::string op_name = "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   this->PrintIndent();
   auto var_name_1 = PrintBufferOffset(op->args[1].as<CallNode>());
   auto var_name_2 = PrintBufferOffset(op->args[2].as<CallNode>());
   auto var_name_3 = PrintBufferOffset(op->args[3].as<CallNode>());
 
-  this->stream << op_name << "(" << var_name_1 << ", " << var_name_2 << ", " << var_name_3 << ", "
-               << PrintExpr(op->args[4]) << ", " << PrintExpr(op->args[5]) << ");\n";
+  this->stream << op_name << "(" << var_name_1 << ", " << var_name_2 << ", "
+               << var_name_3 << ", " << PrintExpr(op->args[4]) << ", "
+               << PrintExpr(op->args[5]) << ");\n";
 }
 
 void CodeGenTileLangAscend::ClampCodegen(const CallNode *op) {
-  std::string op_name = "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   this->PrintIndent();
   auto var_name_1 = PrintBufferOffset(op->args[1].as<CallNode>());
   auto var_name_2 = PrintBufferOffset(op->args[2].as<CallNode>());
   auto var_name_3 = PrintBufferOffset(op->args[3].as<CallNode>());
 
-  this->stream << op_name << "(" << var_name_1 << ", " << var_name_2 << ", " << var_name_3 << ", "
-               << PrintExpr(op->args[4]) << ", " << PrintExpr(op->args[5]) << ", " << PrintExpr(op->args[6]) << ");\n";
+  this->stream << op_name << "(" << var_name_1 << ", " << var_name_2 << ", "
+               << var_name_3 << ", " << PrintExpr(op->args[4]) << ", "
+               << PrintExpr(op->args[5]) << ", " << PrintExpr(op->args[6])
+               << ");\n";
 }
 
 void CodeGenTileLangAscend::ReinterpretCastCodegen(const CallNode *op) {
@@ -1997,49 +2019,55 @@ void CodeGenTileLangAscend::ReinterpretCastCodegen(const CallNode *op) {
     var_names.push_back(var_name);
   }
   this->PrintIndent();
-  this->stream << "AscendC::LocalTensor" << "<" << Downcast<StringImm>(op->args[2])->value
-              << "> " << var_names[0] << " = " << var_names[1] << "."
-              << "ReinterpretCast" << "<" << Downcast<StringImm>(op->args[2])->value << ">" << "();\n";
+  this->stream << "AscendC::LocalTensor" << "<"
+               << Downcast<StringImm>(op->args[2])->value << "> "
+               << var_names[0] << " = " << var_names[1] << "."
+               << "ReinterpretCast" << "<"
+               << Downcast<StringImm>(op->args[2])->value << ">" << "();\n";
 }
 
-void CodeGenTileLangAscend::CreateSubExperimentCodegen(const CallNode *op,
-                                                  const std::string &op_name) {
+void CodeGenTileLangAscend::CreateSubExperimentCodegen(
+    const CallNode *op, const std::string &op_name) {
   PrintOpCall(op, op_name, {0, 3}, {3, op->args.size()});
 }
 
-void CodeGenTileLangAscend::CreateAbsExperimentCodegen(const CallNode *op,
-                                                  const std::string &op_name) {
+void CodeGenTileLangAscend::CreateAbsExperimentCodegen(
+    const CallNode *op, const std::string &op_name) {
   PrintOpCall(op, op_name, {0, 2}, {2, op->args.size()});
 }
 
-void CodeGenTileLangAscend::CreateMinsExperimentCodegen(const CallNode *op,
-                                                  const std::string &op_name) {
+void CodeGenTileLangAscend::CreateMinsExperimentCodegen(
+    const CallNode *op, const std::string &op_name) {
   PrintOpCall(op, op_name, {0, 2}, {2, op->args.size()});
 }
 
-void CodeGenTileLangAscend::CreateReduceSumExperimentCodegen(const CallNode *op,
-                                                  const std::string &op_name) {
+void CodeGenTileLangAscend::CreateReduceSumExperimentCodegen(
+    const CallNode *op, const std::string &op_name) {
   PrintOpCall(op, op_name, {0, 3}, {3, op->args.size()});
 }
 
 void CodeGenTileLangAscend::GatherMaskExperimentCodegen(const CallNode *op) {
-  std::string op_name = "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   PrintOpCall(op, op_name, {1, 4}, {4, op->args.size()});
 }
 
 void CodeGenTileLangAscend::FillExperimentCodegen(const CallNode *op) {
-  std::string op_name = "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   PrintOpCall(op, op_name, {1, 2}, {2, op->args.size()});
 }
 
 void CodeGenTileLangAscend::SumExperimentCodegen(const CallNode *op) {
-  std::string op_name = "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   PrintOpCall(op, op_name, {1, 3}, {3, op->args.size()});
 }
 
-void CodeGenTileLangAscend::CreateDatacacheExperimentCodegen(const CallNode *op) {
+void CodeGenTileLangAscend::CreateDatacacheExperimentCodegen(
+    const CallNode *op) {
   std::string op_name = Downcast<StringImm>(op->args[0])->value;
-  this->PrintIndent();                                                  
+  this->PrintIndent();
   this->stream << op_name << "(";
   this->stream << PrintBufferOffset(op->args[1].as<CallNode>());
   this->stream << ");\n";

--- a/src/transform/ascend_infer_buffer_scope.cc
+++ b/src/transform/ascend_infer_buffer_scope.cc
@@ -3,21 +3,21 @@
 
 #include <tvm/ir/op.h>
 
-#include <tvm/tir/transform.h>
-#include <tvm/tir/stmt_functor.h>
-#include <tvm/tir/analysis.h>
 #include <tvm/arith/analyzer.h>
 #include <tvm/runtime/registry.h>
+#include <tvm/tir/analysis.h>
 #include <tvm/tir/builtin.h>
 #include <tvm/tir/op.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
 
+#include <iostream>
+#include <regex>
+#include <set>
 #include <string>
 #include <unordered_map>
-#include <vector>
-#include <set>
 #include <utility>
-#include <regex>
-#include <iostream>
+#include <vector>
 namespace tvm {
 namespace tir {
 
@@ -35,7 +35,7 @@ public:
 
     auto new_body = this->operator()(func->body);
 
-    PrimFuncNode* fptr = func.CopyOnWrite();
+    PrimFuncNode *fptr = func.CopyOnWrite();
     fptr->body = new_body;
 
     // PrintDebugInfo();
@@ -49,12 +49,12 @@ private:
     bool used_in_vector = false;
     std::set<int> gemm_positions;
     std::set<std::string> func_names;
-    std::vector<const CallNode*> call_sites;
+    std::vector<const CallNode *> call_sites;
   };
 
   struct BufferAllocationInfo {
-    const AllocateNode* alloc_node = nullptr;
-    const VarNode* handle_var = nullptr;
+    const AllocateNode *alloc_node = nullptr;
+    const VarNode *handle_var = nullptr;
     std::string original_scope;
     std::string corrected_scope;
     bool is_data_bound = false;
@@ -63,17 +63,19 @@ private:
   struct AscendCopyPositionInfo {
     bool is_first_in_at_least_one = false;
     bool is_second_in_at_least_one = false;
-    std::vector<std::pair<const VarNode*, const VarNode*>> first_second_pairs;
-    std::vector<std::pair<const VarNode*, const VarNode*>> second_first_pairs;
+    std::vector<std::pair<const VarNode *, const VarNode *>> first_second_pairs;
+    std::vector<std::pair<const VarNode *, const VarNode *>> second_first_pairs;
   };
 
   class BufferUseCollector : public StmtExprVisitor {
-   public:
-    std::unordered_map<const VarNode*, AscendCopyPositionInfo> ascend_copy_position_info;
-    std::vector<std::pair<const VarNode*, const VarNode*>> ascend_copy_buffer_pairs_;
-    std::unordered_map<const VarNode*, BufferUseInfo> buffer_use_info;
-    std::unordered_map<const VarNode*, BufferAllocationInfo> alloc_info;
-    std::unordered_map<const VarNode*, const AllocateNode*> handle_to_alloc;
+  public:
+    std::unordered_map<const VarNode *, AscendCopyPositionInfo>
+        ascend_copy_position_info;
+    std::vector<std::pair<const VarNode *, const VarNode *>>
+        ascend_copy_buffer_pairs_;
+    std::unordered_map<const VarNode *, BufferUseInfo> buffer_use_info;
+    std::unordered_map<const VarNode *, BufferAllocationInfo> alloc_info;
+    std::unordered_map<const VarNode *, const AllocateNode *> handle_to_alloc;
 
     static bool IsGEMMFunction(const std::string &func_name) {
       return IsGEMMInternal(ToLower(func_name));
@@ -91,25 +93,26 @@ private:
     }
 
     static std::string GetPtrStorageScope(Var buffer_var) {
-      if (auto* ptr_type = buffer_var->type_annotation.as<PointerTypeNode>()) {
+      if (auto *ptr_type = buffer_var->type_annotation.as<PointerTypeNode>()) {
         return ptr_type->storage_scope;
       }
       return "";
     }
 
-    void BuildHandleAllocMapping(const Stmt& stmt) {
+    void BuildHandleAllocMapping(const Stmt &stmt) {
       class MappingBuilder : public StmtExprVisitor {
-       public:
-        MappingBuilder(BufferUseCollector* parent) : parent_(parent) {}
+      public:
+        MappingBuilder(BufferUseCollector *parent) : parent_(parent) {}
 
-        void VisitStmt_(const BlockNode* op) override {
-          for (const Buffer& buffer : op->alloc_buffers) {
-            const VarNode* handle_var = buffer->data.get();
+        void VisitStmt_(const BlockNode *op) override {
+          for (const Buffer &buffer : op->alloc_buffers) {
+            const VarNode *handle_var = buffer->data.get();
 
             BufferAllocationInfo info;
             info.alloc_node = nullptr;
             info.handle_var = handle_var;
-            info.original_scope = BufferUseCollector::GetPtrStorageScope(buffer->data);
+            info.original_scope =
+                BufferUseCollector::GetPtrStorageScope(buffer->data);
             info.is_data_bound = false;
             info.from_block_alloc = true;
 
@@ -120,14 +123,15 @@ private:
           StmtExprVisitor::VisitStmt_(op);
         }
 
-        void VisitStmt_(const AllocateNode* op) override {
+        void VisitStmt_(const AllocateNode *op) override {
 
-          const VarNode* handle_var = op->buffer_var.get();
+          const VarNode *handle_var = op->buffer_var.get();
 
           BufferAllocationInfo info;
           info.alloc_node = op;
           info.handle_var = handle_var;
-          info.original_scope = BufferUseCollector::GetPtrStorageScope(op->buffer_var);
+          info.original_scope =
+              BufferUseCollector::GetPtrStorageScope(op->buffer_var);
           info.is_data_bound = false;
           info.from_block_alloc = false;
 
@@ -137,19 +141,20 @@ private:
           StmtExprVisitor::VisitStmt_(op);
         }
 
-       private:
-        BufferUseCollector* parent_;
+      private:
+        BufferUseCollector *parent_;
       };
 
       MappingBuilder builder(this);
       builder.operator()(stmt);
     }
 
-    void VisitStmt_(const AllocateNode* op) override {
+    void VisitStmt_(const AllocateNode *op) override {
 
       if (alloc_info.find(op->buffer_var.get()) == alloc_info.end()) {
-        std::string scope = op->buffer_var->type_annotation.defined() ?
-                           GetPtrStorageScope(op->buffer_var) : "";
+        std::string scope = op->buffer_var->type_annotation.defined()
+                                ? GetPtrStorageScope(op->buffer_var)
+                                : "";
 
         BufferAllocationInfo info;
         info.alloc_node = op;
@@ -164,14 +169,15 @@ private:
       StmtExprVisitor::VisitStmt_(op);
     }
 
-    void VisitStmt_(const BlockNode* op) override {
+    void VisitStmt_(const BlockNode *op) override {
 
-      for (const Buffer& buffer : op->alloc_buffers) {
-        const VarNode* handle_var = buffer->data.get();
+      for (const Buffer &buffer : op->alloc_buffers) {
+        const VarNode *handle_var = buffer->data.get();
 
         if (alloc_info.find(handle_var) == alloc_info.end()) {
-          std::string scope = buffer->data->type_annotation.defined() ?
-                             GetPtrStorageScope(buffer->data) : "";
+          std::string scope = buffer->data->type_annotation.defined()
+                                  ? GetPtrStorageScope(buffer->data)
+                                  : "";
 
           BufferAllocationInfo info;
           info.alloc_node = nullptr;
@@ -181,16 +187,15 @@ private:
           info.from_block_alloc = true;
           alloc_info[handle_var] = info;
           handle_to_alloc[handle_var] = nullptr;
-
         }
       }
 
       StmtExprVisitor::VisitStmt_(op);
     }
 
-    void VisitExpr_(const CallNode* op) override {
+    void VisitExpr_(const CallNode *op) override {
       std::string op_name = "";
-      if (const OpNode* tl_op = op->op.as<OpNode>()) {
+      if (const OpNode *tl_op = op->op.as<OpNode>()) {
         op_name = tl_op->name;
         if (tl_op->name == "tl.ascend_copy") {
 
@@ -198,42 +203,51 @@ private:
             return;
           }
 
-          const VarNode* first_buf_handle = nullptr;
-          const CallNode* first_region = op->args[0].as<CallNode>();
-          if (first_region && !first_region->args.empty() && first_region->args[0].as<BufferLoadNode>()) {
-            const BufferLoadNode* first_buf_load = first_region->args[0].as<BufferLoadNode>();
+          const VarNode *first_buf_handle = nullptr;
+          const CallNode *first_region = op->args[0].as<CallNode>();
+          if (first_region && !first_region->args.empty() &&
+              first_region->args[0].as<BufferLoadNode>()) {
+            const BufferLoadNode *first_buf_load =
+                first_region->args[0].as<BufferLoadNode>();
             first_buf_handle = first_buf_load->buffer->data.get();
           }
 
-          const VarNode* second_buf_handle = nullptr;
-          const CallNode* second_region = op->args[1].as<CallNode>();
-          if (second_region && !second_region->args.empty() && second_region->args[0].as<BufferLoadNode>()) {
-            const BufferLoadNode* second_buf_load = second_region->args[0].as<BufferLoadNode>();
+          const VarNode *second_buf_handle = nullptr;
+          const CallNode *second_region = op->args[1].as<CallNode>();
+          if (second_region && !second_region->args.empty() &&
+              second_region->args[0].as<BufferLoadNode>()) {
+            const BufferLoadNode *second_buf_load =
+                second_region->args[0].as<BufferLoadNode>();
             second_buf_handle = second_buf_load->buffer->data.get();
           }
 
           if (first_buf_handle && second_buf_handle) {
             std::string first_name = first_buf_handle->name_hint;
             std::string second_name = second_buf_handle->name_hint;
-            ascend_copy_buffer_pairs_.emplace_back(first_buf_handle, second_buf_handle);
-            AscendCopyPositionInfo& first_info = ascend_copy_position_info[first_buf_handle];
-            AscendCopyPositionInfo& second_info = ascend_copy_position_info[second_buf_handle];
+            ascend_copy_buffer_pairs_.emplace_back(first_buf_handle,
+                                                   second_buf_handle);
+            AscendCopyPositionInfo &first_info =
+                ascend_copy_position_info[first_buf_handle];
+            AscendCopyPositionInfo &second_info =
+                ascend_copy_position_info[second_buf_handle];
 
             first_info.is_first_in_at_least_one = true;
-            first_info.first_second_pairs.emplace_back(first_buf_handle, second_buf_handle);
+            first_info.first_second_pairs.emplace_back(first_buf_handle,
+                                                       second_buf_handle);
 
             second_info.is_second_in_at_least_one = true;
-            second_info.second_first_pairs.emplace_back(second_buf_handle, first_buf_handle);
+            second_info.second_first_pairs.emplace_back(second_buf_handle,
+                                                        first_buf_handle);
           }
 
           if (first_buf_handle) {
-            BufferUseInfo& info = buffer_use_info[first_buf_handle];
+            BufferUseInfo &info = buffer_use_info[first_buf_handle];
             info.func_names.insert("tl.ascend_copy");
             info.call_sites.push_back(op);
           }
 
           if (second_buf_handle) {
-            BufferUseInfo& info = buffer_use_info[second_buf_handle];
+            BufferUseInfo &info = buffer_use_info[second_buf_handle];
             info.func_names.insert("tl.ascend_copy");
             info.call_sites.push_back(op);
           }
@@ -242,7 +256,7 @@ private:
 
       if (op->op.same_as(builtin::call_extern())) {
         if (op->args.size() > 0) {
-          if (auto* func_name = op->args[0].as<StringImmNode>()) {
+          if (auto *func_name = op->args[0].as<StringImmNode>()) {
             std::string name = func_name->value;
 
             for (size_t i = 1; i < op->args.size(); ++i) {
@@ -250,28 +264,27 @@ private:
             }
           }
         }
-      }
-      else {
-        if (!op_name.empty()){
+      } else {
+        if (!op_name.empty()) {
           for (size_t i = 0; i < op->args.size(); ++i) {
-              AnalyzeBufferInCall(op, i, op_name);
+            AnalyzeBufferInCall(op, i, op_name);
           }
         }
       }
       StmtExprVisitor::VisitExpr_(op);
     }
 
-    void AnalyzeBufferInCall(const CallNode* call, size_t arg_idx,
-                            const std::string& func_name) {
-      auto* arg = call->args[arg_idx].as<CallNode>();
+    void AnalyzeBufferInCall(const CallNode *call, size_t arg_idx,
+                             const std::string &func_name) {
+      auto *arg = call->args[arg_idx].as<CallNode>();
       if (!arg || !arg->op.same_as(builtin::tvm_access_ptr())) {
         return;
       }
 
       if (arg->args.size() > 1) {
-        if (auto* var = arg->args[1].as<VarNode>()) {
+        if (auto *var = arg->args[1].as<VarNode>()) {
 
-          BufferUseInfo& info = buffer_use_info[var];
+          BufferUseInfo &info = buffer_use_info[var];
           info.func_names.insert(func_name);
           info.call_sites.push_back(call);
 
@@ -291,11 +304,11 @@ private:
       }
     }
 
-    int DetermineGEMMPosition(const CallNode* call, size_t arg_idx,
-                             const std::string& func_name) {
+    int DetermineGEMMPosition(const CallNode *call, size_t arg_idx,
+                              const std::string &func_name) {
       int access_ptr_count = 0;
       for (size_t i = 1; i < arg_idx; ++i) {
-        if (auto* prev_arg = call->args[i].as<CallNode>()) {
+        if (auto *prev_arg = call->args[i].as<CallNode>()) {
           if (prev_arg->op.same_as(builtin::tvm_access_ptr())) {
             access_ptr_count++;
           }
@@ -303,25 +316,28 @@ private:
       }
       if (func_name.find("gemm") != std::string::npos ||
           func_name.find("mma") != std::string::npos) {
-        if (access_ptr_count == 0) return 0; // A -> L0A
-        if (access_ptr_count == 1) return 1; // B -> L0B
-        if (access_ptr_count == 2) return 2; // C -> L0C
+        if (access_ptr_count == 0)
+          return 0; // A -> L0A
+        if (access_ptr_count == 1)
+          return 1; // B -> L0B
+        if (access_ptr_count == 2)
+          return 2; // C -> L0C
       }
 
       return -1;
     }
 
-    const AllocateNode* GetAllocForHandle(const VarNode* handle) const {
+    const AllocateNode *GetAllocForHandle(const VarNode *handle) const {
       auto it = handle_to_alloc.find(handle);
       return it != handle_to_alloc.end() ? it->second : nullptr;
     }
 
-    BufferAllocationInfo* GetAllocInfo(const VarNode* handle) {
+    BufferAllocationInfo *GetAllocInfo(const VarNode *handle) {
       auto it = alloc_info.find(handle);
       return it != alloc_info.end() ? &it->second : nullptr;
     }
 
-    BufferUseInfo* GetUseInfo(const VarNode* handle) {
+    BufferUseInfo *GetUseInfo(const VarNode *handle) {
       auto it = buffer_use_info.find(handle);
       return it != buffer_use_info.end() ? &it->second : nullptr;
     }
@@ -352,12 +368,13 @@ private:
   };
 
   void InferCorrectScopes() {
-    for (const auto& kv : collector_->alloc_info) {
-      const VarNode* handle = kv.first;
-      BufferAllocationInfo* alloc_info = collector_->GetAllocInfo(handle);
-      if (!alloc_info) continue;
+    for (const auto &kv : collector_->alloc_info) {
+      const VarNode *handle = kv.first;
+      BufferAllocationInfo *alloc_info = collector_->GetAllocInfo(handle);
+      if (!alloc_info)
+        continue;
 
-      BufferUseInfo* use_info = collector_->GetUseInfo(handle);
+      BufferUseInfo *use_info = collector_->GetUseInfo(handle);
 
       std::string original_scope = alloc_info->original_scope;
       std::string corrected_scope = original_scope;
@@ -365,11 +382,11 @@ private:
       if (original_scope == "local.fragment") {
         if (use_info && !use_info->gemm_positions.empty()) {
           if (use_info->gemm_positions.count(0) > 0) {
-            corrected_scope = "wmma.matrix_a";  // L0A
+            corrected_scope = "wmma.matrix_a"; // L0A
           } else if (use_info->gemm_positions.count(1) > 0) {
-            corrected_scope = "wmma.matrix_b";  // L0B
+            corrected_scope = "wmma.matrix_b"; // L0B
           } else if (use_info->gemm_positions.count(2) > 0) {
-            corrected_scope = "wmma.accumulator";  // L0C
+            corrected_scope = "wmma.accumulator"; // L0C
           } else {
             corrected_scope = "wmma.accumulator";
           }
@@ -405,17 +422,16 @@ private:
         }
 
         handle_scope_corrections_[handle] = corrected_scope;
-
       }
 
-      for (const auto& kv : collector_->alloc_info) {
-        const VarNode* handle = kv.first;
-        BufferAllocationInfo* alloc_info = collector_->GetAllocInfo(handle);
+      for (const auto &kv : collector_->alloc_info) {
+        const VarNode *handle = kv.first;
+        BufferAllocationInfo *alloc_info = collector_->GetAllocInfo(handle);
         if (!alloc_info || alloc_info->original_scope != "shared.dyn") {
           continue;
-    }
+        }
 
-        BufferUseInfo* use_info = collector_->GetUseInfo(handle);
+        BufferUseInfo *use_info = collector_->GetUseInfo(handle);
         if (!use_info) {
           continue;
         }
@@ -423,8 +439,9 @@ private:
         bool only_in_ascend_copy = false;
         if (!use_info->used_in_cube) {
           bool only_valid_funcs = true;
-          for (const auto& func_name : use_info->func_names) {
-            if (func_name != "tl.ascend_copy" && func_name != "tl.ascend_dump_tensor") {
+          for (const auto &func_name : use_info->func_names) {
+            if (func_name != "tl.ascend_copy" &&
+                func_name != "tl.ascend_dump_tensor") {
               only_valid_funcs = false;
               break;
             }
@@ -442,13 +459,14 @@ private:
           continue;
         }
 
-        const AscendCopyPositionInfo& pos_info = pos_info_it->second;
+        const AscendCopyPositionInfo &pos_info = pos_info_it->second;
 
         bool found_qualified_copy = false;
 
-        for (const auto& pair : pos_info.first_second_pairs) {
-          const VarNode* second_handle = pair.second;
-          BufferAllocationInfo* second_alloc = collector_->GetAllocInfo(second_handle);
+        for (const auto &pair : pos_info.first_second_pairs) {
+          const VarNode *second_handle = pair.second;
+          BufferAllocationInfo *second_alloc =
+              collector_->GetAllocInfo(second_handle);
           if (!second_alloc) {
             continue;
           }
@@ -458,7 +476,8 @@ private:
             second_scope = second_alloc->original_scope;
           }
 
-          if (second_scope == "wmma.matrix_a" || second_scope == "wmma.matrix_b") {
+          if (second_scope == "wmma.matrix_a" ||
+              second_scope == "wmma.matrix_b") {
             found_qualified_copy = true;
             break;
           }
@@ -468,10 +487,10 @@ private:
         } else {
           alloc_info->corrected_scope = "shared";
         }
-        
+
         bool has_dump_tensor = false;
         if (use_info) {
-          for (const auto& func : use_info->func_names) {
+          for (const auto &func : use_info->func_names) {
             if (func == "tl.ascend_dump_tensor" || func == "tl.dump_tensor") {
               has_dump_tensor = true;
               break;
@@ -486,9 +505,10 @@ private:
           should_apply = true;
         }
 
-        if (should_apply) {        
+        if (should_apply) {
           if (alloc_info->alloc_node) {
-            scope_corrections_[alloc_info->alloc_node] = alloc_info->corrected_scope;
+            scope_corrections_[alloc_info->alloc_node] =
+                alloc_info->corrected_scope;
           }
           handle_scope_corrections_[handle] = alloc_info->corrected_scope;
         }
@@ -496,19 +516,21 @@ private:
     }
     const std::string UB_SCOPE = "shared";
 
-    for (const auto& buf_pair : collector_->ascend_copy_buffer_pairs_) {
-      const VarNode* first_buf_handle = buf_pair.first;
-      const VarNode* second_buf_handle = buf_pair.second;
+    for (const auto &buf_pair : collector_->ascend_copy_buffer_pairs_) {
+      const VarNode *first_buf_handle = buf_pair.first;
+      const VarNode *second_buf_handle = buf_pair.second;
 
-      BufferAllocationInfo* first_alloc_info = collector_->GetAllocInfo(first_buf_handle);
-      BufferAllocationInfo* second_alloc_info = collector_->GetAllocInfo(second_buf_handle);
+      BufferAllocationInfo *first_alloc_info =
+          collector_->GetAllocInfo(first_buf_handle);
+      BufferAllocationInfo *second_alloc_info =
+          collector_->GetAllocInfo(second_buf_handle);
       if (!first_alloc_info || !second_alloc_info) {
         continue;
       }
 
       std::string first_buf_scope = first_alloc_info->corrected_scope.empty()
-                                    ? first_alloc_info->original_scope
-                                    : first_alloc_info->corrected_scope;
+                                        ? first_alloc_info->original_scope
+                                        : first_alloc_info->corrected_scope;
       bool first_is_ub = (first_buf_scope == UB_SCOPE);
       std::string first_name = first_buf_handle->name_hint;
       std::string second_name = second_buf_handle->name_hint;
@@ -517,12 +539,14 @@ private:
         continue;
       }
 
-      BufferUseInfo* second_use_info = collector_->GetUseInfo(second_buf_handle);
+      BufferUseInfo *second_use_info =
+          collector_->GetUseInfo(second_buf_handle);
       bool second_no_cube_vector = false;
       if (second_use_info == nullptr) {
         second_no_cube_vector = true;
       } else {
-        if (!second_use_info->used_in_cube && !second_use_info->used_in_vector) {
+        if (!second_use_info->used_in_cube &&
+            !second_use_info->used_in_vector) {
           second_no_cube_vector = true;
         }
       }
@@ -532,8 +556,8 @@ private:
       }
 
       std::string second_old_scope = second_alloc_info->corrected_scope.empty()
-                                      ? second_alloc_info->original_scope
-                                      : second_alloc_info->corrected_scope;
+                                         ? second_alloc_info->original_scope
+                                         : second_alloc_info->corrected_scope;
 
       second_alloc_info->corrected_scope = UB_SCOPE;
       handle_scope_corrections_[second_buf_handle] = UB_SCOPE;
@@ -543,17 +567,17 @@ private:
     }
   }
 
-  bool CheckSharedBufferConflict(const BufferUseInfo* use_info) {
+  bool CheckSharedBufferConflict(const BufferUseInfo *use_info) {
     return false;
   }
 
   void PrintDebugInfo() {
     LOG(INFO) << "=== Scope Correction Results ===";
-    for (const auto& kv : collector_->alloc_info) {
-      const VarNode* handle = kv.first;
-      const BufferAllocationInfo& info = kv.second;
+    for (const auto &kv : collector_->alloc_info) {
+      const VarNode *handle = kv.first;
+      const BufferAllocationInfo &info = kv.second;
 
-      BufferUseInfo* use_info = collector_->GetUseInfo(handle);
+      BufferUseInfo *use_info = collector_->GetUseInfo(handle);
 
       LOG(INFO) << "Buffer: " << handle->name_hint;
       LOG(INFO) << "  Original scope: " << info.original_scope;
@@ -562,7 +586,7 @@ private:
       if (use_info) {
         if (!use_info->func_names.empty()) {
           LOG(INFO) << "  Used in functions:";
-          for (const auto& func : use_info->func_names) {
+          for (const auto &func : use_info->func_names) {
             LOG(INFO) << "    - " << func;
           }
         }
@@ -570,10 +594,13 @@ private:
         if (!use_info->gemm_positions.empty()) {
           LOG(INFO) << "  GEMM positions:";
           for (int pos : use_info->gemm_positions) {
-            const char* role = "Unknown";
-            if (pos == 0) role = "A (L0A)";
-            else if (pos == 1) role = "B (L0B)";
-            else if (pos == 2) role = "C (L0C)";
+            const char *role = "Unknown";
+            if (pos == 0)
+              role = "A (L0A)";
+            else if (pos == 1)
+              role = "B (L0B)";
+            else if (pos == 2)
+              role = "C (L0C)";
             LOG(INFO) << "    - Position " << pos << ": " << role;
           }
         }
@@ -585,20 +612,21 @@ private:
     }
   }
 
-  std::unordered_map<const AllocateNode*, std::string> scope_corrections_;
-  std::unordered_map<const VarNode*, std::string> handle_scope_corrections_;
-  std::unordered_map<const VarNode*, Var> var_replacements_;
+  std::unordered_map<const AllocateNode *, std::string> scope_corrections_;
+  std::unordered_map<const VarNode *, std::string> handle_scope_corrections_;
+  std::unordered_map<const VarNode *, Var> var_replacements_;
   std::unique_ptr<BufferUseCollector> collector_;
-  std::unordered_map<const VarNode*, Buffer> buffer_replacements_;
+  std::unordered_map<const VarNode *, Buffer> buffer_replacements_;
 
   static std::string GetPtrStorageScope(Var buffer_var) {
-    if (auto* ptr_type = buffer_var->type_annotation.as<PointerTypeNode>()) {
+    if (auto *ptr_type = buffer_var->type_annotation.as<PointerTypeNode>()) {
       return ptr_type->storage_scope;
     }
     return "";
   }
 
-  Var CreateVarWithCorrectScope(const Var& old_var, const std::string& new_scope) {
+  Var CreateVarWithCorrectScope(const Var &old_var,
+                                const std::string &new_scope) {
     auto it = var_replacements_.find(old_var.get());
     if (it != var_replacements_.end()) {
       return it->second;
@@ -633,7 +661,7 @@ private:
       return true;
     }
 
-    // Construct the new buffer 
+    // Construct the new buffer
     Var new_data =
         CreateVarWithCorrectScope(old_buffer->data, scope_it->second);
     *new_buffer = Buffer(new_data, old_buffer->dtype, old_buffer->shape,
@@ -643,7 +671,7 @@ private:
     return true;
   }
 
-  Stmt VisitStmt_(const AllocateNode* op) override {
+  Stmt VisitStmt_(const AllocateNode *op) override {
     auto it = scope_corrections_.find(op);
     if (it != scope_corrections_.end()) {
       std::string new_scope = it->second;
@@ -651,21 +679,22 @@ private:
       Var new_buffer_var = op->buffer_var;
       auto handle_it = handle_scope_corrections_.find(op->buffer_var.get());
       if (handle_it != handle_scope_corrections_.end()) {
-        new_buffer_var = CreateVarWithCorrectScope(op->buffer_var, handle_it->second);
+        new_buffer_var =
+            CreateVarWithCorrectScope(op->buffer_var, handle_it->second);
       }
 
-      return Allocate(new_buffer_var, op->dtype, op->extents,
-                      op->condition, VisitStmt(op->body));
+      return Allocate(new_buffer_var, op->dtype, op->extents, op->condition,
+                      VisitStmt(op->body));
     }
 
     return StmtExprMutator::VisitStmt_(op);
   }
 
-  Stmt VisitStmt_(const BlockNode* op) override {
+  Stmt VisitStmt_(const BlockNode *op) override {
     Array<Buffer> new_alloc_buffers;
 
-    for (const Buffer& buffer : op->alloc_buffers) {
-      const VarNode* handle = buffer->data.get();
+    for (const Buffer &buffer : op->alloc_buffers) {
+      const VarNode *handle = buffer->data.get();
       auto it = handle_scope_corrections_.find(handle);
 
       if (it != handle_scope_corrections_.end()) {
@@ -674,10 +703,10 @@ private:
         Var new_data = CreateVarWithCorrectScope(buffer->data, new_scope);
         var_replacements_[handle] = new_data;
 
-        auto new_buffer = Buffer(new_data, buffer->dtype, buffer->shape,
-                                buffer->strides, buffer->elem_offset,
-                                buffer->name, buffer->data_alignment,
-                                buffer->offset_factor, buffer->buffer_type);
+        auto new_buffer =
+            Buffer(new_data, buffer->dtype, buffer->shape, buffer->strides,
+                   buffer->elem_offset, buffer->name, buffer->data_alignment,
+                   buffer->offset_factor, buffer->buffer_type);
 
         new_alloc_buffers.push_back(new_buffer);
         buffer_replacements_[handle] = new_buffer;
@@ -687,20 +716,14 @@ private:
     }
 
     auto new_body = VisitStmt(op->body);
-    auto new_block = Block(op->iter_vars,
-                          op->reads,
-                          op->writes,
-                          op->name_hint,
-                          new_body,
-                          op->init,
-                          new_alloc_buffers,
-                          op->match_buffers,
-                          op->annotations);
+    auto new_block =
+        Block(op->iter_vars, op->reads, op->writes, op->name_hint, new_body,
+              op->init, new_alloc_buffers, op->match_buffers, op->annotations);
 
     return new_block;
   }
 
-  PrimExpr VisitExpr_(const VarNode* op) override {
+  PrimExpr VisitExpr_(const VarNode *op) override {
     auto it = handle_scope_corrections_.find(op);
     if (it != handle_scope_corrections_.end()) {
       Var old_var = GetRef<Var>(op);
@@ -750,17 +773,18 @@ private:
     return BufferStore(new_buffer, value, indices);
   }
 
-  PrimExpr VisitExpr_(const CallNode* op) override {
+  PrimExpr VisitExpr_(const CallNode *op) override {
     if (op->op.same_as(builtin::tvm_access_ptr())) {
 
       if (op->args.size() > 1) {
-        if (auto* var = op->args[1].as<VarNode>()) {
+        if (auto *var = op->args[1].as<VarNode>()) {
           auto it = handle_scope_corrections_.find(var);
           if (it != handle_scope_corrections_.end()) {
 
             Array<PrimExpr> new_args;
-            new_args.push_back(op->args[0]);  // type annotation
-            new_args.push_back(CreateVarWithCorrectScope(GetRef<Var>(var), it->second));
+            new_args.push_back(op->args[0]); // type annotation
+            new_args.push_back(
+                CreateVarWithCorrectScope(GetRef<Var>(var), it->second));
 
             for (size_t i = 2; i < op->args.size(); ++i) {
               new_args.push_back(VisitExpr(op->args[i]));
@@ -781,12 +805,11 @@ transform::Pass InferAllocScope() {
     ScopeCorrector corrector;
     return corrector.Correct(std::move(f));
   };
-  return transform::CreatePrimFuncPass(pass_func, 0,
-                                      "tl.InferAllocScope", {});
+  return transform::CreatePrimFuncPass(pass_func, 0, "tl.InferAllocScope", {});
 }
 
 TVM_REGISTER_GLOBAL("tl.transform.InferAllocScope")
     .set_body_typed(InferAllocScope);
 
-}  // namespace tir
-}  // namespace tvm
+} // namespace tir
+} // namespace tvm

--- a/src/transform/ascend_infer_buffer_scope.cc
+++ b/src/transform/ascend_infer_buffer_scope.cc
@@ -421,13 +421,16 @@ private:
         }
 
         bool only_in_ascend_copy = false;
-        if (!use_info->used_in_cube && !use_info->used_in_vector) {
-          only_in_ascend_copy = true;
+        if (!use_info->used_in_cube) {
+          bool only_valid_funcs = true;
           for (const auto& func_name : use_info->func_names) {
-            if (func_name != "tl.ascend_copy") {
-              only_in_ascend_copy = false;
+            if (func_name != "tl.ascend_copy" && func_name != "tl.ascend_dump_tensor") {
+              only_valid_funcs = false;
               break;
             }
+          }
+          if (only_valid_funcs) {
+            only_in_ascend_copy = true;
           }
         }
 
@@ -465,8 +468,25 @@ private:
         } else {
           alloc_info->corrected_scope = "shared";
         }
+        
+        bool has_dump_tensor = false;
+        if (use_info) {
+          for (const auto& func : use_info->func_names) {
+            if (func == "tl.ascend_dump_tensor" || func == "tl.dump_tensor") {
+              has_dump_tensor = true;
+              break;
+            }
+          }
+        }
 
-        if (alloc_info->corrected_scope != alloc_info->original_scope) {
+        bool should_apply = false;
+        if (has_dump_tensor && alloc_info->corrected_scope == "shared.dyn") {
+          should_apply = true;
+        } else if (alloc_info->corrected_scope != alloc_info->original_scope) {
+          should_apply = true;
+        }
+
+        if (should_apply) {        
           if (alloc_info->alloc_node) {
             scope_corrections_[alloc_info->alloc_node] = alloc_info->corrected_scope;
           }

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -482,27 +482,29 @@ private:
       auto map =
           op->annotations.Get(attr::kLayoutMap).as<Map<Var, Layout>>().value();
       for (auto it : map) {
-          Var target_var = it.first;
-          Layout target_layout = it.second;
-          Buffer found_buffer;
-          if (buffer_data_to_buffer_.count(target_var)) {
-              found_buffer = buffer_data_to_buffer_[target_var];
-          } else {
-              for (auto const& kv : buffer_data_to_buffer_) {
-                  Var current_var = kv.first;
-                  Buffer current_buf = kv.second;
-                  if (current_var->name_hint == target_var->name_hint &&
-                      StructuralEqual()(current_buf->shape, target_layout->InputShape()) &&
-                      current_var->dtype == target_var->dtype) {
-                      found_buffer = current_buf;
-                      break;
-                  }
-              }
+        Var target_var = it.first;
+        Layout target_layout = it.second;
+        Buffer found_buffer;
+        if (buffer_data_to_buffer_.count(target_var)) {
+          found_buffer = buffer_data_to_buffer_[target_var];
+        } else {
+          for (auto const &kv : buffer_data_to_buffer_) {
+            Var current_var = kv.first;
+            Buffer current_buf = kv.second;
+            if (current_var->name_hint == target_var->name_hint &&
+                StructuralEqual()(current_buf->shape,
+                                  target_layout->InputShape()) &&
+                current_var->dtype == target_var->dtype) {
+              found_buffer = current_buf;
+              break;
+            }
           }
-          if (!found_buffer.defined()) {
-              ICHECK(false) << "Buffer " << target_var->name_hint << " has no matching definition in this scope.";
-          }
-          annotated_layout_map_.Set(found_buffer, target_layout);
+        }
+        if (!found_buffer.defined()) {
+          ICHECK(false) << "Buffer " << target_var->name_hint
+                        << " has no matching definition in this scope.";
+        }
+        annotated_layout_map_.Set(found_buffer, target_layout);
       }
     }
     IRVisitorWithAnalyzer::VisitStmt_(op);
@@ -554,7 +556,7 @@ private:
   LayoutInferencer(const LayoutInferenceResult result,
                    bool skip_thread_partition, arith::Analyzer *analyzer)
       : arith::IRMutatorWithAnalyzer(analyzer), result_(result),
-        skip_thread_partition_(skip_thread_partition){};
+        skip_thread_partition_(skip_thread_partition) {};
 
   Stmt VisitStmt_(const BlockNode *op) final {
     Block block = Downcast<Block>(IRMutatorWithAnalyzer::VisitStmt_(op));

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -481,12 +481,28 @@ private:
     if (op->annotations.count(attr::kLayoutMap)) {
       auto map =
           op->annotations.Get(attr::kLayoutMap).as<Map<Var, Layout>>().value();
-      for (const auto &[var, layout] : map) {
-        ICHECK(buffer_data_to_buffer_.count(var))
-            << "buffer " << var << " is not found in the block";
-        auto buffer = buffer_data_to_buffer_[var];
-        ICHECK(StructuralEqual()(layout->InputShape(), buffer->shape));
-        annotated_layout_map_.Set(buffer, layout);
+      for (auto it : map) {
+          Var target_var = it.first;
+          Layout target_layout = it.second;
+          Buffer found_buffer;
+          if (buffer_data_to_buffer_.count(target_var)) {
+              found_buffer = buffer_data_to_buffer_[target_var];
+          } else {
+              for (auto const& kv : buffer_data_to_buffer_) {
+                  Var current_var = kv.first;
+                  Buffer current_buf = kv.second;
+                  if (current_var->name_hint == target_var->name_hint &&
+                      StructuralEqual()(current_buf->shape, target_layout->InputShape()) &&
+                      current_var->dtype == target_var->dtype) {
+                      found_buffer = current_buf;
+                      break;
+                  }
+              }
+          }
+          if (!found_buffer.defined()) {
+              ICHECK(false) << "Buffer " << target_var->name_hint << " has no matching definition in this scope.";
+          }
+          annotated_layout_map_.Set(found_buffer, target_layout);
       }
     }
     IRVisitorWithAnalyzer::VisitStmt_(op);


### PR DESCRIPTION
Core Objective:
Ensures correct mapping between Var handles and their corresponding Layout objects, even when the original Var pointers have been invalidated or re-created (re-bound) during IR transformations.

Key Mechanism:
Primary Lookup: First attempts a direct pointer-based lookup in buffer_data_to_buffer_ for maximum efficiency.
Fallback Logic (Fuzzy Match): If the pointer lookup fails, it performs a deep scan of available buffers by verifying three structural criteria:
Identity: name_hint (e.g., "A_L1") matches.
Geometry: shape is structurally equal to the layout's input shape.
Type: dtype (e.g., float16) is identical.

Validation: Enforces that every target variable must resolve to a defined buffer; otherwise, it throws a descriptive ICHECK error to prevent silent mapping failures.