### PR TITLE
[AscendNPU-IR][Developer] Fix T.copy gm2ub and ub2gm implicit cast realization

### DIFF
--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1101,6 +1101,44 @@ mlir::Value CodeGenTileLangNPUIRDEV::InsertSlice(
   return insertOp.getResult();
 }
 
+// Helper to handle slice insertion with optional type casting
+mlir::Value CodeGenTileLangNPUIRDEV::InsertSliceWithCast(
+    mlir::Value src_slice, mlir::Value dst, const SliceRange& dstR,
+    mlir::Location loc) {
+  auto srcElemTy = mlir::getElementTypeOrSelf(src_slice.getType());
+  auto dstElemTy = mlir::getElementTypeOrSelf(dst.getType());
+
+  if (srcElemTy == dstElemTy) {
+    return InsertSlice(
+        src_slice, dst,
+        const_cast<llvm::SmallVector<mlir::OpFoldResult> &>(dstR.offs),
+        const_cast<llvm::SmallVector<mlir::OpFoldResult> &>(dstR.sizes),
+        const_cast<llvm::SmallVector<mlir::OpFoldResult> &>(dstR.strides));
+  }
+
+  // Type mismatch path: use intermediate empty tensor of rank D to avoid rank
+  // mismatch in backend vcast fusion
+  auto dstTy = dst.getType().cast<mlir::RankedTensorType>();
+  auto shadowTy = mlir::RankedTensorType::get(dstTy.getShape(), srcElemTy);
+
+  llvm::SmallVector<mlir::Value> dynamicDims;
+  for (int64_t i = 0; i < dstTy.getRank(); ++i) {
+    if (dstTy.isDynamicDim(i)) {
+      dynamicDims.push_back(builder.create<mlir::tensor::DimOp>(loc, dst, i));
+    }
+  }
+  mlir::Value shadow_empty =
+      builder.create<mlir::tensor::EmptyOp>(loc, shadowTy, dynamicDims);
+
+  mlir::Value inserted = InsertSlice(
+      src_slice, shadow_empty,
+      const_cast<llvm::SmallVector<mlir::OpFoldResult> &>(dstR.offs),
+      const_cast<llvm::SmallVector<mlir::OpFoldResult> &>(dstR.sizes),
+      const_cast<llvm::SmallVector<mlir::OpFoldResult> &>(dstR.strides));
+
+  return CreateCastIfTypeMismatch(inserted, dst);
+}
+
 // Smart reshape tensor using expand_shape or collapse_shape when possible,
 // falling back to collapse_shape + expand_shape only when necessary.
 //
@@ -1666,8 +1704,6 @@ void CodeGenTileLangNPUIRDEV::EmitCopyMemrefToTensor(
   auto ubTy = base_ub.getType().cast<mlir::MemRefType>();
 
   if ((int64_t)copy_sizes.size() == ubTy.getRank()) {
-    // When shape is static and matches alloc shape (offsets are 0), skip
-    // subview
     if (OpFoldResultsEqualStaticShape(copy_sizes, ub_alloc_shape)) {
       ub_view = base_ub;
     } else {
@@ -1709,20 +1745,10 @@ void CodeGenTileLangNPUIRDEV::EmitCopyMemrefToTensor(
   mlir::Value loaded_tensor = builder.create<mlir::bufferization::ToTensorOp>(
       loc, ub_view, /*restrict=*/true, /*writable=*/false);
 
-  // 7) Type Cast (skip reshape - let InsertSlice handle rank difference to
-  // avoid
-  //    expand_shape failures on strided memrefs from subview)
-  mlir::Value casted_tensor = CreateCastIfTypeMismatch(loaded_tensor, dst);
+  // 7) Insert slice with optional cast
+  mlir::Value result = InsertSliceWithCast(loaded_tensor, dst, dstR, loc);
 
-  // 8) InsertSlice - tensor.insert_slice can handle source rank < dest rank,
-  //    using dstR.sizes to specify the slice shape in the destination.
-  mlir::Value result = InsertSlice(
-      casted_tensor, dst,
-      const_cast<llvm::SmallVector<mlir::OpFoldResult> &>(dstR.offs),
-      const_cast<llvm::SmallVector<mlir::OpFoldResult> &>(dstR.sizes),
-      const_cast<llvm::SmallVector<mlir::OpFoldResult> &>(dstR.strides));
-
-  // 9) SetVarValue
+  // 8) SetVarValue
   SetVarValue(npuirop.dst, result);
 }
 
@@ -1795,13 +1821,8 @@ void CodeGenTileLangNPUIRDEV::EmitCopyTensorToTensor(
   mlir::Value src_slice = CreateRankReducedExtractSlice(
       src, srcR.offs, srcR.sizes, srcR.strides, srcC.projected, loc);
 
-  mlir::Value casted_tensor = CreateCastIfTypeMismatch(src_slice, dst);
-
-  mlir::Value result = InsertSlice(
-      casted_tensor, dst,
-      const_cast<llvm::SmallVector<mlir::OpFoldResult> &>(dstR.offs),
-      const_cast<llvm::SmallVector<mlir::OpFoldResult> &>(dstR.sizes),
-      const_cast<llvm::SmallVector<mlir::OpFoldResult> &>(dstR.strides));
+  // Insert slice with optional cast
+  mlir::Value result = InsertSliceWithCast(src_slice, dst, dstR, loc);
 
   SetVarValue(npuirop.dst, result);
 }

--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1659,7 +1659,7 @@ void CodeGenTileLangNPUIRDEV::EmitCopyMemrefToTensor(
       << "dst with dynamic dimension(s) not supported for UB alloc";
 
   mlir::Value base_ub = CreateStaticLocalUB(
-      ub_alloc_shape, dst_tensor_type_ori.getElementType(), loc);
+      ub_alloc_shape, src_memref_type_ori.getElementType(), loc);
 
   // 4) Create ub_view matching copy rank
   mlir::Value ub_view;

--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1102,9 +1102,10 @@ mlir::Value CodeGenTileLangNPUIRDEV::InsertSlice(
 }
 
 // Helper to handle slice insertion with optional type casting
-mlir::Value CodeGenTileLangNPUIRDEV::InsertSliceWithCast(
-    mlir::Value src_slice, mlir::Value dst, const SliceRange& dstR,
-    mlir::Location loc) {
+mlir::Value CodeGenTileLangNPUIRDEV::InsertSliceWithCast(mlir::Value src_slice,
+                                                         mlir::Value dst,
+                                                         const SliceRange &dstR,
+                                                         mlir::Location loc) {
   auto srcElemTy = mlir::getElementTypeOrSelf(src_slice.getType());
   auto dstElemTy = mlir::getElementTypeOrSelf(dst.getType());
 

--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1064,23 +1064,114 @@ mlir::Value CodeGenTileLangNPUIRDEV::CreateCastIfTypeMismatch(mlir::Value src,
       mlir::RankedTensorType::get(srcTensorTy.getShape(), dstElemTy);
 
   auto loc = builder.getUnknownLoc();
-
-  SmallVector<mlir::Value> dynamicDims;
-  for (int64_t i = 0, rank = srcTensorTy.getRank(); i < rank; ++i) {
-    if (srcTensorTy.isDynamicDim(i)) {
-      dynamicDims.push_back(builder.create<mlir::tensor::DimOp>(loc, src, i));
-    }
-  }
-
-  auto castDstTensor =
-      builder.create<mlir::tensor::EmptyOp>(loc, resultTensorTy, dynamicDims);
+  mlir::Value castDstTensor =
+      CreateStaticBackedTensor(resultTensorTy, src, dst, loc);
 
   auto newCastOp = builder.create<mlir::hivm::VCastOp>(
-      loc, resultTensorTy, src, castDstTensor.getResult(),
+      loc, resultTensorTy, src, castDstTensor,
       mlir::hivm::RoundModeAttr::get(&context, mlir::hivm::RoundMode::RINT),
       nullptr);
 
   return newCastOp->getResult(0);
+}
+
+int64_t CodeGenTileLangNPUIRDEV::InferStaticUpperBoundForDim(
+    mlir::Value shaped_value, int64_t dim) {
+  if (!shaped_value)
+    return mlir::ShapedType::kDynamic;
+
+  auto shapedTy = shaped_value.getType().dyn_cast<mlir::ShapedType>();
+  if (!shapedTy || !shapedTy.hasRank() || dim < 0 || dim >= shapedTy.getRank())
+    return mlir::ShapedType::kDynamic;
+
+  if (!shapedTy.isDynamicDim(dim))
+    return shapedTy.getDimSize(dim);
+
+  if (auto toTensor =
+          shaped_value.getDefiningOp<mlir::bufferization::ToTensorOp>()) {
+    return InferStaticUpperBoundForDim(toTensor.getMemref(), dim);
+  }
+
+  if (auto extract =
+          shaped_value.getDefiningOp<mlir::tensor::ExtractSliceOp>()) {
+    auto srcTy = extract.getSource().getType().dyn_cast<mlir::ShapedType>();
+    if (srcTy && srcTy.hasRank() && srcTy.getRank() == shapedTy.getRank()) {
+      return InferStaticUpperBoundForDim(extract.getSource(), dim);
+    }
+  }
+
+  if (auto insert = shaped_value.getDefiningOp<mlir::tensor::InsertSliceOp>()) {
+    return InferStaticUpperBoundForDim(insert.getDest(), dim);
+  }
+
+  if (auto tensorCast = shaped_value.getDefiningOp<mlir::tensor::CastOp>()) {
+    return InferStaticUpperBoundForDim(tensorCast.getSource(), dim);
+  }
+
+  if (auto subview = shaped_value.getDefiningOp<mlir::memref::SubViewOp>()) {
+    auto srcTy = subview.getSource().getType().dyn_cast<mlir::ShapedType>();
+    if (srcTy && srcTy.hasRank() && srcTy.getRank() == shapedTy.getRank()) {
+      return InferStaticUpperBoundForDim(subview.getSource(), dim);
+    }
+  }
+
+  return mlir::ShapedType::kDynamic;
+}
+
+mlir::Value CodeGenTileLangNPUIRDEV::CreateDimValueForShaped(
+    mlir::Location loc, mlir::Value shaped_value, int64_t dim) {
+  if (shaped_value.getType().isa<mlir::RankedTensorType>()) {
+    return builder.create<mlir::tensor::DimOp>(loc, shaped_value, dim);
+  }
+  if (shaped_value.getType().isa<mlir::MemRefType>()) {
+    return builder.create<mlir::memref::DimOp>(loc, shaped_value, dim);
+  }
+  ICHECK(false) << "expected ranked tensor or memref for dim query";
+  return mlir::Value{};
+}
+
+mlir::Value CodeGenTileLangNPUIRDEV::CreateStaticBackedTensor(
+    mlir::RankedTensorType tensor_type, mlir::Value runtime_shape_source,
+    mlir::Value static_bound_source, mlir::Location loc) {
+  llvm::SmallVector<int64_t> staticShape(tensor_type.getShape().begin(),
+                                         tensor_type.getShape().end());
+  bool needsSlice = false;
+  for (int64_t i = 0, rank = tensor_type.getRank(); i < rank; ++i) {
+    if (!tensor_type.isDynamicDim(i))
+      continue;
+    needsSlice = true;
+    int64_t upperBound = InferStaticUpperBoundForDim(runtime_shape_source, i);
+    if (mlir::ShapedType::isDynamic(upperBound)) {
+      upperBound = InferStaticUpperBoundForDim(static_bound_source, i);
+    }
+    ICHECK(!mlir::ShapedType::isDynamic(upperBound))
+        << "failed to infer static upper bound for dynamic tensor dim " << i;
+    staticShape[i] = upperBound;
+  }
+
+  mlir::Value fullEmpty = builder.create<mlir::tensor::EmptyOp>(
+      loc, staticShape, tensor_type.getElementType());
+  if (!needsSlice) {
+    return fullEmpty;
+  }
+
+  llvm::SmallVector<mlir::OpFoldResult> offsets(tensor_type.getRank(),
+                                                builder.getIndexAttr(0));
+  llvm::SmallVector<mlir::OpFoldResult> strides(tensor_type.getRank(),
+                                                builder.getIndexAttr(1));
+  llvm::SmallVector<mlir::OpFoldResult> sizes;
+  sizes.reserve(tensor_type.getRank());
+
+  for (int64_t i = 0, rank = tensor_type.getRank(); i < rank; ++i) {
+    if (tensor_type.isDynamicDim(i)) {
+      sizes.push_back(CreateDimValueForShaped(loc, runtime_shape_source, i));
+    } else {
+      sizes.push_back(builder.getIndexAttr(tensor_type.getDimSize(i)));
+    }
+  }
+
+  return builder.create<mlir::tensor::ExtractSliceOp>(
+      loc, tensor_type, fullEmpty, offsets, sizes, strides);
 }
 
 // Insert slice into tensor
@@ -1121,15 +1212,8 @@ mlir::Value CodeGenTileLangNPUIRDEV::InsertSliceWithCast(mlir::Value src_slice,
   // mismatch in backend vcast fusion
   auto dstTy = dst.getType().cast<mlir::RankedTensorType>();
   auto shadowTy = mlir::RankedTensorType::get(dstTy.getShape(), srcElemTy);
-
-  llvm::SmallVector<mlir::Value> dynamicDims;
-  for (int64_t i = 0; i < dstTy.getRank(); ++i) {
-    if (dstTy.isDynamicDim(i)) {
-      dynamicDims.push_back(builder.create<mlir::tensor::DimOp>(loc, dst, i));
-    }
-  }
   mlir::Value shadow_empty =
-      builder.create<mlir::tensor::EmptyOp>(loc, shadowTy, dynamicDims);
+      CreateStaticBackedTensor(shadowTy, dst, src_slice, loc);
 
   mlir::Value inserted = InsertSlice(
       src_slice, shadow_empty,
@@ -1780,20 +1864,25 @@ void CodeGenTileLangNPUIRDEV::EmitCopyTensorToMemref(
   llvm::ArrayRef<mlir::OpFoldResult> copy_sizes = srcC.sizes;
   llvm::ArrayRef<int64_t> copy_projected = srcC.projected;
 
-  // 2) Create rank-reduced tensor.extract_slice
-  mlir::Value src_slice = CreateRankReducedExtractSlice(
-      src, srcR.offs, srcR.sizes, srcR.strides, copy_projected, loc);
+  // 2) Cast the full source tensor first when element types differ, so backend
+  // vcast always sees a static full tensor instead of a dynamic extract_slice.
+  mlir::Value copy_src = src;
+  if (mlir::getElementTypeOrSelf(src.getType()) !=
+      mlir::getElementTypeOrSelf(dst.getType())) {
+    copy_src = CreateCastIfTypeMismatch(src, dst);
+  }
 
-  // 3) Create rank-reduced memref.subview
+  // 3) Create rank-reduced tensor.extract_slice from the copy source
+  mlir::Value src_slice = CreateRankReducedExtractSlice(
+      copy_src, srcR.offs, srcR.sizes, srcR.strides, copy_projected, loc);
+
+  // 4) Create rank-reduced memref.subview
   mlir::Value dst_view = CreateRankReducedSubviewFromBaseRank(
       dst, dstR.offs, dstR.sizes, dstR.strides, copy_projected, loc);
 
-  // 4) Type cast if element types differ
-  mlir::Value casted_tensor = CreateCastIfTypeMismatch(src_slice, dst_view);
-
   // 5) Materialize directly (no reshape needed - shapes match!)
   auto matOp = builder.create<mlir::bufferization::MaterializeInDestinationOp>(
-      loc, casted_tensor, dst_view);
+      loc, src_slice, dst_view);
   matOp.setWritable(true);
 }
 

--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1075,96 +1075,62 @@ mlir::Value CodeGenTileLangNPUIRDEV::CreateCastIfTypeMismatch(mlir::Value src,
   return newCastOp->getResult(0);
 }
 
-int64_t CodeGenTileLangNPUIRDEV::InferStaticUpperBoundForDim(
-    mlir::Value shaped_value, int64_t dim) {
-  if (!shaped_value)
-    return mlir::ShapedType::kDynamic;
-
-  auto shapedTy = shaped_value.getType().dyn_cast<mlir::ShapedType>();
-  if (!shapedTy || !shapedTy.hasRank() || dim < 0 || dim >= shapedTy.getRank())
-    return mlir::ShapedType::kDynamic;
-
-  if (!shapedTy.isDynamicDim(dim))
-    return shapedTy.getDimSize(dim);
-
-  if (auto toTensor =
-          shaped_value.getDefiningOp<mlir::bufferization::ToTensorOp>()) {
-    return InferStaticUpperBoundForDim(toTensor.getMemref(), dim);
-  }
-
-  if (auto extract =
-          shaped_value.getDefiningOp<mlir::tensor::ExtractSliceOp>()) {
-    auto srcTy = extract.getSource().getType().dyn_cast<mlir::ShapedType>();
-    if (srcTy && srcTy.hasRank() && srcTy.getRank() == shapedTy.getRank()) {
-      return InferStaticUpperBoundForDim(extract.getSource(), dim);
-    }
-  }
-
-  if (auto insert = shaped_value.getDefiningOp<mlir::tensor::InsertSliceOp>()) {
-    return InferStaticUpperBoundForDim(insert.getDest(), dim);
-  }
-
-  if (auto tensorCast = shaped_value.getDefiningOp<mlir::tensor::CastOp>()) {
-    return InferStaticUpperBoundForDim(tensorCast.getSource(), dim);
-  }
-
-  if (auto subview = shaped_value.getDefiningOp<mlir::memref::SubViewOp>()) {
-    auto srcTy = subview.getSource().getType().dyn_cast<mlir::ShapedType>();
-    if (srcTy && srcTy.hasRank() && srcTy.getRank() == shapedTy.getRank()) {
-      return InferStaticUpperBoundForDim(subview.getSource(), dim);
-    }
-  }
-
-  return mlir::ShapedType::kDynamic;
-}
-
-mlir::Value CodeGenTileLangNPUIRDEV::CreateDimValueForShaped(
-    mlir::Location loc, mlir::Value shaped_value, int64_t dim) {
-  if (shaped_value.getType().isa<mlir::RankedTensorType>()) {
-    return builder.create<mlir::tensor::DimOp>(loc, shaped_value, dim);
-  }
-  if (shaped_value.getType().isa<mlir::MemRefType>()) {
-    return builder.create<mlir::memref::DimOp>(loc, shaped_value, dim);
-  }
-  ICHECK(false) << "expected ranked tensor or memref for dim query";
-  return mlir::Value{};
-}
-
 mlir::Value CodeGenTileLangNPUIRDEV::CreateStaticBackedTensor(
     mlir::RankedTensorType tensor_type, mlir::Value runtime_shape_source,
     mlir::Value static_bound_source, mlir::Location loc) {
+  // Fast path: all dims are static, just create empty tensor
+  if (tensor_type.hasStaticShape()) {
+    return builder.create<mlir::tensor::EmptyOp>(loc, tensor_type.getShape(),
+                                                 tensor_type.getElementType());
+  }
+
+  // Dynamic dims path: derive static upper bounds directly from source types.
+  // In codegen, callers always provide GM buffer values (static shapes) as
+  // sources, so we check their types directly without recursive SSA traversal.
+  auto tryGetStaticDim = [](mlir::Value val, int64_t dim) -> int64_t {
+    if (!val)
+      return mlir::ShapedType::kDynamic;
+    auto ty = val.getType().dyn_cast<mlir::ShapedType>();
+    if (!ty || !ty.hasRank() || dim < 0 || dim >= ty.getRank())
+      return mlir::ShapedType::kDynamic;
+    return ty.getDimSize(dim); // static or kDynamic
+  };
+
+  auto rank = tensor_type.getRank();
   llvm::SmallVector<int64_t> staticShape(tensor_type.getShape().begin(),
                                          tensor_type.getShape().end());
-  bool needsSlice = false;
-  for (int64_t i = 0, rank = tensor_type.getRank(); i < rank; ++i) {
+  for (int64_t i = 0; i < rank; ++i) {
     if (!tensor_type.isDynamicDim(i))
       continue;
-    needsSlice = true;
-    int64_t upperBound = InferStaticUpperBoundForDim(runtime_shape_source, i);
-    if (mlir::ShapedType::isDynamic(upperBound)) {
-      upperBound = InferStaticUpperBoundForDim(static_bound_source, i);
-    }
-    ICHECK(!mlir::ShapedType::isDynamic(upperBound))
-        << "failed to infer static upper bound for dynamic tensor dim " << i;
-    staticShape[i] = upperBound;
+    int64_t bound = tryGetStaticDim(runtime_shape_source, i);
+    if (mlir::ShapedType::isDynamic(bound))
+      bound = tryGetStaticDim(static_bound_source, i);
+    ICHECK(!mlir::ShapedType::isDynamic(bound))
+        << "failed to infer static upper bound for dynamic tensor dim " << i
+        << "; ensure callers provide a static-shaped source";
+    staticShape[i] = bound;
   }
 
   mlir::Value fullEmpty = builder.create<mlir::tensor::EmptyOp>(
       loc, staticShape, tensor_type.getElementType());
-  if (!needsSlice) {
-    return fullEmpty;
-  }
 
-  llvm::SmallVector<mlir::OpFoldResult> offsets(tensor_type.getRank(),
-                                                builder.getIndexAttr(0));
-  llvm::SmallVector<mlir::OpFoldResult> strides(tensor_type.getRank(),
-                                                builder.getIndexAttr(1));
+  // Build extract_slice to recover the dynamic shape from runtime_shape_source
+  llvm::SmallVector<mlir::OpFoldResult> offsets(rank, builder.getIndexAttr(0));
+  llvm::SmallVector<mlir::OpFoldResult> strides(rank, builder.getIndexAttr(1));
   llvm::SmallVector<mlir::OpFoldResult> sizes;
-  sizes.reserve(tensor_type.getRank());
-
-  for (int64_t i = 0, rank = tensor_type.getRank(); i < rank; ++i) {
+  sizes.reserve(rank);
+  for (int64_t i = 0; i < rank; ++i) {
     if (tensor_type.isDynamicDim(i)) {
-      sizes.push_back(CreateDimValueForShaped(loc, runtime_shape_source, i));
+      // Inline DimOp creation — runtime_shape_source is always tensor or memref
+      if (runtime_shape_source.getType().isa<mlir::RankedTensorType>()) {
+        sizes.push_back(
+            builder.create<mlir::tensor::DimOp>(loc, runtime_shape_source, i)
+                .getResult());
+      } else {
+        sizes.push_back(
+            builder.create<mlir::memref::DimOp>(loc, runtime_shape_source, i)
+                .getResult());
+      }
     } else {
       sizes.push_back(builder.getIndexAttr(tensor_type.getDimSize(i)));
     }

--- a/src/target/codegen_npuir_dev.h
+++ b/src/target/codegen_npuir_dev.h
@@ -296,12 +296,10 @@ private:
   // === helpers for ascend_copy lowering (member-functionized) ===
   mlir::Value CreateCastIfTypeMismatch(mlir::Value src_value,
                                        mlir::Value dst_value);
-  int64_t InferStaticUpperBoundForDim(mlir::Value shaped_value, int64_t dim);
-  mlir::Value CreateDimValueForShaped(mlir::Location loc,
-                                      mlir::Value shaped_value, int64_t dim);
-  mlir::Value CreateStaticBackedTensor(
-      mlir::RankedTensorType tensor_type, mlir::Value runtime_shape_source,
-      mlir::Value static_bound_source, mlir::Location loc);
+  mlir::Value CreateStaticBackedTensor(mlir::RankedTensorType tensor_type,
+                                       mlir::Value runtime_shape_source,
+                                       mlir::Value static_bound_source,
+                                       mlir::Location loc);
   mlir::Value ReshapeTensorImpl(mlir::Value src,
                                 llvm::ArrayRef<int64_t> dstShapeStatic,
                                 llvm::ArrayRef<mlir::OpFoldResult> dstShapeOFR);

--- a/src/target/codegen_npuir_dev.h
+++ b/src/target/codegen_npuir_dev.h
@@ -57,7 +57,7 @@ using namespace mlir;
 // For using MLIR APIs to support developer codegen here
 
 namespace tvm {
-namespace tl{
+namespace tl {
 struct AscendCopy;
 }
 namespace codegen {
@@ -130,7 +130,7 @@ public:
   */
   struct PrimExprMapKey {
     tvm::PrimExpr expr;
-    const mlir::Block* block;
+    const mlir::Block *block;
 
     bool operator==(const PrimExprMapKey &key) const {
       // Use StructuralEqual instead of pointer comparison
@@ -147,16 +147,17 @@ public:
     }
   };
   // map to restrict the creation of duplicated nodes in MLIR
-  std::unordered_map<PrimExprMapKey, mlir::Value, PrimExprMapKeyHash> prim_expr_map;
+  std::unordered_map<PrimExprMapKey, mlir::Value, PrimExprMapKeyHash>
+      prim_expr_map;
 
   /*
   Using composite key for mlir_value_map consisting of mlir::Value and Block
-  Two mlir::Value are treated equal only if they are similar and are in same scope
-  Block keeps scope of mlir::Value
+  Two mlir::Value are treated equal only if they are similar and are in same
+  scope Block keeps scope of mlir::Value
   */
   struct MLIRValueMapKey {
     mlir::Value value;
-    const mlir::Block* block;
+    const mlir::Block *block;
     // check if both value and scope are same
     bool operator==(const MLIRValueMapKey &key) const {
       return value == key.value && block == key.block;
@@ -169,8 +170,10 @@ public:
       return llvm::hash_combine(key.value.getAsOpaquePointer(), key.block);
     }
   };
-  // map to restrict the creation of duplicated nodes in MLIR (using MLIR value as key)
-  std::unordered_map<MLIRValueMapKey, mlir::Value, MMLIRValueKeyHash> mlir_value_map;
+  // map to restrict the creation of duplicated nodes in MLIR (using MLIR value
+  // as key)
+  std::unordered_map<MLIRValueMapKey, mlir::Value, MMLIRValueKeyHash>
+      mlir_value_map;
 
   // Get current function name
   String GetCurrentFunctionName();
@@ -207,7 +210,7 @@ protected:
   std::unique_ptr<arith::Analyzer> analyzer_;
   // set of var that are not restricted(can alias)
   std::unordered_set<const VarNode *> alias_var_set_;
-  // Get variable value 
+  // Get variable value
   mlir::Value GetVarValue(const VarNode *v) const;
   mlir::Value GetVarValue(const CallNode *region_node) const;
   mlir::Value GetVarValue(const Buffer &buffer_data) const;
@@ -220,15 +223,14 @@ protected:
   // Delete variable value layer
   void DeleteVarLayer();
   // Get the corresponding thread index
-  template <typename T>
-  mlir::Value GetAndCastIndexOp(const IterVar iv);
+  template <typename T> mlir::Value GetAndCastIndexOp(const IterVar iv);
   std::vector<int64_t> GetStrideFromShapeAPI(Array<tvm::PrimExpr> shape);
   // Collect all variables defined outside the loop body
-  void CollectVarsUsedInBodyButDefinedOutside(const ForNode *op, 
-      std::vector<const VarNode*>& loop_carried_vars);
+  void CollectVarsUsedInBodyButDefinedOutside(
+      const ForNode *op, std::vector<const VarNode *> &loop_carried_vars);
   // Collect all variables defined outside the if block
-  void CollectVarsUsedInBodyButDefinedOutside(const IfThenElseNode* op,
-      std::vector<const VarNode*>& if_carried_vars);
+  void CollectVarsUsedInBodyButDefinedOutside(
+      const IfThenElseNode *op, std::vector<const VarNode *> &if_carried_vars);
 
 private:
   mlir::Value GetEventID(PrimExpr id);
@@ -268,9 +270,12 @@ private:
   void BarrierCodegen(const CallNode *op);
   void VselectCodegen(const CallNode *op);
   template <typename T, typename U>
-  mlir::Value BinaryOpCodegen(const PrimExprNode *op, U mode, mlir::Value lhs, mlir::Value rhs);
-  mlir::Value NeedGenInsertSlice(Buffer buffer_data, Array<Range> range, mlir::Value src);
-  mlir::Value ReshapeCastAndInsertSlice(mlir::Value tensor, mlir::Value dst, Array<Range> dst_range); 
+  mlir::Value BinaryOpCodegen(const PrimExprNode *op, U mode, mlir::Value lhs,
+                              mlir::Value rhs);
+  mlir::Value NeedGenInsertSlice(Buffer buffer_data, Array<Range> range,
+                                 mlir::Value src);
+  mlir::Value ReshapeCastAndInsertSlice(mlir::Value tensor, mlir::Value dst,
+                                        Array<Range> dst_range);
   // returns HIVM address space against given address space
   mlir::hivm::AddressSpace GetHIVMAddressSpace(String address_space);
   std::vector<long int> GetShape(Array<PrimExpr> extents);
@@ -284,89 +289,81 @@ private:
   mlir::Value GenExtractSliceFromRegion(Buffer buffer_data, Array<Range> range);
   mlir::Value CreateIndexCastOp(mlir::Value src);
   std::pair<bool, mlir::Value> CheckMLIRValueMap(mlir::Value val);
-  std::pair<bool, mlir::Value> CheckPrimExprMap(const PrimExprNode * op);
-  void UpdatePrimExprMap(const PrimExprNode * key, mlir::Value val);
-  void UpdateMLIRValueMap(const mlir::Value key,  mlir::Value val);
+  std::pair<bool, mlir::Value> CheckPrimExprMap(const PrimExprNode *op);
+  void UpdatePrimExprMap(const PrimExprNode *key, mlir::Value val);
+  void UpdateMLIRValueMap(const mlir::Value key, mlir::Value val);
 
   // === helpers for ascend_copy lowering (member-functionized) ===
-  mlir::Value CreateCastIfTypeMismatch(mlir::Value src_value, mlir::Value dst_value);
+  mlir::Value CreateCastIfTypeMismatch(mlir::Value src_value,
+                                       mlir::Value dst_value);
   mlir::Value ReshapeTensorImpl(mlir::Value src,
                                 llvm::ArrayRef<int64_t> dstShapeStatic,
                                 llvm::ArrayRef<mlir::OpFoldResult> dstShapeOFR);
-  mlir::Value MaybeReshapeTensorByDstSize(mlir::Value src, llvm::ArrayRef<mlir::OpFoldResult> sizes);
-  mlir::Value ReshapeTensorWithTensorReshape(mlir::Value src, llvm::ArrayRef<mlir::OpFoldResult> dstSizes);
-  std::tuple<SmallVector<mlir::OpFoldResult>, 
-             SmallVector<mlir::OpFoldResult>, 
-             SmallVector<mlir::OpFoldResult>> 
-  CreateOpFoldResultArray(const Array<Range>& range);
-  mlir::Value InsertSlice(
-      mlir::Value src_slice, 
-      mlir::Value dst_tensor, 
-      llvm::SmallVector<mlir::OpFoldResult>& dst_offsets,
-      llvm::SmallVector<mlir::OpFoldResult>& dst_sizes,
-      llvm::SmallVector<mlir::OpFoldResult>& dst_strides);
+  mlir::Value
+  MaybeReshapeTensorByDstSize(mlir::Value src,
+                              llvm::ArrayRef<mlir::OpFoldResult> sizes);
+  mlir::Value
+  ReshapeTensorWithTensorReshape(mlir::Value src,
+                                 llvm::ArrayRef<mlir::OpFoldResult> dstSizes);
+  std::tuple<SmallVector<mlir::OpFoldResult>, SmallVector<mlir::OpFoldResult>,
+             SmallVector<mlir::OpFoldResult>>
+  CreateOpFoldResultArray(const Array<Range> &range);
+  mlir::Value InsertSlice(mlir::Value src_slice, mlir::Value dst_tensor,
+                          llvm::SmallVector<mlir::OpFoldResult> &dst_offsets,
+                          llvm::SmallVector<mlir::OpFoldResult> &dst_sizes,
+                          llvm::SmallVector<mlir::OpFoldResult> &dst_strides);
   struct SliceRange {
     llvm::SmallVector<mlir::OpFoldResult> offs;
     llvm::SmallVector<mlir::OpFoldResult> sizes;
     llvm::SmallVector<mlir::OpFoldResult> strides;
   };
-  mlir::Value InsertSliceWithCast(
-      mlir::Value src_slice,
-      mlir::Value dst_tensor,
-      const SliceRange& dstR,
-      mlir::Location loc);
+  mlir::Value InsertSliceWithCast(mlir::Value src_slice, mlir::Value dst_tensor,
+                                  const SliceRange &dstR, mlir::Location loc);
   struct CollapsedDims {
-    llvm::SmallVector<mlir::OpFoldResult> sizes;   // after dropping static-1 dims
-    llvm::SmallVector<int64_t> projected;          // same rank as sizes; kDynamic allowed
-    llvm::SmallVector<unsigned> keptIdx;           // kept indices from original rank
+    llvm::SmallVector<mlir::OpFoldResult> sizes; // after dropping static-1 dims
+    llvm::SmallVector<int64_t>
+        projected;                       // same rank as sizes; kDynamic allowed
+    llvm::SmallVector<unsigned> keptIdx; // kept indices from original rank
   };
   // Entry dispatch
-  void EmitCopyMemrefToTensor(
-      const tvm::tl::AscendCopy& npuirop,
-      mlir::Value src, mlir::Value dst,
-      const SliceRange& srcR, const SliceRange& dstR,
-      mlir::Location loc);
-  void EmitCopyTensorToMemref(
-      const tvm::tl::AscendCopy& npuirop,
-      mlir::Value src, mlir::Value dst,
-      const SliceRange& srcR, const SliceRange& dstR,
-      mlir::Location loc);
-  void EmitCopyTensorToTensor(
-      const tvm::tl::AscendCopy& npuirop,
-      mlir::Value src, mlir::Value dst,
-      const SliceRange& srcR, const SliceRange& dstR,
-      mlir::Location loc);
+  void EmitCopyMemrefToTensor(const tvm::tl::AscendCopy &npuirop,
+                              mlir::Value src, mlir::Value dst,
+                              const SliceRange &srcR, const SliceRange &dstR,
+                              mlir::Location loc);
+  void EmitCopyTensorToMemref(const tvm::tl::AscendCopy &npuirop,
+                              mlir::Value src, mlir::Value dst,
+                              const SliceRange &srcR, const SliceRange &dstR,
+                              mlir::Location loc);
+  void EmitCopyTensorToTensor(const tvm::tl::AscendCopy &npuirop,
+                              mlir::Value src, mlir::Value dst,
+                              const SliceRange &srcR, const SliceRange &dstR,
+                              mlir::Location loc);
   // Small utilities
-  template <typename RangeT>
-  SliceRange MakeSliceRange(const RangeT& range);
-  mlir::Value CreateStaticLocalUB(
-      llvm::ArrayRef<int64_t> shape,
-      mlir::Type elem_type,
-      mlir::Location loc);
+  template <typename RangeT> SliceRange MakeSliceRange(const RangeT &range);
+  mlir::Value CreateStaticLocalUB(llvm::ArrayRef<int64_t> shape,
+                                  mlir::Type elem_type, mlir::Location loc);
   bool IsStaticOneOFR(mlir::OpFoldResult ofr) const;
   // Collapse static-1 dims with an optional rank limit. When maxRank < 0,
   // removes all static-1 dims.
-  CollapsedDims CollapseStaticOneDims(
-      llvm::ArrayRef<mlir::OpFoldResult> fullSizes,
-      int64_t maxRank = -1);
+  CollapsedDims
+  CollapseStaticOneDims(llvm::ArrayRef<mlir::OpFoldResult> fullSizes,
+                        int64_t maxRank = -1);
   mlir::Value CreateRankReducedSubviewFromBaseRank(
       mlir::Value base,
-      llvm::ArrayRef<mlir::OpFoldResult> fullOffsets,  // len == baseRank
-      llvm::ArrayRef<mlir::OpFoldResult> fullSizes,    // len == baseRank
-      llvm::ArrayRef<mlir::OpFoldResult> fullStrides,  // len == baseRank
-      llvm::ArrayRef<int64_t> projectedReducedShape,   // result rank
+      llvm::ArrayRef<mlir::OpFoldResult> fullOffsets, // len == baseRank
+      llvm::ArrayRef<mlir::OpFoldResult> fullSizes,   // len == baseRank
+      llvm::ArrayRef<mlir::OpFoldResult> fullStrides, // len == baseRank
+      llvm::ArrayRef<int64_t> projectedReducedShape,  // result rank
       mlir::Location loc);
   mlir::Value CreateRankReducedExtractSlice(
-      mlir::Value base,
-      llvm::ArrayRef<mlir::OpFoldResult> fullOffsets,
+      mlir::Value base, llvm::ArrayRef<mlir::OpFoldResult> fullOffsets,
       llvm::ArrayRef<mlir::OpFoldResult> fullSizes,
       llvm::ArrayRef<mlir::OpFoldResult> fullStrides,
-      llvm::ArrayRef<int64_t> projectedReducedShape,
-      mlir::Location loc);
-  mlir::Value CreateSameRankDynamicSubview(
-      mlir::Value base,
-      llvm::ArrayRef<mlir::OpFoldResult> sizesSameRank,
-      mlir::Location loc);
+      llvm::ArrayRef<int64_t> projectedReducedShape, mlir::Location loc);
+  mlir::Value
+  CreateSameRankDynamicSubview(mlir::Value base,
+                               llvm::ArrayRef<mlir::OpFoldResult> sizesSameRank,
+                               mlir::Location loc);
   llvm::SmallVector<int64_t> ComputeUBAllocShapeFromDstRange(
       mlir::RankedTensorType dst_tensor_type_ori,
       llvm::ArrayRef<mlir::OpFoldResult> dstR_sizes);
@@ -384,27 +381,26 @@ private:
   std::string current_function_name;
 
 private:
-  class LoopCarriedVarCollector
-      : public tir::StmtExprVisitor {
+  class LoopCarriedVarCollector : public tir::StmtExprVisitor {
   private:
-    CodeGenTileLangNPUIRDEV* outer_;
-    std::vector<const VarNode*>& loop_carried_vars_;
+    CodeGenTileLangNPUIRDEV *outer_;
+    std::vector<const VarNode *> &loop_carried_vars_;
     std::unordered_set<const VarNode *> vars_set_;
 
-    void CheckVar(const tir::VarNode* var_node);
-    
+    void CheckVar(const tir::VarNode *var_node);
+
   public:
-    LoopCarriedVarCollector(CodeGenTileLangNPUIRDEV* outer, 
-                            std::vector<const VarNode*>& loop_carried_vars)
+    LoopCarriedVarCollector(CodeGenTileLangNPUIRDEV *outer,
+                            std::vector<const VarNode *> &loop_carried_vars)
         : outer_(outer), loop_carried_vars_(loop_carried_vars) {}
-    
-    using tir::StmtExprVisitor::VisitStmt;
+
     using tir::StmtExprVisitor::VisitExpr;
-    
-    void VisitExpr_(const tir::CallNode* call) override;
-    void VisitStmt_(const tir::BufferStoreNode* op) override;
-    
-    void VisitStmt_(const tir::ForNode* for_node) override {
+    using tir::StmtExprVisitor::VisitStmt;
+
+    void VisitExpr_(const tir::CallNode *call) override;
+    void VisitStmt_(const tir::BufferStoreNode *op) override;
+
+    void VisitStmt_(const tir::ForNode *for_node) override {
       VisitStmt(for_node->body);
     }
   };

--- a/src/target/codegen_npuir_dev.h
+++ b/src/target/codegen_npuir_dev.h
@@ -310,6 +310,11 @@ private:
     llvm::SmallVector<mlir::OpFoldResult> sizes;
     llvm::SmallVector<mlir::OpFoldResult> strides;
   };
+  mlir::Value InsertSliceWithCast(
+      mlir::Value src_slice,
+      mlir::Value dst_tensor,
+      const SliceRange& dstR,
+      mlir::Location loc);
   struct CollapsedDims {
     llvm::SmallVector<mlir::OpFoldResult> sizes;   // after dropping static-1 dims
     llvm::SmallVector<int64_t> projected;          // same rank as sizes; kDynamic allowed

--- a/src/target/codegen_npuir_dev.h
+++ b/src/target/codegen_npuir_dev.h
@@ -296,6 +296,12 @@ private:
   // === helpers for ascend_copy lowering (member-functionized) ===
   mlir::Value CreateCastIfTypeMismatch(mlir::Value src_value,
                                        mlir::Value dst_value);
+  int64_t InferStaticUpperBoundForDim(mlir::Value shaped_value, int64_t dim);
+  mlir::Value CreateDimValueForShaped(mlir::Location loc,
+                                      mlir::Value shaped_value, int64_t dim);
+  mlir::Value CreateStaticBackedTensor(
+      mlir::RankedTensorType tensor_type, mlir::Value runtime_shape_source,
+      mlir::Value static_bound_source, mlir::Location loc);
   mlir::Value ReshapeTensorImpl(mlir::Value src,
                                 llvm::ArrayRef<int64_t> dstShapeStatic,
                                 llvm::ArrayRef<mlir::OpFoldResult> dstShapeOFR);

--- a/testing/npuir/memory_ops/test_copy_simple_dev.py
+++ b/testing/npuir/memory_ops/test_copy_simple_dev.py
@@ -202,6 +202,29 @@ def implicit_cast_copy_1d(L, block_L, dtype="float16", mid_dtype="float32"):
     return implicit_cast_copy_1d
 
 
+@tilelang.jit(target="npuir")
+def implicit_cast_copy_1d_dynamic(
+    L, block_L, dtype="float16", mid_dtype="float32"
+):
+
+    @T.prim_func
+    def implicit_cast_copy_1d_dynamic(
+        In: T.Tensor((L,), dtype),
+        Out: T.Tensor((L,), dtype),
+        shape_L: T.int32,
+    ):
+        with T.Kernel(T.ceildiv(L, block_L), is_npu=True) as (cid, _):
+            start_idx = cid * block_L
+            tile_size = T.min(block_L, shape_L - start_idx)
+
+            A_frag = T.alloc_fragment((block_L,), mid_dtype)
+
+            T.copy(In[start_idx : start_idx + tile_size], A_frag[0:tile_size])
+            T.copy(A_frag[0:tile_size], Out[start_idx : start_idx + tile_size])
+
+    return implicit_cast_copy_1d_dynamic
+
+
 @pytest.mark.parametrize(
     "dtype, mid_dtype", [("float16", "float32"), ("float32", "float16")]
 )
@@ -213,6 +236,24 @@ def test_copy_implicit_cast_dev(dtype, mid_dtype):
     output_tensor = gen_tensor((L,), dtype, kind="zeros")
 
     kernel(input_tensor, output_tensor)
+
+    expected_tensor = input_tensor.to(getattr(torch, mid_dtype)).to(
+        getattr(torch, dtype)
+    )
+    assert_close(output_tensor.cpu(), expected_tensor.cpu(), dtype=dtype)
+
+
+def test_copy_implicit_cast_dynamic_dev():
+    dtype, mid_dtype = "float16", "float32"
+    L, block_L = 1000, 256
+    kernel = implicit_cast_copy_1d_dynamic(
+        L, block_L, dtype=dtype, mid_dtype=mid_dtype
+    )
+
+    input_tensor = gen_tensor((L,), dtype, kind="randn")
+    output_tensor = gen_tensor((L,), dtype, kind="zeros")
+
+    kernel(input_tensor, output_tensor, L)
 
     expected_tensor = input_tensor.to(getattr(torch, mid_dtype)).to(
         getattr(torch, dtype)

--- a/testing/npuir/memory_ops/test_copy_simple_dev.py
+++ b/testing/npuir/memory_ops/test_copy_simple_dev.py
@@ -203,9 +203,7 @@ def implicit_cast_copy_1d(L, block_L, dtype="float16", mid_dtype="float32"):
 
 
 @tilelang.jit(target="npuir")
-def implicit_cast_copy_1d_dynamic(
-    L, block_L, dtype="float16", mid_dtype="float32"
-):
+def implicit_cast_copy_1d_dynamic(L, block_L, dtype="float16", mid_dtype="float32"):
 
     @T.prim_func
     def implicit_cast_copy_1d_dynamic(
@@ -246,9 +244,7 @@ def test_copy_implicit_cast_dev(dtype, mid_dtype):
 def test_copy_implicit_cast_dynamic_dev():
     dtype, mid_dtype = "float16", "float32"
     L, block_L = 1000, 256
-    kernel = implicit_cast_copy_1d_dynamic(
-        L, block_L, dtype=dtype, mid_dtype=mid_dtype
-    )
+    kernel = implicit_cast_copy_1d_dynamic(L, block_L, dtype=dtype, mid_dtype=mid_dtype)
 
     input_tensor = gen_tensor((L,), dtype, kind="randn")
     output_tensor = gen_tensor((L,), dtype, kind="zeros")

--- a/testing/npuir/memory_ops/test_copy_simple_dev.py
+++ b/testing/npuir/memory_ops/test_copy_simple_dev.py
@@ -56,7 +56,10 @@ def simple_copy_2d(M, N, block_M, block_N, dtype="float16", accum_dtype="float32
         B: T.Tensor((M, N), dtype),
         C: T.Tensor((M, N), accum_dtype),
     ):
-        with T.Kernel(T.ceildiv(N, block_N) * T.ceildiv(M, block_M), is_npu=True) as (cid, _):
+        with T.Kernel(T.ceildiv(N, block_N) * T.ceildiv(M, block_M), is_npu=True) as (
+            cid,
+            _,
+        ):
             by = cid // T.ceildiv(N, block_N)
             bx = cid % T.ceildiv(N, block_N)
 
@@ -77,7 +80,9 @@ def simple_copy_2d(M, N, block_M, block_N, dtype="float16", accum_dtype="float32
 
 
 @tilelang.jit(target="npuir")
-def simple_copy_3d(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="float32"):
+def simple_copy_3d(
+    M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="float32"
+):
     @T.prim_func
     def simple_copy_3d(
         In: T.Tensor((M, N, K), dtype),
@@ -85,7 +90,10 @@ def simple_copy_3d(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dt
         B: T.Tensor((M, N, K), dtype),
         C: T.Tensor((M, N, K), accum_dtype),
     ):
-        with T.Kernel(T.ceildiv(M, block_M) * T.ceildiv(N, block_N) * T.ceildiv(K, block_K), is_npu=True) as (cid, _):
+        with T.Kernel(
+            T.ceildiv(M, block_M) * T.ceildiv(N, block_N) * T.ceildiv(K, block_K),
+            is_npu=True,
+        ) as (cid, _):
             num_blocks_N = T.ceildiv(N, block_N)
             num_blocks_K = T.ceildiv(K, block_K)
 
@@ -127,7 +135,9 @@ def test_copy_simple_1d_dev(dtype, L, block_L):
 
     assert_close(a.cpu(), input_tensor.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     assert_close(b.cpu(), (a * 2).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
-    assert_close(c.cpu(), b.to(torch.float32).cpu(), dtype="float32", rtol=1e-5, atol=1e-5)
+    assert_close(
+        c.cpu(), b.to(torch.float32).cpu(), dtype="float32", rtol=1e-5, atol=1e-5
+    )
 
 
 @pytest.mark.parametrize("dtype", DTYPES)
@@ -144,7 +154,9 @@ def test_copy_simple_2d_dev(dtype, M, N, block_M, block_N):
 
     assert_close(a.cpu(), input_tensor.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     assert_close(b.cpu(), (a * 2).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
-    assert_close(c.cpu(), b.to(torch.float32).cpu(), dtype="float32", rtol=1e-5, atol=1e-5)
+    assert_close(
+        c.cpu(), b.to(torch.float32).cpu(), dtype="float32", rtol=1e-5, atol=1e-5
+    )
 
 
 @pytest.mark.parametrize("dtype", DTYPES)
@@ -165,4 +177,41 @@ def test_copy_simple_3d_dev(dtype, M, N, K, block_M, block_N, block_K):
 
     assert_close(a.cpu(), input_tensor.cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
     assert_close(b.cpu(), (a * 2).cpu(), dtype=dtype, rtol=1e-5, atol=1e-5)
-    assert_close(c.cpu(), b.to(torch.float32).cpu(), dtype="float32", rtol=1e-5, atol=1e-5)
+    assert_close(
+        c.cpu(), b.to(torch.float32).cpu(), dtype="float32", rtol=1e-5, atol=1e-5
+    )
+
+
+@tilelang.jit(target="npuir")
+def implicit_cast_copy_1d(L, block_L, dtype="float16", mid_dtype="float32"):
+
+    @T.prim_func
+    def implicit_cast_copy_1d(
+        In: T.Tensor((L,), dtype),
+        Out: T.Tensor((L,), dtype),
+    ):
+        with T.Kernel(T.ceildiv(L, block_L), is_npu=True) as (cid, _):
+            start_idx = cid * block_L
+            # Alloc UB with mid_dtype (different from dtype)
+            A_frag = T.alloc_fragment((block_L,), mid_dtype)
+            # GM(dtype) -> UB(mid_dtype) : Implicit Cast during GM2UB
+            T.copy(In[start_idx], A_frag)
+            # UB(mid_dtype) -> GM(dtype) : Implicit Cast during UB2GM
+            T.copy(A_frag, Out[start_idx])
+
+    return implicit_cast_copy_1d
+
+
+@pytest.mark.parametrize(
+    "dtype, mid_dtype", [("float16", "float32"), ("float32", "float16")]
+)
+def test_copy_implicit_cast_dev(dtype, mid_dtype):
+    L, block_L = 1024, 256
+    kernel = implicit_cast_copy_1d(L, block_L, dtype=dtype, mid_dtype=mid_dtype)
+
+    input_tensor = gen_tensor((L,), dtype, kind="randn")
+    output_tensor = gen_tensor((L,), dtype, kind="zeros")
+
+    kernel(input_tensor, output_tensor)
+
+    assert_close(output_tensor.cpu(), input_tensor.cpu(), dtype=dtype)

--- a/testing/npuir/memory_ops/test_copy_simple_dev.py
+++ b/testing/npuir/memory_ops/test_copy_simple_dev.py
@@ -214,4 +214,7 @@ def test_copy_implicit_cast_dev(dtype, mid_dtype):
 
     kernel(input_tensor, output_tensor)
 
-    assert_close(output_tensor.cpu(), input_tensor.cpu(), dtype=dtype)
+    expected_tensor = input_tensor.to(getattr(torch, mid_dtype)).to(
+        getattr(torch, dtype)
+    )
+    assert_close(output_tensor.cpu(), expected_tensor.cpu(), dtype=dtype)


### PR DESCRIPTION
## Bug

The current implicit-cast lowering for `T.copy` has two problems:

* **GM -> UB path:** The local UB buffer must use the **source** element type; otherwise, `memref.copy` encounters mismatched element types.
* **Slice-based copy paths:** Attaching the cast to a rank-reduced slice is fragile for downstream passes and backend `vcast` handling, especially when dealing with **dynamic tiles**.

---

## Fix

* **GM -> UB Copies:** Use the **source** element type when creating the local UB buffer.
* **CreateStaticBackedTensor:** Added to build a static-backed tensor for dynamic shapes by combining:
    * Runtime extents from the dynamic source.
    * Static upper bounds from a static-shaped source.
* **InsertSliceWithCast:** * If element types match: Perform a standard `tensor.insert_slice`.
    * If element types differ: First insert into a **shadow tensor** with the source element type, then cast the inserted result to the destination element type.
* **Tensor -> Memref Copies:** Cast the **full source tensor** before creating the rank-reduced `extract_slice`. This ensures the backend `vcast` operates on a full tensor rather than a dynamic rank-reduced slice.

---

## Notes

* This change avoids generating casts on **rank-reduced slice values**.
* For **tensor -> tensor** and **GM -> tensor** paths, moving the cast after `insert_slice` better matches kernel-side behavior (e.g., executing `T.vcast` immediately after a copy).
* For **tensor -> memref**, applying the cast before `extract_slice` prevents the backend from seeing a rank-reduced dynamic value at the cast site.

---

## Tests

* Add implicit-cast `T.copy` coverage for **1D static** cases.
* Add implicit-cast `T.copy` coverage for **1D dynamic tile** cases.