### PR TITLE
[AscendNPU-IR] Support WrapHostFunc pass

### DIFF
--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -281,6 +281,7 @@ def lower(
         pipeline = Pipeline()
         pipeline.add(transforms.mlir.canonicalize, top_down=True)
         pipeline.add(transforms.bishengir.adapt_triton_kernel)
+        pipeline.add(transforms.tilelangir.wrap_host_function)
         if dump_ir:
             pipeline.enable_ir_printing()
         mlir_str = pipeline.run(mlir_str)

--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -1,5 +1,4 @@
 # Copyright (c) Huawei Technologies Co., Ltd. 2025.
-import ctypes
 import os
 import re
 import subprocess
@@ -17,6 +16,7 @@ from ..utils import (
     get_runtime_file_cache,
     get_npu_launcher_header,
     safe_copy,
+    _NpuSoHostProbe,
 )
 
 from tvm import tir
@@ -1102,45 +1102,6 @@ class compiler_npu:
     def __init__(self) -> None:
         pass
 
-    def _get_workspace_size(self, lib_path, suffix, default=32768):
-        # Try to get the infer_workspace_shape_function in the kernel, then use the return value as workspace_size
-        # Use default to avoid except
-        # If you have set the os env "TILELANG_ASCEND_WORKSPACE_SIZE", "TILELANG_ASCEND_WORKSPACE_SIZE" has a higher priority
-        if not os.path.exists(lib_path):
-            return default
-        symbols = []
-        # Try to get the kernel symbol table and match function name "***_infer_workspace_shape_function"
-        try:
-            result = subprocess.run(
-                ["nm", "-D", lib_path], capture_output=True, text=True, timeout=2
-            )
-            if result.returncode == 0:
-                for line in result.stdout.split("\n"):
-                    parts = line.strip().split()
-                    if len(parts) >= 3:
-                        sym_name = parts[2]
-                        if sym_name.endswith(suffix):
-                            symbols.append(sym_name)
-        except (subprocess.SubprocessError, FileNotFoundError, OSError, TimeoutError):
-            pass
-
-        if not symbols:
-            return default
-        # Load the lib
-        try:
-            lib = ctypes.CDLL(lib_path)
-        except OSError:
-            return default
-        # Get the return value
-        for func_name in symbols:
-            try:
-                func = getattr(lib, func_name)
-                func.restype = ctypes.c_int
-                return func()
-            except (AttributeError, OSError, TypeError):
-                continue
-        return default
-
     def compile(self, mod: PrimFunc, out_idx=None) -> JitKernel_NPU:
         self.original_mod = mod
         # extract_param_info
@@ -1166,10 +1127,6 @@ class compiler_npu:
         else:
             self.mlir_content = mlir_path
         self.constants = {}
-        # get signature information
-        self.signature = self._parse_signature()
-
-        self.metadata["signature"] = self.signature
         self.metadata["primfunc"] = self.mod
         self.metadata["mlir_content"] = self.mlir_content
 
@@ -1177,6 +1134,8 @@ class compiler_npu:
         self.lock_ini_val = 0
         self._parse_npuir_metadata()
         self.metadata["kernel_src"] = self._npuir_to_bin_enable_npu_compile()
+        self.metadata["signature"] = self.signature
+
         self.header_path = get_npu_launcher_header()
         self.wrapper_src = generate_npu_wrapper_src(
             self.constants,
@@ -1302,127 +1261,17 @@ class compiler_npu:
 
     def _parse_npuir_metadata(self) -> None:
         """
-        Parse NPU IR to extract metadata required for NPU compilation.
-        Extracts and updates the following fields in metadata:
-          - mix_mode
-          - kernel_name
-          - tensor_kinds (currently hardcoded)
-          - shared (currently hardcoded)
-          - name (combined kernel_name and mix_mode)
-
-        Additionally, removes the mix_mode attribute from the IR.
+        Parse NPU IR to extract mix_mode from module-level attribute.
+        Other metadata (kernel_name, name, signature) are extracted from
+        the compiled .so via the WrapHostFunction pass.
         """
-        # --- Regular expressions and examples ---
-        # Example: func.func @gather_sorted_kernel(%arg0: ...) -> gather_sorted_kernel
-        KERNEL_NAME_REGEX = r"func\.func\s+@(\w+)"
-
-        # Example：hivm.module_core_type<MIX> -> MIX
         MIX_MODE_REGEX = r"#hivm\.module_core_type<([^>]+)>"
 
-        # Example: test_mix_aic -> test
-        MIX_SUFFIX_REGEX = r"_(mix_aic|mix_aiv)$"
-
-        # Note: Compiled Kernel requires to estimate size of shared memory to occupy
-        # Currently, NPU backend does not limit on shared memory
         self.metadata["shared"] = 1
-        # the mix mode is also encoded into metadata['name'] for runtime to distinguish
-        kernel_name = re.search(KERNEL_NAME_REGEX, self.mlir_content).group(1)
-        self.metadata["kernel_name"] = kernel_name
-        # matching the end of the _mix_aic or _mix_aiv
-        self.metadata["name"] = re.sub(MIX_SUFFIX_REGEX, "", kernel_name)
         self.metadata["tensor_kinds"] = []
         self.metadata["mix_mode"] = (
             re.search(MIX_MODE_REGEX, self.mlir_content).group(1).lower()
         )
-
-    def _parse_signature(self) -> dict:
-        """
-        Parse parameter types from MLIR text and return a dictionary.
-        """
-        # Define the data types of concern
-        target_types = {
-            "i1",
-            "i8",
-            "i16",
-            "i32",
-            "i64",
-            "u32",
-            "u64",
-            "fp16",
-            "bf16",
-            "fp32",
-            "f32",
-            "fp64",
-            "f16",
-        }
-
-        # Extract the function signature part (the content within the parentheses)
-        pattern = r"func\.func\s*@[^(]*\(([^)]*)\)"
-        match = re.search(pattern, self.mlir_content)
-
-        if not match:
-            return {}
-
-        params_str = match.group(1)
-
-        # Segmentation parameters
-        params = []
-        current_param = ""
-        brace_count = 0
-        angle_count = 0
-
-        for char in params_str:
-            if char == "," and brace_count == 0 and angle_count == 0:
-                params.append(current_param.strip())
-                current_param = ""
-            else:
-                current_param += char
-                if char == "{":
-                    brace_count += 1
-                elif char == "}":
-                    brace_count -= 1
-                elif char == "<":
-                    angle_count += 1
-                elif char == ">":
-                    angle_count -= 1
-
-        if current_param:
-            params.append(current_param.strip())
-
-        result = {}
-        index = 0
-
-        # Skip parameters insert by compiler
-        for param in params[3:-6]:
-            # Check if the type includes the target type
-            found_type = None
-            for t_type in target_types:
-                # Check for types with an x prefix (e.g., xf16)
-                x_pattern = r"\bx" + t_type + r"\b"
-                if re.search(x_pattern, param):
-                    found_type = "*" + t_type
-                    break
-                # Check the common type (such as i32)
-                elif re.search(r"\b" + t_type + r"\b", param):
-                    found_type = t_type
-                    break
-
-            if found_type:
-                # Special handling: f16 should be mapped to fp16,
-                # and f32 should be mapped to fp32.
-                if found_type == "f16":
-                    found_type = "fp16"
-                elif found_type == "*f16":
-                    found_type = "*fp16"
-                elif found_type == "f32":
-                    found_type = "fp32"
-                elif found_type == "*f32":
-                    found_type = "*fp32"
-
-                result[index] = found_type
-                index += 1
-
-        return result
 
     def _npuir_to_bin_enable_npu_compile(self):
         linalg = self.mlir_content
@@ -1470,10 +1319,19 @@ class compiler_npu:
                 raise RuntimeError(f"NPU IR opt failed: {e.stderr}") from e
             except Exception as e:
                 raise RuntimeError(f"NPU IR opt failed: {e.stderr}") from e
-            result = self._get_workspace_size(
-                so_path, "_infer_workspace_shape_function"
-            )
-            self.workspace_size = result
+            
+            self.workspace_size = _NpuSoHostProbe._get_workspace_size(so_path)
+
+            # Extract kernel signature & base name from host functions
+            # generated by the WrapHostFunction pass.
+            kernel_name, base_name, sig = _NpuSoHostProbe._get_kernel_signature(so_path)
+            if kernel_name is None or base_name is None or sig is None:
+                raise RuntimeError(
+                    "Failed to extract kernel metadata from compiled .so. "
+                )
+            self.metadata["name"] = base_name
+            self.metadata["kernel_name"] = kernel_name
+            self.signature = sig
 
             if not Path(bin_path).exists():
                 err_lines = [

--- a/tilelang/tladapter/transforms/tilelangir.py
+++ b/tilelang/tladapter/transforms/tilelangir.py
@@ -6,3 +6,4 @@ from tilelang.tladapter.utils import pass_fn
 
 cv_split = pass_fn("tilelangir-cv-split")
 vectorize = pass_fn("tilelangir-vectorize")
+wrap_host_function = pass_fn("tilelangir-wrap-host-function")

--- a/tilelang/utils/__init__.py
+++ b/tilelang/utils/__init__.py
@@ -31,3 +31,4 @@ from .npu_arch import (
     supports_native_bf16,  # noqa: F401
     get_arch_obj,  # noqa: F401
 )
+from .npu_host_funcs import _NpuSoHostProbe  # noqa: F401

--- a/tilelang/utils/npu_host_funcs.py
+++ b/tilelang/utils/npu_host_funcs.py
@@ -1,0 +1,151 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+import ctypes
+import os
+import subprocess
+from typing import Dict, List, Optional, Tuple
+
+_HOST_SUFFIX_GET_KERNEL_NUM_ARGS = "_get_kernel_num_args"
+_HOST_SUFFIX_GET_KERNEL_ARG_TYPE = "_get_kernel_arg_type"
+_HOST_SUFFIX_INFER_WORKSPACE_SHAPE = "_infer_workspace_shape_function"
+
+_NM_TIMEOUT_SEC = 2
+_DEFAULT_WORKSPACE_SIZE = 32768
+
+# Type encoding (must stay in sync with WrapHostFunction.cpp ElementTypeCode)
+
+_WRAPHOST_POINTER_FLAG = 0x80
+_WRAPHOST_TYPE_CODE_MASK = 0x7F
+_WRAPHOST_UNKNOWN_TYPE_CODE = 0x7F
+_WRAPHOST_TYPE_CODE_TO_SIG: Dict[int, str] = {
+    0: "fp32",
+    1: "fp16",
+    2: "bf16",
+    3: "i8",
+    4: "i16",
+    5: "i32",
+    6: "i64",
+    7: "u32",
+    8: "u64",
+    9: "fp64",
+    10: "i1",
+}
+
+
+class _NpuSoHostProbe:
+    """Facade for probing compiled ``.so`` host callbacks (internal API)."""
+
+    @staticmethod
+    def _find_symbols(lib_path: str, suffix: str) -> list:
+        """List dynamic symbol names in ``lib_path`` that end with ``suffix`` (``nm -D``)."""
+        symbols = []
+        if not os.path.exists(lib_path):
+            return symbols
+        try:
+            result = subprocess.run(
+                ["nm", "-D", lib_path],
+                capture_output=True,
+                text=True,
+                timeout=_NM_TIMEOUT_SEC,
+            )
+            if result.returncode == 0:
+                for line in result.stdout.split("\n"):
+                    parts = line.strip().split()
+                    if len(parts) >= 3 and parts[2].endswith(suffix):
+                        symbols.append(parts[2])
+        except (subprocess.SubprocessError, FileNotFoundError, OSError, TimeoutError):
+            pass
+        return symbols
+
+    @staticmethod
+    def _call_so_symbol(lib_path: str, func_name: str, restype=ctypes.c_int):
+        """``CDLL`` + call exported ``func_name``."""
+        try:
+            lib = ctypes.CDLL(lib_path)
+            func = getattr(lib, func_name)
+            func.restype = restype
+            return func()
+        except (OSError, AttributeError, TypeError):
+            return None
+
+    @staticmethod
+    def _pick_num_args_symbol(
+        lib_path: str, num_args_symbols: List[str]
+    ) -> Optional[str]:
+        """Pick a deterministic ``*_get_kernel_num_args`` symbol."""
+        if not num_args_symbols:
+            return None
+        type_symbols = set(
+            _NpuSoHostProbe._find_symbols(lib_path, _HOST_SUFFIX_GET_KERNEL_ARG_TYPE)
+        )
+        for sym_name in sorted(num_args_symbols):
+            base_name = sym_name[: -len(_HOST_SUFFIX_GET_KERNEL_NUM_ARGS)]
+            if base_name + _HOST_SUFFIX_GET_KERNEL_ARG_TYPE in type_symbols:
+                return sym_name
+        return sorted(num_args_symbols)[0]
+
+    @staticmethod
+    def _get_kernel_signature(
+        lib_path: str,
+    ) -> Tuple[Optional[str], Optional[str], Optional[Dict[int, str]]]:
+        """Extract kernel symbol name, base name and signature from compiled ``.so``."""
+        num_args_syms = _NpuSoHostProbe._find_symbols(
+            lib_path, _HOST_SUFFIX_GET_KERNEL_NUM_ARGS
+        )
+        if not num_args_syms:
+            return None, None, None
+
+        sym_name = _NpuSoHostProbe._pick_num_args_symbol(lib_path, num_args_syms)
+        if sym_name is None:
+            return None, None, None
+        kernel_name = sym_name[: -len(_HOST_SUFFIX_GET_KERNEL_NUM_ARGS)]
+        base_name = kernel_name
+        if base_name.endswith("_mix_aic") or base_name.endswith("_mix_aiv"):
+            base_name = base_name[:-8]
+        type_func_name = kernel_name + _HOST_SUFFIX_GET_KERNEL_ARG_TYPE
+
+        num_args = _NpuSoHostProbe._call_so_symbol(lib_path, sym_name, ctypes.c_int)
+        if num_args is None:
+            return kernel_name, base_name, None
+
+        try:
+            lib = ctypes.CDLL(lib_path)
+            type_func = getattr(lib, type_func_name)
+            type_func.restype = ctypes.c_int
+            type_func.argtypes = [ctypes.c_int]
+        except (OSError, AttributeError):
+            return kernel_name, base_name, None
+
+        sig: Dict[int, str] = {}
+        for i in range(num_args):
+            type_code = type_func(i)
+            is_ptr = bool(type_code & _WRAPHOST_POINTER_FLAG)
+            elem_code = type_code & _WRAPHOST_TYPE_CODE_MASK
+            type_str = _WRAPHOST_TYPE_CODE_TO_SIG.get(elem_code)
+            if elem_code == _WRAPHOST_UNKNOWN_TYPE_CODE or type_str is None:
+                raise RuntimeError(
+                    "Unknown kernel arg type code from host symbol: "
+                    f"func={type_func_name}, arg_index={i}, type_code={type_code}, "
+                    f"elem_code={elem_code}, so_path={lib_path}"
+                )
+            sig[i] = f"*{type_str}" if is_ptr else type_str
+        return kernel_name, base_name, sig
+
+    @staticmethod
+    def _get_workspace_size(
+        lib_path: str, default: int = _DEFAULT_WORKSPACE_SIZE
+    ) -> int:
+        """Resolve workspace size via ``*_infer_workspace_shape_function`` exports."""
+        symbols = _NpuSoHostProbe._find_symbols(
+            lib_path, _HOST_SUFFIX_INFER_WORKSPACE_SHAPE
+        )
+        if not symbols:
+            return default
+        for func_name in symbols:
+            val = _NpuSoHostProbe._call_so_symbol(lib_path, func_name, ctypes.c_int)
+            if val is not None:
+                return val
+        return default

--- a/tilelangir/include/tilelangir/Transforms/Passes.td
+++ b/tilelangir/include/tilelangir/Transforms/Passes.td
@@ -27,4 +27,21 @@ def TileLangIRVectorize : Pass<"tilelangir-vectorize", "::mlir::ModuleOp"> {
   }];
 }
 
+def TileLangIRWrapHostFunction : Pass<"tilelangir-wrap-host-function", "::mlir::ModuleOp"> {
+  let summary = "Generate host-side functions encoding kernel signature metadata";
+  let description = [{
+    For each device entry kernel, creates two host-side functions:
+      {baseName}_get_kernel_num_args()        - returns number of user args
+      {baseName}_get_kernel_arg_type(int idx) - returns type code for arg idx
+
+    Type code: bit 7 set for memref/pointer; bits 0-6 encode the element type
+    (0=fp32, 1=fp16, 2=bf16, 3=i8, 4=i16, 5=i32, 6=i64, 7=u32, 8=u64,
+     9=fp64, 10=i1).
+
+    User arguments are identified by skipping the first 3 compiler-inserted
+    parameters (ffts_base, sync_block_lock, workspace) and the last 6 grid
+    parameters.
+  }];
+}
+
 #endif // TILELANGIR_TRANSFORMS_PASSES_TD

--- a/tilelangir/lib/Transforms/CMakeLists.txt
+++ b/tilelangir/lib/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(tilelangir_transforms STATIC
   CVSplit.cpp
   Vectorize.cpp
+  WrapHostFunction.cpp
 )
 set_target_properties(tilelangir_transforms PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_compile_options(tilelangir_transforms PRIVATE -frtti)

--- a/tilelangir/lib/Transforms/WrapHostFunction.cpp
+++ b/tilelangir/lib/Transforms/WrapHostFunction.cpp
@@ -1,0 +1,217 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+
+/*!
+ * \file tilelangir/lib/Transforms/WrapHostFunction.cpp
+ * \brief Generate host-side functions encoding kernel parameter signatures.
+ *
+ * For each device entry kernel two host functions are injected:
+ *   {baseName}_get_kernel_num_args  – returns the number of user arguments
+ *   {baseName}_get_kernel_arg_type  – takes an i32 index, returns type code
+ */
+
+#include "tilelangir/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/StringSet.h"
+
+#include "bishengir/Dialect/HACC/IR/HACC.h"
+#include "bishengir/Dialect/HACC/Utils/Utils.h"
+
+namespace mlir {
+namespace tilelangir {
+
+#define GEN_PASS_DEF_TILELANGIRWRAPHOSTFUNCTION
+#include "tilelangir/Transforms/Passes.h.inc"
+
+} // namespace tilelangir
+} // namespace mlir
+
+#define DEBUG_TYPE "tilelangir-wrap-host-function"
+
+using namespace mlir;
+using namespace mlir::tilelangir;
+
+namespace {
+
+enum ElementTypeCode : int {
+  kFP32 = 0,
+  kFP16 = 1,
+  kBF16 = 2,
+  kI8 = 3,
+  kI16 = 4,
+  kI32 = 5,
+  kI64 = 6,
+  kU32 = 7,
+  kU64 = 8,
+  kFP64 = 9,
+  kI1 = 10,
+  kUnknown = 0x7F,
+  kPointerFlag = 0x80,
+};
+
+static int encodeElementType(Type type) {
+  if (type.isF32())
+    return kFP32;
+  if (type.isF16())
+    return kFP16;
+  if (type.isBF16())
+    return kBF16;
+  if (type.isInteger(8))
+    return kI8;
+  if (type.isInteger(16))
+    return kI16;
+  if (type.isInteger(32))
+    return kI32;
+  if (type.isInteger(64))
+    return kI64;
+  if (type.isF64())
+    return kFP64;
+  if (type.isInteger(1))
+    return kI1;
+  if (auto intTy = dyn_cast<IntegerType>(type)) {
+    if (intTy.isUnsigned()) {
+      if (intTy.getWidth() == 32)
+        return kU32;
+      if (intTy.getWidth() == 64)
+        return kU64;
+    }
+  }
+  return kUnknown;
+}
+
+static int encodeArgType(Type type) {
+  if (auto memrefTy = dyn_cast<MemRefType>(type))
+    return kPointerFlag | encodeElementType(memrefTy.getElementType());
+  return encodeElementType(type);
+}
+
+static std::string deriveBaseName(StringRef funcName) {
+  if (funcName.ends_with("_mix_aic"))
+    return funcName.drop_back(8).str();
+  if (funcName.ends_with("_mix_aiv"))
+    return funcName.drop_back(8).str();
+  return funcName.str();
+}
+
+static constexpr unsigned kCompilerPrefixArgs = 3;
+static constexpr unsigned kGridSuffixArgs = 6;
+
+/// Create `int {name}()` that returns \p numArgs.
+static func::FuncOp createNumArgsHostFunc(func::FuncOp entryFunc,
+                                          StringRef hostFuncName, int numArgs) {
+  OpBuilder builder(entryFunc.getContext());
+  builder.setInsertionPoint(entryFunc);
+  Location loc = entryFunc.getLoc();
+  auto i32Ty = builder.getI32Type();
+
+  auto hostFunc = builder.create<func::FuncOp>(
+      loc, hostFuncName,
+      FunctionType::get(entryFunc.getContext(), /*inputs=*/{},
+                        /*results=*/{i32Ty}));
+
+  Block *block = hostFunc.addEntryBlock();
+  builder.setInsertionPointToStart(block);
+
+  auto val = builder.create<arith::ConstantOp>(
+      loc, builder.getI32IntegerAttr(numArgs));
+  builder.create<func::ReturnOp>(loc, ValueRange{val});
+
+  hacc::utils::setHost(hostFunc);
+  return hostFunc;
+}
+
+/// Create `int {name}(int index)` that maps index → type code via
+/// a chain of `arith.select`, supporting an arbitrary number of entries.
+static func::FuncOp createArgTypeHostFunc(func::FuncOp entryFunc,
+                                          StringRef hostFuncName,
+                                          ArrayRef<int> typeCodes) {
+  OpBuilder builder(entryFunc.getContext());
+  builder.setInsertionPoint(entryFunc);
+  Location loc = entryFunc.getLoc();
+  auto i32Ty = builder.getI32Type();
+
+  auto hostFunc = builder.create<func::FuncOp>(
+      loc, hostFuncName,
+      FunctionType::get(entryFunc.getContext(), /*inputs=*/{i32Ty},
+                        /*results=*/{i32Ty}));
+
+  Block *block = hostFunc.addEntryBlock();
+  builder.setInsertionPointToStart(block);
+
+  Value indexArg = block->getArgument(0);
+
+  // Default for out-of-range index
+  Value result =
+      builder.create<arith::ConstantOp>(loc, builder.getI32IntegerAttr(-1));
+
+  // Build select chain from last to first so that index 0 is outermost
+  for (int i = static_cast<int>(typeCodes.size()) - 1; i >= 0; --i) {
+    Value idx =
+        builder.create<arith::ConstantOp>(loc, builder.getI32IntegerAttr(i));
+    Value typeVal = builder.create<arith::ConstantOp>(
+        loc, builder.getI32IntegerAttr(typeCodes[i]));
+    Value cmp = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
+                                              indexArg, idx);
+    result = builder.create<arith::SelectOp>(loc, cmp, typeVal, result);
+  }
+
+  builder.create<func::ReturnOp>(loc, ValueRange{result});
+
+  hacc::utils::setHost(hostFunc);
+  return hostFunc;
+}
+
+} // anonymous namespace
+
+namespace mlir {
+namespace tilelangir {
+
+struct TileLangIRWrapHostFunction
+    : public impl::TileLangIRWrapHostFunctionBase<TileLangIRWrapHostFunction> {
+  void runOnOperation() override {
+    auto module = getOperation();
+
+    llvm::StringSet<> processedBaseNames;
+    SmallVector<func::FuncOp> entryFuncs;
+
+    module.walk([&](func::FuncOp func) {
+      if (func->hasAttr("hacc.entry") || func->hasAttr("hivm.entry"))
+        entryFuncs.push_back(func);
+    });
+
+    for (auto entryFunc : entryFuncs) {
+      std::string baseName = deriveBaseName(entryFunc.getSymName());
+      if (!processedBaseNames.insert(baseName).second)
+        continue;
+
+      unsigned totalArgs = entryFunc.getNumArguments();
+      unsigned numUserArgs = 0;
+      SmallVector<int> typeCodes;
+
+      if (totalArgs >= kCompilerPrefixArgs + kGridSuffixArgs) {
+        numUserArgs = totalArgs - kCompilerPrefixArgs - kGridSuffixArgs;
+        auto argTypes = entryFunc.getArgumentTypes();
+        for (unsigned i = 0; i < numUserArgs; ++i) {
+          typeCodes.push_back(encodeArgType(argTypes[kCompilerPrefixArgs + i]));
+        }
+      }
+
+      createNumArgsHostFunc(entryFunc, baseName + "_get_kernel_num_args",
+                            static_cast<int>(numUserArgs));
+      createArgTypeHostFunc(entryFunc, baseName + "_get_kernel_arg_type",
+                            typeCodes);
+    }
+  }
+};
+
+std::unique_ptr<Pass> createTileLangIRWrapHostFunctionPass() {
+  return std::make_unique<TileLangIRWrapHostFunction>();
+}
+
+} // namespace tilelangir
+} // namespace mlir


### PR DESCRIPTION
The current jit_npu uses regular expressions to extract metadata, which can lead to incorrect information extraction when host-side functions are present. A new host-side function added to achieve secure metadata extraction.