### PR TITLE
[feat] Pass combinecv newly add sync side effect call, allow keeping original code about sync

### DIFF
--- a/src/transform/ascend_combinecv.cc
+++ b/src/transform/ascend_combinecv.cc
@@ -599,6 +599,11 @@ public:
       return StmtMutator::VisitStmt_(op);
     }
     current_proccess_switch_ = false; // turn off
+
+    if (IsSyncSideEffectCall(call_node, is_aiv_)) {
+      return StmtMutator::VisitStmt_(op);
+    }
+
     return Evaluate(0);
   }
 
@@ -651,6 +656,87 @@ private:
       {"wmma.accumulator", "cube"},
       {"shared.dyn", "cube"},
       {"shared", "vec"}};
+
+  bool IsSyncSideEffectCall(const CallNode* call_node, bool is_aiv) {
+    if (!call_node) return false;
+
+    if (call_node->op.as<OpNode>()) {
+      auto op_name = call_node->op.as<OpNode>()->name;
+      if (op_name == "tl.ascend_set_flag" || 
+        op_name == "tl.ascend_wait_flag" || 
+        op_name == "tl.ascend_pipe_barrier" || 
+        op_name == "tl.ascend_auto_set_flag" || 
+        op_name == "tl.ascend_auto_wait_flag") {
+        if (call_node->args.size() >= 3) {
+          if (const auto* src_pipe = call_node->args[0].as<StringImmNode>()) {
+            if (const auto* dst_pipe = call_node->args[1].as<StringImmNode>()) {
+              if (const auto* event_id = call_node->args[2].as<StringImmNode>()) {
+                std::string src = src_pipe->value;
+                std::string dst = dst_pipe->value;
+
+                bool src_is_cube = IsCubePipeline(src);
+                bool dst_is_cube = IsCubePipeline(dst);
+
+                bool src_is_vector = IsVectorPipeline(src);
+                bool dst_is_vector = IsVectorPipeline(dst);
+
+                if (is_aiv) {
+                  return src_is_vector && dst_is_vector;
+                } else {
+                  return src_is_cube && dst_is_cube;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if (op_name == "tl.ascend_pipe_barrier") {
+      if (const auto* pipe = call_node->args[0].as<StringImmNode>()) {
+        std::string pipe_name = pipe->value;
+        if (pipe_name == "ALL") {
+          return true;
+        }
+
+        if (is_aiv) {
+          return pipe_name == "V";
+        } else {
+          return pipe_name == "M";
+        }
+      }
+    }
+
+    if (call_node->op.same_as(builtin::call_extern())) {
+      if (call_node->args.size() > 0) {
+        if (const auto* str_imm = call_node->args[0].as<StringImmNode>()) {
+          std::string func_name = str_imm->value;
+          if (func_name.find("ascend_set_flag") != std::string::npos ||
+            func_name.find("ascend_wait_flag") != std::string::npos ||
+            func_name.find("ascend_pipe_barrier") != std::string::npos ||
+            func_name.find("pipe_barrier") != std::string::npos ||
+            func_name.find("barrier_all") != std::string::npos) {
+              return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  bool IsCubePipeline(const std::string& pipe) {
+    static const std::unordered_set<std::string> cube_pipelines = {
+      "M", "MTE1", "FIX"
+    }
+    return cube_pipelines.find(pipe) != cube_pipelines.end();
+  }
+  
+  bool IsVectorPipeline(const std::string& pipe) {
+    static const std::unordered_set<std::string> vector_pipelines = {
+      "V", "MTE2", "MTE3"
+    }
+    return vector_pipelines.find(pipe) != vector_pipelines.end();
+  }
 };
 
 class CombineCV : public arith::IRMutatorWithAnalyzer {

--- a/src/transform/ascend_combinecv.cc
+++ b/src/transform/ascend_combinecv.cc
@@ -670,7 +670,7 @@ private:
         if (call_node->args.size() >= 3) {
           if (const auto* src_pipe = call_node->args[0].as<StringImmNode>()) {
             if (const auto* dst_pipe = call_node->args[1].as<StringImmNode>()) {
-              if (const auto* event_id = call_node->args[2].as<StringImmNode>()) {
+              if (const auto* event_id = call_node->args[2].as<IntImmNode>()) {
                 std::string src = src_pipe->value;
                 std::string dst = dst_pipe->value;
 
@@ -727,14 +727,14 @@ private:
   bool IsCubePipeline(const std::string& pipe) {
     static const std::unordered_set<std::string> cube_pipelines = {
       "M", "MTE1", "FIX"
-    }
+    };
     return cube_pipelines.find(pipe) != cube_pipelines.end();
   }
   
   bool IsVectorPipeline(const std::string& pipe) {
     static const std::unordered_set<std::string> vector_pipelines = {
       "V", "MTE2", "MTE3"
-    }
+    };
     return vector_pipelines.find(pipe) != vector_pipelines.end();
   }
 };

--- a/src/transform/ascend_combinecv.cc
+++ b/src/transform/ascend_combinecv.cc
@@ -600,7 +600,7 @@ public:
     }
     current_proccess_switch_ = false; // turn off
 
-    if (IsSyncSideEffectCall(call_node, is_aiv_)) {
+    if (IsSyncSideEffectCall(call_node_, is_aiv_)) {
       return StmtMutator::VisitStmt_(op);
     }
 
@@ -690,19 +690,19 @@ private:
           }
         }
       }
-    }
 
-    if (op_name == "tl.ascend_pipe_barrier") {
-      if (const auto* pipe = call_node->args[0].as<StringImmNode>()) {
-        std::string pipe_name = pipe->value;
-        if (pipe_name == "ALL") {
-          return true;
-        }
-
-        if (is_aiv) {
-          return pipe_name == "V";
-        } else {
-          return pipe_name == "M";
+      if (op_name == "tl.ascend_pipe_barrier") {
+        if (const auto* pipe = call_node->args[0].as<StringImmNode>()) {
+          std::string pipe_name = pipe->value;
+          if (pipe_name == "ALL") {
+            return true;
+          }
+  
+          if (is_aiv) {
+            return pipe_name == "V";
+          } else {
+            return pipe_name == "M";
+          }
         }
       }
     }


### PR DESCRIPTION
Pass combinecv newly add sync side effect call, allow keeping original code about sync.
Fix the execution stuck bug in sfa_pipeline_sync_miss.py.
for example:
T.set_flag("mte3", "mte2", 0)
T.set_flag("mte3", "mte2", 1)