### PR TITLE
[AscendNPU-IR][tvm] Support bfloat16 for binary and unary ops

### DIFF
--- a/src/transform/legalize_npuir_bf16.cc
+++ b/src/transform/legalize_npuir_bf16.cc
@@ -9,6 +9,7 @@
 #include <tvm/tir/op.h>
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
+#include <tvm/node/structural_equal.h>
 
 #include <string>
 #include <utility>
@@ -24,16 +25,16 @@ using namespace tir;
 using arith::IRMutatorWithAnalyzer;
 
 class LegalizeNpuirBF16Mutator : public IRMutatorWithAnalyzer {
- public:
+public:
   static PrimFunc Substitute(PrimFunc f) {
     arith::Analyzer analyzer;
     LegalizeNpuirBF16Mutator mutator(&analyzer);
-    PrimFuncNode* fptr = f.CopyOnWrite();
+    PrimFuncNode *fptr = f.CopyOnWrite();
     fptr->body = mutator.VisitStmt(f->body);
     return f;
   }
 
- private:
+private:
   using IRMutatorWithAnalyzer::IRMutatorWithAnalyzer;
 
   struct PreparedRegion {
@@ -41,88 +42,141 @@ class LegalizeNpuirBF16Mutator : public IRMutatorWithAnalyzer {
     Array<Stmt> prefix;
   };
 
-  bool IsBF16(const Buffer& buffer) const {
+  struct CachedSourceCast {
+    Buffer src_buffer;
+    Array<Range> ranges;
+    String scope;
+    Buffer temp_f32;
+  };
+
+  bool IsBF16(const Buffer &buffer) const {
     return buffer.defined() && buffer->dtype == DataType::BFloat(16);
   }
 
-  bool IsNpuirAdd(const CallNode* call) const {
-    return call != nullptr && call->op.same_as(Op::Get("tl.npuir_add"));
+  bool IsBinaryOp(const CallNode *call) const {
+    if (call == nullptr) {
+      return false;
+    }
+    std::vector<std::string> binary_ops = {"tl.npuir_add", "tl.npuir_mul",
+                                           "tl.npuir_max", "tl.npuir_min",
+                                           "tl.npuir_div", "tl.npuir_sub"};
+    return std::any_of(binary_ops.begin(), binary_ops.end(),
+                       [&](const std::string &op_name) {
+                         return call->op.same_as(Op::Get(op_name));
+                       });
   }
 
-  Buffer CreateTempBuffer(const Array<Range>& region, DataType dtype, const String& scope,
-                          const std::string& prefix) {
+  bool IsUnaryOp(const CallNode *call) const {
+    if (call == nullptr) {
+      return false;
+    }
+    std::vector<std::string> unary_ops = {
+        "tl.npuir_exp",  "tl.npuir_relu",  "tl.npuir_sigmoid", "tl.npuir_ln",
+        "tl.npuir_sqrt", "tl.npuir_rsqrt", "tl.npuir_abs",     "tl.npuir_rec"};
+    return std::any_of(unary_ops.begin(), unary_ops.end(),
+                       [&](const std::string &op_name) {
+                         return call->op.same_as(Op::Get(op_name));
+                       });
+  }
+
+  Buffer CreateTempBuffer(const Array<Range> &region, DataType dtype,
+                          const String &scope, const std::string &prefix) {
     Array<PrimExpr> shape;
-    for (const Range& r : region) {
+    for (const Range &r : region) {
       shape.push_back(r->extent);
     }
 
     std::string name = prefix + "_" + std::to_string(temp_buffer_id_++);
-    Buffer buf(Var(name, PointerType(PrimType(dtype), scope)), dtype, shape, {}, PrimExpr(0), name, 0,
-               0, kDefault);
+    Buffer buf(Var(name, PointerType(PrimType(dtype), scope)), dtype, shape, {},
+               PrimExpr(0), name, 0, 0, kDefault);
     ICHECK(!block_temp_buffers_.empty())
         << "BF16 legalization expects to create temporaries inside a Block.";
     block_temp_buffers_.back().push_back(buf);
     return buf;
   }
 
-  PrimExpr CreateRegion(const Buffer& buffer, const Array<Range>& region, int access_mask) const {
+  PrimExpr CreateRegion(const Buffer &buffer, const Array<Range> &region,
+                        int access_mask) const {
     Array<PrimExpr> indices;
     Array<PrimExpr> args;
 
-    for (const Range& r : region) {
+    for (const Range &r : region) {
       indices.push_back(make_zero(r->min.dtype()));
     }
 
     args.push_back(BufferLoad(buffer, indices));
     args.push_back(make_const(DataType::Int(32), access_mask));
-    for (const Range& r : region) {
+    for (const Range &r : region) {
       args.push_back(r->extent);
     }
     return Call(DataType::Handle(), Op::Get("tl.region"), args);
   }
 
-  Stmt CreateCastStmt(const PrimExpr& src_region, const PrimExpr& dst_region) const {
+  Stmt CreateCastStmt(const PrimExpr &src_region,
+                      const PrimExpr &dst_region) const {
     Array<PrimExpr> args{src_region, dst_region, StringImm("rint")};
     return Evaluate(Call(DataType::Void(), Op::Get("tl.npuir_cast"), args));
   }
 
-  PreparedRegion PrepareSourceRegion(const RegionOp& src, const String& scope) {
-    PreparedRegion prepared{CreateRegion(src.GetBuffer(), src.GetRanges(), /*access_mask=*/1), {}};
+  PreparedRegion PrepareSourceRegion(const RegionOp &src, const String &scope) {
+    PreparedRegion prepared{
+        CreateRegion(src.GetBuffer(), src.GetRanges(), /*access_mask=*/1), {}};
     if (!IsBF16(src.GetBuffer())) {
       return prepared;
     }
 
-    Buffer temp = CreateTempBuffer(src.GetRanges(), DataType::Float(32), scope, "bf16_src_f32");
-    PrimExpr temp_dst_region = CreateRegion(temp, src.GetRanges(), /*access_mask=*/2);
+    ICHECK(!block_source_cast_cache_.empty())
+        << "BF16 legalization source-cache expects to run inside a Block.";
+
+    for (const CachedSourceCast &cached : block_source_cast_cache_.back()) {
+      if (cached.src_buffer.same_as(src.GetBuffer()) &&
+          cached.scope == scope &&
+          StructuralEqual()(cached.ranges, src.GetRanges())) {
+        prepared.region =
+            CreateRegion(cached.temp_f32, src.GetRanges(), /*access_mask=*/1);
+        return prepared;
+      }
+    }
+
+    Buffer temp = CreateTempBuffer(src.GetRanges(), DataType::Float(32), scope,
+                                   "bf16_src_f32");
+    PrimExpr temp_dst_region =
+        CreateRegion(temp, src.GetRanges(), /*access_mask=*/2);
     prepared.prefix.push_back(CreateCastStmt(prepared.region, temp_dst_region));
     prepared.region = CreateRegion(temp, src.GetRanges(), /*access_mask=*/1);
+    block_source_cast_cache_.back().push_back(
+        CachedSourceCast{src.GetBuffer(), src.GetRanges(), scope, temp});
     return prepared;
   }
 
-  PreparedRegion PrepareDestinationRegion(const RegionOp& dst) {
-    PreparedRegion prepared{CreateRegion(dst.GetBuffer(), dst.GetRanges(), /*access_mask=*/2), {}};
+  PreparedRegion PrepareDestinationRegion(const RegionOp &dst) {
+    PreparedRegion prepared{
+        CreateRegion(dst.GetBuffer(), dst.GetRanges(), /*access_mask=*/2), {}};
     if (!IsBF16(dst.GetBuffer())) {
       return prepared;
     }
 
-    Buffer temp = CreateTempBuffer(dst.GetRanges(), DataType::Float(32), dst.GetBuffer().scope(),
-                                   "bf16_dst_f32");
-    PrimExpr temp_src_region = CreateRegion(temp, dst.GetRanges(), /*access_mask=*/1);
+    Buffer temp = CreateTempBuffer(dst.GetRanges(), DataType::Float(32),
+                                   dst.GetBuffer().scope(), "bf16_dst_f32");
+    PrimExpr temp_src_region =
+        CreateRegion(temp, dst.GetRanges(), /*access_mask=*/1);
     prepared.prefix.push_back(CreateCastStmt(temp_src_region, prepared.region));
     prepared.region = CreateRegion(temp, dst.GetRanges(), /*access_mask=*/2);
     return prepared;
   }
 
-  Stmt VisitStmt_(const BlockNode* op) final {
+  Stmt VisitStmt_(const BlockNode *op) final {
     block_temp_buffers_.push_back({});
+    block_source_cast_cache_.push_back({});
 
     Block new_block = Downcast<Block>(IRMutatorWithAnalyzer::VisitStmt_(op));
 
     Array<Buffer> new_allocs = new_block->alloc_buffers;
-    for (const Buffer& buf : block_temp_buffers_.back()) {
+    for (const Buffer &buf : block_temp_buffers_.back()) {
       new_allocs.push_back(buf);
     }
     block_temp_buffers_.pop_back();
+    block_source_cast_cache_.pop_back();
 
     if (new_allocs.same_as(new_block->alloc_buffers)) {
       return new_block;
@@ -132,21 +186,14 @@ class LegalizeNpuirBF16Mutator : public IRMutatorWithAnalyzer {
     return new_block;
   }
 
-  Stmt VisitStmt_(const EvaluateNode* op) final {
-    PrimExpr new_value = this->VisitExpr(op->value);
-    const CallNode* call = new_value.as<CallNode>();
-    if (!IsNpuirAdd(call) || block_temp_buffers_.empty()) {
-      if (new_value.same_as(op->value)) {
-        return GetRef<Stmt>(op);
-      }
-      return Evaluate(new_value);
-    }
-
-    const CallNode* src0_call = call->args[0].as<CallNode>();
-    const CallNode* src1_call = call->args[1].as<CallNode>();
-    const CallNode* dst_call = call->args[2].as<CallNode>();
+  Stmt processBinaryOp(const PrimExpr &new_value) {
+    const auto *call = new_value.as<CallNode>();
+    const auto *src0_call = call->args[0].as<CallNode>();
+    const auto *src1_call = call->args[1].as<CallNode>();
+    const auto *dst_call = call->args[2].as<CallNode>();
     if (src0_call == nullptr || src1_call == nullptr || dst_call == nullptr ||
-        !src0_call->op.same_as(Op::Get("tl.region")) || !src1_call->op.same_as(Op::Get("tl.region")) ||
+        !src0_call->op.same_as(Op::Get("tl.region")) ||
+        !src1_call->op.same_as(Op::Get("tl.region")) ||
         !dst_call->op.same_as(Op::Get("tl.region"))) {
       return Evaluate(new_value);
     }
@@ -165,35 +212,88 @@ class LegalizeNpuirBF16Mutator : public IRMutatorWithAnalyzer {
     PreparedRegion dst = PrepareDestinationRegion(dst_region);
 
     Array<Stmt> seq;
-    for (const Stmt& stmt : src0.prefix) {
+    for (const Stmt &stmt : src0.prefix) {
       seq.push_back(stmt);
     }
-    for (const Stmt& stmt : src1.prefix) {
+    for (const Stmt &stmt : src1.prefix) {
       seq.push_back(stmt);
     }
-    Array<PrimExpr> add_args{src0.region, src1.region, dst.region};
-    seq.push_back(Evaluate(Call(DataType::Void(), Op::Get("tl.npuir_add"), add_args)));
-    for (const Stmt& stmt : dst.prefix) {
+    Array<PrimExpr> op_args{src0.region, src1.region, dst.region};
+    seq.push_back(Evaluate(Call(DataType::Void(), call->op, op_args)));
+    for (const Stmt &stmt : dst.prefix) {
       seq.push_back(stmt);
     }
     return SeqStmt::Flatten(seq);
   }
 
+  Stmt processUnaryOp(const PrimExpr &new_value) {
+    const auto *call = new_value.as<CallNode>();
+    const auto *src_call = call->args[0].as<CallNode>();
+    const auto *dst_call = call->args[1].as<CallNode>();
+    if (src_call == nullptr || dst_call == nullptr ||
+        !src_call->op.same_as(Op::Get("tl.region")) ||
+        !dst_call->op.same_as(Op::Get("tl.region"))) {
+      return Evaluate(new_value);
+    }
+
+    RegionOp src_region(src_call->args, BufferMap{});
+    RegionOp dst_region(dst_call->args, BufferMap{});
+    if (!IsBF16(src_region.GetBuffer()) && !IsBF16(dst_region.GetBuffer())) {
+      return Evaluate(new_value);
+    }
+
+    String compute_scope = dst_region.GetBuffer().scope();
+    PreparedRegion src = PrepareSourceRegion(src_region, compute_scope);
+    PreparedRegion dst = PrepareDestinationRegion(dst_region);
+
+    Array<Stmt> seq;
+    for (const Stmt &stmt : src.prefix) {
+      seq.push_back(stmt);
+    }
+    Array<PrimExpr> op_args{src.region, dst.region};
+    seq.push_back(Evaluate(Call(DataType::Void(), call->op, op_args)));
+    for (const Stmt &stmt : dst.prefix) {
+      seq.push_back(stmt);
+    }
+    return SeqStmt::Flatten(seq);
+  }
+
+  Stmt VisitStmt_(const EvaluateNode *op) final {
+    PrimExpr new_value = this->VisitExpr(op->value);
+    const auto *call = new_value.as<CallNode>();
+    if ((!IsBinaryOp(call) && !IsUnaryOp(call)) ||
+        block_temp_buffers_.empty()) {
+      if (new_value.same_as(op->value)) {
+        return GetRef<Stmt>(op);
+      }
+      return Evaluate(new_value);
+    }
+    if (IsBinaryOp(call)) {
+      return processBinaryOp(new_value);
+    }
+
+    return processUnaryOp(new_value);
+  }
+
   int temp_buffer_id_{0};
   std::vector<std::vector<Buffer>> block_temp_buffers_;
+  std::vector<std::vector<CachedSourceCast>> block_source_cast_cache_;
 };
 
 namespace transform {
 
 tvm::transform::Pass LegalizeNpuirBF16() {
-  auto pass_func = [=](PrimFunc f, IRModule m, tvm::transform::PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, IRModule m,
+                       tvm::transform::PassContext ctx) {
     return LegalizeNpuirBF16Mutator::Substitute(std::move(f));
   };
-  return tir::transform::CreatePrimFuncPass(pass_func, 0, "tl.LegalizeNpuirBF16", {});
+  return tir::transform::CreatePrimFuncPass(pass_func, 0,
+                                            "tl.LegalizeNpuirBF16", {});
 }
 
-TVM_REGISTER_GLOBAL("tl.transform.LegalizeNpuirBF16").set_body_typed(LegalizeNpuirBF16);
+TVM_REGISTER_GLOBAL("tl.transform.LegalizeNpuirBF16")
+    .set_body_typed(LegalizeNpuirBF16);
 
-}  // namespace transform
-}  // namespace tl
-}  // namespace tvm
+} // namespace transform
+} // namespace tl
+} // namespace tvm

--- a/src/transform/legalize_npuir_bf16.cc
+++ b/src/transform/legalize_npuir_bf16.cc
@@ -1,0 +1,199 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+
+/*!
+ * \file legalize_npuir_bf16.cc
+ * \brief Legalize BF16 tl.npuir_add into fp32 compute plus casts.
+ */
+
+#include <tvm/tir/op.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "../op/op.h"
+#include "arith/ir_mutator_with_analyzer.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+using arith::IRMutatorWithAnalyzer;
+
+class LegalizeNpuirBF16Mutator : public IRMutatorWithAnalyzer {
+ public:
+  static PrimFunc Substitute(PrimFunc f) {
+    arith::Analyzer analyzer;
+    LegalizeNpuirBF16Mutator mutator(&analyzer);
+    PrimFuncNode* fptr = f.CopyOnWrite();
+    fptr->body = mutator.VisitStmt(f->body);
+    return f;
+  }
+
+ private:
+  using IRMutatorWithAnalyzer::IRMutatorWithAnalyzer;
+
+  struct PreparedRegion {
+    PrimExpr region;
+    Array<Stmt> prefix;
+  };
+
+  bool IsBF16(const Buffer& buffer) const {
+    return buffer.defined() && buffer->dtype == DataType::BFloat(16);
+  }
+
+  bool IsNpuirAdd(const CallNode* call) const {
+    return call != nullptr && call->op.same_as(Op::Get("tl.npuir_add"));
+  }
+
+  Buffer CreateTempBuffer(const Array<Range>& region, DataType dtype, const String& scope,
+                          const std::string& prefix) {
+    Array<PrimExpr> shape;
+    for (const Range& r : region) {
+      shape.push_back(r->extent);
+    }
+
+    std::string name = prefix + "_" + std::to_string(temp_buffer_id_++);
+    Buffer buf(Var(name, PointerType(PrimType(dtype), scope)), dtype, shape, {}, PrimExpr(0), name, 0,
+               0, kDefault);
+    ICHECK(!block_temp_buffers_.empty())
+        << "BF16 legalization expects to create temporaries inside a Block.";
+    block_temp_buffers_.back().push_back(buf);
+    return buf;
+  }
+
+  PrimExpr CreateRegion(const Buffer& buffer, const Array<Range>& region, int access_mask) const {
+    Array<PrimExpr> indices;
+    Array<PrimExpr> args;
+
+    for (const Range& r : region) {
+      indices.push_back(make_zero(r->min.dtype()));
+    }
+
+    args.push_back(BufferLoad(buffer, indices));
+    args.push_back(make_const(DataType::Int(32), access_mask));
+    for (const Range& r : region) {
+      args.push_back(r->extent);
+    }
+    return Call(DataType::Handle(), Op::Get("tl.region"), args);
+  }
+
+  Stmt CreateCastStmt(const PrimExpr& src_region, const PrimExpr& dst_region) const {
+    Array<PrimExpr> args{src_region, dst_region, StringImm("rint")};
+    return Evaluate(Call(DataType::Void(), Op::Get("tl.npuir_cast"), args));
+  }
+
+  PreparedRegion PrepareSourceRegion(const RegionOp& src, const String& scope) {
+    PreparedRegion prepared{CreateRegion(src.GetBuffer(), src.GetRanges(), /*access_mask=*/1), {}};
+    if (!IsBF16(src.GetBuffer())) {
+      return prepared;
+    }
+
+    Buffer temp = CreateTempBuffer(src.GetRanges(), DataType::Float(32), scope, "bf16_src_f32");
+    PrimExpr temp_dst_region = CreateRegion(temp, src.GetRanges(), /*access_mask=*/2);
+    prepared.prefix.push_back(CreateCastStmt(prepared.region, temp_dst_region));
+    prepared.region = CreateRegion(temp, src.GetRanges(), /*access_mask=*/1);
+    return prepared;
+  }
+
+  PreparedRegion PrepareDestinationRegion(const RegionOp& dst) {
+    PreparedRegion prepared{CreateRegion(dst.GetBuffer(), dst.GetRanges(), /*access_mask=*/2), {}};
+    if (!IsBF16(dst.GetBuffer())) {
+      return prepared;
+    }
+
+    Buffer temp = CreateTempBuffer(dst.GetRanges(), DataType::Float(32), dst.GetBuffer().scope(),
+                                   "bf16_dst_f32");
+    PrimExpr temp_src_region = CreateRegion(temp, dst.GetRanges(), /*access_mask=*/1);
+    prepared.prefix.push_back(CreateCastStmt(temp_src_region, prepared.region));
+    prepared.region = CreateRegion(temp, dst.GetRanges(), /*access_mask=*/2);
+    return prepared;
+  }
+
+  Stmt VisitStmt_(const BlockNode* op) final {
+    block_temp_buffers_.push_back({});
+
+    Block new_block = Downcast<Block>(IRMutatorWithAnalyzer::VisitStmt_(op));
+
+    Array<Buffer> new_allocs = new_block->alloc_buffers;
+    for (const Buffer& buf : block_temp_buffers_.back()) {
+      new_allocs.push_back(buf);
+    }
+    block_temp_buffers_.pop_back();
+
+    if (new_allocs.same_as(new_block->alloc_buffers)) {
+      return new_block;
+    }
+
+    new_block.CopyOnWrite()->alloc_buffers = std::move(new_allocs);
+    return new_block;
+  }
+
+  Stmt VisitStmt_(const EvaluateNode* op) final {
+    PrimExpr new_value = this->VisitExpr(op->value);
+    const CallNode* call = new_value.as<CallNode>();
+    if (!IsNpuirAdd(call) || block_temp_buffers_.empty()) {
+      if (new_value.same_as(op->value)) {
+        return GetRef<Stmt>(op);
+      }
+      return Evaluate(new_value);
+    }
+
+    const CallNode* src0_call = call->args[0].as<CallNode>();
+    const CallNode* src1_call = call->args[1].as<CallNode>();
+    const CallNode* dst_call = call->args[2].as<CallNode>();
+    if (src0_call == nullptr || src1_call == nullptr || dst_call == nullptr ||
+        !src0_call->op.same_as(Op::Get("tl.region")) || !src1_call->op.same_as(Op::Get("tl.region")) ||
+        !dst_call->op.same_as(Op::Get("tl.region"))) {
+      return Evaluate(new_value);
+    }
+
+    RegionOp src0_region(src0_call->args, BufferMap{});
+    RegionOp src1_region(src1_call->args, BufferMap{});
+    RegionOp dst_region(dst_call->args, BufferMap{});
+    if (!IsBF16(src0_region.GetBuffer()) && !IsBF16(src1_region.GetBuffer()) &&
+        !IsBF16(dst_region.GetBuffer())) {
+      return Evaluate(new_value);
+    }
+
+    String compute_scope = dst_region.GetBuffer().scope();
+    PreparedRegion src0 = PrepareSourceRegion(src0_region, compute_scope);
+    PreparedRegion src1 = PrepareSourceRegion(src1_region, compute_scope);
+    PreparedRegion dst = PrepareDestinationRegion(dst_region);
+
+    Array<Stmt> seq;
+    for (const Stmt& stmt : src0.prefix) {
+      seq.push_back(stmt);
+    }
+    for (const Stmt& stmt : src1.prefix) {
+      seq.push_back(stmt);
+    }
+    Array<PrimExpr> add_args{src0.region, src1.region, dst.region};
+    seq.push_back(Evaluate(Call(DataType::Void(), Op::Get("tl.npuir_add"), add_args)));
+    for (const Stmt& stmt : dst.prefix) {
+      seq.push_back(stmt);
+    }
+    return SeqStmt::Flatten(seq);
+  }
+
+  int temp_buffer_id_{0};
+  std::vector<std::vector<Buffer>> block_temp_buffers_;
+};
+
+namespace transform {
+
+tvm::transform::Pass LegalizeNpuirBF16() {
+  auto pass_func = [=](PrimFunc f, IRModule m, tvm::transform::PassContext ctx) {
+    return LegalizeNpuirBF16Mutator::Substitute(std::move(f));
+  };
+  return tir::transform::CreatePrimFuncPass(pass_func, 0, "tl.LegalizeNpuirBF16", {});
+}
+
+TVM_REGISTER_GLOBAL("tl.transform.LegalizeNpuirBF16").set_body_typed(LegalizeNpuirBF16);
+
+}  // namespace transform
+}  // namespace tl
+}  // namespace tvm

--- a/src/transform/lower_npuir_block.cc
+++ b/src/transform/lower_npuir_block.cc
@@ -1,0 +1,60 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+
+/*!
+ * \file lower_npuir_block.cc
+ * \brief Strip residual TIR Block/BlockRealize shells for NPUIR codegen.
+ */
+
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/op.h>
+#include <tvm/tir/transform.h>
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+
+class LowerNpuirBlockMutator : public StmtExprMutator {
+ public:
+  static PrimFunc Substitute(PrimFunc f) {
+    LowerNpuirBlockMutator mutator;
+    PrimFuncNode* fptr = f.CopyOnWrite();
+    fptr->body = mutator.VisitStmt(f->body);
+    return f;
+  }
+
+ private:
+  Stmt VisitStmt_(const BlockRealizeNode* op) final {
+    Stmt body = VisitStmt(op->block);
+    PrimExpr predicate = VisitExpr(op->predicate);
+    if (!is_one(predicate)) {
+      body = IfThenElse(predicate, std::move(body));
+    }
+    return body;
+  }
+
+  Stmt VisitStmt_(const BlockNode* op) final {
+    Stmt body = VisitStmt(op->body);
+    if (op->init.defined()) {
+      Array<Stmt> stmts{VisitStmt(op->init.value()), body};
+      body = SeqStmt::Flatten(stmts);
+    }
+    return body;
+  }
+};
+
+namespace transform {
+
+tvm::transform::Pass LowerNpuirBlock() {
+  auto pass_func = [=](PrimFunc f, IRModule m, tvm::transform::PassContext ctx) {
+    return LowerNpuirBlockMutator::Substitute(std::move(f));
+  };
+  return tir::transform::CreatePrimFuncPass(pass_func, 0, "tl.LowerNpuirBlock", {});
+}
+
+TVM_REGISTER_GLOBAL("tl.transform.LowerNpuirBlock").set_body_typed(LowerNpuirBlock);
+
+}  // namespace transform
+}  // namespace tl
+}  // namespace tvm

--- a/testing/npuir/bf16_support/test_binary_bf16_dev.py
+++ b/testing/npuir/bf16_support/test_binary_bf16_dev.py
@@ -1,0 +1,111 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025.
+from numpy import tile
+import pytest
+import torch
+import torch_npu 
+
+import tilelang
+import tilelang.language as T
+
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+  pytest.mark.op("bf16_binary")
+  pytest.mark.mode("Developer")
+]
+
+DTYPES = ["bfloat16"]
+
+@tilelang.jit(target="npuir")
+def binary_bf16_kernel(M, N, block_M, block_N, dtype):
+  grid_M = (M + block_M - 1) // block_M
+  grid_N = (N + block_N - 1) // block_N
+  @T.prim_func
+  def binary_bf16(
+    A: T.Tensor((M, N), dtype),
+    B: T.Tensor((M, N), dtype),
+    C: T.Tensor((M, N), dtype)
+  ):
+    with T.Kernel(grid_M * grid_N, is_npu=True) as (cid, _):
+      blockx = cid % grid_N
+      bx = blockx * block_M
+      blocky = cid // grid_N
+      by = blocky * block_N
+
+      A_VEC = T.alloc_shared([block_M, block_N], dtype)
+      B_VEC = T.alloc_shared([block_M, block_N], dtype)
+      C_VEC = T.alloc_shared([block_M, block_N], dtype)
+
+      T.copy(A[by:by + block_M, bx:bx + block_N], A_VEC)
+      T.copy(B[by:by + block_M, bx:bx + block_N], B_VEC)
+      T.vadd(A_VEC, B_VEC, C_VEC)
+      T.copy(C_VEC, C[by:by + block_M, bx:bx + block_N])
+      
+    return binary_bf16
+
+
+@tilelang.jit(target="npuir")
+def binary_bf16_multi(M, N, block_M, block_N, dtype):
+  grid_M = (M + block_M - 1) // block_M
+  grid_N = (N + block_N - 1) // block_N
+  @T.prim_func
+  def binary_bf16_mul(
+    A: T.Tensor((M, N), dtype),
+    B: T.Tensor((M, N), dtype),
+    C: T.Tensor((M, N), dtype),
+    D: T.Tensor((M, N), dtype)
+  ):
+    with T.Kernel(grid_M * grid_N, is_npu=True) as (cid, _):
+      blockx = cid % grid_N
+      bx = blockx * block_M
+      blocky = cid // grid_N
+      by = blocky * block_N
+
+      A_VEC = T.alloc_shared([block_M, block_N], dtype)
+      B_VEC = T.alloc_shared([block_M, block_N], dtype)
+      C_VEC = T.alloc_shared([block_M, block_N], dtype)
+      D_VEC = T.alloc_shared([block_M, block_N], dtype)
+
+      T.copy(A[by:by + block_M, bx:bx + block_N], A_VEC)
+      T.copy(B[by:by + block_M, bx:bx + block_N], B_VEC)
+      T.vadd(A_VEC, B_VEC, C_VEC)
+      T.vdiv(B_VEC, A_VEC, D_VEC)
+      T.copy(C_VEC, C[by:by + block_M, bx:bx + block_N])
+      T.copy(D_VEC, D[by:by + block_M, bx:bx + block_N])
+      
+    return binary_bf16_mul
+  
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_bf16_binary(dtype):
+  M, N = 128, 128
+  kernel = binary_bf16_kernel(M, N, 32, 32, dtype)
+
+  a = gen_tensor([M, N], dtype, kind="randn")
+  b = gen_tensor([M, N], dtype, kind="randn")
+  c = gen_tensor([M, N], dtype, kind="zeros")
+
+  kernel(a, b, c)
+
+  expected = a + b
+
+  assert_close(c, expected, dtype=dtype)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_bf16_binary_multi(dtype):
+  M, N = 128, 128
+  kernel = binary_bf16_multi(M, N, 32, 32, dtype)
+
+  a = gen_tensor([M, N], dtype, kind="randn")
+  b = gen_tensor([M, N], dtype, kind="randn")
+  c = gen_tensor([M, N], dtype, kind="zeros")
+  d = gen_tensor([M, N], dtype, kind="zeros")
+
+  kernel(a, b, c, d)
+
+  expected_c = a + b
+  expected_d = b / a
+
+  assert_close(c, expected_c, dtype=dtype)
+  assert_close(d, expected_d, dtype=dtype)

--- a/testing/npuir/bf16_support/test_unary_bf16_dev.py
+++ b/testing/npuir/bf16_support/test_unary_bf16_dev.py
@@ -1,0 +1,91 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025.
+from numpy import tile
+import pytest
+import torch
+import torch_npu
+
+import tilelang
+import tilelang.language as T
+
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+  pytest.mark.op("bf16_unary")
+  pytest.mark.mode("Developer")
+]
+
+DTYPES = ["bfloat16"]
+
+@tilelang.jit(target="npuir")
+def unary_bf16_kernel(M, N, block_M, block_N, dtype):
+  grid_M = (M + block_M - 1) // block_M
+  grid_N = (N + block_N - 1) // block_N
+  @T.prim_func
+  def unary_bf16(
+    A: T.Tensor((M, N), dtype),
+    B: T.Tensor((M, N), dtype)
+  ):
+    with T.Kernel(grid_M * grid_N, is_npu=True) as (cid, _):
+      blockx = cid % grid_N
+      bx = blockx * block_M
+      blocky = cid // grid_N
+      by = blocky * block_N
+
+      A_VEC = T.alloc_shared([block_M, block_N], dtype)
+      B_VEC = T.alloc_shared([block_M, block_N], dtype)
+
+      T.copy(A[by:by + block_M, bx:bx + block_N], A_VEC)
+      T.vabs(A_VEC, B_VEC)
+      T.copy(B_VEC, B[by:by + block_M, bx:bx + block_N])
+      
+    return unary_bf16
+  
+
+@tilelang.jit(target="npuir")
+def unary_bf16_multi(M, N, block_M, block_N, dtype):
+  grid_M = (M + block_M - 1) // block_M
+  grid_N = (N + block_N - 1) // block_N
+  @T.prim_func
+  def unary_bf16_multi(
+    A: T.Tensor((M, N), dtype),
+    B: T.Tensor((M, N), dtype),
+    C: T.Tensor((M, N), dtype)
+  ):
+    with T.Kernel(grid_M * grid_N, is_npu=True) as (cid, _):
+      blockx = cid % grid_N
+      bx = blockx * block_M
+      blocky = cid // grid_N
+      by = blocky * block_N
+
+      A_VEC = T.alloc_shared([block_M, block_N], dtype)
+      B_VEC = T.alloc_shared([block_M, block_N], dtype)
+      C_VEC = T.alloc_shared([block_M, block_N], dtype)
+
+      T.copy(A[by:by + block_M, bx:bx + block_N], A_VEC)
+      T.vabs(A_VEC, B_VEC)
+      T.vexp(A_VEC, C_VEC)
+      T.copy(B_VEC, B[by:by + block_M, bx:bx + block_N])
+      T.copy(C_VEC, C[by:by + block_M, bx:bx + block_N])
+      
+    return unary_bf16_multi
+  
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_bf16_unary(dtype):
+  M, N = 128, 128
+  kernel = unary_bf16_kernel(M, N, 32, 32, dtype)
+  A = gen_tensor((M, N), dtype, kind="randn")
+  B = torch.empty_like(A)
+  kernel(A, B)
+  assert_close(B, torch.abs(A))
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_bf16_unary_multi(dtype):
+  M, N = 128, 128
+  kernel = unary_bf16_multi(M, N, 32, 32, dtype)
+  A = gen_tensor((M, N), dtype, kind="randn")
+  B = torch.empty_like(A)
+  C = torch.empty_like(A)
+  kernel(A, B, C)
+  assert_close(B, torch.abs(A))
+  assert_close(C, torch.exp(A))

--- a/testing/npuir/memory_ops/test_copy_dtypes_dev.py
+++ b/testing/npuir/memory_ops/test_copy_dtypes_dev.py
@@ -1,0 +1,115 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025.
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+import tilelang
+import tilelang.language as T
+
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("copy"),
+    pytest.mark.mode("Developer"),
+]
+
+DTYPES = ["bfloat16"]
+COPY_1D_CASES = [(1024, 256)]
+
+
+@tilelang.jit(target="npuir")
+def copy_1d_demo(L, block_L, dtype="bfloat16", calc_type="float32"):
+    @T.prim_func
+    def simple_copy_1d(
+        In: T.Tensor((L,), dtype),
+        A: T.Tensor((L,), dtype),
+        B: T.Tensor((L,), dtype),
+        C: T.Tensor((L,), calc_type),
+    ):
+        with T.Kernel(T.ceildiv(L, block_L), is_npu=True) as (cid, _):
+            start_idx = cid * block_L
+
+            in_frag = T.alloc_fragment((block_L,), dtype)
+            A_frag = T.alloc_fragment((block_L,), calc_type)
+            B_frag = T.alloc_fragment((block_L,), calc_type)
+            out_frag = T.alloc_fragment((block_L,), dtype)
+
+            T.copy(In[start_idx], in_frag)
+            T.vcast(in_frag, A_frag, round_mode="rint")
+            T.npuir_add(A_frag, A_frag, B_frag)
+            T.vcast(B_frag, out_frag, round_mode="rint")
+
+            T.copy(A_frag, A[start_idx])
+            T.copy(B_frag, B[start_idx])
+            T.copy(out_frag, C[start_idx])
+
+    return simple_copy_1d
+
+
+@tilelang.jit(target="npuir")
+def copy_1d_bf16(L, block_L, dtype="bfloat16"):
+    @T.prim_func
+    def simple_copy_1d(
+        In: T.Tensor((L,), dtype),
+        A: T.Tensor((L,), dtype),
+        B: T.Tensor((L,), dtype),
+        C: T.Tensor((L,), dtype),
+    ):
+        with T.Kernel(T.ceildiv(L, block_L), is_npu=True) as (cid, _):
+            start_idx = cid * block_L
+
+            in_frag = T.alloc_fragment((block_L,), dtype)
+            A_frag = T.alloc_fragment((block_L,), dtype)
+            B_frag = T.alloc_fragment((block_L,), dtype)
+            out_frag = T.alloc_fragment((block_L,), dtype)
+
+            T.copy(In[start_idx], in_frag)
+            T.copy(in_frag, A_frag)
+            T.npuir_add(A_frag, A_frag, B_frag)
+            T.copy(B_frag, out_frag)
+
+            T.copy(A_frag, A[start_idx])
+            T.copy(B_frag, B[start_idx])
+            T.copy(out_frag, C[start_idx])
+
+    return simple_copy_1d
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("L, block_L", COPY_1D_CASES)
+def test_copy_1d_demo(dtype, L, block_L):
+    kernel = copy_1d_demo(L, block_L, dtype=dtype)
+
+    input_tensor = gen_tensor((L,), dtype, kind="randn")
+    a = gen_tensor((L,), dtype, kind="zeros")
+    b = gen_tensor((L,), dtype, kind="zeros")
+    c = gen_tensor((L,), "float32", kind="zeros")
+
+    kernel(input_tensor, a, b, c)
+
+    expected_a = input_tensor
+    expected_b = (input_tensor.to(torch.float32) * 2).to(getattr(torch, dtype))
+    expected_c = expected_b.to(torch.float32)
+
+    assert_close(a.cpu(), expected_a.cpu(), dtype=dtype)
+    assert_close(b.cpu(), expected_b.cpu(), dtype=dtype)
+    assert_close(c.cpu(), expected_c.cpu(), dtype="float32")
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("L, block_L", COPY_1D_CASES)
+def test_copy_1d_bf16(dtype, L, block_L):
+    kernel = copy_1d_bf16(L, block_L, dtype=dtype)
+
+    input_tensor = gen_tensor((L,), dtype, kind="randn")
+    a = gen_tensor((L,), dtype, kind="zeros")
+    b = gen_tensor((L,), dtype, kind="zeros")
+    c = gen_tensor((L,), dtype, kind="zeros")
+
+    kernel(input_tensor, a, b, c)
+
+    expected_a = input_tensor
+    expected_b = input_tensor * 2
+    expected_c = expected_b
+
+    assert_close(a.cpu(), expected_a.cpu(), dtype=dtype)
+    assert_close(b.cpu(), expected_b.cpu(), dtype=dtype)
+    assert_close(c.cpu(), expected_c.cpu(), dtype=dtype)

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -1,5 +1,6 @@
 # Copyright (c) Tile-AI Organization.
 # Licensed under the MIT License.
+import os
 from tvm import tir, IRModule
 from tvm.target import Target
 import tilelang
@@ -50,6 +51,27 @@ def allow_vectorize(pass_ctx: Optional[PassContext] = None) -> bool:
         pass_ctx = tilelang.transform.get_pass_context()
     disable_vectorize = pass_ctx.config.get("tir.disable_vectorize", False)
     return not disable_vectorize
+
+
+def get_ascend_device_name() -> str:
+    for env_name in ("TILELANG_ASCEND_DEVICE_NAME", "ASCEND_DEVICE_NAME", "DEVICE_NAME"):
+        device_name = os.environ.get(env_name)
+        if device_name:
+            return device_name.strip()
+    return ""
+
+
+def supports_native_bf16_npuir_add(device_name: str) -> bool:
+    # Placeholder for future device capability table keyed by device_name.
+    _ = device_name
+    return False
+
+
+def need_npuir_bf16_legalize(target: Optional[Target] = None) -> bool:
+    if target is None or target.kind.name != "npuir":
+        return False
+
+    return not supports_native_bf16_npuir_add(get_ascend_device_name())
 
 
 def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
@@ -105,8 +127,11 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
         # 1. must be before LowerOpaqueBlock pass, otherwise the temporary buffer created cannot correctly become T.decl_buffer
         # 2. better to be before PlanAndUpdateBufferAllocationLocation, reuse its ability of Memory reusing
         mod = tilelang.transform.NpuLoopVectorize()(mod)
+        if need_npuir_bf16_legalize(target=target):
+            mod = tilelang.transform.LegalizeNpuirBF16()(mod)
         mod = tilelang.transform.PlanAndUpdateBufferAllocationLocation()(mod)
         mod = tir.transform.LowerOpaqueBlock()(mod)
+        mod = tilelang.transform.LowerNpuirBlock()(mod)
         mod = tir.transform.RemoveNoOp()(mod)
         return mod
     else:

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -235,6 +235,28 @@ def LegalizeSafeMemoryAccess():
     return _ffi_api.LegalizeSafeMemoryAccess()  # type: ignore
 
 
+def LegalizeNpuirBF16():
+    """Legalize unsupported BF16 NPUIR ops into fp32 compute plus casts.
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
+    return _ffi_api.LegalizeNpuirBF16()  # type: ignore
+
+
+def LowerNpuirBlock():
+    """Lower remaining Block/BlockRealize nodes for NPUIR codegen.
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
+    return _ffi_api.LowerNpuirBlock()  # type: ignore
+
+
 def MakePackedAPI():
     """MakePackedAPI
 


### PR DESCRIPTION
This PR introduces bfloat16 support for binary and unary operations in NPUIR and integrates the necessary TVM passes for legalization and code generation.

- BF16 Legalization Pass (LegalizeNpuirBF16): Added a new pass (src/transform/legalize_npuir_bf16.cc) to legalize bfloat16 operations (such as add, mul, exp, relu, etc.) by converting them into float32 computations with appropriate casts. It optimizes performance by caching and removing redundant bf16 casts when multiple arithmetic operations share the same bf16 buffer region.
- Lower NPUIR Block Pass (LowerNpuirBlock): Added a pass (src/transform/lower_npuir_block.cc) to strip residual TIR Block/BlockRealize shells to support NPUIR codegen.
- Compilation Pipeline Integration: Updated tilelang/engine/phase.py to seamlessly integrate the new passes into the optimization pipeline. The LegalizeNpuirBF16 pass is conditionally applied based on device capabilities (whether native bf16 adds are supported).
- Testing: Added comprehensive test cases for bfloat16 binary ops, unary ops, and memory copy data types in the testing/npuir/ directory (test_binary_bf16_dev.py, test_unary_bf16_dev.py, and test_copy_dtypes_dev.py).