### PR TITLE
[AscendNPU-IR]  Add PyTorch operator deployment for TileLang Ascend

### DIFF
--- a/examples/torch_tl_ops/DEVELOPER_GUIDE.md
+++ b/examples/torch_tl_ops/DEVELOPER_GUIDE.md
@@ -1,0 +1,593 @@
+# TileLang Ascend Operators 开发者教程
+
+本文档面向开发者，介绍如何使用和扩展 `tl_ascend_ops` 包。
+
+## 目录
+
+1. [快速开始](#快速开始)
+2. [使用方法](#使用方法)
+3. [新增算子开发流程](#新增算子开发流程)
+4. [开发原理](#开发原理)
+5. [常见问题](#常见问题)
+
+---
+
+## 快速开始
+
+### 安装
+
+```bash
+# 从 wheel 包安装（推荐）
+pip install tl_ascend_ops-0.1.0-py3-none-any.whl
+
+# 或从源码安装
+cd examples/torch_tl_ops
+pip install -e .
+```
+
+### 基本使用
+
+```python
+import torch
+import tl_ascend_ops
+
+# 创建输入张量
+q = torch.randn(512, 128, dtype=torch.float16, device="npu")
+k = torch.randn(512, 128, dtype=torch.float16, device="npu")
+v = torch.randn(512, 128, dtype=torch.float16, device="npu")
+
+# 调用算子
+output = tl_ascend_ops.flash_attention(q, k, v)
+```
+
+---
+
+## 使用方法
+
+### 方式一：通过包调用
+
+```python
+import torch
+import tl_ascend_ops
+
+q = torch.randn(512, 128, dtype=torch.float16, device="npu")
+k = torch.randn(512, 128, dtype=torch.float16, device="npu")
+v = torch.randn(512, 128, dtype=torch.float16, device="npu")
+
+output = tl_ascend_ops.flash_attention(q, k, v)
+```
+
+### 方式二：通过 torch_npu 调用
+
+```python
+import torch
+import torch_npu
+import tl_ascend_ops  # 需要先导入以触发注入
+
+output = torch_npu.flash_attention(q, k, v)
+```
+
+### 方式三：通过 torch.ops 调用
+
+```python
+import torch
+import tl_ascend_ops
+
+output = torch.ops.tl_ascend_ops.flash_attention(q, k, v)
+```
+
+---
+
+## 新增算子开发流程
+
+新增一个算子需要完成以下步骤：
+
+### Step 1: 编写内核定义
+
+在 `compile/kernels/` 目录下创建内核定义文件，例如 `compile/kernels/new_op.py`：
+
+```python
+"""
+New Op 内核定义
+
+描述算子的功能和 shape 特性
+"""
+
+import os
+import torch
+import tilelang
+import tilelang.language as T
+
+
+def compile_new_op_kernel():
+    """编译 New Op 内核"""
+    print("=" * 60)
+    print("编译 New Op 内核")
+    print("=" * 60)
+    
+    os.environ['TILELANG_ASCEND_MODE'] = 'Developer'
+    
+    # 定义内核参数（固定 shape 或动态 shape）
+    # 固定 shape 示例
+    M, N, K = 1024, 1024, 1024
+    
+    # 动态 shape 示例
+    # M = T.symbolic("M")
+    # N = T.symbolic("N")
+    # K = T.symbolic("K")
+    
+    @tilelang.jit(out_idx=[2], target="npuir")  # out_idx 指定输出参数索引
+    def new_op_kernel(block_M=128, block_N=128, dtype="float16"):
+        
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, K), dtype),
+            B: T.Tensor((K, N), dtype),
+            C: T.Tensor((M, N), dtype),  # 输出
+        ):
+            # 编写内核逻辑
+            with T.Kernel(T.ceildiv(M, block_M) * T.ceildiv(N, block_N), is_npu=True) as (cid, _):
+                # ... 内核实现 ...
+                pass
+        
+        return main
+    
+    print("正在编译...")
+    kernel = new_op_kernel()
+    
+    # 测试验证
+    print("\n测试运行...")
+    a = torch.randn(M, K, dtype=torch.float16, device="npu")
+    b = torch.randn(K, N, dtype=torch.float16, device="npu")
+    
+    c = kernel(a, b)
+    
+    # 验证结果
+    ref = a @ b  # 替换为正确的参考实现
+    torch.testing.assert_close(c, ref, rtol=1e-2, atol=1e-2)
+    print("✓ 验证通过")
+    
+    return kernel
+```
+
+### Step 2: 注册内核到编译脚本
+
+在 `compile/kernels/__init__.py` 中注册新内核：
+
+```python
+from .flash_attention import compile_flash_attention_kernel
+from .gemm import compile_gemm_kernel
+from .new_op import compile_new_op_kernel  # 新增
+
+KERNEL_REGISTRY = {
+    "flash_attention": compile_flash_attention_kernel,
+    "gemm": compile_gemm_kernel,
+    "new_op": compile_new_op_kernel,  # 新增
+}
+```
+
+### Step 3: 编写算子定义
+
+在 `src/ops/` 目录下创建算子定义文件，例如 `src/ops/new_op.py`：
+
+```python
+"""
+New Op 算子定义
+"""
+
+from typing import Optional
+import torch
+from .base import BaseOp
+
+
+class NewOpOp(BaseOp):
+    """New Op 算子"""
+    
+    _kernel = None
+    
+    @property
+    def name(self) -> str:
+        return "new_op"
+    
+    @property
+    def signature(self) -> str:
+        # 定义 PyTorch 算子签名
+        return "new_op(Tensor A, Tensor B) -> Tensor"
+    
+    def get_kernel(self, registry):
+        if NewOpOp._kernel is None:
+            NewOpOp._kernel = registry.get_kernel(self.name)
+        return NewOpOp._kernel
+    
+    def impl(self, A: torch.Tensor, B: torch.Tensor, registry=None) -> torch.Tensor:
+        """算子实现"""
+        kernel = self.get_kernel(registry)
+        output = kernel(A, B)
+        return output
+    
+    def python_api(self, A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
+        """
+        New Op 算子
+        
+        Args:
+            A: 输入张量 [M, K], NPU tensor, float16
+            B: 输入张量 [K, N], NPU tensor, float16
+        
+        Returns:
+            输出张量 [M, N]
+        """
+        if A.device.type != "npu":
+            raise ValueError("A must be an NPU tensor")
+        if B.device.type != "npu":
+            raise ValueError("B must be an NPU tensor")
+        
+        return torch.ops.tl_ascend_ops.new_op(A, B)
+
+
+new_op_op = NewOpOp()
+```
+
+### Step 4: 注册算子
+
+在 `src/registry.py` 中注册新算子：
+
+```python
+def register_all_ops() -> Dict[str, BaseOp]:
+    """注册所有算子"""
+    from .ops.flash_attention import flash_attention_op
+    from .ops.gemm import gemm_op
+    from .ops.new_op import new_op_op  # 新增
+    
+    ops = {
+        "flash_attention": flash_attention_op,
+        "gemm": gemm_op,
+        "new_op": new_op_op,  # 新增
+    }
+    
+    for name, op in ops.items():
+        _register_op(op)
+    
+    print(f"✓ 已注册 {len(ops)} 个算子: {', '.join(ops.keys())}")
+    return ops
+```
+
+### Step 5: 导出 Python API
+
+在 `src/__init__.py` 中导出新算子：
+
+```python
+# 导入算子 Python API
+from .ops.flash_attention import flash_attention_op
+from .ops.gemm import gemm_op
+from .ops.new_op import new_op_op  # 新增
+
+flash_attention = flash_attention_op.python_api
+gemm = gemm_op.python_api
+new_op = new_op_op.python_api  # 新增
+
+__all__ = [
+    "flash_attention",
+    "gemm",
+    "new_op",  # 新增
+    ...
+]
+```
+
+### Step 6: 编写测试
+
+在 `tests/` 目录下创建测试文件，例如 `tests/test_new_op.py`：
+
+```python
+"""
+New Op 算子测试
+"""
+
+import torch
+import torch_npu
+import tl_ascend_ops
+
+
+def test_new_op():
+    """测试 New Op 算子"""
+    print("=" * 60)
+    print("测试 New Op 算子")
+    print("=" * 60)
+    
+    M, N, K = 1024, 1024, 1024
+    
+    a = torch.randn(M, K, dtype=torch.float16, device="npu:0")
+    b = torch.randn(K, N, dtype=torch.float16, device="npu:0")
+    ref = a @ b
+    
+    # 方式 1: 通过包调用
+    c = tl_ascend_ops.new_op(a, b)
+    torch.testing.assert_close(c, ref, rtol=1e-2, atol=1e-2)
+    print("  ✓ tl_ascend_ops.new_op 验证通过")
+    
+    # 方式 2: 通过 torch_npu 调用
+    c2 = torch_npu.new_op(a, b)
+    torch.testing.assert_close(c2, ref, rtol=1e-2, atol=1e-2)
+    print("  ✓ torch_npu.new_op 验证通过")
+    
+    # 方式 3: 通过 torch.ops 调用
+    c3 = torch.ops.tl_ascend_ops.new_op(a, b)
+    torch.testing.assert_close(c3, ref, rtol=1e-2, atol=1e-2)
+    print("  ✓ torch.ops.tl_ascend_ops.new_op 验证通过")
+
+
+if __name__ == "__main__":
+    test_new_op()
+```
+
+### Step 7: 预编译和测试
+
+```bash
+# 预编译内核
+cd examples/torch_tl_ops
+python compile/precompile.py
+
+# 安装
+pip install -e .
+
+# 测试
+python tests/test_new_op.py
+```
+
+---
+
+## 开发原理
+
+### 架构概览
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      用户代码                                 │
+│  tl_ascend_ops.flash_attention(q, k, v)                     │
+│  torch_npu.flash_attention(q, k, v)                         │
+│  torch.ops.tl_ascend_ops.flash_attention(q, k, v, scale)    │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    PyTorch 算子层                            │
+│  registry.py: 注册算子到 torch.library                       │
+│  ops/*.py: 算子定义和 Python API                             │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    内核加载层                                │
+│  loader.py: NPUKernelLoader                                 │
+│  - 加载 metadata.pkl (内核元数据)                            │
+│  - 加载 main.so (启动器)                                     │
+│  - 加载 npu_utils.so (工具库)                                │
+│  - 计算动态 shape 和 grid                                    │
+│  - 执行内核                                                  │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    预编译内核                                │
+│  kernels/flash_attention/                                   │
+│  ├── metadata.pkl    # 内核元数据                            │
+│  ├── main.so         # 启动器                               │
+│  └── npu_utils.so    # 工具库                               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 为什么需要预编译？
+
+#### 1. 消除编译时依赖
+
+TileLang 编译内核需要：
+- tilelang 源码
+- Bisheng 编译器（华为 Ascend 编译器）
+- g++ 编译器
+- TVM 框架
+
+预编译后，运行时只需要：
+- PyTorch
+- torch_npu
+
+#### 2. 提高部署效率
+
+| 阶段 | 编译时 | 运行时 |
+|------|--------|--------|
+| 编译内核 | 分钟级 | - |
+| 加载内核 | - | 毫秒级 |
+
+#### 3. 保护知识产权
+
+预编译后的 `.so` 文件是二进制格式，无法直接查看源码。
+
+### 预编译产物说明
+
+#### metadata.pkl
+
+包含内核运行所需的所有元数据：
+
+```python
+{
+    "symbolic": {"M": (0, 0), "N": (0, 1), "K": (0, 0)},  # 动态 shape 变量
+    "out_idx": [2],              # 输出参数索引
+    "param_info": [              # 参数信息
+        {"dtype": torch.float16, "shape": ["M", "K"], "is_output": False},
+        {"dtype": torch.float16, "shape": ["K", "N"], "is_output": False},
+        {"dtype": torch.float16, "shape": ["M", "N"], "is_output": True},
+    ],
+    "signature": {0: "input", 1: "input", 2: "output"},  # 参数签名
+    "gridfunc": "ceildiv(M, 128) * ceildiv(N, 128)",     # Grid 计算表达式
+    "kernel_src": b"...",         # 内核二进制代码
+    "kernel_name": "matmul",      # 内核名称
+    "tensor_kinds": [...],        # 张量类型
+    "shared": 0,                  # 共享内存大小
+    "mix_mode": "",               # 混合模式
+}
+```
+
+#### main.so
+
+启动器，包含 `launch` 函数，负责：
+- 接收参数
+- 调用内核执行
+
+#### npu_utils.so
+
+工具库，包含：
+- `load_kernel_binary`: 加载内核二进制到设备
+- 其他 NPU 运行时工具函数
+
+### 内核加载流程
+
+```python
+# 1. 加载 metadata.pkl
+with open("metadata.pkl", "rb") as f:
+    metadata = pickle.load(f)
+
+# 2. 加载 main.so
+spec = importlib.util.spec_from_file_location("main", "main.so")
+main_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(main_module)
+launch = main_module.launch
+
+# 3. 加载 npu_utils.so
+spec = importlib.util.spec_from_file_location("npu_utils", "npu_utils.so")
+npu_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(npu_utils)
+
+# 4. 加载内核二进制到设备
+npu_utils.load_kernel_binary(
+    kernel_name,
+    kernel_src,
+    shared,
+    device,
+    kernel_mode,
+)
+
+# 5. 执行内核
+launch(grid_x, grid_y, grid_z, stream, t_function, ...)
+```
+
+### 动态 Shape 处理
+
+#### 原理
+
+TileLang 支持 `T.symbolic()` 定义动态 shape：
+
+```python
+M = T.symbolic("M")
+N = T.symbolic("N")
+K = T.symbolic("K")
+
+@T.prim_func
+def matmul(
+    A: T.Tensor((M, K), dtype),
+    B: T.Tensor((K, N), dtype),
+    C: T.Tensor((M, N), dtype),
+):
+    ...
+```
+
+#### 运行时计算
+
+`loader.py` 在执行时根据输入张量的实际 shape 计算动态值：
+
+```python
+def _calc_grid(self, orig_to_input, *args):
+    """计算 grid 维度和动态值"""
+    dynamic_val = {}
+    
+    for name, (arg_idx, dim_idx) in self.symbolic.items():
+        # 从输入张量获取实际值
+        arg = args[arg_idx]
+        value = arg.shape[dim_idx]
+        dynamic_val[name] = value
+    
+    # 计算 grid
+    grid_value = eval(self.gridfunc, {"math": math, **dynamic_val})
+    
+    return dynamic_val
+```
+
+### PyTorch 算子注册原理
+
+使用 `torch.library.Library` API 注册算子：
+
+```python
+# 定义算子签名
+lib_def = torch.library.Library("tl_ascend_ops", "DEF")
+lib_def.define("flash_attention(Tensor Q, Tensor K, Tensor V) -> Tensor")
+
+# 注册实现
+lib_impl = torch.library.Library("tl_ascend_ops", "IMPL")
+lib_impl.impl("flash_attention", _flash_attention_impl, "PrivateUse1")
+```
+
+`PrivateUse1` 是 PyTorch 的扩展 dispatch key，用于自定义后端实现。
+
+---
+
+## 常见问题
+
+### Q1: 如何调试内核加载问题？
+
+添加调试打印：
+
+```python
+# loader.py
+print(f"Loading kernel from: {self.kernel_dir}")
+print(f"metadata: {self.metadata}")
+print(f"grid: {self.grid}")
+print(f"dynamic_val: {dynamic_val}")
+```
+
+### Q2: 如何处理 TVM 依赖问题？
+
+确保 `precompile.py` 中的 `_to_pure_python` 函数正确转换所有 TVM 类型：
+
+```python
+def _to_pure_python(obj):
+    # TVM IntImm -> int
+    if hasattr(obj, 'value'):
+        return int(obj.value)
+    
+    # TVM tir.Var -> str
+    if hasattr(obj, 'name'):
+        return str(obj.name)
+    
+    # 保留 torch.dtype 等不涉及 TVM 的类型
+    if isinstance(obj, torch.dtype):
+        return obj
+    
+    ...
+```
+
+### Q3: 如何支持新的数据类型？
+
+在内核定义中使用 `dtype` 参数：
+
+```python
+@tilelang.jit(out_idx=[2], target="npuir")
+def my_kernel(dtype="float16"):
+    ...
+```
+
+### Q4: 如何优化内核性能？
+
+1. 调整 block 大小
+2. 使用流水线（`T.Pipelined`）
+3. 使用共享内存（`T.alloc_shared`）
+4. 参考 TileLang 性能优化文档
+
+---
+
+## 参考资料
+
+- [TileLang 文档](https://github.com/tilelang/tilelang)
+- [PyTorch 自定义算子](https://pytorch.org/tutorials/advanced/custom_ops.html)
+- [华为 Ascend 开发文档](https://www.hiascend.com/)
+
+---
+
+*文档版本: 0.1.0*
+*更新时间: 2026-03-16*

--- a/examples/torch_tl_ops/README.md
+++ b/examples/torch_tl_ops/README.md
@@ -1,0 +1,176 @@
+# TileLang Ascend Operators
+
+将 TileLang Ascend 算子注册到 PyTorch，支持 **离线安装即用**。
+
+## 特点
+
+- ✅ **离线安装即用** - 无需编译器，安装后直接使用
+- ✅ **独立运行时** - 不依赖 tilelang 源码
+- ✅ **PyTorch 集成** - 支持 `torch.ops.tl_ascend_ops.xxx` 调用
+- ✅ **torch_npu 注入** - 支持 `torch_npu.xxx` 调用
+
+## 安装
+
+### 环境要求
+
+- Python >= 3.8
+- PyTorch > 2.6.0
+- torch_npu
+
+### 方式一：从 wheel 包安装（推荐）
+
+```bash
+# 安装预编译的 wheel 包
+pip install tl_ascend_ops-0.1.0-py3-none-any.whl
+```
+
+### 方式二：从源码安装
+
+```bash
+cd examples/torch_tl_ops
+pip install -e .
+```
+
+## 使用方法
+
+### 方式一：通过包调用
+
+```python
+import torch
+import tl_ascend_ops
+
+q = torch.randn(512, 128, dtype=torch.float16, device="npu")
+k = torch.randn(512, 128, dtype=torch.float16, device="npu")
+v = torch.randn(512, 128, dtype=torch.float16, device="npu")
+
+output = tl_ascend_ops.flash_attention(q, k, v)
+```
+
+### 方式二：通过 torch_npu 调用
+
+```python
+import torch
+import torch_npu
+import tl_ascend_ops  # 需要先导入以触发注入
+
+q = torch.randn(512, 128, dtype=torch.float16, device="npu")
+k = torch.randn(512, 128, dtype=torch.float16, device="npu")
+v = torch.randn(512, 128, dtype=torch.float16, device="npu")
+
+output = torch_npu.flash_attention(q, k, v)
+```
+
+### 方式三：通过 torch.ops 调用
+
+```python
+import torch
+import tl_ascend_ops
+
+q = torch.randn(512, 128, dtype=torch.float16, device="npu")
+k = torch.randn(512, 128, dtype=torch.float16, device="npu")
+v = torch.randn(512, 128, dtype=torch.float16, device="npu")
+
+output = torch.ops.tl_ascend_ops.flash_attention(q, k, v)
+```
+
+## 开发指南
+
+### 预编译内核
+
+在开发机上运行预编译脚本：
+
+```bash
+cd examples/torch_tl_ops
+python compile/precompile.py
+```
+
+预编译产物会保存到 `src/kernels/` 目录。
+
+### 打包发布
+
+```bash
+cd examples/torch_tl_ops
+
+# 方式一：使用 pip wheel
+pip wheel . --no-deps -w dist/
+
+# 方式二：使用 build
+pip install build
+python -m build --wheel
+```
+
+打包后的 wheel 文件在 `dist/` 目录下。
+
+### 目录结构
+
+```
+examples/torch_tl_ops/
+├── src/                    # 包源码 (tl_ascend_ops 包)
+│   ├── __init__.py         # 包入口，算子注入
+│   ├── loader.py           # 独立内核加载器
+│   ├── registry.py         # 算子注册中心
+│   ├── ops/                # 算子定义
+│   │   ├── base.py         # 基类
+│   │   ├── flash_attention.py
+│   │   └── gemm.py
+│   ├── utils/              # 共享工具库
+│   │   └── npu_utils.so    # NPU 工具库 (所有内核共享)
+│   └── kernels/            # 预编译内核
+│       └── flash_attention/
+│           ├── metadata.pkl    # 内核元数据
+│           └── main.so         # 启动器
+├── compile/                # 编译脚本
+│   ├── precompile.py       # 预编译脚本
+│   └── kernels/            # 内核定义
+│       ├── flash_attention.py
+│       └── gemm.py
+├── tests/                  # 测试文件
+│   ├── test_flash_attention.py
+│   └── test_gemm.py
+├── setup.py                # 安装配置
+└── README.md
+```
+
+## 技术实现
+
+### 独立加载器
+
+`loader.py` 实现了独立的内核加载器，不依赖 tilelang 源码：
+
+```python
+from tl_ascend_ops.loader import KernelRegistry
+
+# 加载预编译内核
+kernel = KernelRegistry.get_kernel("flash_attention")
+
+# 执行内核
+output = kernel(q, k, v)
+```
+
+### 内核文件
+
+| 文件 | 说明 |
+|------|------|
+| `metadata.pkl` | 内核元数据（参数信息、shape、grid 等） |
+| `main.so` | 启动器，包含 `launch` 函数 |
+| `npu_utils.so` | 工具库，包含内核加载函数 |
+
+### 依赖关系
+
+| 依赖 | 编译时 | 运行时 |
+|------|--------|--------|
+| tilelang | ✅ | ❌ |
+| Bisheng 编译器 | ✅ | ❌ |
+| g++ | ✅ | ❌ |
+| torch | ✅ | ✅ |
+| torch_npu | ✅ | ✅ |
+
+## 可用算子
+
+| 算子 | Shape | 说明 |
+|------|-------|------|
+| `flash_attention` | 固定 (512, 128) | Flash Attention |
+
+## License
+
+MIT License

--- a/examples/torch_tl_ops/compile/kernels/__init__.py
+++ b/examples/torch_tl_ops/compile/kernels/__init__.py
@@ -1,0 +1,19 @@
+"""
+TileLang Kernel Definitions Directory
+
+Each kernel is defined in a separate file for easy maintenance and extension.
+"""
+
+from .flash_attention import compile_flash_attention_kernel
+from .gemm import compile_gemm_kernel
+
+KERNEL_REGISTRY = {
+    "flash_attention": compile_flash_attention_kernel,
+    "gemm": compile_gemm_kernel,
+}
+
+__all__ = [
+    "compile_flash_attention_kernel",
+    "compile_gemm_kernel",
+    "KERNEL_REGISTRY",
+]

--- a/examples/torch_tl_ops/compile/kernels/flash_attention.py
+++ b/examples/torch_tl_ops/compile/kernels/flash_attention.py
@@ -1,0 +1,122 @@
+"""
+Flash Attention Kernel Definition
+
+Fixed shape: seq_len=512, dim=128
+Uses online softmax algorithm
+"""
+
+import os
+import torch
+import tilelang
+import tilelang.language as T
+
+seq_len = 512
+dim = 128
+
+
+def compile_flash_attention_kernel():
+    """Compile Flash Attention kernel"""
+    print("=" * 60)
+    print("Compiling Flash Attention kernel")
+    print("=" * 60)
+    
+    os.environ['TILELANG_ASCEND_MODE'] = 'Developer'
+    
+    @tilelang.jit(out_idx=[-1], target="npuir")
+    def online_flash_attention(block_M=64, block_N=64, block_K=32, dtype="float16", accum_dtype="float32"):
+        shape_q = [seq_len, dim]
+        shape_k = [seq_len, dim]
+        shape_v = [seq_len, dim]
+        shape_o = [seq_len, dim]
+        block_m = block_M
+        block_n = block_N
+        
+        @T.prim_func
+        def flash_attention(
+            Q: T.Tensor(shape_q, dtype),
+            K: T.Tensor(shape_k, dtype),
+            V: T.Tensor(shape_v, dtype),
+            Output: T.Tensor(shape_o, dtype),
+        ):
+            with T.Kernel(T.ceildiv(seq_len, block_m), is_npu=True) as (cid, _):
+                offset = cid * block_m
+                Q_shared = T.alloc_shared([block_m, dim], dtype)
+                T.copy(Q[offset : offset + block_m, 0 : dim], Q_shared)
+
+                K_shared = T.alloc_shared([block_n, dim], dtype)
+                V_shared = T.alloc_shared([block_n, dim], dtype)
+                scores = T.alloc_fragment([block_m, block_n], accum_dtype)
+                scores_cast = T.alloc_fragment([block_m, block_n], dtype)
+                correction = T.alloc_fragment([block_m, 1], accum_dtype)
+                local_max = T.alloc_fragment([block_m, 1], accum_dtype)
+                local_sum = T.alloc_fragment([block_m, 1], accum_dtype)
+                acc_m = T.alloc_fragment([block_m, 1], accum_dtype)
+                acc_l = T.alloc_fragment([block_m, 1], accum_dtype)
+                acc_o = T.alloc_fragment([block_m, dim], accum_dtype)
+                tmp = T.alloc_fragment([block_m, block_n], accum_dtype)
+                tmp1 = T.alloc_fragment([block_m, 1], accum_dtype)
+                new_max = T.alloc_fragment([block_m, 1], accum_dtype)
+                scales = T.alloc_fragment([block_m, block_n], accum_dtype)
+
+                value_zero = 0
+                scale = (1.0 / dim) ** 0.5
+                value_min = -T.infinity(accum_dtype)
+                T.vbrc(value_zero, acc_o)
+                T.vbrc(value_zero, acc_l)
+                T.vbrc(value_min, acc_m)
+                T.vbrc(scale, scales)
+
+                for k in T.Pipelined(T.ceildiv(seq_len, block_n), num_stages=2):
+                    T.copy(K[k * block_n : (k + 1) * block_n, 0 : dim], K_shared)
+                    T.gemm(Q_shared, K_shared, scores, initC=True, b_transpose=True)
+
+                    T.vmul(scores, scales, scores)
+                    T.reduce_max(scores, local_max, dim=1)
+                    T.vmax(acc_m, local_max, new_max)
+                    T.vsub(acc_m, new_max, tmp1)
+                    T.vexp(tmp1, correction)
+                    T.vsub(scores, new_max, tmp)
+                    T.vexp(tmp, scores)
+                    T.reduce_sum(scores, local_sum, dim=1)
+                    T.vmul(acc_l, correction, acc_l)
+                    T.vadd(acc_l, local_sum, acc_l)
+                    T.vmul(acc_o, correction, acc_o)
+                    T.vcast(scores, scores_cast, round_mode="rint")
+                    T.vbrc(value_zero, tmp1)
+                    T.vadd(tmp1, new_max, acc_m)
+
+                    T.copy(V[k * block_n : (k + 1) * block_n, 0 : dim], V_shared)
+                    T.gemm(scores_cast, V_shared, acc_o, initC=False)
+
+                T.vdiv(acc_o, acc_l, acc_o)
+                O_cast = T.alloc_shared([block_m, dim], dtype)
+                T.vcast(acc_o, O_cast, round_mode="rint")
+                real_m = T.min(block_m, seq_len - cid * block_m)
+                T.copy(O_cast, Output[cid * block_m : cid * block_m + real_m, 0 : dim])
+
+        return flash_attention
+    
+    print("Compiling...")
+    kernel = online_flash_attention()
+    
+    print(f"Kernel compilation completed")
+    print(f"  - symbolic: {kernel.symbolic}")
+    print(f"  - param_info: {kernel.param_info}")
+    print(f"  - out_idx: {kernel.out_idx}")
+    
+    print("\nRunning test...")
+    q = torch.randn(seq_len, dim, dtype=torch.float16, device="npu")
+    k = torch.randn(seq_len, dim, dtype=torch.float16, device="npu")
+    v = torch.randn(seq_len, dim, dtype=torch.float16, device="npu")
+    
+    output = kernel(q, k, v)
+    
+    scale = (1.0 / dim) ** 0.5
+    ref = torch.nn.functional.softmax(
+        (q @ k.T).to(torch.float32) * scale, dim=-1
+    ).to(torch.float16) @ v
+    
+    torch.testing.assert_close(output, ref, rtol=1e-2, atol=1e-2)
+    print("✓ Verification passed")
+    
+    return kernel

--- a/examples/torch_tl_ops/compile/kernels/gemm.py
+++ b/examples/torch_tl_ops/compile/kernels/gemm.py
@@ -1,0 +1,88 @@
+"""
+Dynamic Shape GEMM Kernel Definition
+
+Supports arbitrary M, N, K dimensions for matrix multiplication
+"""
+
+import os
+import torch
+import tilelang
+import tilelang.language as T
+
+
+def compile_gemm_kernel():
+    """Compile dynamic shape GEMM kernel"""
+    print("=" * 60)
+    print("Compiling dynamic shape GEMM kernel")
+    print("=" * 60)
+    
+    os.environ['TILELANG_ASCEND_MODE'] = 'Expert'
+    
+    @tilelang.jit(target="npuir")
+    def matmul(block_M=128, block_N=256, K_L1=16, dtype="float16", accum_dtype="float32"):
+        M = T.symbolic("M")
+        N = T.symbolic("N")
+        K = T.symbolic("K")
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, K), dtype),
+            B: T.Tensor((K, N), dtype),
+            C: T.Tensor((M, N), dtype)
+        ):
+            with T.Kernel(T.ceildiv(M, block_M) * T.ceildiv(N, block_N), is_npu=True) as (cid, _):
+                with T.Scope("Cube"):
+                    bx = cid // T.ceildiv(N, block_N) * block_M
+                    by = cid % T.ceildiv(N, block_N) * block_N
+                    A_BUF = T.alloc_L1([block_M, K_L1], dtype)
+                    B_BUF = T.alloc_L1([K_L1, block_N], dtype)
+                    C_BUF = T.alloc_L0C([block_M, block_N], accum_dtype)
+
+                    remain_M = T.min(M - bx, block_M)
+                    remain_N = T.min(N - by, block_N)
+
+                    for i in T.serial(T.ceildiv(K, K_L1)):
+                        remain_K = T.min(K - i * K_L1, K_L1)
+                        T.load_nd2nz(A[bx, i * K_L1], A_BUF, [remain_M, remain_K])
+                        T.load_nd2nz(B[i * K_L1, by], B_BUF, [remain_K, remain_N])
+
+                        if i == 0:
+                            T.gemm(A_BUF, B_BUF, C_BUF, initC=True, b_transpose=False,
+                                size=[remain_M, remain_K, remain_N])
+                        else:
+                            T.gemm(A_BUF, B_BUF, C_BUF, initC=False, b_transpose=False,
+                                size=[remain_M, remain_K, remain_N])
+
+                        T.store_fixpipe(C_BUF, C[bx, by],
+                            size=[remain_M, remain_N], enable_nz2nd=True)
+
+        return main
+    
+    print("Compiling...")
+    kernel = matmul()
+    
+    print(f"Kernel compilation completed")
+    print(f"  - symbolic: {kernel.symbolic}")
+    print(f"  - param_info: {kernel.param_info}")
+    print(f"  - out_idx: {kernel.out_idx}")
+    
+    print("\nRunning tests...")
+    test_cases = [
+        (1024, 512, 2048),
+        (512, 1024, 512),
+    ]
+    
+    for M, N, K in test_cases:
+        print(f"  Testing shape: M={M}, N={N}, K={K}")
+        a = torch.randn(M, K, dtype=torch.float16, device="npu")
+        b = torch.randn(K, N, dtype=torch.float16, device="npu")
+        c = torch.randn(M, N, dtype=torch.float16, device="npu")
+        
+        kernel(a, b, c)
+        
+        ref = a @ b
+        torch.testing.assert_close(c, ref, rtol=1e-2, atol=1e-2)
+        print(f"    ✓ Verification passed")
+    
+    print("✓ Dynamic GEMM kernel tests passed")
+    return kernel

--- a/examples/torch_tl_ops/compile/precompile.py
+++ b/examples/torch_tl_ops/compile/precompile.py
@@ -1,0 +1,215 @@
+"""
+TileLang Ascend Operators - Precompile Script
+
+Compiles all operator kernels and saves them to the kernels directory.
+
+Usage:
+    python compile/precompile.py              # Compile all kernels
+    python compile/precompile.py flash_attention  # Compile only specified kernel
+"""
+
+import os
+import sys
+import shutil
+import pickle
+from pathlib import Path
+from copy import deepcopy
+
+import torch
+
+torch.npu.set_device(0)
+
+SCRIPT_DIR = Path(__file__).parent
+PROJECT_DIR = SCRIPT_DIR.parent
+PACKAGE_DIR = PROJECT_DIR / "src"
+KERNELS_DIR = PACKAGE_DIR / "kernels"
+UTILS_DIR = PACKAGE_DIR / "utils"
+
+sys.path.insert(0, str(SCRIPT_DIR))
+from kernels import KERNEL_REGISTRY
+
+from tilelang.utils.npu_utils import NPUUtils, get_runtime_file_cache
+
+
+def save_npu_utils():
+    """Save npu_utils.so to utils directory (shared by all kernels)"""
+    utils_dir = UTILS_DIR
+    utils_dir.mkdir(parents=True, exist_ok=True)
+    
+    npu_utils_so_path = utils_dir / "npu_utils.so"
+    
+    if npu_utils_so_path.exists() and npu_utils_so_path.stat().st_size > 0:
+        print(f"  npu_utils.so already exists at {npu_utils_so_path}")
+        return npu_utils_so_path
+    
+    npu_utils = NPUUtils.get()
+    
+    import tilelang.utils.npu_utils as npu_utils_module
+    pkg_root = os.path.dirname(os.path.abspath(npu_utils_module.__file__))
+    npu_utils_cpp = os.path.join(pkg_root, "npu_utils.cpp")
+    cache_path = get_runtime_file_cache(npu_utils_cpp)
+    source_so_path = Path(cache_path) / "npu_utils.so"
+    
+    if source_so_path.exists():
+        shutil.copy(source_so_path, npu_utils_so_path)
+        print(f"  ✓ Saved npu_utils.so to {npu_utils_so_path}")
+        return npu_utils_so_path
+    else:
+        raise FileNotFoundError(f"Cannot find npu_utils.so at {source_so_path}")
+
+
+def _to_pure_python(obj):
+    """
+    Recursively convert TVM types to pure Python types
+    
+    Preserves types that don't involve TVM dependencies (e.g. torch.dtype)
+    """
+    if obj is None:
+        return None
+    
+    # Return basic types directly
+    if isinstance(obj, (bool, int, float, str)):
+        return obj
+    
+    # Return bytes directly
+    if isinstance(obj, bytes):
+        return obj
+    
+    # Return torch.dtype directly (no TVM dependency)
+    if isinstance(obj, torch.dtype):
+        return obj
+    
+    # TVM IntImm -> int
+    if hasattr(obj, 'value') and not isinstance(obj, (bool, int, float, str, torch.dtype)):
+        try:
+            return int(obj.value)
+        except:
+            pass
+    
+    # TVM tir.Var -> str (variable name)
+    if hasattr(obj, 'name') and not isinstance(obj, (bool, int, float, str, torch.dtype)):
+        try:
+            return str(obj.name)
+        except:
+            pass
+    
+    # list/tuple -> recursive conversion
+    if isinstance(obj, (list, tuple)):
+        return [_to_pure_python(item) for item in obj]
+    
+    # dict -> recursive conversion
+    if isinstance(obj, dict):
+        return {
+            _to_pure_python(k): _to_pure_python(v)
+            for k, v in obj.items()
+        }
+    
+    # Try to convert other types to string
+    try:
+        return str(obj)
+    except:
+        return None
+
+
+def save_kernel(kernel, name: str):
+    """Save kernel to kernels directory"""
+    kernel_dir = KERNELS_DIR / name
+    kernel_dir.mkdir(parents=True, exist_ok=True)
+    
+    print(f"\nSaving kernel to: {kernel_dir}")
+    
+    # Deep convert all fields to pure Python types
+    metadata = {
+        "symbolic": _to_pure_python(kernel.symbolic),
+        "out_idx": _to_pure_python(kernel.out_idx),
+        "param_info": _to_pure_python(kernel.param_info),
+        "signature": _to_pure_python(kernel.signature),
+        "shared": _to_pure_python(kernel.utils_shared),
+        "kernel_name": _to_pure_python(kernel.kernel_name),
+        "gridfunc": _to_pure_python(kernel.gridfunc),
+        "mix_mode": _to_pure_python(kernel.mix_mode),
+        "name": _to_pure_python(kernel.utils_name),
+        "tensor_kinds": _to_pure_python(kernel.tensor_kinds),
+        "kernel_src": _to_pure_python(kernel.utils_kernel_src),
+    }
+    
+    # Print converted content for debugging
+    print(f"  symbolic: {metadata['symbolic']}")
+    print(f"  out_idx: {metadata['out_idx']}")
+    print(f"  param_info: {metadata['param_info']}")
+    
+    metadata_path = kernel_dir / "metadata.pkl"
+    with open(metadata_path, "wb") as f:
+        pickle.dump(metadata, f)
+    print(f"  ✓ Saved metadata.pkl (using standard pickle)")
+    
+    # .so files are in current working directory
+    cwd = Path(os.getcwd())
+    
+    # Copy main.so (launcher)
+    launcher_so_path = cwd / kernel.so_launcher_path
+    
+    if launcher_so_path.exists():
+        shutil.copy(launcher_so_path, kernel_dir / "main.so")
+        print(f"  ✓ Saved main.so (from {launcher_so_path})")
+    else:
+        print(f"  ✗ Error: Cannot find {launcher_so_path}")
+        print(f"    .so files in current directory: {list(cwd.glob('*.so'))}")
+
+
+def main():
+    print("TileLang Ascend Operators - Precompile Script")
+    print("=" * 60)
+    print(f"Available kernels: {list(KERNEL_REGISTRY.keys())}")
+    print(f"Current working directory: {os.getcwd()}")
+    print(f"Kernel output directory: {KERNELS_DIR}")
+    print(f"Utils output directory: {UTILS_DIR}")
+    print("=" * 60)
+    
+    if len(sys.argv) > 1:
+        kernels_to_compile = sys.argv[1:]
+    else:
+        kernels_to_compile = list(KERNEL_REGISTRY.keys())
+    
+    print(f"Will compile: {kernels_to_compile}")
+    
+    # Save npu_utils.so to utils directory (shared by all kernels)
+    print("\nSaving npu_utils.so...")
+    save_npu_utils()
+    
+    if KERNELS_DIR.exists():
+        shutil.rmtree(KERNELS_DIR)
+    KERNELS_DIR.mkdir(parents=True, exist_ok=True)
+    
+    success_kernels = []
+    for name in kernels_to_compile:
+        if name not in KERNEL_REGISTRY:
+            print(f"Warning: Unknown kernel '{name}', skipping")
+            continue
+        
+        try:
+            compile_func = KERNEL_REGISTRY[name]
+            kernel = compile_func()
+            save_kernel(kernel, name)
+            success_kernels.append(name)
+        except Exception as e:
+            print(f"Error: Failed to compile '{name}': {e}")
+            import traceback
+            traceback.print_exc()
+    
+    print("\n" + "=" * 60)
+    print(f"✓ Precompilation completed! Successful: {success_kernels}")
+    print(f"Kernel directory: {KERNELS_DIR}")
+    print(f"Utils directory: {UTILS_DIR}")
+    
+    # List generated files
+    for name in success_kernels:
+        kernel_dir = KERNELS_DIR / name
+        files = list(kernel_dir.glob("*"))
+        print(f"  {name}/: {[f.name for f in files]}")
+    
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/torch_tl_ops/setup.py
+++ b/examples/torch_tl_ops/setup.py
@@ -1,0 +1,44 @@
+"""
+TileLang Ascend Operators - Installation Configuration
+
+Pure Python package, dependencies:
+- torch > 2.6.0
+- torch_npu
+"""
+
+from setuptools import setup, find_packages
+from pathlib import Path
+
+PACKAGE_NAME = "tl_ascend_ops"
+VERSION = "0.1.0"
+
+readme_path = Path(__file__).parent / "README.md"
+long_description = readme_path.read_text(encoding="utf-8") if readme_path.exists() else ""
+
+setup(
+    name=PACKAGE_NAME,
+    version=VERSION,
+    author="TileLang Ascend Team",
+    description="PyTorch operators for TileLang Ascend kernels - offline installation ready",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/tile-ai/tilelang-ascend/tree/npuir",
+    packages=[
+        "tl_ascend_ops",
+        "tl_ascend_ops.ops",
+        "tl_ascend_ops.kernels",
+        "tl_ascend_ops.utils",
+    ],
+    package_dir={"tl_ascend_ops": "src"},
+    package_data={
+        "tl_ascend_ops": ["kernels/**/*", "utils/**/*", "*.so", "*.pkl"],
+    },
+    include_package_data=True,
+    python_requires=">=3.8",
+    install_requires=[
+        "torch>2.6.0",
+    ],
+    extras_require={
+        "npu": ["torch_npu"],
+    },
+)

--- a/examples/torch_tl_ops/src/__init__.py
+++ b/examples/torch_tl_ops/src/__init__.py
@@ -1,0 +1,73 @@
+"""
+TileLang Ascend Operators Package
+
+Provides PyTorch operator interfaces with offline installation support.
+
+Dependencies:
+- torch > 2.6.0
+- torch_npu
+
+Usage:
+    import tl_ascend_ops
+    
+    # Method 1: Call via package
+    output = tl_ascend_ops.flash_attention(q, k, v)
+    c = tl_ascend_ops.gemm(a, b)
+    
+    # Method 2: Call via torch_npu
+    import torch_npu
+    output = torch_npu.flash_attention(q, k, v)
+    c = torch_npu.gemm(a, b)
+    
+    # Method 3: Call via torch.ops
+    output = torch.ops.tl_ascend_ops.flash_attention(q, k, v)
+    torch.ops.tl_ascend_ops.gemm(a, b, c)
+"""
+
+from .loader import KernelRegistry
+from .registry import register_all_ops, get_kernel_registry
+
+__version__ = "0.1.0"
+
+# Register all operators
+_registered_ops = register_all_ops()
+
+# Import operator Python APIs
+from .ops.flash_attention import flash_attention_op
+from .ops.gemm import gemm_op
+
+flash_attention = flash_attention_op.python_api
+gemm = gemm_op.python_api
+
+# Inject into torch_npu module
+def _inject_to_torch_npu():
+    """Inject operator interfaces into torch_npu module"""
+    try:
+        import torch_npu
+        
+        # Dynamically inject all registered operators
+        injected_ops = []
+        for op_name, op in _registered_ops.items():
+            op_func = getattr(op, 'python_api', None)
+            if op_func is not None:
+                setattr(torch_npu, op_name, op_func)
+                injected_ops.append(op_name)
+        
+        torch_npu.KernelRegistry = KernelRegistry
+        print(f"✓ Injected operators into torch_npu: {', '.join(injected_ops)}")
+    except ImportError:
+        print(f"⚠ torch_npu not installed, skipping injection")
+
+_inject_to_torch_npu()
+
+__all__ = [
+    "flash_attention",
+    "gemm",
+    "KernelRegistry",
+    "flash_attention_op",
+    "gemm_op",
+    "register_all_ops",
+    "get_kernel_registry",
+]
+
+print(f"✓ tl_ascend_ops loaded successfully")

--- a/examples/torch_tl_ops/src/kernels/__init__.py
+++ b/examples/torch_tl_ops/src/kernels/__init__.py
@@ -1,0 +1,5 @@
+"""
+Precompiled Kernel Directory
+
+This directory contains precompiled kernel files that will be included in the wheel package.
+"""

--- a/examples/torch_tl_ops/src/loader.py
+++ b/examples/torch_tl_ops/src/loader.py
@@ -1,0 +1,262 @@
+"""
+TileLang Ascend Operators - Standalone Kernel Loader
+
+Does not depend on tilelang source code, only depends on:
+- torch
+- torch_npu
+"""
+
+import os
+import math
+import pickle
+import torch
+import importlib.util
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def replace_by_longest_key(calculate_str: str, replace_dict: dict) -> str:
+    """Replace variable names in string"""
+    sorted_keys = sorted(replace_dict.keys(), key=lambda x: (-len(x), x))
+    result = calculate_str
+    for key in sorted_keys:
+        result = result.replace(key, str(replace_dict[key]))
+    return result
+
+
+_shared_npu_utils = None
+
+
+def get_shared_npu_utils():
+    """Get shared npu_utils module (singleton)"""
+    global _shared_npu_utils
+    if _shared_npu_utils is None:
+        utils_path = Path(__file__).parent / "utils" / "npu_utils.so"
+        if not utils_path.exists():
+            raise FileNotFoundError(f"npu_utils.so not found at {utils_path}")
+        spec = importlib.util.spec_from_file_location("npu_utils", str(utils_path))
+        _shared_npu_utils = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(_shared_npu_utils)
+    return _shared_npu_utils
+
+
+class NPUKernelLoader:
+    """
+    Standalone NPU Kernel Loader
+    
+    Loads kernels from precompiled files:
+    - metadata.pkl: Kernel metadata
+    - main.so: Launcher
+    - npu_utils.so: Utility library (shared, stored in utils/)
+    - kernel.o: Kernel binary (optional, embedded in metadata)
+    """
+    
+    def __init__(self, kernel_dir: str):
+        self.kernel_dir = Path(kernel_dir)
+        
+        # TODO: Workspace derivation is not currently handled.
+        # Once the cache mechanism is stable, switch to cache-based mode.
+        
+        # Load metadata
+        metadata_path = self.kernel_dir / "metadata.pkl"
+        with open(metadata_path, "rb") as f:
+            self.metadata = pickle.load(f)
+        
+        # Extract metadata fields
+        self.signature = self.metadata.get("signature", {})
+        self.out_idx = self.metadata.get("out_idx", None)
+        # Keep None, only convert int to list
+        if isinstance(self.out_idx, int):
+            self.out_idx = [self.out_idx]
+        self.param_info = self.metadata.get("param_info", [])
+        self.symbolic = self.metadata.get("symbolic", {})
+        self.gridfunc = self.metadata.get("gridfunc", "")
+        self.kernel_src = self.metadata.get("kernel_src", b"")
+        self.kernel_name = self.metadata.get("name", "kernel")
+        self.tensor_kinds = self.metadata.get("tensor_kinds", [])
+        self.shared = self.metadata.get("shared", 1)
+        self.mix_mode = self.metadata.get("mix_mode", False)
+        
+        # Device info
+        self.device = torch.npu.current_device()
+        self.stream = torch.npu.current_stream(self.device).npu_stream
+        
+        # Load main.so (launcher)
+        self._load_launcher()
+        
+        # Load npu_utils.so (utility library, shared)
+        self._load_npu_utils()
+        
+        # Load kernel binary
+        self._load_kernel_binary()
+    
+    def _load_launcher(self):
+        """Load main.so launcher"""
+        launcher_path = self.kernel_dir / "main.so"
+        spec = importlib.util.spec_from_file_location(
+            "__tilelang_launcher", str(launcher_path)
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        self.launch = getattr(mod, "launch")
+    
+    def _load_npu_utils(self):
+        """Load npu_utils.so utility library (shared)"""
+        self.npu_utils = get_shared_npu_utils()
+    
+    def _load_kernel_binary(self):
+        """Load kernel binary to device"""
+        kernel_mode = "aicore" if not self.mix_mode else "aiv"
+        
+        result = self.npu_utils.load_kernel_binary(
+            self.kernel_name,
+            self.kernel_src,
+            0,
+            self.device,
+            kernel_mode,
+        )
+        
+        self.t_module, self.t_function, self.t_n_regs, self.t_n_spills = result
+    
+    def _calc_grid(self, orig_to_input: dict, *args):
+        """Calculate grid dimensions and dynamic values"""
+        dynamic_val = {}
+        extra_args = []
+        
+        for key, pos in self.symbolic.items():
+            if isinstance(pos, (tuple, list)) and len(pos) >= 2:
+                tensor_idx, dim_idx = pos[0], pos[1]
+                if tensor_idx in orig_to_input:
+                    arg_pos = orig_to_input[tensor_idx]
+                    arg = args[arg_pos]
+                    if isinstance(arg, torch.Tensor) and dim_idx < len(arg.shape):
+                        value = arg.shape[dim_idx]
+                        dynamic_val[str(key)] = value
+                        extra_args.append(value)
+                    else:
+                        raise ValueError(f"Cannot resolve symbolic {key}")
+                else:
+                    raise ValueError(f"Symbolic {key} depends on output")
+        
+        self.extra_args = extra_args
+        
+        # Calculate grid
+        result = replace_by_longest_key(self.gridfunc, dynamic_val)
+        
+        try:
+            if isinstance(result, (int, float)):
+                grid_value = result
+            elif isinstance(result, str):
+                grid_value = eval(
+                    result,
+                    {"__builtins__": {}},
+                    {"math": math, **dynamic_val},
+                )
+            else:
+                grid_value = result
+            
+            if hasattr(grid_value, "__iter__"):
+                self.grid = [int(x) for x in grid_value]
+            else:
+                self.grid = [int(grid_value), 1, 1]
+        except Exception as e:
+            raise ValueError(f"Failed to evaluate grid expression '{result}': {e}")
+        
+        return dynamic_val
+    
+    def __call__(self, *args) -> Any:
+        """Execute kernel"""
+        total_params = len(self.param_info)
+        num_inputs = total_params - (len(self.out_idx) if self.out_idx is not None else 0)
+        
+        if len(args) != num_inputs:
+            raise ValueError(f"Expected {num_inputs} inputs, got {len(args)}")
+        
+        # Build input position mapping
+        orig_to_input = {}
+        input_pos = 0
+        for i, info in enumerate(self.param_info):
+            if not info["is_output"]:
+                orig_to_input[i] = input_pos
+                input_pos += 1
+        
+        # Calculate grid and dynamic values
+        dynamic_val = self._calc_grid(orig_to_input, *args)
+        
+        # Build complete parameter list
+        full_args = [None] * total_params
+        input_ptr = 0
+        
+        for i, info in enumerate(self.param_info):
+            if info["is_output"]:
+                # Output parameter: create empty tensor
+                dtype = info["dtype"]
+                shape = []
+                for dim in info["shape"]:
+                    if isinstance(dim, str):
+                        val = dynamic_val.get(dim)
+                        if val is None:
+                            raise ValueError(f"Missing value for {dim}")
+                        shape.append(val)
+                    else:
+                        shape.append(int(dim))
+                
+                device = args[0].device if args else torch.device("npu")
+                full_args[i] = torch.empty(shape, dtype=dtype, device=device)
+            else:
+                # Input parameter
+                full_args[i] = args[input_ptr]
+                input_ptr += 1
+        
+        # Add extra parameters
+        full_args.extend(self.extra_args)
+        
+        # Execute kernel
+        self.launch(
+            self.grid[0],
+            self.grid[1],
+            self.grid[2],
+            self.stream,
+            self.t_function,
+            {"kernel_name": self.kernel_name, "tensor_kinds": self.tensor_kinds},
+            {},
+            None,  # enter_hook
+            None,  # exit_hook
+            *full_args
+        )
+        
+        # Return result
+        if self.out_idx is None:
+            return None
+        elif len(self.out_idx) == 1:
+            return full_args[self.out_idx[0]]
+        else:
+            return [full_args[i] for i in self.out_idx]
+
+
+class KernelRegistry:
+    """Kernel registry"""
+    
+    _kernels: Dict[str, NPUKernelLoader] = {}
+    _kernel_dir: Optional[Path] = None
+    
+    @classmethod
+    def set_kernel_dir(cls, kernel_dir: str):
+        """Set kernel directory"""
+        cls._kernel_dir = Path(kernel_dir)
+    
+    @classmethod
+    def get_kernel(cls, name: str) -> NPUKernelLoader:
+        """Get kernel (with cache)"""
+        if name not in cls._kernels:
+            if cls._kernel_dir is None:
+                # Default to kernels directory in package
+                cls._kernel_dir = Path(__file__).parent / "kernels"
+            
+            kernel_path = cls._kernel_dir / name
+            if not kernel_path.exists():
+                raise ValueError(f"Kernel '{name}' not found at {kernel_path}")
+            
+            cls._kernels[name] = NPUKernelLoader(str(kernel_path))
+        
+        return cls._kernels[name]

--- a/examples/torch_tl_ops/src/ops/__init__.py
+++ b/examples/torch_tl_ops/src/ops/__init__.py
@@ -1,0 +1,15 @@
+"""
+TileLang Ascend Operators - Operator Definitions Directory
+
+Each operator is defined in a separate file for easy maintenance and extension.
+"""
+
+from .flash_attention import FlashAttentionOp, flash_attention_op
+from .gemm import GemmOp, gemm_op
+
+__all__ = [
+    "FlashAttentionOp",
+    "GemmOp",
+    "flash_attention_op",
+    "gemm_op",
+]

--- a/examples/torch_tl_ops/src/ops/base.py
+++ b/examples/torch_tl_ops/src/ops/base.py
@@ -1,0 +1,40 @@
+"""
+Operator Base Class Definition
+
+All operators need to inherit from this base class and implement the required methods.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Optional
+import torch
+
+
+class BaseOp(ABC):
+    """Operator base class"""
+    
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Operator name, used for kernel directory and registration"""
+        pass
+    
+    @property
+    @abstractmethod
+    def signature(self) -> str:
+        """PyTorch operator signature, e.g. 'flash_attention(Tensor Q, Tensor K, Tensor V, float scale) -> Tensor'"""
+        pass
+    
+    @abstractmethod
+    def get_kernel(self, registry) -> Any:
+        """Get kernel from registry"""
+        pass
+    
+    @abstractmethod
+    def impl(self, *args, **kwargs) -> torch.Tensor:
+        """Operator implementation, calls kernel to execute computation"""
+        pass
+    
+    @abstractmethod
+    def python_api(self, *args, **kwargs) -> torch.Tensor:
+        """Python API interface, includes parameter validation and default value handling"""
+        pass

--- a/examples/torch_tl_ops/src/ops/flash_attention.py
+++ b/examples/torch_tl_ops/src/ops/flash_attention.py
@@ -1,0 +1,65 @@
+"""
+Flash Attention Operator Definition
+
+Fixed shape: seq_len=512, dim=128
+"""
+
+import torch
+from .base import BaseOp
+
+
+class FlashAttentionOp(BaseOp):
+    """Flash Attention operator"""
+    
+    _kernel = None
+    
+    @property
+    def name(self) -> str:
+        return "flash_attention"
+    
+    @property
+    def signature(self) -> str:
+        return "flash_attention(Tensor Q, Tensor K, Tensor V) -> Tensor"
+    
+    def get_kernel(self, registry):
+        if FlashAttentionOp._kernel is None:
+            FlashAttentionOp._kernel = registry.get_kernel(self.name)
+        return FlashAttentionOp._kernel
+    
+    def impl(self, Q: torch.Tensor, K: torch.Tensor, V: torch.Tensor, registry=None) -> torch.Tensor:
+        kernel = self.get_kernel(registry)
+        output = kernel(Q, K, V)
+        return output
+    
+    def python_api(
+        self,
+        Q: torch.Tensor,
+        K: torch.Tensor,
+        V: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Flash Attention operator
+        
+        Args:
+            Q: Query tensor [seq_len, dim], NPU tensor, float16
+            K: Key tensor [seq_len, dim], NPU tensor, float16
+            V: Value tensor [seq_len, dim], NPU tensor, float16
+        
+        Returns:
+            Output tensor [seq_len, dim]
+        """
+        if Q.device.type != "npu":
+            raise ValueError("Q must be an NPU tensor")
+        if K.device.type != "npu":
+            raise ValueError("K must be an NPU tensor")
+        if V.device.type != "npu":
+            raise ValueError("V must be an NPU tensor")
+        
+        seq_len, dim = Q.shape
+        if K.shape != (seq_len, dim) or V.shape != (seq_len, dim):
+            raise ValueError(f"Shape mismatch: Q={Q.shape}, K={K.shape}, V={V.shape}")
+        
+        return torch.ops.tl_ascend_ops.flash_attention(Q, K, V)
+
+
+flash_attention_op = FlashAttentionOp()

--- a/examples/torch_tl_ops/src/ops/gemm.py
+++ b/examples/torch_tl_ops/src/ops/gemm.py
@@ -1,0 +1,72 @@
+"""
+Dynamic Shape GEMM Operator Definition
+
+Supports arbitrary M, N, K dimensions for matrix multiplication
+"""
+
+from typing import Optional
+import torch
+from .base import BaseOp
+
+
+class GemmOp(BaseOp):
+    """Dynamic shape GEMM operator"""
+    
+    _kernel = None
+    
+    @property
+    def name(self) -> str:
+        return "gemm"
+    
+    @property
+    def signature(self) -> str:
+        return "gemm(Tensor A, Tensor B, Tensor C) -> Tensor"
+    
+    def get_kernel(self, registry):
+        if GemmOp._kernel is None:
+            GemmOp._kernel = registry.get_kernel(self.name)
+        return GemmOp._kernel
+    
+    def impl(self, A: torch.Tensor, B: torch.Tensor, C: torch.Tensor, registry=None) -> torch.Tensor:
+        kernel = self.get_kernel(registry)
+        kernel(A, B, C)
+        return C
+    
+    def python_api(
+        self,
+        A: torch.Tensor,
+        B: torch.Tensor,
+        C: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """
+        Dynamic shape GEMM operator (C = A @ B)
+        
+        Args:
+            A: Input matrix [M, K], NPU tensor, float16
+            B: Input matrix [K, N], NPU tensor, float16
+            C: Output matrix [M, N], NPU tensor, float16 (optional, auto-allocated if not provided)
+        
+        Returns:
+            Output matrix [M, N], float16
+        """
+        if A.device.type != "npu":
+            raise ValueError("A must be an NPU tensor")
+        if B.device.type != "npu":
+            raise ValueError("B must be an NPU tensor")
+        
+        M, K = A.shape
+        K2, N = B.shape
+        if K != K2:
+            raise ValueError(f"Matrix dimension mismatch: A.shape[1]={K} != B.shape[0]={K2}")
+        
+        if C is None:
+            C = torch.empty(M, N, dtype=torch.float16, device=A.device)
+        elif C.device.type != "npu":
+            raise ValueError("C must be an NPU tensor")
+        elif C.shape != (M, N):
+            raise ValueError(f"C shape mismatch: expected ({M}, {N}), got {C.shape}")
+        
+        return torch.ops.tl_ascend_ops.gemm(A, B, C)
+
+
+gemm_op = GemmOp()

--- a/examples/torch_tl_ops/src/registry.py
+++ b/examples/torch_tl_ops/src/registry.py
@@ -1,0 +1,58 @@
+"""
+TileLang Ascend Operators - Operator Registry
+
+Manages PyTorch registration for all operators.
+"""
+
+import torch
+from typing import Dict
+from .loader import KernelRegistry
+from .ops.base import BaseOp
+
+_kernel_registry = KernelRegistry
+
+_lib_def = None
+_lib_impl = None
+
+
+def _ensure_lib_initialized():
+    """Ensure PyTorch operator library is initialized"""
+    global _lib_def, _lib_impl
+    
+    if _lib_def is None:
+        _lib_def = torch.library.Library("tl_ascend_ops", "DEF")
+        _lib_impl = torch.library.Library("tl_ascend_ops", "IMPL")
+
+
+def _register_op(op: BaseOp):
+    """Register a single operator to PyTorch"""
+    _ensure_lib_initialized()
+    
+    _lib_def.define(op.signature)
+    
+    def _impl_wrapper(*args, **kwargs):
+        return op.impl(*args, **kwargs, registry=_kernel_registry)
+    
+    _lib_impl.impl(op.name, _impl_wrapper, "PrivateUse1")
+
+
+def register_all_ops() -> Dict[str, BaseOp]:
+    """Register all operators"""
+    from .ops.flash_attention import flash_attention_op
+    from .ops.gemm import gemm_op
+    
+    ops = {
+        "flash_attention": flash_attention_op,
+        "gemm": gemm_op,
+    }
+    
+    for name, op in ops.items():
+        _register_op(op)
+    
+    print(f"✓ Registered {len(ops)} operators: {', '.join(ops.keys())}")
+    return ops
+
+
+def get_kernel_registry():
+    """Get kernel registry"""
+    return _kernel_registry

--- a/examples/torch_tl_ops/src/utils/__init__.py
+++ b/examples/torch_tl_ops/src/utils/__init__.py
@@ -1,0 +1,5 @@
+"""
+Shared utilities for tl_ascend_ops kernels.
+
+This package contains shared resources like npu_utils.so.
+"""

--- a/examples/torch_tl_ops/tests/__init__.py
+++ b/examples/torch_tl_ops/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+TileLang Ascend Operators Test Package
+"""

--- a/examples/torch_tl_ops/tests/test_flash_attention.py
+++ b/examples/torch_tl_ops/tests/test_flash_attention.py
@@ -1,0 +1,48 @@
+"""
+Flash Attention Operator Test
+"""
+
+import torch
+import torch_npu
+import tl_ascend_ops
+
+
+def test_flash_attention():
+    """Test Flash Attention operator"""
+    print("=" * 60)
+    print("Testing Flash Attention operator")
+    print("=" * 60)
+    
+    seq_len = 512
+    dim = 128
+    
+    print(f"\nTesting shape: seq_len={seq_len}, dim={dim}")
+    
+    q = torch.randn(seq_len, dim, dtype=torch.float16, device="npu:0")
+    k = torch.randn(seq_len, dim, dtype=torch.float16, device="npu:0")
+    v = torch.randn(seq_len, dim, dtype=torch.float16, device="npu:0")
+    
+    scale = (1.0 / dim) ** 0.5
+    
+    ref = torch.nn.functional.softmax(
+        (q @ k.T).to(torch.float32) * scale, dim=-1
+    ).to(torch.float16) @ v
+    
+    # Method 1: Call via package
+    output = tl_ascend_ops.flash_attention(q, k, v)
+    torch.testing.assert_close(output, ref, rtol=1e-2, atol=1e-2)
+    print("  ✓ tl_ascend_ops.flash_attention verification passed")
+    
+    # Method 2: Call via torch_npu
+    output2 = torch_npu.flash_attention(q, k, v)
+    torch.testing.assert_close(output2, ref, rtol=1e-2, atol=1e-2)
+    print("  ✓ torch_npu.flash_attention verification passed")
+    
+    # Method 3: Call via torch.ops
+    output3 = torch.ops.tl_ascend_ops.flash_attention(q, k, v)
+    torch.testing.assert_close(output3, ref, rtol=1e-2, atol=1e-2)
+    print("  ✓ torch.ops.tl_ascend_ops.flash_attention verification passed")
+
+
+if __name__ == "__main__":
+    test_flash_attention()

--- a/examples/torch_tl_ops/tests/test_gemm.py
+++ b/examples/torch_tl_ops/tests/test_gemm.py
@@ -1,0 +1,47 @@
+"""
+Dynamic Shape GEMM Operator Test
+"""
+
+import torch
+import torch_npu
+import tl_ascend_ops
+
+
+def test_gemm():
+    """Test dynamic shape GEMM operator"""
+    print("=" * 60)
+    print("Testing dynamic shape GEMM operator")
+    print("=" * 60)
+    
+    test_cases = [
+        (1024, 512, 2048),
+        (512, 1024, 512),
+        (256, 256, 256),
+    ]
+    
+    for M, N, K in test_cases:
+        print(f"\nTesting shape: M={M}, N={N}, K={K}")
+        
+        a = torch.randn(M, K, dtype=torch.float16, device="npu:0")
+        b = torch.randn(K, N, dtype=torch.float16, device="npu:0")
+        ref = a @ b
+        
+        # Method 1: Call via package
+        c = tl_ascend_ops.gemm(a, b)
+        torch.testing.assert_close(c, ref, rtol=1e-2, atol=1e-2)
+        print("  ✓ tl_ascend_ops.gemm verification passed")
+        
+        # Method 2: Call via torch_npu
+        c2 = torch_npu.gemm(a, b)
+        torch.testing.assert_close(c2, ref, rtol=1e-2, atol=1e-2)
+        print("  ✓ torch_npu.gemm verification passed")
+        
+        # Method 3: Call via torch.ops
+        c3 = torch.zeros(M, N, dtype=torch.float16, device="npu:0")
+        torch.ops.tl_ascend_ops.gemm(a, b, c3)
+        torch.testing.assert_close(c3, ref, rtol=1e-2, atol=1e-2)
+        print("  ✓ torch.ops.tl_ascend_ops.gemm verification passed")
+
+
+if __name__ == "__main__":
+    test_gemm()


### PR DESCRIPTION
## Summary

Register TileLang Ascend operators to PyTorch with offline installation support.

## Changes

- **Operator Framework**: Add base operator class (`BaseOp`) with abstract methods for name, signature, kernel loading, implementation, and Python API
- **Operator Implementations**: 
  - `FlashAttentionOp`: Fixed shape (seq_len=512, dim=128) with online softmax algorithm
  - `GemmOp`: Dynamic shape GEMM supporting arbitrary M, N, K dimensions
- **Kernel Loader**: Standalone `NPUKernelLoader` that loads precompiled kernels without tilelang source code dependency
- **Operator Registry**: PyTorch operator registration with `torch.library.Library`
- **Precompile Script**: Compile and save kernels for offline distribution

## Usage

Three ways to call the operators:

```python
# Method 1: Package API
import tl_ascend_ops
output = tl_ascend_ops.flash_attention(q, k, v)
c = tl_ascend_ops.gemm(a, b)

# Method 2: Via torch_npu (requires tl_ascend_ops import first)
import tl_ascend_ops
import torch_npu
output = torch_npu.flash_attention(q, k, v)
c = torch_npu.gemm(a, b)

# Method 3: Via torch.ops
import tl_ascend_ops
output = torch.ops.tl_ascend_ops.flash_attention(q, k, v)
torch.ops.tl_ascend_ops.gemm(a, b, c)
```

## Dependencies

- torch >= 2.6.0
- torch_npu