### PR TITLE
fix: Replace last step in installation script with a note

### DIFF
--- a/install_npuir.sh
+++ b/install_npuir.sh
@@ -209,14 +209,6 @@ if ! grep -Fq "${BISHENGIR_PY_PKGS}/mlir_core" ~/.bashrc; then
     echo "Added AscendNPU-IR python_packages (mlir_core + bishengir) to PYTHONPATH for NPUIR."
 fi
 
-# Step 12: Source .bashrc to apply changes
-echo "Applying environment changes by sourcing .bashrc..."
-source ~/.bashrc
-if [ $? -ne 0 ]; then
-    echo "Error: Failed to source .bashrc."
-    exit 1
-else
-    echo "Environment configured successfully."
-fi
+echo "NOTE: Please run \"source ~/.bashrc\" or relaunch the terminal to apply the environment changes"
 
 echo "Installation script completed successfully."


### PR DESCRIPTION
In the installation scripts, it always shows at the end that it added environment updates to `~/.bashrc` and that it sourced it.

This should tell the user that he's ready to use `tilelang` in python, but it's not true because he has to source `~/.bashrc` himself or relaunch a new terminal that will source `~/.bashrc` automatically.

The reason for this is that the user will usually call the script by launching another bash shell instead of sourcing the installation script (not recommended), so sourcing `~/.bashrc` in the installation script will have no effect after the script exits.