### PR TITLE
[AscendNPU-IR][A5] fix: reorder link libraries to resolve NPUIR symbol dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,4 @@
 [submodule "3rdparty/AscendNPU-IR-Dev"]
 	path = 3rdparty/AscendNPU-IR-Dev
 	url = https://gitcode.com/Ascend/AscendNPU-IR-Dev.git
+	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,11 +244,11 @@ target_link_libraries(
   tilelang_module
   PUBLIC
   tvm
-  zstd
-  z
   -Wl,--start-group
   ${NPUIR_LIBS}
   -Wl,--end-group
+  zstd
+  z
 )
 
 # Install targets


### PR DESCRIPTION
Reordered zstd and z after ${NPUIR_LIBS}.