### PR TITLE
[Refactor] Fix cross-core pipeline counter reset, revert transpose auto-inference 🤖

### DIFF
--- a/examples/flash_attention/fa_opt/flash_attn_bhsd_auto_pipeline_h16_d128.py
+++ b/examples/flash_attention/fa_opt/flash_attn_bhsd_auto_pipeline_h16_d128.py
@@ -182,14 +182,14 @@ def flash_attention_fwd(
                     # ---- C: QK matmul (even) → ws1[0] ----
                     T.copy(K[bz, kv_by, kv_offset * block_N : (kv_offset + 1) * block_N, :], k_l1)
                     T.copy(q_l1, l0a[0, :, :])
-                    T.copy(k_l1, l0b[0, :, :])
+                    T.copy(k_l1, l0b[0, :, :], transpose=True)
                     T.mma(l0a[0, :, :], l0b[0, :, :], l0c[0, :, :], init=True)
                     T.copy(l0c[0, :, :], workspace_1[cid, 0, :, :])
 
                     # ---- C: QK matmul (odd) → ws1[1] ----
                     T.copy(K[bz, kv_by, (kv_offset + 1) * block_N : (kv_offset + 2) * block_N, :], k_l1)
                     T.copy(q_l1, l0a[1, :, :])
-                    T.copy(k_l1, l0b[1, :, :])
+                    T.copy(k_l1, l0b[1, :, :], transpose=True)
                     T.mma(l0a[1, :, :], l0b[1, :, :], l0c[1, :, :], init=True)
                     T.copy(l0c[1, :, :], workspace_1[cid, 1, :, :])
 

--- a/examples/flash_attention/fa_opt/flash_attn_bhsd_expert_h16_d128.py
+++ b/examples/flash_attention/fa_opt/flash_attn_bhsd_expert_h16_d128.py
@@ -174,7 +174,7 @@ def flash_attention_fwd(
                                 T.copy(q_l1, l0a[side, :, :])
 
                             T.wait_flag("MTE2", "MTE1", SIG_K_L1)
-                            T.copy(k_l1, l0b[side, :, :])
+                            T.copy(k_l1, l0b[side, :, :], transpose=True)
                             T.set_flag("MTE1", "MTE2", SIG_K_L1)
                             T.set_flag("MTE1", "M", SIG_L0AB + side)
 

--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -205,14 +205,6 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
                << ", dst = " << dst.scope();
   }
 
-  // Auto-infer transpose for L1→L0 copies from layout_map.
-  // nZ layout implies the L1 data needs transpose on load to L0.
-  if (config.l12l0 && !transposeL1 && T.layout_map.count(src)) {
-    if (T.layout_map[src]->AscendLayoutStr() == "layout::nZ") {
-      transposeL1 = true;
-    }
-  }
-
   if (!config.print_ub) {
     ss << "<" << get_dtype(src) << ", ";
 
@@ -249,7 +241,7 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     } else {
       ss << src->shape[src_ndim - 2] << ", " << src->shape[src_ndim - 1];
       if (config.l12l0) {
-        ss << ", " << (transposeL1 ? "true" : "false") << ">";
+        transposeL1 == 0 ? ss << ", false" << ">" : ss << ", true" << ">";
       }
       // ss << src->shape[src_ndim - 2] << ", " << src->shape[src_ndim - 1] <<
       // ", "

--- a/src/op/ascend.h
+++ b/src/op/ascend.h
@@ -33,7 +33,7 @@ private:
   Array<PrimExpr> src_extents, dst_extents;
   int srcN;
   bool enRelu;
-  mutable bool transposeL1;
+  bool transposeL1;
   PrimExpr padValue;
 };
 

--- a/src/transform/cross_core_pipeline.cc
+++ b/src/transform/cross_core_pipeline.cc
@@ -328,7 +328,6 @@ public:
 
     bool has_new_C = saved_statements_C.size() < all_statements_C_.size();
     bool has_new_V = saved_statements_V.size() < all_statements_V_.size();
-    size_t new_all = all_statements_.size() - saved_statements.size();
 
     if (has_new_V) {
       ProcessInfo(workspace_writes_V_, all_statements_V_, saved_statements_V,
@@ -345,6 +344,7 @@ public:
       unified_for_info.scope = core_scope_;
       ProcessInfoUnified(all_statements_, saved_statements, saved_idx,
                          unified_for_info);
+      current_idx_ = all_statements_.size();
     }
   }
 
@@ -367,12 +367,7 @@ private:
 
     std::set<std::string> for_node_buffers;
     std::vector<AccessInfo> for_node_accesses;
-    // Use saved_statements.size() as array start position, NOT for_info.idx.
-    // for_info.idx tracks logical statement index (current_idx_X_) which drifts
-    // ahead of actual array size when previous ForNodes collapse N entries
-    // into 1.
-    size_t inner_start = saved_statements.size();
-    for (size_t i = inner_start; i < all_statements.size(); i++) {
+    for (size_t i = for_info.idx; i < all_statements.size(); i++) {
       auto buffers = all_statements[i].used_buffers;
       for (auto it = buffers.begin(); it != buffers.end(); ++it) {
         for_node_buffers.insert(*it);
@@ -394,9 +389,7 @@ private:
 
     std::set<std::string> for_node_buffers;
     std::vector<AccessInfo> for_node_accesses;
-    // Same fix: use array position, not logical index.
-    size_t inner_start = saved_statements.size();
-    for (size_t i = inner_start; i < all_statements.size(); i++) {
+    for (size_t i = for_info.idx; i < all_statements.size(); i++) {
       for (const auto &buf : all_statements[i].used_buffers) {
         for_node_buffers.insert(buf);
       }
@@ -689,9 +682,7 @@ public:
   LoopRewriter(const LoopAnalyzer &analyzer, const ForNode *original_loop,
                int num_stages, int cross_interval = 1)
       : analyzer_(analyzer), original_loop_(original_loop),
-        all_statements_(analyzer.all_statements()),
-        all_statements_C_(analyzer.all_statements_C()),
-        all_statements_V_(analyzer.all_statements_V()), num_stages_(num_stages),
+        all_statements_(analyzer.all_statements()), num_stages_(num_stages),
         cross_interval_(cross_interval) {
     original_loop_var_ = original_loop->loop_var;
     std::string outer_var_name = original_loop_var_->name_hint + "_outer";
@@ -899,8 +890,6 @@ private:
   const LoopAnalyzer &analyzer_;
   const ForNode *original_loop_;
   const std::vector<LoopAnalyzer::StmtInfo> &all_statements_;
-  const std::vector<LoopAnalyzer::StmtInfo> &all_statements_C_;
-  const std::vector<LoopAnalyzer::StmtInfo> &all_statements_V_;
   std::set<std::string> shared_buffers_;
   int num_stages_;
   int cross_interval_;


### PR DESCRIPTION
## Summary

Follow-up to #698 (which squash-merged #673). A few changes from #673's final commit (f6ea0a0) were not included in the squash — this PR brings them over.

## Changes

### Cross-Core Pipeline (`cross_core_pipeline.cc`)
- **Fix `current_idx_` not reset** after `ProcessInfoUnified` folds inner statements into a ForNode — add `current_idx_ = all_statements_.size()` after the call
- **Revert `inner_start` workaround** back to `for_info.idx` in `ProcessInfo` / `ProcessInfoUnified` loops — with the counter reset, `for_info.idx` correctly tracks array position again
- **Remove unused `new_all` variable**
- **Remove dead `all_statements_C_` / `all_statements_V_` references** from `LoopRewriter`

### Transpose Auto-Inference (`ascend.cc`, `ascend.h`)
- **Revert transpose auto-inference** from layout_map in `AscendCopy::Lower` — users should explicitly pass `transpose=True` in `T.copy` for nZ-layout buffers

## Context

#698 adopted the `inner_start = saved_statements.size()` workaround for the pipeline index drift bug. #673's final commit (f6ea0a0) found a cleaner fix: reset `current_idx_` after folding, which lets the original `for_info.idx` loop work correctly without the workaround.

The transpose auto-inference was also reverted in f6ea0a0 — explicit `transpose=True` is more predictable than silently inferring from layout_map, which can change behavior when layout annotations change.