### PR TITLE
buffer region adaptation

### DIFF
--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -1403,20 +1403,30 @@ void CodeGenTileLangAscendPto::GatherMaskCodegen(const CallNode *op,
 }
 
 void CodeGenTileLangAscendPto::PowCodegen(const CallNode *op) {
-  BufferInfo dst_info = GetBufferInfo(op->args[0]);
-  BufferInfo src0_info = GetBufferInfo(op->args[1]);
-  BufferInfo src1_info = GetBufferInfo(op->args[2]);
-  BufferInfo tmp_info = GetBufferInfo(op->args[3]);
+  ShapeInfo src0_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+  ShapeInfo src1_shape_info = GetSliceInfo(op->args[2].as<CallNode>());
+  ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
+  ShapeInfo temp_shape_info = GetSliceInfo(op->args[3].as<CallNode>());
 
-  const auto &M = dst_info.shape[0];
-  const auto &N = dst_info.shape[1];
-
+  if (src0_shape_info.is_slice || src1_shape_info.is_slice || dst_shape_info.is_slice) {
+    auto src0_temp_name = GetTempVarName(src0_shape_info.ub_name);
+    auto src1_temp_name = GetTempVarName(src1_shape_info.ub_name);
+    auto dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
+    CreateUbVariableND(src0_temp_name, src0_shape_info);
+    CreateUbVariableND(src1_temp_name, src1_shape_info);
+    CreateUbVariableND(dst_temp_name, dst_shape_info);
+    this->PrintIndent();
+    this->stream << kAscendPtoScope << "pow" << "<" << dst_shape_info.type << ", "
+               << dst_shape_info.slice_row << ", " << dst_shape_info.slice_col << "," << temp_shape_info.row ">"
+               << "(" << dst_temp_name << ", " << src0_temp_name << ", " << src1_temp_name << ", " << temp_shape_info.ub_name <<
+               << ");\n";
+  } else {
   this->PrintIndent();
-  this->stream << kAscendPtoScope << "pow" << "<" << getType(dst_info.dtype)
-               << ", " << PrintExpr(M) << ", " << PrintExpr(N) << ", "
-               << PrintExpr(tmp_info.shape[0]) << ">"
-               << "(" << dst_info.id << ", " << src0_info.id << ", "
-               << src1_info.id << ", " << tmp_info.id << ");\n";
+  this->stream << kAscendPtoScope << "pow" << "<" << dst_shape_info.type << ", "
+               << dst_shape_info.row << ", " << dst_shape_info.col << ", " << temp_shape_info.row << ">"
+               << "(" << dst_shape_info.ub_name << ", " << src0_shape_info.ub_name << ", " << src1_shape_info.ub_name
+               << ", " << temp_shape_info.bu_name << ");\n";
+  }
 }
 
 void CodeGenTileLangAscendPto::Sort32Codegen(const CallNode *op,
@@ -1452,64 +1462,109 @@ void CodeGenTileLangAscendPto::TransposeCodegen(const CallNode *op,
 
 void CodeGenTileLangAscendPto::XorCodegen(const CallNode *op,
                                           const std::string &op_name) {
+  ShapeInfo src0_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+  ShapeInfo src1_shape_info = GetSliceInfo(op->args[2].as<CallNode>());
+  ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
+  auto tmp_name = PrintExpr(op->args[3].as<CallNode>()->args[1]);
+  
+  if (src0_shape_info.is_slice || src1_shape_info.is_slice || dst_shape_info.is_slice) {
+    auto src0_temp_name = GetTempVarName(src0_shape_info.ub_name);
+    auto src1_temp_name = GetTempVarName(src1_shape_info.ub_name);
+    auto dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
+    CreateUbVariableND(src0_temp_name, src0_shape_info);
+    CreateUbVariableND(src1_temp_name, src1_shape_info);
+    CreateUbVariableND(dst_temp_name, dst_shape_info);
+    this->PrintIndent();
+    this->stream << op_name << "(" << dst_temp_name << ", " << src0_temp_name << ", "
+               << src1_temp_name << ", " << tmp_name << ");\n";
+  } else {
   this->PrintIndent();
-  std::string dst_name = PrintExpr(op->args[0].as<CallNode>()->args[1]);
-  std::string src0_name = PrintExpr(op->args[1].as<CallNode>()->args[1]);
-  std::string src1_name = PrintExpr(op->args[2].as<CallNode>()->args[1]);
-  std::string tmp_name = PrintExpr(op->args[3].as<CallNode>()->args[1]);
-  this->stream << op_name << "(" << dst_name << ", " << src0_name << ", "
-               << src1_name << ", " << tmp_name << ");\n";
+  this->stream << op_name << "(" << dst_shape_info.ub_name << ", " << src0_shape_info.ub_name << ", "
+               << src1_shape_info.ub_name << ", " << tmp_name << ");\n";
+  }
 }
 
 void CodeGenTileLangAscendPto::CompareCodegen(const CallNode *op,
                                               const std::string &op_name) {
+  ShapeInfo src0_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+  ShapeInfo src1_shape_info = GetSliceInfo(op->args[2].as<CallNode>());
+  ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
+  auto mode = Downcast<StringImm>(op->args[3])->value;
+  if (src0_shape_info.is_slice || src1_shape_info.is_slice || dst_shape_info.is_slice) {
+    auto src0_temp_name = GetTempVarName(src0_shape_info.ub_name);
+    auto src1_temp_name = GetTempVarName(src1_shape_info.ub_name);
+    auto dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
+    CreateUbVariableND(src0_temp_name, src0_shape_info);
+    CreateUbVariableND(src1_temp_name, src1_shape_info);
+    CreateUbVariableND(dst_temp_name, dst_shape_info);
+    this->PrintIndent();
+    this->stream << kAscendPtoScope << "compare(" << dst_temp_name << ", " << src0_temp_name << ", " << src1_temp_name
+                 << ", " << "CmpMode::" << mode << ");\n";
+  } else {
   this->PrintIndent();
-  std::string dst_name = PrintExpr(op->args[0].as<CallNode>()->args[1]);
-  std::string src0_name = PrintExpr(op->args[1].as<CallNode>()->args[1]);
-  std::string src1_name = PrintExpr(op->args[2].as<CallNode>()->args[1]);
-  std::string mode = Downcast<StringImm>(op->args[3])->value;
-
-  this->stream << kAscendPtoScope << "compare(" << dst_name << ", " << src0_name
-               << ", " << src1_name << ", " << "CmpMode::" << mode << ");\n";
+  this->stream << kAscendPtoScope << "compare(" << dst_shape_info.ub_name << ", " << src0_shape_info.ub_name
+               << ", " << src1_shape_info.ub_name << ", " << "CmpMode::" << mode << ");\n";
+  }
 }
 
 void CodeGenTileLangAscendPto::CompareScalarCodegen(
     const CallNode *op, const std::string &op_name) {
-  this->PrintIndent();
+  ShapeInfo src0_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+  ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
+  auto src1_name = PrintExpr(op->args[2]);
+  auto mode = Downcast<StringImm>(op->args[3])->value;
+
   std::string dst_name = PrintExpr(op->args[0].as<CallNode>()->args[1]);
   std::string src0_name = PrintExpr(op->args[1].as<CallNode>()->args[1]);
 
-  DataType src_dtype = GetAccessPtrDtypePto(op->args[1].as<CallNode>());
+  DataType src_dtype = op->args[1].as<CallNode>()->dtype;
   DataType scalar_dtype = op->args[2].dtype();
-  std::string src1_name = PrintExpr(op->args[2]);
   if (scalar_dtype != src_dtype) {
     std::string target_type = getType(src_dtype);
     src1_name = target_type + "(" + src1_name + ")";
   }
-
-  std::string mode = Downcast<StringImm>(op->args[3])->value;
-
-  this->stream << kAscendPtoScope << "compare_scalar(" << dst_name << ", "
-               << src0_name << ", " << src1_name << ", " << "CmpMode::" << mode
+  if (src0_shape_info.is_slice || dst_shape_info.is_slice) {
+    auto src0_temp_name = GetTempVarName(src0_shape_info.ub_name);
+    auto dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
+    CreateUbVariableND(src0_temp_name, src0_shape_info);
+    CreateUbVariableND(dst_temp_name, dst_shape_info);
+    this->PrintIndent();
+    this->stream << kAscendPtoScope << "compare_scalar(" << dst_temp_name << ", " << src0_temp_name << ", " << src1_name
+                 << ", " << "CmpMode::" << mode << ");\n";
+  } else {
+  this->PrintIndent();
+  this->stream << kAscendPtoScope << "compare_scalar(" << dst_shape_info.ub_name << ", "
+               << src0_shape_info.ub_name << ", " << src1_name << ", " << "CmpMode::" << mode
                << ");\n";
+  }
 }
 
 void CodeGenTileLangAscendPto::TshCodegen(const CallNode *op,
                                           const std::string &op_name) {
   this->PrintIndent();
-  std::string dst_name = PrintExpr(op->args[0].as<CallNode>()->args[1]);
-  std::string src0_name = PrintExpr(op->args[1].as<CallNode>()->args[1]);
+  ShapeInfo src0_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+  ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
+  auto src1_name = op->args[2].as<IntImmNode>()->value;
 
-  DataType src_dtype = GetAccessPtrDtypePto(op->args[1].as<CallNode>());
+  DataType src_dtype = op->args[1].as<CallNode>()->dtype;
   DataType scalar_dtype = op->args[2].dtype();
-  std::string src1_name = PrintExpr(op->args[2]);
+
   if (scalar_dtype != src_dtype) {
     std::string target_type = getType(src_dtype);
     src1_name = target_type + "(" + src1_name + ")";
   }
-
-  this->stream << op_name << "(" << dst_name << ", " << src0_name << ", "
+  if (src0_shape_info.is_slice || dst_shape_info.is_slice) {
+    auto src_temp_name = GetTempVarName(src0_shape_info.ub_name);
+    auto dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
+    CreateUbVariableND(src_temp_name, src0_shape_info);
+    CreateUbVariableND(dst_temp_name, dst_shape_info);
+    this->PrintIndent();
+    this->stream << op_name << "(" << dst_temp_name << ", " << src_temp_name << ", " << src1_name
+                 << ");\n";
+  } else {
+    this->stream << op_name << "(" << dst_shape_info.ub_name << ", " << src0_shape_info.ub_name << ", "
                << src1_name << ");\n";
+  }
 }
 
 void CodeGenTileLangAscendPto::ArithProgressionCodegen(
@@ -1834,35 +1889,55 @@ void CodeGenTileLangAscendPto::UnaryVecOpCodegen(const CallNode *op,
 
 void CodeGenTileLangAscendPto::ScalarOpCodegen(const CallNode *op,
                                                const std::string &op_name) {
-  this->PrintIndent();
-  this->stream << op_name << "("
-               << PrintBufferOffset(op->args[0].as<CallNode>()) << ", "
-               << PrintBufferOffset(op->args[1].as<CallNode>()) << ", "
+  ShapeInfo src_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+  ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
+
+  if (src_shape_info.is_slice || dst_shape_info.is_slice) {
+    auto src_temp_name = GetTempVarName(src_shape_info.ub_name);
+    auto dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
+    CreateUbVariableND(src_temp_name, src_shape_info);
+    CreateUbVariableND(dst_temp_name, dst_shape_info);
+    this->PrintIndent();
+    this->stream << op_name << "(" << dst_temp_name << ", " << src_temp_name << "," << PrintExpr(op->args[2]) << ");\n";
+  } else {
+    this->PrintIndent();
+    this->stream << op_name << "("
+               << dst_shape_info.ub_name << ", "
+               << src_shape_info.ub_name << ", "
                << PrintExpr(op->args[2]) << ");\n";
+  }
 }
 
 void CodeGenTileLangAscendPto::AxpyCodegen(const CallNode *op) {
-  BufferInfo dst_info = GetBufferInfo(op->args[0]);
-  BufferInfo src0_info = GetBufferInfo(op->args[1]);
-  std::string scalar = PrintExpr(op->args[2]);
+  ShapeInfo src_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+  ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
+  auto scalar = PrintExpr(op->args[2]);
 
-  const auto &M = dst_info.shape[0];
-  const auto &N = dst_info.shape[1];
-
+  DataType dtype0 = op->args[0].as<CallNode>()->dtype;
   DataType scalar_dtype = op->args[2].dtype();
-  if (getType(dst_info.dtype) != getType(scalar_dtype)) {
-    if (dst_info.dtype.is_float16()) {
+  if (scalar_dtype != dtype0) {
+    if (dtype0.is_float16()) {
       scalar = "float(" + scalar + ")";
     } else {
       scalar = getType(dst_info.dtype) + "(" + scalar + ")";
     }
   }
 
-  this->PrintIndent();
-  this->stream << kAscendPtoScope << "axpy" << "<" << getType(dst_info.dtype)
-               << ", " << PrintExpr(M) << ", " << PrintExpr(N) << ">"
-               << "(" << dst_info.id << ", " << src0_info.id << ", " << scalar
-               << ");\n";
+  if (src_shape_info.is_slice || dst_shape_info.is_slice) {
+    auto src_temp_name = GetTempVarName(src_shape_info.ub_name);
+    auto dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
+    CreateUbVariableND(src_temp_name, src_shape_info);
+    CreateUbVariableND(dst_temp_name, dst_shape_info);
+    this->PrintIndent();
+    this->stream << kAscendPtoScope << "axpy" << "<" << src_shape_info.type << ", " << src_shape_info.slice_row << 
+      ", " << src_shape_info.slice_col << ">" << "(" << dst_temp_name << ", " << src_temp_name << ", " << scalar << ");\n";
+  } else {
+    this->PrintIndent();
+    this->stream << kAscendPtoScope << "axpy" << "<" << dst_shape_info.type << ", "
+                << dst_shape_info.row << ", " << dst_shape_info.col << ">"
+                << "(" << dst_shape_info.ub_name << ", " << src_shape_info.ub_name << ", " << scalar
+                << ");\n";
+  }
 }
 
 void CodeGenTileLangAscendPto::BinaryVecClampMaxMinOpsCodegen(
@@ -1873,95 +1948,96 @@ void CodeGenTileLangAscendPto::BinaryVecClampMaxMinOpsCodegen(
     auto var_name = PrintBufferOffset(op->args[i].as<CallNode>());
     var_names.push_back(var_name);
   }
+  ShapeInfo src_shape_info = GetSliceInfo(op->args[2].as<CallNode>());
+  ShapeInfo dst_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+
   if (op->args[4].as<CallNode>()) {
-    auto var_name = PrintBufferOffset(op->args[4].as<CallNode>());
-    std::string ub_name_dst = var_names[1];
-    std::string ub_name_src = var_names[2];
     this->PrintIndent();
+    auto var_name = PrintBufferOffset(op->args[4].as<CallNode>());
     std::string index = PrintExpr(op->args[op->args.size() - 2]);
     std::string scalar_name = var_name + "_scalar";
     this->stream << "auto " << scalar_name << "= " << var_name << ".GetValue("
                  << index << ");\n";
-    this->stream << operation << "(";
-    this->stream << ub_name_dst << ", " << ub_name_src << ", " << scalar_name;
+    if (src_shape_info.is_slice || dst_shape_info.is_slice) {
+      auto src_temp_name = GetTempVarName(src_shape_info.ub_name);
+      auto dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
+      CreateUbVariableND(src_temp_name, src_shape_info);
+      CreateUbVariableND(dst_temp_name, dst_shape_info);
+      this->PrintIndent();
+      this->stream << operation << "(" << dst_temp_name << ", " << src_temp_name << ", " << scalar_name << ");\n";
+    } else {
+      this->PrintIndent();
+      this->stream << operation << "(" << dst_shape_info.ub_name << ", " << src_shape_info.ub_name << ", " << scalar_name << ");\n";
+    }    
+  } else {
+    auto scalar = PrintExpr(op->args[op->args.size() - 2]);
+    if (src_shape_info.is_slice || dst_shape_info.is_slice) {
+      auto src_temp_name = GetTempVarName(src_shape_info.ub_name);
+      auto dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
+      CreateUbVariableND(src_temp_name, src_shape_info);
+      CreateUbVariableND(dst_temp_name, dst_shape_info);
+      this->PrintIndent();
+      this->stream << operation << "(" << dst_temp_name << ", " << src_temp_name << ", " << scalar << ");\n";
+    } else {
+      this->PrintIndent();
+      this->stream << operation << "(" << dst_shape_info.ub_name << ", " << src_shape_info.ub_name << ", " << scalar << ");\n";
+    }
+  }
+}
+
+void CodeGenTileLangAscendPto::BinaryVecClampOpsCodegen(
+  const CallNode *op, const std::string &op_name) {
+  ShapeInfo src_shape_info = GetSliceInfo(op->args[2].as<CallNode>());
+  ShapeInfo dst_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+  auto scalar_min = PrintExpr(op->args[op->args.size() - 3]);
+  auto scalar_max = PrintExpr(op->args[op->args.size() - 2]);
+
+  if (src_shape_info.is_slice || dst_shape_info.is_slice) {
+    std::string src_temp_name = GetTempVarName(src_shape_info.ub_name);
+    std::string dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
+    CreateUbVariableND(src_temp_name, src_shape_info);
+    CreateUbVariableND(dst_temp_name, dst_shape_info);
+    this->PrintIndent();
+    this->stream << "TMAXS" << "(" << dst_temp_name << ", " << src_temp_name << "," << scalar_min << ");\n";
+    this->PrintIndent();
+    this->stream << "TMINS" << "(" << dst_temp_name << ", " << src_temp_name << "," << scalar_max << ");\n";
   } else {
     this->PrintIndent();
-    this->stream << operation << "(";
-    std::string scalar = PrintExpr(op->args[op->args.size() - 2]);
-    var_names.push_back(scalar);
+    this->stream << "TMAXS" << "(" << dst_shape_info.ub_name << ", " << src_shape_info.ub_name << "," << scalar_min << ");\n";
+    this->PrintIndent();
+    this->stream << "TMINS" << "(" << dst_shape_info.ub_name << ", " << src_shape_info.ub_name << "," << scalar_max << ");\n";
+  }
+}
+
+void CodeGenTileLangAscendPto::SigmoidCodegen(const CallNode *op, const std::string& op_name) {
+  std::vector<std::string> var_names;
+  for (int i = 0; i < op->args.size() - 2; i++) {
+    auto var_name = PrintBufferOffset(op->args[i].as<CallNode>());
+    var_names.push_back(var_name);
+  }
+  ShapeInfo src_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+  ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
+
+  if (src_shape_info.is_slice || dst_shape_info.is_slice) {
+    auto src_temp_name = GetTempVarName(src_shape_info.ub_name);
+    auto dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
+    CreateUbVariableND(src_temp_name, src_shape_info);
+    CreateUbVariableND(dst_temp_name, dst_shape_info);
+    this->PrintIndent();
+    this->stream << kAscendPtoScope << op_name << "<" << src_shape_info.type << ", " << src_shape_info.slice_row 
+    << ", " << src_shape_info.slice_col << ">" << "(" << dst_temp_name << ", " << src_temp_name << ");\n";
+  } else {
+    this->PrintIndent();
+    this->stream << kAscendPtoScope << op_name << "<" << dst_shape_info.type << ", " 
+    << dst_shape_info.row << ", " << dst_shape_info.col << ">" << "(";
     for (int i = 0; i < var_names.size(); i++) {
       this->stream << var_names[i];
       if (i != var_names.size() - 1) {
         this->stream << ", ";
       }
     }
+    this->stream << ");\n";
   }
-  this->stream << ");\n";
-}
-
-void CodeGenTileLangAscendPto::BinaryVecClampOpsCodegen(
-    const CallNode *op, const std::string &op_name) {
-  std::vector<std::string> var_names;
-  std::string operation = op_name;
-  std::string scalar_min = PrintExpr(op->args[op->args.size() - 3]);
-  std::string scalar_max = PrintExpr(op->args[op->args.size() - 2]);
-  for (int i = 1; i < op->args.size() - 4; i++) {
-    auto var_name = PrintBufferOffset(op->args[i].as<CallNode>());
-    var_names.push_back(var_name);
-  }
-  this->PrintIndent();
-  // clamp_min: achieve with TMAXS
-  this->stream << "TMAXS" << "(";
-  for (int i = 0; i < var_names.size(); i++) {
-    this->stream << var_names[i];
-    if (i != var_names.size() - 1) {
-      this->stream << ", ";
-    }
-  }
-  this->stream << ", " << scalar_min << ");\n";
-  // clamp_max: achieve with TMINS
-  this->stream << "TMINS" << "(";
-  for (int i = 0; i < var_names.size(); i++) {
-    if (i != 1) {
-      this->stream << var_names[i];
-      if (i != var_names.size() - 1) {
-        this->stream << ", ";
-      }
-    } else {
-      this->stream << var_names[0];
-      if (i != var_names.size() - 1) {
-        this->stream << ", ";
-      }
-    }
-  }
-  this->stream << ", " << scalar_max << ");\n";
-}
-
-void CodeGenTileLangAscendPto::SigmoidCodegen(const CallNode *op,
-                                              const std::string &op_name) {
-  ShapeInfo dst = GetSliceInfo(op->args[0].as<CallNode>());
-  ShapeInfo src = GetSliceInfo(op->args[1].as<CallNode>());
-
-  std::string dst_name = dst.ub_name;
-  std::string src_name = src.ub_name;
-
-  if (dst.is_slice) {
-    dst_name = GetTempVarName(dst.ub_name);
-    CreateUbVariableND(dst_name, dst);
-  }
-
-  if (src.is_slice) {
-    src_name = GetTempVarName(src.ub_name);
-    CreateUbVariableND(src_name, src);
-  }
-
-  const auto &M = dst.slice_row;
-  const auto &N = dst.slice_col;
-
-  this->PrintIndent();
-  this->stream << kAscendPtoScope << op_name << "<" << dst.type << ", "
-               << PrintExpr(M) << ", " << PrintExpr(N) << ">"
-               << "(" << dst_name << ", " << src_name << ");\n";
 }
 
 void CodeGenTileLangAscendPto::CastCodegen(const CallNode *op,

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -862,35 +862,35 @@ void CodeGenTileLangAscendPto::VisitExpr_(const CallNode *op,
   } else if (op->op.same_as(tl::ascend_mma())) {
     MmaCodegen(op);
   } else if (op->op.same_as(builtin::if_then_else())) {
-      // conditional that skips eval if cond evals to false
-      // std::cout<<"here"<<std::endl;
-      std::string result = name_supply_->FreshName("condval");
-      std::string cond = PrintExpr(op->args[0]);
+    // conditional that skips eval if cond evals to false
+    // std::cout<<"here"<<std::endl;
+    std::string result = name_supply_->FreshName("condval");
+    std::string cond = PrintExpr(op->args[0]);
+    this->PrintIndent();
+    PrintType(op->dtype, this->stream);
+    this->stream << " " << result << ";\n";
+    this->PrintIndent();
+    this->stream << "if (" << cond << ") {\n";
+    {
+      int then_scope = this->BeginScope();
+      std::string true_val = PrintExpr(op->args[1]);
       this->PrintIndent();
-      PrintType(op->dtype, this->stream);
-      this->stream << " " << result << ";\n";
+      this->stream << result << " = " << true_val << ";\n";
+      this->EndScope(then_scope);
       this->PrintIndent();
-      this->stream << "if (" << cond << ") {\n";
-      {
-        int then_scope = this->BeginScope();
-        std::string true_val = PrintExpr(op->args[1]);
-        this->PrintIndent();
-        this->stream << result << " = " << true_val << ";\n";
-        this->EndScope(then_scope);
-        this->PrintIndent();
-        this->stream << "} else {\n";
-      }
-      {
-        int else_scope = this->BeginScope();
-        std::string false_val = PrintExpr(op->args[2]);
-        this->PrintIndent();
-        this->stream << result << " = " << false_val << ";\n";
-        this->EndScope(else_scope);
-        this->PrintIndent();
-        this->stream << "}\n";
-      }
-      os << result;
-    } else {
+      this->stream << "} else {\n";
+    }
+    {
+      int else_scope = this->BeginScope();
+      std::string false_val = PrintExpr(op->args[2]);
+      this->PrintIndent();
+      this->stream << result << " = " << false_val << ";\n";
+      this->EndScope(else_scope);
+      this->PrintIndent();
+      this->stream << "}\n";
+    }
+    os << result;
+  } else {
     CodeGenC::VisitExpr_(op, os);
   }
 }
@@ -1094,8 +1094,7 @@ void CodeGenTileLangAscendPto::GMCopyCall(const CallNode *call,
          << getType(local_info.dtype) << ", " << shape_tmpl << ", "
          << stride_tmpl << ", ";
   if (op_name.rfind("copy_gm_to_ub", 0) == 0) {
-    stream << slice_info.slice_row << ", " << slice_info.slice_col
-           << ", ";
+    stream << slice_info.slice_row << ", " << slice_info.slice_col << ", ";
     stream << GetPadEnum(call->args[6]);
   } else if (op_name.rfind("copy_ub_to_gm", 0) == 0) {
     stream << slice_info.slice_row << ", " << slice_info.slice_col;
@@ -1105,8 +1104,7 @@ void CodeGenTileLangAscendPto::GMCopyCall(const CallNode *call,
   stream << ">(";
 
   // gm addr
-  stream << copy_base_addr_map_.at(gm_info.id) << " + "
-         << gm_offset_string;
+  stream << copy_base_addr_map_.at(gm_info.id) << " + " << gm_offset_string;
 
   if (is_dynamic) {
     stream << ", pto::Shape<" << shape_tmpl << ">()"
@@ -1169,14 +1167,14 @@ void CodeGenTileLangAscendPto::CopyL1ToL0Codegen(const CallNode *call,
     std::string src_temp_name = GetTempVarName(src_shape_info.ub_name);
     CreateCubeVariable(src_temp_name, src_shape_info,
                        kAscendPtoScope + "TileMatL1");
-    src_name =   src_temp_name;
+    src_name = src_temp_name;
   }
 
   if (dst_shape_info.is_slice) {
     std::string dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
     CreateCubeVariable(dst_temp_name, dst_shape_info,
                        kAscendPtoScope + tile_name);
-    dst_name  = dst_temp_name;
+    dst_name = dst_temp_name;
   }
 
   this->PrintIndent();
@@ -1185,10 +1183,9 @@ void CodeGenTileLangAscendPto::CopyL1ToL0Codegen(const CallNode *call,
                << dst_shape_info.slice_col << ", " << src_shape_info.slice_row
                << ", " << src_shape_info.slice_col << ">";
 
-    this->stream << "(" << dst_name << ", " << src_name << ", "
-                 << PrintExpr(index_row) << ", " << PrintExpr(index_col)
-                 << ");\n";
-  
+  this->stream << "(" << dst_name << ", " << src_name << ", "
+               << PrintExpr(index_row) << ", " << PrintExpr(index_col)
+               << ");\n";
 }
 
 void CodeGenTileLangAscendPto::CallExternCodegen(const CallNode *op) {
@@ -1443,7 +1440,8 @@ void CodeGenTileLangAscendPto::PowCodegen(const CallNode *op) {
   ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
   ShapeInfo temp_shape_info = GetSliceInfo(op->args[3].as<CallNode>());
 
-  if (src0_shape_info.is_slice || src1_shape_info.is_slice || dst_shape_info.is_slice) {
+  if (src0_shape_info.is_slice || src1_shape_info.is_slice ||
+      dst_shape_info.is_slice) {
     auto src0_temp_name = GetTempVarName(src0_shape_info.ub_name);
     auto src1_temp_name = GetTempVarName(src1_shape_info.ub_name);
     auto dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
@@ -1451,16 +1449,20 @@ void CodeGenTileLangAscendPto::PowCodegen(const CallNode *op) {
     CreateUbVariableND(src1_temp_name, src1_shape_info);
     CreateUbVariableND(dst_temp_name, dst_shape_info);
     this->PrintIndent();
-    this->stream << kAscendPtoScope << "pow" << "<" << dst_shape_info.type << ", "
-               << dst_shape_info.slice_row << ", " << dst_shape_info.slice_col << "," << temp_shape_info.row << ">" 
-               << "(" << dst_temp_name << ", " << src0_temp_name << ", " << src1_temp_name << ", " << temp_shape_info.ub_name
-               << ");\n";
+    this->stream << kAscendPtoScope << "pow" << "<" << dst_shape_info.type
+                 << ", " << dst_shape_info.slice_row << ", "
+                 << dst_shape_info.slice_col << "," << temp_shape_info.row
+                 << ">"
+                 << "(" << dst_temp_name << ", " << src0_temp_name << ", "
+                 << src1_temp_name << ", " << temp_shape_info.ub_name << ");\n";
   } else {
-  this->PrintIndent();
-  this->stream << kAscendPtoScope << "pow" << "<" << dst_shape_info.type << ", "
-               << dst_shape_info.row << ", " << dst_shape_info.col << ", " << temp_shape_info.row << ">"
-               << "(" << dst_shape_info.ub_name << ", " << src0_shape_info.ub_name << ", " << src1_shape_info.ub_name
-               << ", " << temp_shape_info.ub_name << ");\n";
+    this->PrintIndent();
+    this->stream << kAscendPtoScope << "pow" << "<" << dst_shape_info.type
+                 << ", " << dst_shape_info.row << ", " << dst_shape_info.col
+                 << ", " << temp_shape_info.row << ">"
+                 << "(" << dst_shape_info.ub_name << ", "
+                 << src0_shape_info.ub_name << ", " << src1_shape_info.ub_name
+                 << ", " << temp_shape_info.ub_name << ");\n";
   }
 }
 
@@ -1501,8 +1503,9 @@ void CodeGenTileLangAscendPto::XorCodegen(const CallNode *op,
   ShapeInfo src1_shape_info = GetSliceInfo(op->args[2].as<CallNode>());
   ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
   auto tmp_name = PrintExpr(op->args[3].as<CallNode>()->args[1]);
-  
-  if (src0_shape_info.is_slice || src1_shape_info.is_slice || dst_shape_info.is_slice) {
+
+  if (src0_shape_info.is_slice || src1_shape_info.is_slice ||
+      dst_shape_info.is_slice) {
     auto src0_temp_name = GetTempVarName(src0_shape_info.ub_name);
     auto src1_temp_name = GetTempVarName(src1_shape_info.ub_name);
     auto dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
@@ -1510,12 +1513,13 @@ void CodeGenTileLangAscendPto::XorCodegen(const CallNode *op,
     CreateUbVariableND(src1_temp_name, src1_shape_info);
     CreateUbVariableND(dst_temp_name, dst_shape_info);
     this->PrintIndent();
-    this->stream << op_name << "(" << dst_temp_name << ", " << src0_temp_name << ", "
-               << src1_temp_name << ", " << tmp_name << ");\n";
+    this->stream << op_name << "(" << dst_temp_name << ", " << src0_temp_name
+                 << ", " << src1_temp_name << ", " << tmp_name << ");\n";
   } else {
-  this->PrintIndent();
-  this->stream << op_name << "(" << dst_shape_info.ub_name << ", " << src0_shape_info.ub_name << ", "
-               << src1_shape_info.ub_name << ", " << tmp_name << ");\n";
+    this->PrintIndent();
+    this->stream << op_name << "(" << dst_shape_info.ub_name << ", "
+                 << src0_shape_info.ub_name << ", " << src1_shape_info.ub_name
+                 << ", " << tmp_name << ");\n";
   }
 }
 
@@ -1525,7 +1529,8 @@ void CodeGenTileLangAscendPto::CompareCodegen(const CallNode *op,
   ShapeInfo src1_shape_info = GetSliceInfo(op->args[2].as<CallNode>());
   ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
   auto mode = Downcast<StringImm>(op->args[3])->value;
-  if (src0_shape_info.is_slice || src1_shape_info.is_slice || dst_shape_info.is_slice) {
+  if (src0_shape_info.is_slice || src1_shape_info.is_slice ||
+      dst_shape_info.is_slice) {
     auto src0_temp_name = GetTempVarName(src0_shape_info.ub_name);
     auto src1_temp_name = GetTempVarName(src1_shape_info.ub_name);
     auto dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
@@ -1533,12 +1538,15 @@ void CodeGenTileLangAscendPto::CompareCodegen(const CallNode *op,
     CreateUbVariableND(src1_temp_name, src1_shape_info);
     CreateUbVariableND(dst_temp_name, dst_shape_info);
     this->PrintIndent();
-    this->stream << kAscendPtoScope << "compare(" << dst_temp_name << ", " << src0_temp_name << ", " << src1_temp_name
-                 << ", " << "CmpMode::" << mode << ");\n";
+    this->stream << kAscendPtoScope << "compare(" << dst_temp_name << ", "
+                 << src0_temp_name << ", " << src1_temp_name << ", "
+                 << "CmpMode::" << mode << ");\n";
   } else {
-  this->PrintIndent();
-  this->stream << kAscendPtoScope << "compare(" << dst_shape_info.ub_name << ", " << src0_shape_info.ub_name
-               << ", " << src1_shape_info.ub_name << ", " << "CmpMode::" << mode << ");\n";
+    this->PrintIndent();
+    this->stream << kAscendPtoScope << "compare(" << dst_shape_info.ub_name
+                 << ", " << src0_shape_info.ub_name << ", "
+                 << src1_shape_info.ub_name << ", " << "CmpMode::" << mode
+                 << ");\n";
   }
 }
 
@@ -1564,13 +1572,14 @@ void CodeGenTileLangAscendPto::CompareScalarCodegen(
     CreateUbVariableND(src0_temp_name, src0_shape_info);
     CreateUbVariableND(dst_temp_name, dst_shape_info);
     this->PrintIndent();
-    this->stream << kAscendPtoScope << "compare_scalar(" << dst_temp_name << ", " << src0_temp_name << ", " << src1_name
-                 << ", " << "CmpMode::" << mode << ");\n";
+    this->stream << kAscendPtoScope << "compare_scalar(" << dst_temp_name
+                 << ", " << src0_temp_name << ", " << src1_name << ", "
+                 << "CmpMode::" << mode << ");\n";
   } else {
-  this->PrintIndent();
-  this->stream << kAscendPtoScope << "compare_scalar(" << dst_shape_info.ub_name << ", "
-               << src0_shape_info.ub_name << ", " << src1_name << ", " << "CmpMode::" << mode
-               << ");\n";
+    this->PrintIndent();
+    this->stream << kAscendPtoScope << "compare_scalar("
+                 << dst_shape_info.ub_name << ", " << src0_shape_info.ub_name
+                 << ", " << src1_name << ", " << "CmpMode::" << mode << ");\n";
   }
 }
 
@@ -1594,11 +1603,11 @@ void CodeGenTileLangAscendPto::TshCodegen(const CallNode *op,
     CreateUbVariableND(src_temp_name, src0_shape_info);
     CreateUbVariableND(dst_temp_name, dst_shape_info);
     this->PrintIndent();
-    this->stream << op_name << "(" << dst_temp_name << ", " << src_temp_name << ", " << src1_name
-                 << ");\n";
+    this->stream << op_name << "(" << dst_temp_name << ", " << src_temp_name
+                 << ", " << src1_name << ");\n";
   } else {
-    this->stream << op_name << "(" << dst_shape_info.ub_name << ", " << src0_shape_info.ub_name << ", "
-               << src1_name << ");\n";
+    this->stream << op_name << "(" << dst_shape_info.ub_name << ", "
+                 << src0_shape_info.ub_name << ", " << src1_name << ");\n";
   }
 }
 
@@ -1930,13 +1939,13 @@ void CodeGenTileLangAscendPto::ScalarOpCodegen(const CallNode *op,
     CreateUbVariableND(src_temp_name, src_shape_info);
     CreateUbVariableND(dst_temp_name, dst_shape_info);
     this->PrintIndent();
-    this->stream << op_name << "(" << dst_temp_name << ", " << src_temp_name << "," << PrintExpr(op->args[2]) << ");\n";
+    this->stream << op_name << "(" << dst_temp_name << ", " << src_temp_name
+                 << "," << PrintExpr(op->args[2]) << ");\n";
   } else {
     this->PrintIndent();
-    this->stream << op_name << "("
-               << dst_shape_info.ub_name << ", "
-               << src_shape_info.ub_name << ", "
-               << PrintExpr(op->args[2]) << ");\n";
+    this->stream << op_name << "(" << dst_shape_info.ub_name << ", "
+                 << src_shape_info.ub_name << ", " << PrintExpr(op->args[2])
+                 << ");\n";
   }
 }
 
@@ -1961,14 +1970,17 @@ void CodeGenTileLangAscendPto::AxpyCodegen(const CallNode *op) {
     CreateUbVariableND(src_temp_name, src_shape_info);
     CreateUbVariableND(dst_temp_name, dst_shape_info);
     this->PrintIndent();
-    this->stream << kAscendPtoScope << "axpy" << "<" << src_shape_info.type << ", " << src_shape_info.slice_row << 
-      ", " << src_shape_info.slice_col << ">" << "(" << dst_temp_name << ", " << src_temp_name << ", " << scalar << ");\n";
+    this->stream << kAscendPtoScope << "axpy" << "<" << src_shape_info.type
+                 << ", " << src_shape_info.slice_row << ", "
+                 << src_shape_info.slice_col << ">" << "(" << dst_temp_name
+                 << ", " << src_temp_name << ", " << scalar << ");\n";
   } else {
     this->PrintIndent();
-    this->stream << kAscendPtoScope << "axpy" << "<" << dst_shape_info.type << ", "
-                << dst_shape_info.row << ", " << dst_shape_info.col << ">"
-                << "(" << dst_shape_info.ub_name << ", " << src_shape_info.ub_name << ", " << scalar
-                << ");\n";
+    this->stream << kAscendPtoScope << "axpy" << "<" << dst_shape_info.type
+                 << ", " << dst_shape_info.row << ", " << dst_shape_info.col
+                 << ">"
+                 << "(" << dst_shape_info.ub_name << ", "
+                 << src_shape_info.ub_name << ", " << scalar << ");\n";
   }
 }
 
@@ -1996,11 +2008,13 @@ void CodeGenTileLangAscendPto::BinaryVecClampMaxMinOpsCodegen(
       CreateUbVariableND(src_temp_name, src_shape_info);
       CreateUbVariableND(dst_temp_name, dst_shape_info);
       this->PrintIndent();
-      this->stream << operation << "(" << dst_temp_name << ", " << src_temp_name << ", " << scalar_name << ");\n";
+      this->stream << operation << "(" << dst_temp_name << ", " << src_temp_name
+                   << ", " << scalar_name << ");\n";
     } else {
       this->PrintIndent();
-      this->stream << operation << "(" << dst_shape_info.ub_name << ", " << src_shape_info.ub_name << ", " << scalar_name << ");\n";
-    }    
+      this->stream << operation << "(" << dst_shape_info.ub_name << ", "
+                   << src_shape_info.ub_name << ", " << scalar_name << ");\n";
+    }
   } else {
     auto scalar = PrintExpr(op->args[op->args.size() - 2]);
     if (src_shape_info.is_slice || dst_shape_info.is_slice) {
@@ -2009,10 +2023,12 @@ void CodeGenTileLangAscendPto::BinaryVecClampMaxMinOpsCodegen(
       CreateUbVariableND(src_temp_name, src_shape_info);
       CreateUbVariableND(dst_temp_name, dst_shape_info);
       this->PrintIndent();
-      this->stream << operation << "(" << dst_temp_name << ", " << src_temp_name << ", " << scalar << ");\n";
+      this->stream << operation << "(" << dst_temp_name << ", " << src_temp_name
+                   << ", " << scalar << ");\n";
     } else {
       this->PrintIndent();
-      this->stream << operation << "(" << dst_shape_info.ub_name << ", " << src_shape_info.ub_name << ", " << scalar << ");\n";
+      this->stream << operation << "(" << dst_shape_info.ub_name << ", "
+                   << src_shape_info.ub_name << ", " << scalar << ");\n";
     }
   }
 }
@@ -2022,14 +2038,15 @@ void CodeGenTileLangAscendPto::BinaryVecClampOpsCodegen(
   // Extract shape information
   ShapeInfo src_shape_info = GetSliceInfo(op->args[2].as<CallNode>());
   ShapeInfo dst_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
-  
+
   // Get scalar bounds (last two arguments)
   auto scalar_min = PrintExpr(op->args[op->args.size() - 3]);
   auto scalar_max = PrintExpr(op->args[op->args.size() - 2]);
-  
-  // Collect variable names (skip first arg and last 3 args: scalar_min, scalar_max, and one more)
+
+  // Collect variable names (skip first arg and last 3 args: scalar_min,
+  // scalar_max, and one more)
   std::vector<std::string> var_names;
-  var_names.reserve(op->args.size() - 5);  // Pre-allocate memory
+  var_names.reserve(op->args.size() - 5); // Pre-allocate memory
   for (size_t i = 1; i < op->args.size() - 4; ++i) {
     var_names.push_back(PrintBufferOffset(op->args[i].as<CallNode>()));
   }
@@ -2037,27 +2054,28 @@ void CodeGenTileLangAscendPto::BinaryVecClampOpsCodegen(
     // Handle slice case with temporary variables
     std::string src_temp_name = GetTempVarName(src_shape_info.ub_name);
     std::string dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
-    
+
     CreateUbVariableND(src_temp_name, src_shape_info);
     CreateUbVariableND(dst_temp_name, dst_shape_info);
-    
+
     this->PrintIndent();
-    this->stream << "TMAXS(" << dst_temp_name << ", " << src_temp_name 
-                 << ", " << scalar_min << ");\n";
+    this->stream << "TMAXS(" << dst_temp_name << ", " << src_temp_name << ", "
+                 << scalar_min << ");\n";
     this->PrintIndent();
-    this->stream << "TMINS(" << dst_temp_name << ", " << dst_temp_name 
-                 << ", " << scalar_max << ");\n";
+    this->stream << "TMINS(" << dst_temp_name << ", " << dst_temp_name << ", "
+                 << scalar_max << ");\n";
   } else {
     this->PrintIndent();
-    this->stream << "TMAXS(" << dst_shape_info.ub_name << ", " << src_shape_info.ub_name 
-                 << ", " << scalar_min << ");\n";
+    this->stream << "TMAXS(" << dst_shape_info.ub_name << ", "
+                 << src_shape_info.ub_name << ", " << scalar_min << ");\n";
     this->PrintIndent();
-    this->stream << "TMINS(" << dst_shape_info.ub_name << ", " << dst_shape_info.ub_name 
-                 << ", " << scalar_max << ");\n";
+    this->stream << "TMINS(" << dst_shape_info.ub_name << ", "
+                 << dst_shape_info.ub_name << ", " << scalar_max << ");\n";
   }
 }
 
-void CodeGenTileLangAscendPto::SigmoidCodegen(const CallNode *op, const std::string& op_name) {
+void CodeGenTileLangAscendPto::SigmoidCodegen(const CallNode *op,
+                                              const std::string &op_name) {
   std::vector<std::string> var_names;
   for (int i = 0; i < op->args.size() - 2; i++) {
     auto var_name = PrintBufferOffset(op->args[i].as<CallNode>());
@@ -2072,12 +2090,15 @@ void CodeGenTileLangAscendPto::SigmoidCodegen(const CallNode *op, const std::str
     CreateUbVariableND(src_temp_name, src_shape_info);
     CreateUbVariableND(dst_temp_name, dst_shape_info);
     this->PrintIndent();
-    this->stream << kAscendPtoScope << op_name << "<" << src_shape_info.type << ", " << src_shape_info.slice_row 
-    << ", " << src_shape_info.slice_col << ">" << "(" << dst_temp_name << ", " << src_temp_name << ");\n";
+    this->stream << kAscendPtoScope << op_name << "<" << src_shape_info.type
+                 << ", " << src_shape_info.slice_row << ", "
+                 << src_shape_info.slice_col << ">" << "(" << dst_temp_name
+                 << ", " << src_temp_name << ");\n";
   } else {
     this->PrintIndent();
-    this->stream << kAscendPtoScope << op_name << "<" << dst_shape_info.type << ", " 
-    << dst_shape_info.row << ", " << dst_shape_info.col << ">" << "(";
+    this->stream << kAscendPtoScope << op_name << "<" << dst_shape_info.type
+                 << ", " << dst_shape_info.row << ", " << dst_shape_info.col
+                 << ">" << "(";
     for (int i = 0; i < var_names.size(); i++) {
       this->stream << var_names[i];
       if (i != var_names.size() - 1) {
@@ -2877,7 +2898,7 @@ void CodeGenTileLangAscendPto::MmaCodegen(const CallNode *op) {
     std::string a_temp_name = GetTempVarName(a_name);
     CreateCubeVariable(a_temp_name, a_shape_info,
                        kAscendPtoScope + "TileMatL0A");
-    a_name =   a_temp_name;
+    a_name = a_temp_name;
   }
 
   if (b_shape_info.is_slice) {
@@ -2889,8 +2910,7 @@ void CodeGenTileLangAscendPto::MmaCodegen(const CallNode *op) {
 
   if (c_shape_info.is_slice) {
     std::string c_temp_name = GetTempVarName(c_name);
-    CreateCubeVariable(c_temp_name, c_shape_info,
-                       "TileAcc");
+    CreateCubeVariable(c_temp_name, c_shape_info, "TileAcc");
     c_name = c_temp_name;
   }
 

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -861,7 +861,36 @@ void CodeGenTileLangAscendPto::VisitExpr_(const CallNode *op,
     SetDeqScaleCodegen(op);
   } else if (op->op.same_as(tl::ascend_mma())) {
     MmaCodegen(op);
-  } else {
+  } else if (op->op.same_as(builtin::if_then_else())) {
+      // conditional that skips eval if cond evals to false
+      // std::cout<<"here"<<std::endl;
+      std::string result = name_supply_->FreshName("condval");
+      std::string cond = PrintExpr(op->args[0]);
+      this->PrintIndent();
+      PrintType(op->dtype, this->stream);
+      this->stream << " " << result << ";\n";
+      this->PrintIndent();
+      this->stream << "if (" << cond << ") {\n";
+      {
+        int then_scope = this->BeginScope();
+        std::string true_val = PrintExpr(op->args[1]);
+        this->PrintIndent();
+        this->stream << result << " = " << true_val << ";\n";
+        this->EndScope(then_scope);
+        this->PrintIndent();
+        this->stream << "} else {\n";
+      }
+      {
+        int else_scope = this->BeginScope();
+        std::string false_val = PrintExpr(op->args[2]);
+        this->PrintIndent();
+        this->stream << result << " = " << false_val << ";\n";
+        this->EndScope(else_scope);
+        this->PrintIndent();
+        this->stream << "}\n";
+      }
+      os << result;
+    } else {
     CodeGenC::VisitExpr_(op, os);
   }
 }
@@ -1059,17 +1088,17 @@ void CodeGenTileLangAscendPto::GMCopyCall(const CallNode *call,
   if (is_dynamic) {
     op_name += "_dynamic";
   }
-
+  auto gm_offset_string = PrintExpr(gm_info.offset);
   this->PrintIndent();
   stream << kAscendPtoScope << op_name << "<" << getType(gm_info.dtype) << ", "
          << getType(local_info.dtype) << ", " << shape_tmpl << ", "
          << stride_tmpl << ", ";
   if (op_name.rfind("copy_gm_to_ub", 0) == 0) {
-    stream << slice_info.slice_valid_row << ", " << slice_info.slice_valid_col
+    stream << slice_info.slice_row << ", " << slice_info.slice_col
            << ", ";
     stream << GetPadEnum(call->args[6]);
   } else if (op_name.rfind("copy_ub_to_gm", 0) == 0) {
-    stream << slice_info.slice_valid_row << ", " << slice_info.slice_valid_col;
+    stream << slice_info.slice_row << ", " << slice_info.slice_col;
   } else {
     stream << slice_info.slice_valid_row << ", " << slice_info.slice_valid_col;
   }
@@ -1077,7 +1106,7 @@ void CodeGenTileLangAscendPto::GMCopyCall(const CallNode *call,
 
   // gm addr
   stream << copy_base_addr_map_.at(gm_info.id) << " + "
-         << PrintExpr(gm_info.offset);
+         << gm_offset_string;
 
   if (is_dynamic) {
     stream << ", pto::Shape<" << shape_tmpl << ">()"
@@ -1134,26 +1163,32 @@ void CodeGenTileLangAscendPto::CopyL1ToL0Codegen(const CallNode *call,
   PrimExpr index_row = floordiv(src_info.offset, src_info.shape[1]);
   PrimExpr index_col = floormod(src_info.offset, src_info.shape[1]);
 
+  auto src_name = src_shape_info.ub_name;
+  auto dst_name = dst_shape_info.ub_name;
+  if (src_shape_info.is_slice) {
+    std::string src_temp_name = GetTempVarName(src_shape_info.ub_name);
+    CreateCubeVariable(src_temp_name, src_shape_info,
+                       kAscendPtoScope + "TileMatL1");
+    src_name =   src_temp_name;
+  }
+
+  if (dst_shape_info.is_slice) {
+    std::string dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
+    CreateCubeVariable(dst_temp_name, dst_shape_info,
+                       kAscendPtoScope + tile_name);
+    dst_name  = dst_temp_name;
+  }
+
   this->PrintIndent();
   this->stream << kAscendPtoScope << api_name << "<" << src_shape_info.type
                << ", " << dst_shape_info.slice_row << ", "
                << dst_shape_info.slice_col << ", " << src_shape_info.slice_row
-               << ", " << src_shape_info.slice_col << "> ";
-  if (src_shape_info.is_slice || dst_shape_info.is_slice) {
-    std::string src_temp_name = GetTempVarName(src_shape_info.ub_name);
-    std::string dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
-    CreateCubeVariable(src_temp_name, src_shape_info,
-                       kAscendPtoScope + "TileMatL1");
-    CreateCubeVariable(dst_temp_name, dst_shape_info,
-                       kAscendPtoScope + "TileMatL0B");
-    this->stream << "(" << dst_temp_name << ", " << src_temp_name
+               << ", " << src_shape_info.slice_col << ">";
+
+    this->stream << "(" << dst_name << ", " << src_name << ", "
                  << PrintExpr(index_row) << ", " << PrintExpr(index_col)
                  << ");\n";
-  } else {
-    this->stream << "(" << dst_info.id << ", " << src_info.id << ", "
-                 << PrintExpr(index_row) << ", " << PrintExpr(index_col)
-                 << ");\n";
-  }
+  
 }
 
 void CodeGenTileLangAscendPto::CallExternCodegen(const CallNode *op) {
@@ -1919,7 +1954,7 @@ void CodeGenTileLangAscendPto::AxpyCodegen(const CallNode *op) {
     if (dtype0.is_float16()) {
       scalar = "float(" + scalar + ")";
     } else {
-      scalar = getType(dst_info.dtype) + "(" + scalar + ")";
+      scalar = dst_shape_info.type + "(" + scalar + ")";
     }
   }
 
@@ -2001,9 +2036,6 @@ void CodeGenTileLangAscendPto::BinaryVecClampOpsCodegen(
   for (size_t i = 1; i < op->args.size() - 4; ++i) {
     var_names.push_back(PrintBufferOffset(op->args[i].as<CallNode>()));
   }
-  
-  this->PrintIndent();
-  
   if (src_shape_info.is_slice || dst_shape_info.is_slice) {
     // Handle slice case with temporary variables
     std::string src_temp_name = GetTempVarName(src_shape_info.ub_name);
@@ -2012,35 +2044,19 @@ void CodeGenTileLangAscendPto::BinaryVecClampOpsCodegen(
     CreateUbVariableND(src_temp_name, src_shape_info);
     CreateUbVariableND(dst_temp_name, dst_shape_info);
     
-    this->stream << "pipe_barrier(PIPE_ALL);\n";
     this->PrintIndent();
     this->stream << "TMAXS(" << dst_temp_name << ", " << src_temp_name 
                  << ", " << scalar_min << ");\n";
-    this->stream << "pipe_barrier(PIPE_ALL);\n";
     this->PrintIndent();
     this->stream << "TMINS(" << dst_temp_name << ", " << dst_temp_name 
                  << ", " << scalar_max << ");\n";
-    this->stream << "pipe_barrier(PIPE_ALL);\n";
   } else {
-    // Handle non-slice case - clamp_min with TMAXS
-    this->stream << "TMAXS(";
-    for (size_t i = 0; i < var_names.size(); ++i) {
-      this->stream << var_names[i];
-      if (i != var_names.size() - 1) {
-        this->stream << ", ";
-      }
-    }
-    this->stream << ", " << scalar_min << ");\n";
-    
-    // clamp_max with TMINS - fixed the bug where index 1 was incorrectly handled
-    this->stream << "TMINS(";
-    for (size_t i = 0; i < var_names.size(); ++i) {
-      this->stream << var_names[i];
-      if (i != var_names.size() - 1) {
-        this->stream << ", ";
-      }
-    }
-    this->stream << ", " << scalar_max << ");\n";
+    this->PrintIndent();
+    this->stream << "TMAXS(" << dst_shape_info.ub_name << ", " << src_shape_info.ub_name 
+                 << ", " << scalar_min << ");\n";
+    this->PrintIndent();
+    this->stream << "TMINS(" << dst_shape_info.ub_name << ", " << dst_shape_info.ub_name 
+                 << ", " << scalar_max << ");\n";
   }
 }
 
@@ -2086,6 +2102,9 @@ void CodeGenTileLangAscendPto::CastCodegen(const CallNode *op,
   ShapeInfo src_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
   ShapeInfo dst_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
   if (src_shape_info.is_slice || dst_shape_info.is_slice) {
+    this->PrintIndent();
+    this->stream << "set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID1);\n";
+    this->stream << "wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID1);\n";
     std::string src_temp_name = GetTempVarName(src_shape_info.ub_name);
     std::string dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
     CreateUbVariableND(src_temp_name, src_shape_info);
@@ -2839,16 +2858,44 @@ void CodeGenTileLangAscendPto::MmaCodegen(const CallNode *op) {
   if (pos != std::string::npos) {
     s.insert(pos, ", " + k);
   }
-
   std::string op_name = kAscendPtoScope + s;
 
   auto a_var = op->args[1].as<CallNode>()->args[1].as<VarNode>();
   auto b_var = op->args[2].as<CallNode>()->args[1].as<VarNode>();
   auto c_var = op->args[3].as<CallNode>()->args[1].as<VarNode>();
 
-  auto a_name = var_idmap_[a_var];
-  auto b_name = var_idmap_[b_var];
-  auto c_name = var_idmap_[c_var];
+  BufferInfo a_info = GetBufferInfo(op->args[1]);
+  BufferInfo b_info = GetBufferInfo(op->args[2]);
+  BufferInfo c_info = GetBufferInfo(op->args[3]);
+
+  ShapeInfo a_shape_info = GetSliceInfo(a_info.access_ptr);
+  ShapeInfo b_shape_info = GetSliceInfo(b_info.access_ptr);
+  ShapeInfo c_shape_info = GetSliceInfo(c_info.access_ptr);
+
+  auto a_name = a_shape_info.ub_name;
+  auto b_name = b_shape_info.ub_name;
+  auto c_name = c_shape_info.ub_name;
+
+  if (a_shape_info.is_slice) {
+    std::string a_temp_name = GetTempVarName(a_name);
+    CreateCubeVariable(a_temp_name, a_shape_info,
+                       kAscendPtoScope + "TileMatL0A");
+    a_name =   a_temp_name;
+  }
+
+  if (b_shape_info.is_slice) {
+    std::string b_temp_name = GetTempVarName(b_name);
+    CreateCubeVariable(b_temp_name, b_shape_info,
+                       kAscendPtoScope + "TileMatL0B");
+    b_name = b_temp_name;
+  }
+
+  if (c_shape_info.is_slice) {
+    std::string c_temp_name = GetTempVarName(c_name);
+    CreateCubeVariable(c_temp_name, c_shape_info,
+                       "TileAcc");
+    c_name = c_temp_name;
+  }
 
   this->PrintIndent();
   this->stream << op_name << "(" << a_name << ", " << b_name << ", " << c_name

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -1517,7 +1517,7 @@ void CodeGenTileLangAscendPto::CompareScalarCodegen(
   std::string dst_name = PrintExpr(op->args[0].as<CallNode>()->args[1]);
   std::string src0_name = PrintExpr(op->args[1].as<CallNode>()->args[1]);
 
-  DataType src_dtype = op->args[1].as<CallNode>()->dtype;
+  DataType src_dtype = GetAccessPtrDtypePto(op->args[1].as<CallNode>());
   DataType scalar_dtype = op->args[2].dtype();
   if (scalar_dtype != src_dtype) {
     std::string target_type = getType(src_dtype);
@@ -1546,7 +1546,7 @@ void CodeGenTileLangAscendPto::TshCodegen(const CallNode *op,
   ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
   auto src1_name = PrintExpr(op->args[2]);
 
-  DataType src_dtype = op->args[1].as<CallNode>()->dtype;
+  DataType src_dtype = GetAccessPtrDtypePto(op->args[1].as<CallNode>());
   DataType scalar_dtype = op->args[2].dtype();
 
   if (scalar_dtype != src_dtype) {
@@ -1913,7 +1913,7 @@ void CodeGenTileLangAscendPto::AxpyCodegen(const CallNode *op) {
   ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
   auto scalar = PrintExpr(op->args[2]);
 
-  DataType dtype0 = op->args[0].as<CallNode>()->dtype;
+  DataType dtype0 = GetAccessPtrDtypePto(op->args[0].as<CallNode>());
   DataType scalar_dtype = op->args[2].dtype();
   if (scalar_dtype != dtype0) {
     if (dtype0.is_float16()) {
@@ -1986,26 +1986,61 @@ void CodeGenTileLangAscendPto::BinaryVecClampMaxMinOpsCodegen(
 }
 
 void CodeGenTileLangAscendPto::BinaryVecClampOpsCodegen(
-  const CallNode *op, const std::string &op_name) {
+    const CallNode *op, const std::string &op_name) {
+  // Extract shape information
   ShapeInfo src_shape_info = GetSliceInfo(op->args[2].as<CallNode>());
   ShapeInfo dst_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+  
+  // Get scalar bounds (last two arguments)
   auto scalar_min = PrintExpr(op->args[op->args.size() - 3]);
   auto scalar_max = PrintExpr(op->args[op->args.size() - 2]);
-
+  
+  // Collect variable names (skip first arg and last 3 args: scalar_min, scalar_max, and one more)
+  std::vector<std::string> var_names;
+  var_names.reserve(op->args.size() - 5);  // Pre-allocate memory
+  for (size_t i = 1; i < op->args.size() - 4; ++i) {
+    var_names.push_back(PrintBufferOffset(op->args[i].as<CallNode>()));
+  }
+  
+  this->PrintIndent();
+  
   if (src_shape_info.is_slice || dst_shape_info.is_slice) {
+    // Handle slice case with temporary variables
     std::string src_temp_name = GetTempVarName(src_shape_info.ub_name);
     std::string dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
+    
     CreateUbVariableND(src_temp_name, src_shape_info);
     CreateUbVariableND(dst_temp_name, dst_shape_info);
+    
+    this->stream << "pipe_barrier(PIPE_ALL);\n";
     this->PrintIndent();
-    this->stream << "TMAXS" << "(" << dst_temp_name << ", " << src_temp_name << "," << scalar_min << ");\n";
+    this->stream << "TMAXS(" << dst_temp_name << ", " << src_temp_name 
+                 << ", " << scalar_min << ");\n";
+    this->stream << "pipe_barrier(PIPE_ALL);\n";
     this->PrintIndent();
-    this->stream << "TMINS" << "(" << dst_temp_name << ", " << src_temp_name << "," << scalar_max << ");\n";
+    this->stream << "TMINS(" << dst_temp_name << ", " << dst_temp_name 
+                 << ", " << scalar_max << ");\n";
+    this->stream << "pipe_barrier(PIPE_ALL);\n";
   } else {
-    this->PrintIndent();
-    this->stream << "TMAXS" << "(" << dst_shape_info.ub_name << ", " << src_shape_info.ub_name << "," << scalar_min << ");\n";
-    this->PrintIndent();
-    this->stream << "TMINS" << "(" << dst_shape_info.ub_name << ", " << src_shape_info.ub_name << "," << scalar_max << ");\n";
+    // Handle non-slice case - clamp_min with TMAXS
+    this->stream << "TMAXS(";
+    for (size_t i = 0; i < var_names.size(); ++i) {
+      this->stream << var_names[i];
+      if (i != var_names.size() - 1) {
+        this->stream << ", ";
+      }
+    }
+    this->stream << ", " << scalar_min << ");\n";
+    
+    // clamp_max with TMINS - fixed the bug where index 1 was incorrectly handled
+    this->stream << "TMINS(";
+    for (size_t i = 0; i < var_names.size(); ++i) {
+      this->stream << var_names[i];
+      if (i != var_names.size() - 1) {
+        this->stream << ", ";
+      }
+    }
+    this->stream << ", " << scalar_max << ");\n";
   }
 }
 
@@ -2772,24 +2807,8 @@ void CodeGenTileLangAscendPto::SelectCodegen(const CallNode *op) {
     src1_name = PrintBufferOffset(op->args[4].as<CallNode>());
     op_name = "TSEL";
   } else if (src1_type == 1) {
-    std::string scalar_value = PrintExpr(op->args[4]);
-    std::string temp_name = GetTempVarName("select_scalar_tmp");
-    this->PrintIndent();
-    this->stream << kAscendPtoScope << "TileUbDataND<" << src0_type << ", "
-                 << dst_shape_info.slice_row << ", " << dst_shape_info.slice_col
-                 << ", " << dst_shape_info.slice_valid_row << ", "
-                 << dst_shape_info.slice_valid_col << "> " << temp_name
-                 << ";\n";
-    this->PrintIndent();
-    this->stream << "TASSIGN(" << temp_name << ", " << dst_shape_info.first_addr
-                 << " + " << dst_shape_info.offset << " * "
-                 << GetTypeLen(src0_type) << ");\n";
-    this->PrintIndent();
-    this->stream << kAscendPtoScope << "fill_scalar(" << temp_name
-                 << ", static_cast<" << src0_type << ">(" << scalar_value
-                 << "));\n";
-    src1_name = temp_name;
-    op_name = "TSEL";
+    src1_name = PrintExpr(op->args[4]);
+    op_name = "TSELS";
   } else {
     LOG(FATAL) << "CodeGenAscendPto: Select currently only supports "
                   "src1_type=2 (Tensor-Tensor mode). "

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -1883,11 +1883,8 @@ void CodeGenTileLangAscendPto::BinaryVecOpsCodegen(const CallNode *op,
                  << applied_scalar << ");\n";
   } else {
     this->PrintIndent();
-    this->stream << operation << "(";
-    for (const auto &name : var_names) {
-      this->stream << name << ", ";
-    }
-    this->stream << applied_scalar << ");\n";
+    this->stream << operation << "(" << var_names[0] << ", " << var_names[1]
+                 << ", " << applied_scalar << ");\n";
   }
 }
 

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -1417,15 +1417,15 @@ void CodeGenTileLangAscendPto::PowCodegen(const CallNode *op) {
     CreateUbVariableND(dst_temp_name, dst_shape_info);
     this->PrintIndent();
     this->stream << kAscendPtoScope << "pow" << "<" << dst_shape_info.type << ", "
-               << dst_shape_info.slice_row << ", " << dst_shape_info.slice_col << "," << temp_shape_info.row ">"
-               << "(" << dst_temp_name << ", " << src0_temp_name << ", " << src1_temp_name << ", " << temp_shape_info.ub_name <<
+               << dst_shape_info.slice_row << ", " << dst_shape_info.slice_col << "," << temp_shape_info.row << ">" 
+               << "(" << dst_temp_name << ", " << src0_temp_name << ", " << src1_temp_name << ", " << temp_shape_info.ub_name
                << ");\n";
   } else {
   this->PrintIndent();
   this->stream << kAscendPtoScope << "pow" << "<" << dst_shape_info.type << ", "
                << dst_shape_info.row << ", " << dst_shape_info.col << ", " << temp_shape_info.row << ">"
                << "(" << dst_shape_info.ub_name << ", " << src0_shape_info.ub_name << ", " << src1_shape_info.ub_name
-               << ", " << temp_shape_info.bu_name << ");\n";
+               << ", " << temp_shape_info.ub_name << ");\n";
   }
 }
 
@@ -1544,7 +1544,7 @@ void CodeGenTileLangAscendPto::TshCodegen(const CallNode *op,
   this->PrintIndent();
   ShapeInfo src0_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
   ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
-  auto src1_name = op->args[2].as<IntImmNode>()->value;
+  auto src1_name = PrintExpr(op->args[2]);
 
   DataType src_dtype = op->args[1].as<CallNode>()->dtype;
   DataType scalar_dtype = op->args[2].dtype();

--- a/src/tl_templates/pto/common.h
+++ b/src/tl_templates/pto/common.h
@@ -767,15 +767,15 @@ pow(TileUbDataND<T, row, col, row, col> &dst,
   pto::TASSIGN(src1_float, reinterpret_cast<uint64_t>(tmp_float0));
 
   pto::TCVT(src0_float, src0, pto::RoundMode::CAST_ROUND);
-
+  pipe_barrier(PIPE_V);
   pto::TLOG(log_src0_float, src0_float);
-
+  pipe_barrier(PIPE_V);    
   pto::TCVT(src1_float, src1, pto::RoundMode::CAST_ROUND);
-
+  pipe_barrier(PIPE_V);
   pto::TMUL(log_src0_float, log_src0_float, src1_float);
-
+  pipe_barrier(PIPE_V);
   pto::TEXP(log_src0_float, log_src0_float);
-
+  pipe_barrier(PIPE_V);
   pto::TCVT(dst, log_src0_float, pto::RoundMode::CAST_ROUND);
 }
 

--- a/src/tl_templates/pto/common.h
+++ b/src/tl_templates/pto/common.h
@@ -740,7 +740,9 @@ pow(TileUbDataND<T, row, col, row, col> &dst,
     TileUbDataND<T, row, col, row, col> &src1,
     TileUbDataND<uint8_t, tmp_rows, col, tmp_rows, col> &tmp) {
   TLOG(src0, src0);
+  pipe_barrier(PIPE_V);
   TMUL(dst, src0, src1);
+  pipe_barrier(PIPE_V);
   TEXP(dst, dst);
 }
 

--- a/src/tl_templates/pto/common.h
+++ b/src/tl_templates/pto/common.h
@@ -769,7 +769,7 @@ pow(TileUbDataND<T, row, col, row, col> &dst,
   pto::TCVT(src0_float, src0, pto::RoundMode::CAST_ROUND);
   pipe_barrier(PIPE_V);
   pto::TLOG(log_src0_float, src0_float);
-  pipe_barrier(PIPE_V);    
+  pipe_barrier(PIPE_V);
   pto::TCVT(src1_float, src1, pto::RoundMode::CAST_ROUND);
   pipe_barrier(PIPE_V);
   pto::TMUL(log_src0_float, log_src0_float, src1_float);

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -425,7 +425,7 @@ def run_test_axpy_slice(M, N, block_M, block_N, target):
     torch.testing.assert_close(b, ref_b, rtol=1e-2, atol=1e-2)
 
 
-@pytest.mark.parametrize("target", ["ascendc"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
 @pytest.mark.parametrize("shape", [(1024, 1024)])
 def test_axpy_slice(target, shape):
     M, N = shape

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -58,8 +58,8 @@ def vec_abs(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -105,9 +105,9 @@ def vec_add_auto_copy(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
-        C: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
+        C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -175,9 +175,9 @@ def vec_add_developer(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
-        C: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
+        C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -236,8 +236,8 @@ def adds(M, N, block_M, block_N, scalar, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
             bx = cid // n_num
@@ -292,9 +292,9 @@ def bitwise_and(M, N, block_M, block_N, dtype="int16"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
-        C: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
+        C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -342,8 +342,8 @@ def axpy(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -392,8 +392,8 @@ def axpy_slice(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -440,10 +440,10 @@ def bilinear_interpolation(mask, h_repeat, repeat_mode, dst_blk_stride, v_r_offs
 
     @T.prim_func
     def main(
-        src0: T.Tensor((src0.shape[0], src0.shape[1]), "float16"),
-        src0_offset: T.Tensor((src0offset.shape[0], src0offset.shape[1]), "uint32"),
-        src1: T.Tensor((src1.shape[0], src1.shape[1]), "float16"),
-        dst: T.Tensor((src0.shape[0], src0.shape[1] // 2), "float16"),
+        src0: T.Tensor((src0.shape[0], src0.shape[1]), "float16"), # type: ignore
+        src0_offset: T.Tensor((src0offset.shape[0], src0offset.shape[1]), "uint32"), # type: ignore
+        src1: T.Tensor((src1.shape[0], src1.shape[1]), "float16"), # type: ignore
+        dst: T.Tensor((src0.shape[0], src0.shape[1] // 2), "float16"), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             src0_ub = T.alloc_ub((src0.shape[0] // VEC_NUM, src0.shape[1]), "float16")
@@ -557,8 +557,8 @@ def bitwise_lshift(M, N, block_M, block_N, scalarvalue, dtype="int32"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -616,8 +616,8 @@ def bitwise_lshift_slice(M, N, block_M, block_N, scalarvalue, dtype="int32"):
 
     @T.prim_func
     def main(
-            A: T.Tensor((M, N), dtype),
-            B: T.Tensor((M, N), dtype),
+            A: T.Tensor((M, N), dtype), # type: ignore
+            B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -676,8 +676,8 @@ def bitwise_not(M, N, block_M, block_N, dtype="int16"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -730,8 +730,8 @@ def bitwise_rshift(M, N, block_M, block_N, scalarvalue, dtype="int32"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -794,8 +794,8 @@ def bitwise_rshift_slice(M, N, block_M, block_N, scalarvalue, dtype="int32"):
 
     @T.prim_func
     def main(
-            A: T.Tensor((M, N), dtype),
-            B: T.Tensor((M, N), dtype),
+            A: T.Tensor((M, N), dtype), # type: ignore
+            B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -858,9 +858,9 @@ def bitwise_xor(M, N, block_M, block_N, dtype="int16"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
-        C: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
+        C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -917,9 +917,9 @@ def bitwise_xor_slice(M, N, block_M, block_N, dtype="int16"):
 
     @T.prim_func
     def main(
-            A: T.Tensor((M, N), dtype),
-            B: T.Tensor((M, N), dtype),
-            C: T.Tensor((M, N), dtype),
+            A: T.Tensor((M, N), dtype), # type: ignore
+            B: T.Tensor((M, N), dtype), # type: ignore
+            C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -976,8 +976,8 @@ def block_reduce_max(M, N, block_M, block_N, repeat, mask, dstRepStride, srcBlkS
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N // dataBlockNum), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N // dataBlockNum), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -1043,8 +1043,8 @@ def block_reduce_min(M, N, block_M, block_N, repeat, mask, dstRepStride, srcBlkS
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N // dataBlockNum), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N // dataBlockNum), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -1112,8 +1112,8 @@ def block_reduce_sum(M, N, block_M, block_N, repeat, mask, dstRepStride, srcBlkS
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N // dataBlockNum), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N // dataBlockNum), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -1181,8 +1181,8 @@ def cast(M, N, block_M, block_N, mode, count):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), "float"),
-        B: T.Tensor((M, N), "float"),
+        A: T.Tensor((M, N), "float"), # type: ignore
+        B: T.Tensor((M, N), "float"), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -1231,8 +1231,8 @@ def cast_slice(M, N, block_M, block_N, mode, count):
 
     @T.prim_func
     def main(
-            A: T.Tensor((M, N), "float"),
-            B: T.Tensor((M, N), "float"),
+            A: T.Tensor((M, N), "float"), # type: ignore
+            B: T.Tensor((M, N), "float"), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -1280,8 +1280,8 @@ def cast_scale(M, N, block_M, block_N, mode, count, scale):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), "int32"),
-        B: T.Tensor((M, N), "float16"),
+        A: T.Tensor((M, N), "int32"), # type: ignore
+        B: T.Tensor((M, N), "float16"), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -1334,8 +1334,8 @@ def clamp(M, N, block_M, block_N, max_val, min_val, dtype="float16"):
 
     @T.prim_func
     def main(
-        input: T.Tensor((M, N), dtype),
-        output: T.Tensor((M, N), dtype),
+        input: T.Tensor((M, N), dtype), # type: ignore
+        output: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(num_blocks, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -1389,8 +1389,8 @@ def clamp_slice(M, N, block_M, block_N, max_val, min_val, dtype="float16"):
 
     @T.prim_func
     def main(
-            input: T.Tensor((M, N), dtype),
-            output: T.Tensor((M, N), dtype),
+            input: T.Tensor((M, N), dtype), # type: ignore
+            output: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(num_blocks, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -1443,9 +1443,9 @@ def compare(M, N, block_M, block_N, mode, dtype="float", out_dtype="uint8"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
-        C: T.Tensor((M, N // 8), out_dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
+        C: T.Tensor((M, N // 8), out_dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -1558,9 +1558,9 @@ def compare_slice(M, N, block_M, block_N, mode, dtype="float", out_dtype="uint8"
 
     @T.prim_func
     def main(
-            A: T.Tensor((M, N), dtype),
-            B: T.Tensor((M, N), dtype),
-            C: T.Tensor((M, N // 8), out_dtype),
+            A: T.Tensor((M, N), dtype), # type: ignore
+            B: T.Tensor((M, N), dtype), # type: ignore
+            C: T.Tensor((M, N // 8), out_dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -1615,7 +1615,7 @@ def compare_scalar(M, N, block_M, block_N, mode, b_scalar, dtype="float", out_dt
     VEC_NUM = 2
 
     @T.prim_func
-    def main(A: T.Tensor((M, N), dtype), C: T.Tensor((M, N // 8), out_dtype)):
+    def main(A: T.Tensor((M, N), dtype), C: T.Tensor((M, N // 8), out_dtype)): # type: ignore
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
             by = cid % n_num
@@ -1709,8 +1709,8 @@ def compare_scalar_slice(M, N, block_M, block_N, mode, b_scalar, dtype="float", 
 
     @T.prim_func
     def main(
-            A: T.Tensor((M, N), dtype),
-            C: T.Tensor((M, N // 8), out_dtype)
+            A: T.Tensor((M, N), dtype), # type: ignore
+            C: T.Tensor((M, N // 8), out_dtype) # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -1768,8 +1768,8 @@ def cos(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor([M, N], dtype),
-        B: T.Tensor([M, N], dtype),
+        A: T.Tensor([M, N], dtype), # type: ignore
+        B: T.Tensor([M, N], dtype), # type: ignore
     ):
         T.func_attr({"enable_auto_sync": True})
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
@@ -1817,8 +1817,8 @@ def cos_slice(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-            A: T.Tensor([M, N], dtype),
-            B: T.Tensor([M, N], dtype),
+            A: T.Tensor([M, N], dtype), # type: ignore
+            B: T.Tensor([M, N], dtype), # type: ignore
     ):
         T.func_attr({"enable_auto_sync": True})
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
@@ -1865,7 +1865,7 @@ def createvecindex(M, N, block_M, block_N, firstValue, dtype="int32"):
 
     @T.prim_func
     def main(
-        C: T.Tensor((M, N), dtype),
+        C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -1940,9 +1940,9 @@ def vec_div(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
-        C: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
+        C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -1995,8 +1995,8 @@ def exp(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -2042,7 +2042,7 @@ def fill(M, N, block_M, block_N, dtype="float"):
     n_num = N // block_N
 
     @T.prim_func
-    def main(A: T.Tensor((M, N), dtype)):
+    def main(A: T.Tensor((M, N), dtype)): # type: ignore
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
             bx = cid // n_num
             by = cid % n_num
@@ -2083,9 +2083,9 @@ def gather(M, N, block_M, block_N, dtype="int32"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), "uint32"),
-        C: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), "uint32"), # type: ignore
+        C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -2175,7 +2175,7 @@ def test_gather(dtype, target, shape):
     block_N = N
     run_test_gather(M, N, block_M, block_N, dtype, target)
 
-def gather(M, N, block_M, block_N, dtype="int32"):
+def gather(M, N, block_M, block_N, dtype="int32"):  # noqa: F811
     m_num = M // block_M
     n_num = N // block_N
 
@@ -2183,9 +2183,9 @@ def gather(M, N, block_M, block_N, dtype="int32"):
 
     @T.prim_func
     def main(
-            A: T.Tensor((M, N), dtype),
-            B: T.Tensor((M, N), "uint32"),
-            C: T.Tensor((M, N), dtype),
+            A: T.Tensor((M, N), dtype), # type: ignore
+            B: T.Tensor((M, N), "uint32"), # type: ignore
+            C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -2212,9 +2212,9 @@ def gather_slice(M, N, block_M, block_N, dtype="int32"):
 
     @T.prim_func
     def main(
-            A: T.Tensor((M, N), dtype),
-            B: T.Tensor((M, N), "uint32"),
-            C: T.Tensor((M, N), dtype),
+            A: T.Tensor((M, N), dtype), # type: ignore
+            B: T.Tensor((M, N), "uint32"), # type: ignore
+            C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -2299,9 +2299,9 @@ def gatherb(M, N, block_M, block_N, b_len, repeat_time, dtype="uint16"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, b_len), "uint32"),
-        C: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, b_len), "uint32"), # type: ignore
+        C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -2386,8 +2386,8 @@ def leaky_relu(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -2438,8 +2438,8 @@ def leaky_relu_slice(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-            A: T.Tensor((M, N), dtype),
-            B: T.Tensor((M, N), dtype),
+            A: T.Tensor((M, N), dtype), # type: ignore
+            B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -2491,8 +2491,8 @@ def ln(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -2543,8 +2543,8 @@ def gathermask_fixed_mode(M, N, block_M, block_N, dtype="int32"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -2611,9 +2611,9 @@ def gathermask_custom_mode(M, N, block_M, block_N, dtype="int32"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        idx: T.Tensor((1, 8), "uint32"),
-        B: T.Tensor((M, 8), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        idx: T.Tensor((1, 8), "uint32"), # type: ignore
+        B: T.Tensor((M, 8), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -2665,9 +2665,9 @@ def vec_max(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
-        C: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
+        C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -2729,8 +2729,8 @@ def vec_maxs(M, N, block_M, block_N, scalar, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
             bx = cid // n_num
@@ -2790,9 +2790,9 @@ def vec_min(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
-        C: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
+        C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -2854,8 +2854,8 @@ def vec_mins(M, N, block_M, block_N, scalar, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
             bx = cid // n_num
@@ -2915,9 +2915,9 @@ def vec_mul(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
-        C: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
+        C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -2979,8 +2979,8 @@ def vec_muls(M, N, block_M, block_N, scalar, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
             bx = cid // n_num
@@ -3038,9 +3038,9 @@ def bitwise_or(M, N, block_M, block_N, dtype="int16"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
-        C: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
+        C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -3095,9 +3095,9 @@ def vec_pow(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
-        C: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
+        C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -3162,9 +3162,9 @@ def vec_pow_slice(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-            A: T.Tensor((M, N), dtype),
-            B: T.Tensor((M, N), dtype),
-            C: T.Tensor((M, N), dtype),
+            A: T.Tensor((M, N), dtype), # type: ignore
+            B: T.Tensor((M, N), dtype), # type: ignore
+            C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -3227,8 +3227,8 @@ def reciprocal(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -3277,8 +3277,8 @@ def relu(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -3338,8 +3338,8 @@ def rsqrt(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -3388,10 +3388,10 @@ def vec_select(M, N, block_M, block_N, mode, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
-        MASK: T.Tensor((M, N // 8), "uint8"),
-        C: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
+        MASK: T.Tensor((M, N // 8), "uint8"), # type: ignore
+        C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -3484,9 +3484,9 @@ def vec_select_scalar(M, N, block_M, block_N, mode, b_scalar, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        MASK: T.Tensor((M, N // 8), "uint8"),
-        C: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        MASK: T.Tensor((M, N // 8), "uint8"), # type: ignore
+        C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -3577,8 +3577,8 @@ def sin(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor([M, N], dtype),
-        B: T.Tensor([M, N], dtype),
+        A: T.Tensor([M, N], dtype), # type: ignore
+        B: T.Tensor([M, N], dtype), # type: ignore
     ):
         T.func_attr({"enable_auto_sync": True})
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
@@ -3625,8 +3625,8 @@ def sin_slice(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-            A: T.Tensor([M, N], dtype),
-            B: T.Tensor([M, N], dtype),
+            A: T.Tensor([M, N], dtype), # type: ignore
+            B: T.Tensor([M, N], dtype), # type: ignore
     ):
         T.func_attr({"enable_auto_sync": True})
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
@@ -3673,9 +3673,9 @@ def sort32(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), "uint32"),
-        C: T.Tensor((M, out_size_multiplier * N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), "uint32"), # type: ignore
+        C: T.Tensor((M, out_size_multiplier * N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -3771,8 +3771,8 @@ def sqrt(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -3821,9 +3821,9 @@ def vec_sub(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
-        C: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
+        C: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -3944,8 +3944,8 @@ def test_vec_subs(dtype, target, shape):
 def transpose(M, N, block_M, block_N, dtype="int16"):
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N), dtype), # type: ignore
     ):
         with T.Kernel(1, is_npu=True) as (cid, vid):
             a_ub = T.alloc_ub((M, N), dtype)
@@ -4006,8 +4006,8 @@ def wholereducemax(M, N, block_M, block_N, mask, repeatTimes, dstRepStride, srcB
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, 2 * N // mask), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, 2 * N // mask), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -4073,8 +4073,8 @@ def wholereducemin(M, N, block_M, block_N, mask, repeatTimes, dstRepStride, srcB
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, 2 * N // mask), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, 2 * N // mask), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -4140,8 +4140,8 @@ def wholereducesum(M, N, block_M, block_N, mask, repeatTimes, dstRepStride, srcB
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M, N // mask), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M, N // mask), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -4201,7 +4201,7 @@ def generate_arithmetic_progression(N, block_size, dtype="int32"):
 
     @T.prim_func
     def main(
-        output: T.Tensor((N,), dtype),
+        output: T.Tensor((N,), dtype), # type: ignore
     ):
         with T.Kernel(num_blocks, is_npu=True) as (cid, _):
             start_idx = cid * block_size
@@ -4245,8 +4245,8 @@ def reduce_sum(M, N, block_M, block_N, dim, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -4302,8 +4302,8 @@ def reduce_max(M, N, block_M, block_N, dim, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -4357,8 +4357,8 @@ def reduce_min(M, N, block_M, block_N, dim, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((M), dtype),
+        A: T.Tensor((M, N), dtype), # type: ignore
+        B: T.Tensor((M), dtype), # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -1427,7 +1427,7 @@ def run_test_clamp_slice(M, N, max_val, min_val, thresh, dtype, target, block_M=
 
 
 @pytest.mark.parametrize("dtype", ["float", "float16"])
-@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("target", ["ascendc"])
 def test_clamp_slice(dtype, target):
     M, N = 1024, 1024
     thresh = 10000

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -404,13 +404,12 @@ def axpy_slice(M, N, block_M, block_N, dtype="float"):
             T.tile.fill(b_ub, 0)
 
             T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
-
-            T.tile.axpy(b_ub, a_ub, 2.0)
+            for i in range(block_M // VEC_NUM):
+                T.tile.axpy(b_ub[i, :], a_ub[i, :], 2.0)
 
             T.copy(b_ub, B[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
 
     return main
-
 
 def run_test_axpy_slice(M, N, block_M, block_N, target):
     func = axpy_slice(M, N, block_M, block_N)
@@ -609,6 +608,65 @@ def test_bitwise_lshift(dtype, target, shape):
     scalarvalue = random.randint(1, max_shift)
     run_test_bitwise_lshift(M, N, 128, 256, scalarvalue=scalarvalue, dtype=dtype, target=target)
 
+def bitwise_lshift_slice(M, N, block_M, block_N, scalarvalue, dtype="int32"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    VEC_NUM = 2
+
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, N), dtype),
+            B: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            for i in range(block_M // VEC_NUM):
+                T.tile.bitwise_lshift(b_ub[i, :], a_ub[i, :], scalarvalue)
+
+            T.copy(b_ub, B[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    return main
+
+
+def run_test_bitwise_lshift_slice(M, N, block_M, block_N, scalarvalue, dtype, target):
+    func = bitwise_lshift_slice(M, N, block_M, block_N, scalarvalue, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch_dtype_map = {
+        "int16": torch.int16,
+        "int32": torch.int32,
+        "uint16": torch.uint16,
+        "uint32": torch.uint32,
+    }
+    torch_dtype = torch_dtype_map[dtype]
+    a = torch.randint(low=1, high=101, size=(M, N), dtype=torch_dtype).npu()
+
+    torch.npu.synchronize()
+
+    b = func(a)
+
+    # Compute reference on CPU to avoid NPU dtype limitations
+    a_cpu = a.cpu()
+    ref_b = (pow(2, scalarvalue) * a_cpu).npu()
+
+    assert_close_npu(b, ref_b, dtype, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["int16", "int32", "uint16", "uint32"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("shape", [(1024, 1024)])
+def test_bitwise_lshift_slice(dtype, target, shape):
+    M, N = shape
+    max_shift = 16 if dtype in ["int16", "uint16"] else 32
+    scalarvalue = random.randint(1, max_shift)
+    run_test_bitwise_lshift_slice(M, N, 128, 256, scalarvalue=scalarvalue, dtype=dtype, target=target)
 
 def bitwise_not(M, N, block_M, block_N, dtype="int16"):
     m_num = M // block_M
@@ -728,6 +786,69 @@ def test_bitwise_rshift(dtype, target, shape):
     scalarvalue = random.randint(1, max_shift)
     run_test_bitwise_rshift(M, N, 128, 256, scalarvalue=scalarvalue, dtype=dtype, target=target)
 
+def bitwise_rshift_slice(M, N, block_M, block_N, scalarvalue, dtype="int32"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    VEC_NUM = 2
+
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, N), dtype),
+            B: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            for i in range(block_M // VEC_NUM):
+                T.tile.bitwise_rshift(b_ub[i, :], a_ub[i, :], scalarvalue)
+
+            T.copy(b_ub, B[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    return main
+
+
+def run_test_bitwise_rshift_slice(M, N, block_M, block_N, scalarvalue, dtype, target):
+    func = bitwise_rshift_slice(M, N, block_M, block_N, scalarvalue, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch_dtype_map = {
+        "int16": torch.int16,
+        "int32": torch.int32,
+        "uint16": torch.uint16,
+        "uint32": torch.uint32,
+    }
+    torch_dtype = torch_dtype_map[dtype]
+    a = torch.randint(low=1, high=101, size=(M, N), dtype=torch_dtype).npu()
+
+    torch.npu.synchronize()
+
+    b = func(a)
+
+    a_cpu = a.cpu()
+    if dtype == "uint16":
+        ref_b = (a_cpu.to(torch.int32) >> scalarvalue).to(torch.uint16).npu()
+    elif dtype == "uint32":
+        ref_b = (a_cpu.to(torch.int64) >> scalarvalue).to(torch.uint32).npu()
+    else:
+        ref_b = (a_cpu >> scalarvalue).npu()
+
+    assert_close_npu(b, ref_b, dtype, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["int16", "int32", "uint16", "uint32"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("shape", [(1024, 1024)])
+def test_bitwise_rshift_slice(dtype, target, shape):
+    M, N = shape
+    max_shift = 16 if dtype in ["int16", "uint16"] else 32
+    scalarvalue = random.randint(1, max_shift)
+    run_test_bitwise_rshift_slice(M, N, 128, 256, scalarvalue=scalarvalue, dtype=dtype, target=target)
 
 def bitwise_xor(M, N, block_M, block_N, dtype="int16"):
     m_num = M // block_M
@@ -788,6 +909,64 @@ def test_bitwise_xor(dtype, target, shape):
     M, N = shape
     run_test_bitwise_xor(M, N, 128, 256, dtype, target)
 
+def bitwise_xor_slice(M, N, block_M, block_N, dtype="int16"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    VEC_NUM = 2
+
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, N), dtype),
+            B: T.Tensor((M, N), dtype),
+            C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            tmp_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+            for i in range(block_M // VEC_NUM):
+                T.tile.bitwise_xor(c_ub[i, :], a_ub[i, :], b_ub[i, :], tmp_ub)
+
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    return main
+
+
+def run_test_bitwise_xor_slice(M, N, block_M, block_N, dtype, target):
+    func = bitwise_xor_slice(M, N, block_M, block_N, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch_dtype = torch.int16 if dtype == "int16" else torch.uint16
+    a = torch.randint(0, 10, (M, N), dtype=torch_dtype).npu()
+    b = torch.randint(0, 10, (M, N), dtype=torch_dtype).npu()
+
+    torch.npu.synchronize()
+
+    c = func(a, b)
+
+    a_cpu = a.cpu()
+    b_cpu = b.cpu()
+    if dtype == "uint16":
+        ref_c = torch.bitwise_xor(a_cpu.to(torch.int32), b_cpu.to(torch.int32)).to(torch.uint16).npu()
+    else:
+        ref_c = torch.bitwise_xor(a_cpu, b_cpu).npu()
+    assert_close_npu(c, ref_c, dtype, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["int16", "uint16"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("shape", [(1024, 1024)])
+def test_bitwise_xor_slice(dtype, target, shape):
+    M, N = shape
+    run_test_bitwise_xor_slice(M, N, 128, 256, dtype, target)
 
 def block_reduce_max(M, N, block_M, block_N, repeat, mask, dstRepStride, srcBlkStride, srcRepStride, dataBlockNum, dtype="float16"):
     m_num = M // block_M
@@ -1044,6 +1223,54 @@ def test_cast(dtype, target, shape):
     M, N = shape
     run_test_cast(M, N, 16, 16, "CAST_RINT", 4096, target)
 
+def cast_slice(M, N, block_M, block_N, mode, count):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    VEC_NUM = 1
+
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, N), "float"),
+            B: T.Tensor((M, N), "float"),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), "float")
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), "float")
+
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            for i in range(block_M // VEC_NUM):
+                T.tile.cast(b_ub[i, :], a_ub[i, :], mode, count)
+
+            T.copy(b_ub, B[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    return main
+
+def run_test_cast_slice(M, N, block_M, block_N, mode, count, target):
+    func = cast_slice(M, N, block_M, block_N, mode, count)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    # without setdeqscale
+    a = torch.full((M, N), 0.5, dtype=torch.float).npu()
+
+    torch.npu.synchronize()
+
+    b = func(a)
+
+    ref_b = torch.full((M, N), 0.0, dtype=torch.float).npu()
+
+    torch.testing.assert_close(b, ref_b, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["float"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("shape", [(64, 64)])
+def test_cast_slice(dtype, target, shape):
+    M, N = shape
+    run_test_cast_slice(M, N, 16, 16, "CAST_RINT", 4096, target)
 
 def cast_scale(M, N, block_M, block_N, mode, count, scale):
     m_num = M // block_M
@@ -1153,6 +1380,60 @@ def test_clamp(dtype, target):
     min_val = random.uniform(-thresh, thresh)
     run_test_clamp(M, N, max_val, min_val, thresh, dtype, target, block_M=64, block_N=64)
 
+def clamp_slice(M, N, block_M, block_N, max_val, min_val, dtype="float16"):
+    m_num = M // block_M
+    n_num = N // block_N
+    num_blocks = m_num * n_num
+
+    VEC_NUM = 2
+
+    @T.prim_func
+    def main(
+            input: T.Tensor((M, N), dtype),
+            output: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(num_blocks, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            block_size = block_M * block_N // VEC_NUM
+            in_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            out_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            tmp_ub = T.alloc_ub((block_M // VEC_NUM, block_N), "uint8")
+
+            T.copy(input[bx * block_M + vid * block_M // VEC_NUM, by * block_N], in_ub)
+            for i in range(block_M // VEC_NUM):
+                T.tile.clamp(out_ub[i, :], in_ub[i, :], tmp_ub, min_val, max_val, block_size)
+
+            T.copy(out_ub, output[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    return main
+
+
+def run_test_clamp_slice(M, N, max_val, min_val, thresh, dtype, target, block_M=64, block_N=64):
+    if min_val > max_val:
+        max_val, min_val = min_val, max_val
+
+    func = clamp_slice(M, N, block_M, block_N, max_val, min_val, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    a = (torch.rand(M, N) - 0.5) * 2 * thresh
+    a = a.half().npu() if dtype == "float16" else a.float().npu()
+
+    b = func(a)
+    ref_b = torch.clamp(a, min_val, max_val)
+
+    torch.testing.assert_close(b, ref_b, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_clamp_slice(dtype, target):
+    M, N = 1024, 1024
+    thresh = 10000
+    max_val = random.uniform(-thresh, thresh)
+    min_val = random.uniform(-thresh, thresh)
+    run_test_clamp_slice(M, N, max_val, min_val, thresh, dtype, target, block_M=64, block_N=64)
 
 def compare(M, N, block_M, block_N, mode, dtype="float", out_dtype="uint8"):
     m_num = M // block_M
@@ -1269,6 +1550,63 @@ def test_compare(out_dtype, dtype, target, shape):
     M, N = shape
     run_test_compare(M, N, 128, 256, "LT", dtype, out_dtype, target)
 
+def compare_slice(M, N, block_M, block_N, mode, dtype="float", out_dtype="uint8"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    VEC_NUM = 2
+
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, N), dtype),
+            B: T.Tensor((M, N), dtype),
+            C: T.Tensor((M, N // 8), out_dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N // 8), out_dtype)
+
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+            for i in range(block_M // VEC_NUM):
+                T.tile.compare(c_ub[i, :], a_ub[i, :], b_ub[i, :], mode)
+
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N // 8])
+
+    return main
+
+def run_test_compare_slice(M, N, block_M, block_N, mode, dtype, out_dtype, target):
+    torch.npu.config.allow_internal_format = True
+
+    func = compare_slice(M, N, block_M, block_N, mode, dtype, out_dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch_dtype = torch.float32 if dtype == "float" else torch.float16
+    a = torch.zeros(M, N, dtype=torch_dtype).npu()
+    b = torch.ones(M, N, dtype=torch_dtype).npu()
+
+    torch.npu.synchronize()
+
+    c = func(a, b)
+
+    torch_out_dtype = torch.int8 if out_dtype == "int8" else torch.uint8
+    ref_c = torch.zeros(M, N // 8, dtype=torch_out_dtype).npu()
+    ref_c = compare_and_set_bits(a, b, ref_c, out_dtype)
+
+    torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("out_dtype", ["int8", "uint8"])
+@pytest.mark.parametrize("dtype", ["float", "float16"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("shape", [(256, 256)])
+def test_compare_slice(out_dtype, dtype, target, shape):
+    M, N = shape
+    run_test_compare_slice(M, N, 128, 256, "LT", dtype, out_dtype, target)
 
 def compare_scalar(M, N, block_M, block_N, mode, b_scalar, dtype="float", out_dtype="uint8"):
     m_num = M // block_M
@@ -1363,6 +1701,64 @@ def test_compare_scalar(out_dtype, dtype, target, shape):
     b_scalar = 1.0
     run_test_compare_scalar(M, N, block_M, block_N, mode, b_scalar, dtype, out_dtype, target)
 
+def compare_scalar_slice(M, N, block_M, block_N, mode, b_scalar, dtype="float", out_dtype="uint8"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    VEC_NUM = 2
+
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, N), dtype),
+            C: T.Tensor((M, N // 8), out_dtype)
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N // 8), out_dtype)
+
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            for i in range(block_M // VEC_NUM):
+                T.tile.compare(c_ub[i, :], a_ub[i, :], b_scalar, mode)
+
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N // 8])
+
+    return main
+
+def run_test_compare_scalar_slice(M, N, block_M, block_N, mode, b_scalar, dtype, out_dtype, target):
+    torch.npu.config.allow_internal_format = True
+
+    func = compare_scalar_slice(M, N, block_M, block_N, mode, b_scalar, dtype, out_dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch_dtype = torch.float32 if dtype == "float" else torch.float16
+    a = torch.zeros(M, N, dtype=torch_dtype).npu()
+
+    torch.npu.synchronize()
+
+    c = func(a)
+
+    torch_out_dtype = torch.int8 if out_dtype == "int8" else torch.uint8
+    ref_c = torch.zeros(M, N // 8, dtype=torch_out_dtype).npu()
+    ref_c = compare_with_scalar_and_set_bits(a, b_scalar, ref_c, out_dtype)
+
+    torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("out_dtype", ["int8", "uint8"])
+@pytest.mark.parametrize("dtype", ["float", "float16"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("shape", [(256, 256)])
+def test_compare_scalar_slice(out_dtype, dtype, target, shape):
+    M, N = shape
+    block_M = 128
+    block_N = 256
+    mode = "LT"
+    b_scalar = 1.0
+    run_test_compare_scalar_slice(M, N, block_M, block_N, mode, b_scalar, dtype, out_dtype, target)
+
 
 def cos(M, N, block_M, block_N, dtype="float"):
     m_num = M // block_M
@@ -1413,6 +1809,53 @@ def run_test_cos(dtype, target):
 def test_cos(dtype, target):
     run_test_cos(dtype, target)
 
+def cos_slice(M, N, block_M, block_N, dtype="float"):
+    m_num = M // block_M
+    n_num = N // block_N
+    VEC_NUM = 2
+    sub_block_M = block_M // VEC_NUM
+
+    @T.prim_func
+    def main(
+            A: T.Tensor([M, N], dtype),
+            B: T.Tensor([M, N], dtype),
+    ):
+        T.func_attr({"enable_auto_sync": True})
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+            a = T.alloc_ub([sub_block_M, block_N], dtype)
+            b = T.alloc_ub([sub_block_M, block_N], dtype)
+            tmp = T.alloc_ub([2 * sub_block_M * block_N], "uint8")
+
+            T.copy(A[bx * block_M + vid * sub_block_M: bx * block_M + (vid + 1) * sub_block_M,
+                   by * block_N: (by + 1) * block_N], a)  # Load input
+            for i in range(sub_block_M):
+                T.tile.cos(b[i, :], a[i, :], tmp)  # Compute cos
+            T.copy(b, B[bx * block_M + vid * sub_block_M: bx * block_M + (vid + 1) * sub_block_M,
+                      by * block_N: (by + 1) * block_N])  # Store output
+
+    return main
+
+
+def run_test_cos_slice(dtype, target):
+    test_configs = [
+        (1024, 1024, 128, 128),
+    ]
+
+    for M, N, block_M, block_N in test_configs:
+        func = cos_slice(M, N, block_M, block_N, dtype)
+        func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+        a = torch.randn(M, N, dtype=torch.float32 if dtype == "float" else torch.float16).npu()
+        b = func(a)
+        ref_b = torch.cos(a)
+        torch.testing.assert_close(b, ref_b, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16"])
+@pytest.mark.parametrize("target", ["ascendc"])
+def test_cos_slice(dtype, target):
+    run_test_cos_slice(dtype, target)
 
 def createvecindex(M, N, block_M, block_N, firstValue, dtype="int32"):
     m_num = M // block_M
@@ -1732,6 +2175,121 @@ def test_gather(dtype, target, shape):
     block_N = N
     run_test_gather(M, N, block_M, block_N, dtype, target)
 
+def gather(M, N, block_M, block_N, dtype="int32"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    VEC_NUM = 2
+
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, N), dtype),
+            B: T.Tensor((M, N), "uint32"),
+            C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), "uint32")
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+
+            T.tile.gather(c_ub, a_ub, b_ub, 0)
+
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    return main
+
+def gather_slice(M, N, block_M, block_N, dtype="int32"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    VEC_NUM = 2
+
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, N), dtype),
+            B: T.Tensor((M, N), "uint32"),
+            C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), "uint32")
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+            for i in range(block_M // VEC_NUM):
+                T.tile.gather(c_ub[i, :], a_ub[i, :], b_ub[i, :], 0)
+
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    return main
+
+def run_test_gather_slice(M, N, block_M, block_N, dtype, target):
+    func = gather_slice(M, N, block_M, block_N, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    dtype_map = {
+        "int16": torch.int16,
+        "int32": torch.int32,
+        "uint16": torch.uint16,
+        "uint32": torch.uint32,
+        "float": torch.float32,
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+    }
+    element_sizes = {
+        "int16": 2,
+        "int32": 4,
+        "uint16": 2,
+        "uint32": 4,
+        "float": 4,
+        "float16": 2,
+        "bfloat16": 2,
+    }
+    torch_dtype = dtype_map.get(dtype, torch.int32)
+    element_size = element_sizes.get(dtype, 4)
+
+    if dtype in ["uint16", "uint32"]:
+        a = torch.arange(N, dtype=torch.int32).to(torch_dtype).unsqueeze(0).expand(M, -1).npu()
+    else:
+        a = torch.arange(N, dtype=torch_dtype).unsqueeze(0).expand(M, -1).npu()
+    all_multiples = torch.arange(0, element_size * N, element_size)
+    random_indices = torch.randperm(len(all_multiples))[:N]
+    random_multiples = all_multiples[random_indices].to(torch.uint32)
+    tmp_tensor = random_multiples.reshape(1, N)
+    tensor_cpu = tmp_tensor.repeat(M, 1)
+    b = tensor_cpu.npu()
+
+    torch.npu.synchronize()
+
+    c = func(a, b)
+
+    ref_c = generate_golden_gather(a, b).npu()
+
+    if dtype in ["uint16", "uint32"]:
+        torch.testing.assert_close(c.cpu(), ref_c.cpu(), rtol=1e-2, atol=1e-2)
+    else:
+        torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["int16", "int32", "uint16", "uint32", "float", "float16", "bfloat16"])
+@pytest.mark.parametrize("target", ["ascendc"])
+@pytest.mark.parametrize("shape", [(128, 1024)])
+def test_gather_slice(dtype, target, shape):
+    M, N = shape
+    block_M = 16
+    block_N = N
+    run_test_gather_slice(M, N, block_M, block_N, dtype, target)
+
 
 def gatherb(M, N, block_M, block_N, b_len, repeat_time, dtype="uint16"):
     m_num = M // block_M
@@ -1871,6 +2429,58 @@ def test_leaky_relu(dtype, target, shape):
     block_M = 128
     block_N = 256
     run_test_leaky_relu(M, N, block_M, block_N, dtype, target)
+
+def leaky_relu_slice(M, N, block_M, block_N, dtype="float"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    VEC_NUM = 2
+
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, N), dtype),
+            B: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            for i in range(block_M // VEC_NUM):
+                T.tile.leaky_relu(b_ub[i, :], a_ub[i, :], 2.0)
+
+            T.copy(b_ub, B[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    return main
+
+
+def run_test_leaky_relu_slice(M, N, block_M, block_N, dtype, target):
+    func = leaky_relu_slice(M, N, block_M, block_N, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    a = torch.randn(M, N, dtype=torch.float32 if dtype == "float" else torch.float16).npu()
+
+    torch.npu.synchronize()
+
+    b = func(a)
+
+    leaky_relu_golden = nn.LeakyReLU(negative_slope=2.0)
+    ref_b = leaky_relu_golden(a)
+
+    torch.testing.assert_close(b, ref_b, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("shape", [(1024, 1024)])
+def test_leaky_relu_slice(dtype, target, shape):
+    M, N = shape
+    block_M = 128
+    block_N = 256
+    run_test_leaky_relu_slice(M, N, block_M, block_N, dtype, target)
 
 
 def ln(M, N, block_M, block_N, dtype="float"):
@@ -2542,6 +3152,72 @@ def test_pow(dtype, target, shape):
     M, N = shape
     run_test_pow(M, N, 128, 128, dtype, target=target)
 
+def vec_pow_slice(M, N, block_M, block_N, dtype="float"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    VEC_NUM = 2
+
+    tmp_size_multiplier = 8 if dtype == "int32" else 2
+
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, N), dtype),
+            B: T.Tensor((M, N), dtype),
+            C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            tmp = T.alloc_ub((tmp_size_multiplier * (block_M // VEC_NUM), block_N), "uint8")
+
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+            for i in range(block_M // VEC_NUM):
+                T.tile.pow(c_ub[i, :], a_ub[i, :], b_ub[i, :], tmp)
+
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    return main
+
+
+def run_test_pow_slice(M, N, block_M, block_N, dtype, target):
+    func = vec_pow_slice(M, N, block_M, block_N, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    dtype_map = {
+        "float": torch.float32,
+        "float16": torch.float16,
+        "int32": torch.int32,
+    }
+    torch_dtype = dtype_map.get(dtype, torch.float32)
+
+    if dtype == "int32":
+        a = torch.randint(1, 10, (M, N), dtype=torch_dtype).npu()
+        b = torch.randint(0, 5, (M, N), dtype=torch_dtype).npu()
+    else:
+        a = torch.rand(M, N, dtype=torch_dtype).npu() + 0.5
+        b = torch.rand(M, N, dtype=torch_dtype).npu()
+
+    torch.npu.synchronize()
+
+    c = func(a, b)
+
+    ref_c = torch.pow(a, b)
+
+    torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16", "int32"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("shape", [(1024, 1024)])
+def test_pow_slice(dtype, target, shape):
+    M, N = shape
+    run_test_pow_slice(M, N, 128, 128, dtype, target=target)
 
 def reciprocal(M, N, block_M, block_N, dtype="float"):
     m_num = M // block_M
@@ -2941,6 +3617,51 @@ def run_test_sin(dtype, target):
 def test_sin(dtype, target):
     run_test_sin(dtype, target)
 
+def sin_slice(M, N, block_M, block_N, dtype="float"):
+    m_num = M // block_M
+    n_num = N // block_N
+    VEC_NUM = 2
+    sub_block_M = block_M // VEC_NUM
+
+    @T.prim_func
+    def main(
+            A: T.Tensor([M, N], dtype),
+            B: T.Tensor([M, N], dtype),
+    ):
+        T.func_attr({"enable_auto_sync": True})
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+            a = T.alloc_ub([sub_block_M, block_N], dtype)
+            b = T.alloc_ub([sub_block_M, block_N], dtype)
+            tmp = T.alloc_ub([2 * sub_block_M * block_N], "uint8")
+            T.copy(A[bx * block_M + vid * sub_block_M: bx * block_M + (vid + 1) * sub_block_M,
+                   by * block_N: (by + 1) * block_N], a)  # Load input
+            for i in range(sub_block_M):
+                T.tile.sin(b[i, :], a[i, :], tmp)  # Compute sin
+            T.copy(b, B[bx * block_M + vid * sub_block_M: bx * block_M + (vid + 1) * sub_block_M,
+                      by * block_N: (by + 1) * block_N])  # Store output
+
+    return main
+
+def run_test_sin_slice(dtype, target):
+    test_configs = [
+        (1024, 1024, 128, 128),
+    ]
+
+    for M, N, block_M, block_N in test_configs:
+        func = sin_slice(M, N, block_M, block_N, dtype)
+        func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+        a = torch.randn(M, N, dtype=torch.float32 if dtype == "float" else torch.float16).npu()
+        b = func(a)
+        ref_b = torch.sin(a)
+        torch.testing.assert_close(b, ref_b, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16"])
+@pytest.mark.parametrize("target", ["ascendc"])
+def test_sin_slice(dtype, target):
+    run_test_sin_slice(dtype, target)
 
 def sort32(M, N, block_M, block_N, dtype="float"):
     m_num = M // block_M

--- a/tilelang/language/ascend.py
+++ b/tilelang/language/ascend.py
@@ -386,6 +386,11 @@ def gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False):
             assert B_shape[i] == 1, (
                 "current only support B as a 2D or higher-order tensor with the last two dimensions being the matrix dimensions"
             )
+    if len(C_shape) > 2:
+        for i in range(len(C_shape) - 2):
+            assert C_shape[i] == 1, (
+                "current only support B as a 2D or higher-order tensor with the last two dimensions being the matrix dimensions"
+            )
 
     M, N = C_shape[-2], C_shape[-1]
     K = A_shape[-2] if transpose_A else A_shape[-1]

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -803,7 +803,7 @@ def scalar_op(
     )
 
 
-def leaky_relu(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], scalar_value: PrimExpr):
+def leaky_relu(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, scalar_value: PrimExpr): # type: ignore  # noqa: F821
     """Performs element-wise Leaky ReLU activation.
 
     Formula: dst = src0 if src0 >= 0 else src0 * scalar_value
@@ -816,7 +816,7 @@ def leaky_relu(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegio
     return scalar_op(dst, src0, scalar_value, "leaky_relu")
 
 
-def axpy(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], scalar_value: PrimExpr):
+def axpy(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, scalar_value: PrimExpr):  # noqa: F821
     """Performs element-wise AXPY operation: dst = scalar_value * src0 + dst.
 
     Note: This operation updates the destination buffer in-place by adding
@@ -830,7 +830,7 @@ def axpy(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], sc
     return scalar_op(dst, src0, scalar_value, "axpy")
 
 
-def bitwise_lshift(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], scalarValue: PrimExpr):
+def bitwise_lshift(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, scalarValue: PrimExpr):  # noqa: F821
     """Performs element-wise bitwise left shift: dst = src0 << scalarValue.
 
     Args:
@@ -864,7 +864,7 @@ def bitwise_lshift(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferR
     )
 
 
-def bitwise_rshift(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], scalarValue: PrimExpr):
+def bitwise_rshift(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, scalarValue: PrimExpr):  # noqa: F821
     """Performs element-wise bitwise right shift: dst = src0 >> scalarValue.
 
     Args:
@@ -1062,7 +1062,7 @@ def transpose(dst: Buffer, src: Buffer):
     )
 
 
-def gather(dst: Union[Buffer, BufferRegion], src: Union[Buffer, BufferRegion], src_offset: Union[Buffer, BufferRegion], src_base_addr: PrimExpr):
+def gather(dst: Buffer | BufferRegion, src: Buffer | BufferRegion, src_offset: Buffer | BufferRegion, src_base_addr: PrimExpr):  # noqa: F821
     """Performs a gather operation.
 
     This intrinsic gathers elements from the source buffer based on the provided
@@ -1229,7 +1229,7 @@ def block_reduce_sum(
 
 
 def compare(
-    dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], src1: Union[Buffer, BufferRegion, BufferLoad, PrimExpr], mode: str  # noqa: FA100
+    dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, src1: Buffer | BufferRegion | BufferLoad | PrimExpr, mode: str  # noqa: F821, FA100
 ):
     """Generic dispatch function for element-wise comparison operations.
 
@@ -1315,7 +1315,7 @@ def compare(
         )
 
 
-def cast(dst: Union[Buffer, BufferRegion], src: Union[Buffer, BufferRegion], mode: str, count: PrimExpr):
+def cast(dst: Buffer | BufferRegion, src: Buffer | BufferRegion, mode: str, count: PrimExpr):  # noqa: F821
     """Performs element-wise data type conversion with a specified rounding mode.
 
     Args:
@@ -1364,7 +1364,7 @@ def cast(dst: Union[Buffer, BufferRegion], src: Union[Buffer, BufferRegion], mod
     )
 
 
-def sin(dst: Union[Buffer, BufferRegion], src: Union[Buffer, BufferRegion], tmp: Buffer):
+def sin(dst: Buffer | BufferRegion, src: Buffer | BufferRegion, tmp: Buffer):  # noqa: F821
     """Performs element-wise sine calculation: dst = sin(src).
 
     Args:
@@ -1401,7 +1401,7 @@ def sin(dst: Union[Buffer, BufferRegion], src: Union[Buffer, BufferRegion], tmp:
     )
 
 
-def cos(dst: Union[Buffer, BufferRegion], src: Union[Buffer, BufferRegion], tmp: Buffer):
+def cos(dst: Buffer | BufferRegion, src: Buffer | BufferRegion, tmp: Buffer):  # noqa: F821
     """Performs element-wise cosine calculation: dst = cos(src).
 
     Args:
@@ -1450,7 +1450,7 @@ def cos(dst: Union[Buffer, BufferRegion], src: Union[Buffer, BufferRegion], tmp:
 #
 #     return cast(dst, src, "CAST_ROUND", count)
 #
-def pow(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], src1: Union[Buffer, BufferRegion], tmp: Buffer):
+def pow(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, src1: Buffer | BufferRegion, tmp: Buffer):  # noqa: F821
     """Performs element-wise power calculation: dst = src0 ^ src1.
 
     Args:
@@ -1487,7 +1487,7 @@ def pow(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], src
     )
 
 
-def bitwise_xor(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], src1: Union[Buffer, BufferRegion], tmp: Buffer):
+def bitwise_xor(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, src1: Buffer | BufferRegion, tmp: Buffer):  # noqa: F821
     """Performs element-wise bitwise XOR operation: dst = src0 ^ src1.
 
     Args:
@@ -1524,7 +1524,7 @@ def bitwise_xor(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegi
     )
 
 
-def clamp_max(out: Union[Buffer, BufferRegion], buffer: Union[Buffer, BufferRegion], tmp: Buffer, scalar_value: PrimExpr, count: PrimExpr):
+def clamp_max(out: Buffer | BufferRegion, buffer: Buffer | BufferRegion, tmp: Buffer, scalar_value: PrimExpr, count: PrimExpr):  # noqa: F821
     """_summary_
     Clip tensor elements to no more than scalar_value, replace elements larger than scalar_value with scalar_value,
     keep original values for elements less than or equal to scalar_value
@@ -1559,7 +1559,7 @@ def clamp_max(out: Union[Buffer, BufferRegion], buffer: Union[Buffer, BufferRegi
         count,
     )
 
-def clamp_min(out: Union[Buffer, BufferRegion], buffer: Union[Buffer, BufferRegion], tmp: Buffer, scalar_value: PrimExpr, count: PrimExpr):
+def clamp_min(out: Buffer | BufferRegion, buffer: Buffer | BufferRegion, tmp: Buffer, scalar_value: PrimExpr, count: PrimExpr):  # noqa: F821
     """
     Clip tensor elements to no less than v, replace elements smaller than scalar_value with scalar_value,
     keep original values for elements greater than or equal to scalar_value
@@ -1594,7 +1594,7 @@ def clamp_min(out: Union[Buffer, BufferRegion], buffer: Union[Buffer, BufferRegi
         count,
     )
 
-def clamp(out: Union[Buffer, BufferRegion], buffer: Union[Buffer, BufferRegion], tmp: Buffer, min_scalar: PrimExpr, max_scalar: PrimExpr, count: PrimExpr):
+def clamp(out: Buffer | BufferRegion, buffer: Buffer | BufferRegion, tmp: Buffer, min_scalar: PrimExpr, max_scalar: PrimExpr, count: PrimExpr):  # noqa: F821
     """
     Clip tensor elements to [min_scalar, max_scalar] range, replace out-of-bounds values with boundary values
     Args:
@@ -1631,7 +1631,7 @@ def clamp(out: Union[Buffer, BufferRegion], buffer: Union[Buffer, BufferRegion],
     )
 
 
-def round(out: Union[Buffer, BufferRegion], buffer: Union[Buffer, BufferRegion], tmp: Buffer, count: PrimExpr):
+def round(out: Buffer | BufferRegion, buffer: Buffer | BufferRegion, tmp: Buffer, count: PrimExpr):  # noqa: F821
     if isinstance(out, BufferRegion):
         out_ptr, _ = _handle_buffer_region(out, "w")
     else:
@@ -1651,9 +1651,9 @@ def round(out: Union[Buffer, BufferRegion], buffer: Union[Buffer, BufferRegion],
         count
     )
 
-def broadcast(dst: Union[Buffer, BufferRegion],  # noqa: FA100
-              src: Union[Buffer, BufferRegion],  # noqa: FA100
-              tmp: Union[Buffer, BufferRegion]):  # noqa: FA100
+def broadcast(dst: Buffer | BufferRegion,  # noqa: F821, FA100
+              src: Buffer | BufferRegion,  # noqa: F821, FA100
+              tmp: Buffer | BufferRegion):  # noqa: F821, FA100
     """Generates a TIR intrinsic call for the AscendC `Broadcast` operation.
 
     This function performs a broadcast copy from the source buffer (`src`) to the

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -803,7 +803,7 @@ def scalar_op(
     )
 
 
-def leaky_relu(dst: Buffer, src0: Buffer, scalar_value: PrimExpr):
+def leaky_relu(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], scalar_value: PrimExpr):
     """Performs element-wise Leaky ReLU activation.
 
     Formula: dst = src0 if src0 >= 0 else src0 * scalar_value
@@ -816,7 +816,7 @@ def leaky_relu(dst: Buffer, src0: Buffer, scalar_value: PrimExpr):
     return scalar_op(dst, src0, scalar_value, "leaky_relu")
 
 
-def axpy(dst: Buffer, src0: Buffer, scalar_value: PrimExpr):
+def axpy(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], scalar_value: PrimExpr):
     """Performs element-wise AXPY operation: dst = scalar_value * src0 + dst.
 
     Note: This operation updates the destination buffer in-place by adding
@@ -830,7 +830,7 @@ def axpy(dst: Buffer, src0: Buffer, scalar_value: PrimExpr):
     return scalar_op(dst, src0, scalar_value, "axpy")
 
 
-def bitwise_lshift(dst: Buffer, src0: Buffer, scalarValue: PrimExpr):
+def bitwise_lshift(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], scalarValue: PrimExpr):
     """Performs element-wise bitwise left shift: dst = src0 << scalarValue.
 
     Args:
@@ -838,22 +838,33 @@ def bitwise_lshift(dst: Buffer, src0: Buffer, scalarValue: PrimExpr):
         src0: The source buffer.
         scalarValue: The number of bits to shift (scalar).
     """
-    size_0 = math.prod(src0.shape)
-    size_2 = math.prod(dst.shape)
+    if isinstance(dst, BufferRegion):
+        dst_ptr, dst_extent = _handle_buffer_region(dst, "w")
+        size_2 = math.prod(dst_extent)
+    else:
+        dst_ptr = dst.access_ptr("w")
+        size_2 = math.prod(dst.shape)
+
+    if isinstance(src0, BufferRegion):
+        src0_ptr, src0_extent = _handle_buffer_region(src0, "r")
+        size_0 = math.prod(src0_extent)
+    else:
+        src0_ptr = src0.access_ptr("r")
+        size_0 = math.prod(src0.shape)
 
     assert size_0 == size_2, "size must be same"
 
     return tir.call_intrin(
         "handle",
         tir.op.Op.get("tl.ascend_bitwise_lshift"),
-        dst.access_ptr("w"),
-        src0.access_ptr("r"),
+        dst_ptr,
+        src0_ptr,
         scalarValue,
         size_0,
     )
 
 
-def bitwise_rshift(dst: Buffer, src0: Buffer, scalarValue: PrimExpr):
+def bitwise_rshift(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], scalarValue: PrimExpr):
     """Performs element-wise bitwise right shift: dst = src0 >> scalarValue.
 
     Args:
@@ -861,16 +872,27 @@ def bitwise_rshift(dst: Buffer, src0: Buffer, scalarValue: PrimExpr):
         src0: The source buffer.
         scalarValue: The number of bits to shift (scalar).
     """
-    size_0 = math.prod(src0.shape)
-    size_2 = math.prod(dst.shape)
+    if isinstance(dst, BufferRegion):
+        dst_ptr, dst_extent = _handle_buffer_region(dst, "w")
+        size_2 = math.prod(dst_extent)
+    else:
+        dst_ptr = dst.access_ptr("w")
+        size_2 = math.prod(dst.shape)
+
+    if isinstance(src0, BufferRegion):
+        src0_ptr, src0_extent = _handle_buffer_region(src0, "r")
+        size_0 = math.prod(src0_extent)
+    else:
+        src0_ptr = src0.access_ptr("r")
+        size_0 = math.prod(src0.shape)
 
     assert size_0 == size_2, "size must be same"
 
     return tir.call_intrin(
         "handle",
         tir.op.Op.get("tl.ascend_bitwise_rshift"),
-        dst.access_ptr("w"),
-        src0.access_ptr("r"),
+        dst_ptr,
+        src0_ptr,
         scalarValue,
         size_0,
     )
@@ -1040,7 +1062,7 @@ def transpose(dst: Buffer, src: Buffer):
     )
 
 
-def gather(dst: Buffer, src: Buffer, src_offset: Buffer, src_base_addr: PrimExpr):
+def gather(dst: Union[Buffer, BufferRegion], src: Union[Buffer, BufferRegion], src_offset: Union[Buffer, BufferRegion], src_base_addr: PrimExpr):
     """Performs a gather operation.
 
     This intrinsic gathers elements from the source buffer based on the provided
@@ -1052,15 +1074,31 @@ def gather(dst: Buffer, src: Buffer, src_offset: Buffer, src_base_addr: PrimExpr
         src_offset: The buffer containing offsets/indices for gathering.
         src_base_addr: The base address offset to be added to the gather indices.
     """
-    count = math.prod(src.shape)
+    if isinstance(dst, BufferRegion):
+        dst_ptr, _ = _handle_buffer_region(dst, "w")
+    else:
+        dst_ptr = dst.access_ptr("w")
+
+    if isinstance(src, BufferRegion):
+        src_ptr, src_extent = _handle_buffer_region(src, "r")
+        size = math.prod(src_extent)
+    else:
+        src_ptr = src.access_ptr("r")
+        size = math.prod(src.shape)
+
+    if isinstance(src, BufferRegion):
+        src_offset_ptr, _ = _handle_buffer_region(src_offset, "r")
+    else:
+        src_offset_ptr = src_offset.access_ptr("r")
+
     return T.call_intrin(
         "handle",
         tir.op.Op.get("tl.ascend_gather"),
-        dst.access_ptr("w"),
-        src.access_ptr("r"),
-        src_offset.access_ptr("r"),
+        dst_ptr,
+        src_ptr,
+        src_offset_ptr,
         src_base_addr,
-        count,
+        size,
     )
 
 
@@ -1191,10 +1229,7 @@ def block_reduce_sum(
 
 
 def compare(
-    dst: Buffer,
-    src0: Buffer,
-    src1: Buffer | BufferLoad | PrimExpr,
-    mode: str,
+    dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], src1: Union[Buffer, BufferRegion, BufferLoad, PrimExpr], mode: str  # noqa: FA100
 ):
     """Generic dispatch function for element-wise comparison operations.
 
@@ -1220,15 +1255,19 @@ def compare(
         A TVM intrinsic call that performs the comparison operation.
     """
     assert mode in ["EQ", "NE", "GT", "GE", "LT", "LE"]
+    if isinstance(dst, BufferRegion):
+        dst_ptr, _ = _handle_buffer_region(dst, "w")
+    else:
+        dst_ptr = dst.access_ptr("w")
 
-    dst_ptr = dst.access_ptr("w")
+    if isinstance(src0, BufferRegion):
+        src0_ptr, src0_extent = _handle_buffer_region(src0, "r")
+        size_0 = math.prod(src0_extent)
+    else:
+        src0_ptr = src0.access_ptr("r")
+        size_0 = math.prod(src0.shape)
 
-    src0_ptr = src0.access_ptr("r")
-    src0_extent = src0.shape
-
-    size_1 = math.prod(src0_extent)
-
-    dst_size = size_1
+    dst_size = size_0
 
     if isinstance(src1, BufferLoad):
         buffer_1 = src1.buffer
@@ -1253,6 +1292,17 @@ def compare(
             mode,
             dst_size,
         )
+    elif isinstance(src1, BufferRegion):
+        src1_ptr, _ = _handle_buffer_region(src1, "r")
+        return T.call_intrin(
+            "handle",
+            tir.op.Op.get("tl.ascend_compare"),
+            dst_ptr,
+            src0_ptr,
+            src1_ptr,
+            mode,
+            dst_size,
+        )
     else:
         return T.call_intrin(
             "handle",
@@ -1265,7 +1315,7 @@ def compare(
         )
 
 
-def cast(dst: Buffer, src: Buffer, mode: str, count: PrimExpr):
+def cast(dst: Union[Buffer, BufferRegion], src: Union[Buffer, BufferRegion], mode: str, count: PrimExpr):
     """Performs element-wise data type conversion with a specified rounding mode.
 
     Args:
@@ -1294,17 +1344,27 @@ def cast(dst: Buffer, src: Buffer, mode: str, count: PrimExpr):
         "CAST_ODD",
     ]
 
+    if isinstance(dst, BufferRegion):
+        dst_ptr, _ = _handle_buffer_region(dst, "w")
+    else:
+        dst_ptr = dst.access_ptr("w")
+
+    if isinstance(src, BufferRegion):
+        src_ptr, _ = _handle_buffer_region(src, "r")
+    else:
+        src_ptr = src.access_ptr("r")
+
     return T.call_intrin(
         "handle",
         tir.op.Op.get("tl.ascend_cast"),
-        dst.access_ptr("w"),
-        src.access_ptr("r"),
+        dst_ptr,
+        src_ptr,
         mode,
         count,
     )
 
 
-def sin(dst: Buffer, src: Buffer, tmp: Buffer):
+def sin(dst: Union[Buffer, BufferRegion], src: Union[Buffer, BufferRegion], tmp: Buffer):
     """Performs element-wise sine calculation: dst = sin(src).
 
     Args:
@@ -1315,22 +1375,33 @@ def sin(dst: Buffer, src: Buffer, tmp: Buffer):
     Returns:
         A TVM intrinsic call that performs the sine operation.
     """
-    size_0 = math.prod(src.shape)
-    size_2 = math.prod(dst.shape)
+    if isinstance(dst, BufferRegion):
+        dst_ptr, dst_extent = _handle_buffer_region(dst, "w")
+        size_2 = math.prod(dst_extent)
+    else:
+        dst_ptr = dst.access_ptr("w")
+        size_2 = math.prod(dst.shape)
+
+    if isinstance(src, BufferRegion):
+        src_ptr, src_extent = _handle_buffer_region(src, "r")
+        size_0 = math.prod(src_extent)
+    else:
+        src_ptr = src.access_ptr("r")
+        size_0 = math.prod(src.shape)
 
     assert size_0 == size_2, "size must be same"
 
     return tir.call_intrin(
         "handle",
         tir.op.Op.get("tl.ascend_sin"),
-        dst.access_ptr("w"),
-        src.access_ptr("r"),
+        dst_ptr,
+        src_ptr,
         tmp.access_ptr("r"),
         size_0,
     )
 
 
-def cos(dst: Buffer, src: Buffer, tmp: Buffer):
+def cos(dst: Union[Buffer, BufferRegion], src: Union[Buffer, BufferRegion], tmp: Buffer):
     """Performs element-wise cosine calculation: dst = cos(src).
 
     Args:
@@ -1341,16 +1412,27 @@ def cos(dst: Buffer, src: Buffer, tmp: Buffer):
     Returns:
         A TVM intrinsic call that performs the cosine operation.
     """
-    size_0 = math.prod(src.shape)
-    size_2 = math.prod(dst.shape)
+    if isinstance(dst, BufferRegion):
+        dst_ptr, dst_extent = _handle_buffer_region(dst, "w")
+        size_2 = math.prod(dst_extent)
+    else:
+        dst_ptr = dst.access_ptr("w")
+        size_2 = math.prod(dst.shape)
+
+    if isinstance(src, BufferRegion):
+        src_ptr, src_extent = _handle_buffer_region(src, "r")
+        size_0 = math.prod(src_extent)
+    else:
+        src_ptr = src.access_ptr("r")
+        size_0 = math.prod(src.shape)
 
     assert size_0 == size_2, "size must be same"
 
     return tir.call_intrin(
         "handle",
         tir.op.Op.get("tl.ascend_cos"),
-        dst.access_ptr("w"),
-        src.access_ptr("r"),
+        dst_ptr,
+        src_ptr,
         tmp.access_ptr("r"),
         size_0,
     )
@@ -1368,7 +1450,7 @@ def cos(dst: Buffer, src: Buffer, tmp: Buffer):
 #
 #     return cast(dst, src, "CAST_ROUND", count)
 #
-def pow(dst: Buffer, src0: Buffer, src1: Buffer, tmp: Buffer):
+def pow(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], src1: Union[Buffer, BufferRegion], tmp: Buffer):
     """Performs element-wise power calculation: dst = src0 ^ src1.
 
     Args:
@@ -1380,17 +1462,32 @@ def pow(dst: Buffer, src0: Buffer, src1: Buffer, tmp: Buffer):
     Returns:
         A TVM intrinsic call that performs the power operation.
     """
+    if isinstance(dst, BufferRegion):
+        dst_ptr, _ = _handle_buffer_region(dst, "w")
+    else:
+        dst_ptr = dst.access_ptr("w")
+
+    if isinstance(src0, BufferRegion):
+        src0_ptr, _ = _handle_buffer_region(src0, "r")
+    else:
+        src0_ptr = src0.access_ptr("r")
+
+    if isinstance(src1, BufferRegion):
+        src1_ptr, _ = _handle_buffer_region(src1, "r")
+    else:
+        src1_ptr = src1.access_ptr("r")
+
     return tir.call_intrin(
         "handle",
         tir.op.Op.get("tl.ascend_pow"),
-        dst.access_ptr("w"),
-        src0.access_ptr("r"),
-        src1.access_ptr("r"),
+        dst_ptr,
+        src0_ptr,
+        src1_ptr,
         tmp.access_ptr("w"),
     )
 
 
-def bitwise_xor(dst: Buffer, src0: Buffer, src1: Buffer, tmp: Buffer):
+def bitwise_xor(dst: Union[Buffer, BufferRegion], src0: Union[Buffer, BufferRegion], src1: Union[Buffer, BufferRegion], tmp: Buffer):
     """Performs element-wise bitwise XOR operation: dst = src0 ^ src1.
 
     Args:
@@ -1402,17 +1499,32 @@ def bitwise_xor(dst: Buffer, src0: Buffer, src1: Buffer, tmp: Buffer):
     Returns:
         A TVM intrinsic call that performs the bitwise XOR operation.
     """
+    if isinstance(dst, BufferRegion):
+        dst_ptr, _ = _handle_buffer_region(dst, "w")
+    else:
+        dst_ptr = dst.access_ptr("w")
+
+    if isinstance(src0, BufferRegion):
+        src0_ptr, _ = _handle_buffer_region(src0, "r")
+    else:
+        src0_ptr = src0.access_ptr("r")
+
+    if isinstance(src1, BufferRegion):
+        src1_ptr, _ = _handle_buffer_region(src1, "r")
+    else:
+        src1_ptr = src1.access_ptr("r")
+
     return tir.call_intrin(
         "handle",
         tir.op.Op.get("tl.ascend_bitwise_xor"),
-        dst.access_ptr("w"),
-        src0.access_ptr("r"),
-        src1.access_ptr("r"),
-        tmp.access_ptr("w"),
+        dst_ptr,
+        src0_ptr,
+        src1_ptr,
+        tmp.access_ptr("w")
     )
 
 
-def clamp_max(out: Buffer, buffer: Buffer, tmp: Buffer, scalar_value: PrimExpr, count: PrimExpr):
+def clamp_max(out: Union[Buffer, BufferRegion], buffer: Union[Buffer, BufferRegion], tmp: Buffer, scalar_value: PrimExpr, count: PrimExpr):
     """_summary_
     Clip tensor elements to no more than scalar_value, replace elements larger than scalar_value with scalar_value,
     keep original values for elements less than or equal to scalar_value
@@ -1426,19 +1538,28 @@ def clamp_max(out: Buffer, buffer: Buffer, tmp: Buffer, scalar_value: PrimExpr, 
     Returns:
         A TVM intrinsic call that performs the clamp_max operation.
     """
+    if isinstance(out, BufferRegion):
+        out_ptr, _ = _handle_buffer_region(out, "w")
+    else:
+        out_ptr = out.access_ptr("w")
+
+    if isinstance(buffer, BufferRegion):
+        buffer_ptr, _ = _handle_buffer_region(buffer, "r")
+    else:
+        buffer_ptr = buffer.access_ptr("r")
+
     return tir.call_intrin(
         "handle",
         tir.op.Op.get("tl.ascend_clamp_max"),
         f"ClampMax<{_dtype(buffer)}>",
-        out.access_ptr("w"),
-        buffer.access_ptr("r"),
+        out_ptr,
+        buffer_ptr,
         tmp.access_ptr("r"),
         scalar_value,
         count,
     )
 
-
-def clamp_min(out: Buffer, buffer: Buffer, tmp: Buffer, scalar_value: PrimExpr, count: PrimExpr):
+def clamp_min(out: Union[Buffer, BufferRegion], buffer: Union[Buffer, BufferRegion], tmp: Buffer, scalar_value: PrimExpr, count: PrimExpr):
     """
     Clip tensor elements to no less than v, replace elements smaller than scalar_value with scalar_value,
     keep original values for elements greater than or equal to scalar_value
@@ -1452,19 +1573,28 @@ def clamp_min(out: Buffer, buffer: Buffer, tmp: Buffer, scalar_value: PrimExpr, 
     Returns:
         A TVM intrinsic call that performs the clamp_min operation.
     """
+    if isinstance(out, BufferRegion):
+        out_ptr, _ = _handle_buffer_region(out, "w")
+    else:
+        out_ptr = out.access_ptr("w")
+
+    if isinstance(buffer, BufferRegion):
+        buffer_ptr, _ = _handle_buffer_region(buffer, "r")
+    else:
+        buffer_ptr = buffer.access_ptr("r")
+
     return tir.call_intrin(
         "handle",
         tir.op.Op.get("tl.ascend_clamp_min"),
         f"ClampMin<{_dtype(buffer)}>",
-        out.access_ptr("w"),
-        buffer.access_ptr("r"),
+        out_ptr,
+        buffer_ptr,
         tmp.access_ptr("r"),
         scalar_value,
         count,
     )
 
-
-def clamp(out: Buffer, buffer: Buffer, tmp: Buffer, min_scalar: PrimExpr, max_scalar: PrimExpr, count: PrimExpr):
+def clamp(out: Union[Buffer, BufferRegion], buffer: Union[Buffer, BufferRegion], tmp: Buffer, min_scalar: PrimExpr, max_scalar: PrimExpr, count: PrimExpr):
     """
     Clip tensor elements to [min_scalar, max_scalar] range, replace out-of-bounds values with boundary values
     Args:
@@ -1478,12 +1608,22 @@ def clamp(out: Buffer, buffer: Buffer, tmp: Buffer, min_scalar: PrimExpr, max_sc
     Returns:
         A TVM intrinsic call that performs the clamp operation.
     """
+    if isinstance(out, BufferRegion):
+        out_ptr, _ = _handle_buffer_region(out, "w")
+    else:
+        out_ptr = out.access_ptr("w")
+
+    if isinstance(buffer, BufferRegion):
+        buffer_ptr, _ = _handle_buffer_region(buffer, "r")
+    else:
+        buffer_ptr = buffer.access_ptr("r")
+
     return tir.call_intrin(
         "handle",
         tir.op.Op.get("tl.ascend_clamp"),
         f"Clamp<{_dtype(buffer)}>",
-        out.access_ptr("w"),
-        buffer.access_ptr("r"),
+        out_ptr,
+        buffer_ptr,
         tmp.access_ptr("r"),
         min_scalar,
         max_scalar,
@@ -1491,18 +1631,29 @@ def clamp(out: Buffer, buffer: Buffer, tmp: Buffer, min_scalar: PrimExpr, max_sc
     )
 
 
-def round(out: Buffer, buffer: Buffer, tmp: Buffer, count: PrimExpr):
+def round(out: Union[Buffer, BufferRegion], buffer: Union[Buffer, BufferRegion], tmp: Buffer, count: PrimExpr):
+    if isinstance(out, BufferRegion):
+        out_ptr, _ = _handle_buffer_region(out, "w")
+    else:
+        out_ptr = out.access_ptr("w")
+
+    if isinstance(buffer, BufferRegion):
+        buffer_ptr, _ = _handle_buffer_region(buffer, "r")
+    else:
+        buffer_ptr = buffer.access_ptr("r")
 
     return tir.call_intrin(
-        "handle", tir.op.Op.get("tl.ascend_round"), out.access_ptr("w"), buffer.access_ptr("r"), tmp.access_ptr("r"), count
+        "handle",
+        tir.op.Op.get("tl.ascend_round"),
+        out_ptr,
+        buffer_ptr,
+        tmp.access_ptr("r"),
+        count
     )
 
-
-def broadcast(
-    dst: Buffer | BufferRegion,
-    src: Buffer | BufferRegion,
-    tmp: Buffer | BufferRegion,
-):
+def broadcast(dst: Union[Buffer, BufferRegion],  # noqa: FA100
+              src: Union[Buffer, BufferRegion],  # noqa: FA100
+              tmp: Union[Buffer, BufferRegion]):  # noqa: FA100
     """Generates a TIR intrinsic call for the AscendC `Broadcast` operation.
 
     This function performs a broadcast copy from the source buffer (`src`) to the

--- a/tilelang/language/customize.py
+++ b/tilelang/language/customize.py
@@ -8,6 +8,7 @@ import tilelang.language as T
 from tvm.tir import PrimExpr, Buffer, BufferRegion, Var
 from tvm import tir
 from tilelang.language.ascend import _dtype
+import math
 
 
 def atomic_add(dst: Buffer, value: PrimExpr) -> PrimExpr:
@@ -186,7 +187,9 @@ def npu_gemm(A, B, C, init=False):
             offset = 0
             for i in range(len(indices)):
                 offset += indices[i] * strides[i]
-            return buffer.access_ptr(access_mask=access_type, offset=offset)
+            extent = [x.extent for x in object.region]
+            size_extent = math.prod(extent)
+            return buffer.access_ptr(access_mask=access_type, offset=offset, extent=size_extent)
         else:
             raise ValueError(f"Unsupported argument type: {type(object)} for buffer {object}")
 

--- a/tilelang/language/customize.py
+++ b/tilelang/language/customize.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import tilelang.language as T
+from tilelang.language.tir import op
 from tvm.tir import PrimExpr, Buffer, BufferRegion, Var
 from tvm import tir
 from tilelang.language.ascend import _dtype
@@ -202,4 +203,4 @@ def npu_gemm(A, B, C, init=False):
 
 def loop_break():
     """Break out of the innermost loop."""
-    return T.call_intrin("handle", op.Op.get("tl.loop_break"))
+    return T.call_intrin("handle", op.Op.get("tl.loop_break"))  # noqa: F821


### PR DESCRIPTION
1. 14 operators, such as sigmoid and scalar_op, support the buffer region.
2. The pto backend adapts to the buffer region of 14 operators, such as sigmoid and scalar_op. 
3. The buffer region test cases of related operators are added to pytest.