### PR TITLE
[WIP][AscendNPU-IR][Expert] Support "expert mode" T.alloc_shared, T.alloc_fragment, T.alloc_workspace

### DIFF
--- a/src/target/codegen_npuir_api.cc
+++ b/src/target/codegen_npuir_api.cc
@@ -84,6 +84,12 @@
 
 #include "bishengir/Dialect/HACC/IR/HACC.h"
 
+//===----------------------------------------------------------------------===//
+// MemRefExt Dialect (workspace alloc)
+//===----------------------------------------------------------------------===//
+
+#include "bishengir/Dialect/MemRefExt/IR/MemRefExt.h"
+
 using namespace mlir;
 
 namespace tvm {
@@ -193,6 +199,21 @@ getBroadcastDim(const llvm::ArrayRef<long int> &buffer_shape0,
     }
   }
   return dims;
+}
+
+static bool IsWorkspaceScope(const std::string &scope) {
+  return scope.find("workspace") == 0 || scope.find("global.workspace") == 0;
+}
+
+// Treat workspace as GM-like scope for copy routing.
+static bool IsGMLikeScope(const std::string &scope) {
+  return scope == "global" || IsWorkspaceScope(scope);
+}
+
+// Scopes that always use pure memref.copy for all copy routing.
+static bool IsPureCopyScope(const std::string &scope) {
+  return scope.find("shared.flat") == 0 || scope.find("local.fragment") == 0 ||
+         IsWorkspaceScope(scope);
 }
 
 static std::map<std::string, mlir::hivm::RoundMode> NPUIR_STR_ROUNDMODE{
@@ -486,11 +507,12 @@ mlir::Value CodeGenTileLangNPUIRAPI::ScalarConvertType(const PrimExpr &imm,
 
 CodeGenTileLangNPUIRAPI::CodeGenTileLangNPUIRAPI() : builder(&context) {
   // Load MLIR dialects in the context
-  this->context
-      .loadDialect<mlir::func::FuncDialect, mlir::arith::ArithDialect,
-                   mlir::linalg::LinalgDialect, mlir::scf::SCFDialect,
-                   mlir::memref::MemRefDialect, mlir::hivm::HIVMDialect,
-                   mlir::hfusion::HFusionDialect>();
+  this->context.loadDialect<
+      mlir::func::FuncDialect, mlir::arith::ArithDialect,
+      mlir::linalg::LinalgDialect, mlir::scf::SCFDialect,
+      mlir::memref::MemRefDialect, mlir::hivm::HIVMDialect,
+      mlir::hfusion::HFusionDialect, bishengir::memref_ext::MemRefExtDialect,
+      mlir::annotation::AnnotationDialect>();
   // Create MLIR module
   this->module = ModuleOp::create(UnknownLoc::get(&this->context));
 }
@@ -1173,10 +1195,19 @@ void CodeGenTileLangNPUIRAPI::AscendCopyCodegen(const CallNode *op) {
   const std::string src_scope = GetPtrStorageScope(npuirop.src->data);
   const std::string dst_scope = GetPtrStorageScope(npuirop.dst->data);
 
-  // Expert mode extension:
-  //   T.copy(GM, L1) => nd2nz
-  // Keep GM min_rank=2 to maintain consistent GM rank across calls.
-  if (src_scope == "global" && dst_scope == "shared.dyn") {
+  // Pure copy path: shared.flat, local.fragment, workspace <-> any scope
+  // Always use GenRankReducedSubviewFromRegion + memref.copy
+  if (IsPureCopyScope(src_scope) || IsPureCopyScope(dst_scope)) {
+    mlir::Value src =
+        GenRankReducedSubviewFromRegion(npuirop.src, npuirop.src_range);
+    mlir::Value dst =
+        GenRankReducedSubviewFromRegion(npuirop.dst, npuirop.dst_range);
+    SmartMemRefCopy(src, dst);
+    return;
+  }
+
+  // GM-like (global / workspace) -> L1: nd2nz
+  if (IsGMLikeScope(src_scope) && dst_scope == "shared.dyn") {
     mlir::Value src = GenRankReducedSubviewFromRegion(
         npuirop.src, npuirop.src_range, /*min_rank=*/2);
     mlir::Value dst =
@@ -1187,12 +1218,8 @@ void CodeGenTileLangNPUIRAPI::AscendCopyCodegen(const CallNode *op) {
     return;
   }
 
-  // Expert mode extension:
-  //   T.copy(L0C, GM) => fixpipe
-  // Defaults match migration intent from explicit npuir_store_fixpipe:
-  //   enable_nz2nd=true, channel_split=false, pre_relu_mode=no_relu.
-  // Keep GM min_rank=2 to maintain consistent GM rank across calls.
-  if (src_scope == "wmma.accumulator" && dst_scope == "global") {
+  // L0C -> GM-like (global / workspace): fixpipe with nz2nd
+  if (src_scope == "wmma.accumulator" && IsGMLikeScope(dst_scope)) {
     mlir::Value src =
         GenRankReducedSubviewFromRegion(npuirop.src, npuirop.src_range);
     mlir::Value dst = GenRankReducedSubviewFromRegion(
@@ -1215,7 +1242,7 @@ void CodeGenTileLangNPUIRAPI::AscendCopyCodegen(const CallNode *op) {
                  dst_dtype == DataType::Int(8)) {
         pre_quant_mode = mlir::hivm::FixpipePreQuantMode::S322I8;
       } else {
-        LOG(FATAL) << "Unexpected pre-quant mode in T.copy(L0C, GM).";
+        LOG(FATAL) << "Unexpected pre-quant mode in T.copy(L0C, GM-like).";
       }
     }
     mlir::hivm::FixpipePreQuantModeAttr pre_quant =
@@ -1231,6 +1258,18 @@ void CodeGenTileLangNPUIRAPI::AscendCopyCodegen(const CallNode *op) {
     return;
   }
 
+  // L1 -> GM-like (global / workspace): nz2nd
+  if (src_scope == "shared.dyn" && IsGMLikeScope(dst_scope)) {
+    mlir::Value src =
+        GenRankReducedSubviewFromRegion(npuirop.src, npuirop.src_range);
+    mlir::Value dst = GenRankReducedSubviewFromRegion(
+        npuirop.dst, npuirop.dst_range, /*min_rank=*/2);
+    builder.create<mlir::hivm::NZ2NDOp>(builder.getUnknownLoc(),
+                                        mlir::TypeRange{}, src, dst);
+    return;
+  }
+
+  // Default path (UB<->workspace, GM<->workspace, UB<->UB, etc.): memref.copy
   mlir::Value src_sub_view =
       GenRankReducedSubviewFromRegion(npuirop.src, npuirop.src_range);
   mlir::Value dst_sub_view =
@@ -2548,6 +2587,73 @@ mlir::Value CodeGenTileLangNPUIRAPI::GetAndCastIndexOp(const IterVar iv) {
 void CodeGenTileLangNPUIRAPI::VisitStmt_(const AllocateNode *op) {
   ICHECK(!is_zero(op->condition));
   std::string scope = GetPtrStorageScope(op->buffer_var);
+
+  // Workspace: lowered to memref_ext.alloc_workspace (GM-like memref)
+  if (IsWorkspaceScope(scope)) {
+    Array<PrimExpr> extents = op->extents;
+    llvm::SmallVector<int64_t> shape;
+    shape.reserve(extents.size());
+    for (const PrimExpr &e : extents) {
+      if (const auto *imm = e.as<IntImmNode>()) {
+        shape.push_back(static_cast<int64_t>(imm->value));
+      } else {
+        LOG(FATAL) << "workspace allocation only supports static shapes";
+      }
+    }
+    auto elemTy = DTypetoMLIRType(op->dtype);
+    auto memrefType = mlir::MemRefType::get(shape, elemTy);
+    int multi_buffer = 0;
+    auto pos = scope.find(";multi_buffer=");
+    if (pos != std::string::npos) {
+      multi_buffer = std::stoi(scope.substr(pos + 14));
+    }
+    auto allocOp = builder.create<bishengir::memref_ext::AllocWorkspaceOp>(
+        builder.getUnknownLoc(), memrefType,
+        /*workspaceArg=*/mlir::Value(),
+        /*dynamicSize=*/mlir::ValueRange{},
+        /*offset=*/mlir::ValueRange{});
+    mlir::Value alloc_val = allocOp.getMemref();
+    if (multi_buffer > 0) {
+      auto markOp = builder.create<mlir::annotation::MarkOp>(
+          builder.getUnknownLoc(), alloc_val);
+      markOp->setAttr("hivm.multi_buffer",
+                      builder.getI32IntegerAttr(multi_buffer));
+    }
+    ICHECK(!var_map_.count(op->buffer_var.get()));
+    var_map_[op->buffer_var.get()] = alloc_val;
+    this->VisitStmt(op->body);
+    return;
+  }
+
+  // Pure-copy buffers: shared.flat and local.fragment
+  // Emit pure memref.alloc without address space, independent of core type
+  if (scope.find("shared.flat") == 0 || scope.find("local.fragment") == 0) {
+    std::vector<long int> shape = GetShape(op->extents);
+    std::vector<int64_t> strides = GetStrideFromShapeAPI(op->extents);
+    auto layoutMap =
+        mlir::StridedLayoutAttr::get(builder.getContext(), 0, strides);
+    auto memrefType = mlir::MemRefType::get(shape, DTypetoMLIRType(op->dtype),
+                                            layoutMap, mlir::Attribute());
+    int multi_buffer = 0;
+    auto pos = scope.find(";multi_buffer=");
+    if (pos != std::string::npos) {
+      multi_buffer = std::stoi(scope.substr(pos + 14));
+    }
+    auto allocOp = builder.create<mlir::memref::AllocOp>(
+        builder.getUnknownLoc(), memrefType);
+    mlir::Value alloc_val = allocOp.getResult();
+    if (multi_buffer > 0) {
+      auto markOp = builder.create<mlir::annotation::MarkOp>(
+          builder.getUnknownLoc(), alloc_val);
+      markOp->setAttr("hivm.multi_buffer",
+                      builder.getI32IntegerAttr(multi_buffer));
+    }
+    ICHECK(!var_map_.count(op->buffer_var.get()));
+    var_map_[op->buffer_var.get()] = alloc_val;
+    this->VisitStmt(op->body);
+    return;
+  }
+
   std::map<std::string, NPU_CORETYPE> scope_coretype_map{
       {"shared", NPU_CORETYPE::AIV},
       {"shared.dyn", NPU_CORETYPE::AIC},
@@ -2561,7 +2667,6 @@ void CodeGenTileLangNPUIRAPI::VisitStmt_(const AllocateNode *op) {
     mlir::hivm::AddressSpace address_space = GetHIVMAddressSpace(scope);
     auto memorySpaceHIVMAttr =
         mlir::hivm::AddressSpaceAttr::get(builder.getContext(), address_space);
-
     auto memrefType = mlir::MemRefType::get(shape, DTypetoMLIRType(op->dtype),
                                             layoutMap, memorySpaceHIVMAttr);
 

--- a/src/target/codegen_npuir_api.h
+++ b/src/target/codegen_npuir_api.h
@@ -43,10 +43,23 @@
 #include "bishengir/Dialect/HIVM/IR/HIVM.h"
 
 //===----------------------------------------------------------------------===//
+// Annotation Dialect
+//===----------------------------------------------------------------------===//
+
+#include "bishengir/Dialect/Annotation/IR/Annotation.h"
+
+//===----------------------------------------------------------------------===//
 // HFusion Dialect
 //===----------------------------------------------------------------------===//
 
 #include "bishengir/Dialect/HFusion/IR/HFusion.h"
+
+//===----------------------------------------------------------------------===//
+// MemRefExt Dialect (workspace alloc)
+//===----------------------------------------------------------------------===//
+
+#include "bishengir/Dialect/MemRefExt/IR/MemRefExt.h"
+
 #include "tvm/ir/attrs.h"
 #include "tvm/ir/expr.h"
 #include "tvm/runtime/data_type.h"

--- a/testing/npuir/wip/workspace_copy_exp.py
+++ b/testing/npuir/wip/workspace_copy_exp.py
@@ -1,0 +1,55 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025.
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+import tilelang
+import tilelang.language as T
+
+import testcommon as tc
+
+pytestmark = [
+    pytest.mark.op("workspace_copy"),
+    pytest.mark.mode("Expert"),
+]
+
+DTYPE = "float16"
+TEST_SHAPES = [
+    (16, 16),
+    (32, 64),
+    (64, 32),
+]
+
+
+def workspace_copy_kernel(M, N, dtype=DTYPE):
+    """GM -> UB -> workspace -> UB -> GM roundtrip via T.alloc_workspace."""
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            ub_in = T.alloc_shared((M, N), dtype, multi_buffer=2)
+            ws = T.alloc_workspace((M, N), dtype, multi_buffer=2)
+            ub_out = T.alloc_fragment((M, N), dtype, multi_buffer=2)
+
+            T.copy(A, ub_in)       # GM -> UB
+            T.copy(ub_in, ws)      # UB -> workspace (memref.copy)
+            T.copy(ws, ub_out)     # workspace -> UB (memref.copy)
+            T.copy(ub_out, B)      # UB -> GM
+
+    return kernel
+
+
+@pytest.mark.parametrize("M, N", TEST_SHAPES)
+def test_workspace_copy_exp(M, N):
+    func = workspace_copy_kernel(M, N)
+    compiled_kernel = tilelang.compile(func, target="npuir")
+
+    src = tc.gen_tensor((M, N), DTYPE, kind="randn")
+    dst = tc.gen_tensor((M, N), DTYPE, kind="zeros")
+    ref = src.clone()
+
+    compiled_kernel(src, dst)
+    tc.assert_close(dst.cpu(), ref.cpu(), dtype=DTYPE)

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -40,6 +40,7 @@ from .allocate import (
     alloc_shared,  # noqa: F401
     alloc_fragment,  # noqa: F401
     alloc_var,  # noqa: F401
+    alloc_workspace,  # noqa: F401
     alloc_L0A,  # noqa: F401
     alloc_L0B,  # noqa: F401
     alloc_L0C,  # noqa: F401

--- a/tilelang/language/allocate.py
+++ b/tilelang/language/allocate.py
@@ -19,13 +19,14 @@ with the appropriate memory scope.
 from tvm.script import tir as T
 
 
-def alloc_shared(shape, dtype, scope="shared.dyn"):
+def alloc_shared(shape, dtype, scope="shared.flat", multi_buffer=None):
     """Allocate a shared memory buffer for inter-thread communication.
 
     Args:
         shape (tuple): The shape of the buffer to allocate
         dtype (str): The data type of the buffer (e.g., 'float32', 'int32')
-        scope (str, optional): The memory scope. Defaults to "shared.dyn"
+        scope (str, optional): The memory scope. Defaults to "shared.flat"
+        multi_buffer (int, optional): The number of multi-buffering stages. Defaults to None.
 
     Returns:
         T.Buffer: A TVM buffer object allocated in shared memory
@@ -34,6 +35,8 @@ def alloc_shared(shape, dtype, scope="shared.dyn"):
         # lei: This is a hack to handle bool type.
         # Because tilelang's merge smem pass cannot merge bool type currently.
         scope = "shared"
+    if multi_buffer is not None:
+        scope = f"{scope};multi_buffer={multi_buffer}"
     return T.alloc_buffer(shape, dtype, scope=scope)
 
 
@@ -51,17 +54,20 @@ def alloc_local(shape, dtype, scope="local"):
     return T.alloc_buffer(shape, dtype, scope=scope)
 
 
-def alloc_fragment(shape, dtype, scope="local.fragment"):
+def alloc_fragment(shape, dtype, scope="local.fragment", multi_buffer=None):
     """Allocate a fragment memory buffer for specialized operations.
 
     Args:
         shape (tuple): The shape of the buffer to allocate
         dtype (str): The data type of the buffer (e.g., 'float32', 'int32')
         scope (str, optional): The memory scope. Defaults to "local.fragment"
+        multi_buffer (int, optional): The number of multi-buffering stages. Defaults to None.
 
     Returns:
         T.Buffer: A TVM buffer object allocated in fragment memory
     """
+    if multi_buffer is not None:
+        scope = f"{scope};multi_buffer={multi_buffer}"
     return T.alloc_buffer(shape, dtype, scope=scope)
 
 
@@ -76,6 +82,23 @@ def alloc_var(dtype, scope="local.var"):
         T.Buffer: A TVM buffer object allocated as a single-element variable
     """
     return T.alloc_buffer([1], dtype, scope=scope)
+
+
+def alloc_workspace(shape, dtype, scope="global.workspace", multi_buffer=None):
+    """Allocate a workspace memory buffer for global memory that needs explicit memory management.
+
+    Args:
+        shape (tuple): The shape of the buffer to allocate
+        dtype (str): The data type of the buffer (e.g., 'float32', 'int32')
+        scope (str, optional): The memory scope. Defaults to "global.workspace"
+        multi_buffer (int, optional): The number of multi-buffering stages. Defaults to None.
+
+    Returns:
+        T.Buffer: A TVM buffer object allocated in workspace memory
+    """
+    if multi_buffer is not None:
+        scope = f"{scope};multi_buffer={multi_buffer}"
+    return T.alloc_buffer(shape, dtype, scope=scope)
 
 
 """


### PR DESCRIPTION
This change includes:
1. Added T.alloc_workspace() Python API in tilelang/language/allocate.py.
2. Updated T.alloc_shared() default scope to "shared.flat" to distinguish it from T.alloc_L1() ("shared.dyn").
3. Implemented IsPureCopyScope for "shared.flat", "local.fragment", and workspace scopes to route copies strictly via pure memref.copy.
4. Updated AllocateNode to emit pure memref.alloc for these pure copy scopes.
5. Implemented workspace allocation support using memref_ext.alloc_workspace.
6. Added expert mode test case for pure copies in testing/npuir/memory_ops/test_workspace_copy_exp.py.