### PR TITLE
turn-off GTEST to avoid TVM build error in cann docker environment

### DIFF
--- a/install_ascend.sh
+++ b/install_ascend.sh
@@ -127,6 +127,10 @@ cp 3rdparty/tvm/cmake/config.cmake build
 cd build
 
 echo "set(USE_ASCEND ON)" >> config.cmake
+# Pip's CMake 4.x + Debian's GTestConfig.cmake: GTest::gtest may not define
+# IMPORTED_LOCATION, which TVM's CMake still queries (fatal error). 
+# C++ gtests are optional for TileLang; keep them off for this install path.
+echo 'set(USE_GTEST OFF)' >> config.cmake
 
 echo "Running CMake for TileLang..."
 cmake ..

--- a/install_ascend.sh
+++ b/install_ascend.sh
@@ -127,8 +127,8 @@ cp 3rdparty/tvm/cmake/config.cmake build
 cd build
 
 echo "set(USE_ASCEND ON)" >> config.cmake
-# Pip's CMake 4.x + Debian's GTestConfig.cmake: GTest::gtest may not define
-# IMPORTED_LOCATION, which TVM's CMake still queries (fatal error). 
+# PGTestConfig.cmake: GTest::gtest may not define IMPORTED_LOCATION,
+# but which TVM's CMake still queries it, causing build error
 # C++ gtests are optional for TileLang; keep them off for this install path.
 echo 'set(USE_GTEST OFF)' >> config.cmake
 


### PR DESCRIPTION
Without this fix, get build error when running `bash install_ascend.sh` inside docker image `quay.io/ascend/vllm-ascend:v0.18.0rc1`:

```
-- Building TVM from source at /workdir/tilelang-ascend/3rdparty/tvm
-- Hide private symbols...
-- Forbidding undefined symbols in shared library, using -Wl,--no-undefined on platform Linux
-- Build with RPC support...
-- Build with Graph Executor support...
-- Build with profiler...
-- Build with AOT Executor support...
-- Found GTest: /usr/lib/aarch64-linux-gnu/cmake/GTest/GTestConfig.cmake (found version "1.11.0")
CMake Error at 3rdparty/tvm/CMakeLists.txt:541 (message):
  Neither GTest::GTest nor GTest::gtest targets defined IMPORTED_LOCATION


-- Configuring incomplete, errors occurred!
Error: CMake configuration failed.
```
