### PR TITLE
[AscendNPU-IR] Add MLIR verifier for exp and dev mode

### DIFF
--- a/src/target/codegen_npuir_api.cc
+++ b/src/target/codegen_npuir_api.cc
@@ -499,6 +499,13 @@ std::string CodeGenTileLangNPUIRAPI::Finish() {
   std::string mlirCode;
   llvm::raw_string_ostream os(mlirCode);
   module->print(os);
+
+  if (failed(mlir::verify(*module))) {
+    LOG(FATAL) << "CodeGenTileLangNPUIRAPI: Generated MLIR module failed "
+                  "verification: \n"
+               << mlirCode;
+  }
+
   return mlirCode;
 }
 

--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -359,6 +359,13 @@ std::string CodeGenTileLangNPUIRDEV::Finish() {
   std::string mlirCode;
   llvm::raw_string_ostream os(mlirCode);
   module->print(os);
+
+  if (failed(mlir::verify(*module))) {
+    LOG(FATAL) << "CodeGenTileLangNPUIRDEV: Generated MLIR module failed "
+                  "verification: \n"
+               << mlirCode;
+  }
+
   return mlirCode;
 }
 


### PR DESCRIPTION
This PR enables built-in MLIR verifier for dev and expert mode. The verifier captures invalid MLIR errors early and doesn't allow invalid MLIR to be passed to the CANN pipeline.