### PR TITLE
[AscendNPU-IR][A5] Track AscendNPU-IR-Dev master branch instead of pinned commit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,4 @@
 [submodule "3rdparty/AscendNPU-IR-Dev"]
 	path = 3rdparty/AscendNPU-IR-Dev
 	url = https://gitcode.com/Ascend/AscendNPU-IR-Dev.git
+	branch = master


### PR DESCRIPTION
[AscendNPU-IR][A5] Track AscendNPU-IR-Dev master branch instead of pinned commit

Previous pinned commit: 800a680ff
New pinned commit: 43340f1e1

The new commit contains fix for lstdc++fs error.