### PR TITLE
[Fix] Remove empty loops to fix PipelinePlanning error 🤖

### DIFF
--- a/examples/pipeline/matmul_add_pipeline.py
+++ b/examples/pipeline/matmul_add_pipeline.py
@@ -4,20 +4,17 @@ import tilelang
 import tilelang.language as T
 import torch
 
-tilelang.cache.clear_cache()
 
-parser = argparse.ArgumentParser(description="NPU Kernel Compilation")
-parser.add_argument("--m", type=int, default=1024, help="Matrix M dimension")
-parser.add_argument("--n", type=int, default=1024, help="Matrix N dimension")
-parser.add_argument("--k", type=int, default=1024, help="Matrix K dimension")
-args = parser.parse_args()
-
-M = args.m
-N = args.n
-K = args.k
-
-
-@tilelang.jit(out_idx=[-2])
+@tilelang.jit(
+    out_idx=[2],
+    workspace_idx=[-1],
+    pass_configs={
+        tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+        tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+        tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+        tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    },
+)
 def matmul_add(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="float"):
     m_num = M // block_M
     n_num = N // block_N
@@ -27,72 +24,73 @@ def matmul_add(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype=
 
     @T.prim_func
     def main(
-            A: T.Tensor((M, K), dtype),
-            B: T.Tensor((K, N), dtype),
-            C: T.Tensor((M, N), dtype),
-            D: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, K), dtype),  # type: ignore
+        B: T.Tensor((K, N), dtype),  # type: ignore
+        C: T.Tensor((M, N), dtype),  # type: ignore
+        D: T.Tensor((M, N), dtype),  # type: ignore
+        workspace_1: T.Tensor((M, N), dtype),  # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
             by = cid % n_num
-            A_L1 = T.alloc_L1((block_M, block_K), dtype)
-            B_L1 = T.alloc_L1((block_K, block_N), dtype)
+            A_L1 = T.alloc_shared((block_M, block_K), dtype)
+            B_L1 = T.alloc_shared((block_K, block_N), dtype)
 
-            C_L0 = T.alloc_L0C((block_M, block_N), accum_dtype)
+            C_L0 = T.alloc_fragment((block_M, block_N), accum_dtype)
 
-            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N // vec_proc), dtype)
-            d_ub = T.alloc_ub((block_M // VEC_NUM, block_N // vec_proc), dtype)
-            e_ub = T.alloc_ub((block_M // VEC_NUM, block_N // vec_proc), dtype)
+            c_ub = T.alloc_shared((block_M // VEC_NUM, block_N // vec_proc), dtype)
+            d_ub = T.alloc_shared((block_M // VEC_NUM, block_N // vec_proc), dtype)
+            e_ub = T.alloc_shared((block_M // VEC_NUM, block_N // vec_proc), dtype)
 
-            with T.Scope("C"):
+            loop_k = T.ceildiv(K, block_K)
+            for k in T.Pipelined(loop_k, num_stages=3):
+                T.copy(A[bx * block_M, k * block_K], A_L1)
+                T.copy(B[k * block_K, by * block_N], B_L1)
 
-                loop_k = T.ceildiv(K, block_K)
-                for k in T.Pipelined(loop_k, num_stages=3):
-                    T.copy(A[bx * block_M, k * block_K], A_L1)
-                    T.copy(B[k * block_K, by * block_N], B_L1)
+                if k == 0:
+                    T.gemm_v0(A_L1, B_L1, C_L0, init=True)
+                else:
+                    T.gemm_v0(A_L1, B_L1, C_L0)
 
-                    T.barrier_all()
-                    if k == 0:
-                        T.gemm_v0(A_L1, B_L1, C_L0, init=True)
-                    else:
-                        T.gemm_v0(A_L1, B_L1, C_L0)
+            T.copy(C_L0, workspace_1[bx * block_M, by * block_N])
 
-                    T.barrier_all()
+            for i in T.Pipelined(vec_proc, num_stages=2):
+                T.copy(workspace_1[bx * block_M + vid * block_M // VEC_NUM, by * block_N + i * block_N // vec_proc], c_ub)
+                T.copy(D[bx * block_M + vid * block_M // VEC_NUM, by * block_N + i * block_N // vec_proc], d_ub)
 
-                T.copy(C_L0, C[bx * block_M, by * block_N])
+                for j, k in T.Parallel(block_M // VEC_NUM, block_N // vec_proc):
+                    e_ub[j, k] = c_ub[j, k] + d_ub[j, k]
 
-                T.set_cross_flag("FIX", 0)
-
-            with T.Scope("V"):
-                T.wait_cross_flag(0)
-
-                for i in T.Pipelined(vec_proc, num_stages=2):
-                    T.copy(C[bx * block_M + vid * block_M // VEC_NUM, by * block_N + i * block_N // vec_proc], c_ub)
-                    T.copy(D[bx * block_M + vid * block_M // VEC_NUM, by * block_N + i * block_N // vec_proc], d_ub)
-
-                    T.barrier_all()
-                    for (j, k) in T.Parallel(block_M // VEC_NUM, block_N // vec_proc):
-                        e_ub[j, k] = c_ub[j, k] + d_ub[j, k]
-                    T.barrier_all()
-
-                    T.copy(e_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N + i * block_N // vec_proc])
-                    T.barrier_all()
+                T.copy(e_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N + i * block_N // vec_proc])
 
     return main
 
 
-func = matmul_add(M, N, K, 128, 256, 64)
+if __name__ == "__main__":
+    tilelang.disable_cache()
 
-torch.manual_seed(0)
+    parser = argparse.ArgumentParser(description="NPU Kernel Compilation")
+    parser.add_argument("--m", type=int, default=1024, help="Matrix M dimension")
+    parser.add_argument("--n", type=int, default=1024, help="Matrix N dimension")
+    parser.add_argument("--k", type=int, default=1024, help="Matrix K dimension")
+    args = parser.parse_args()
 
-a = torch.randn(M, K).half().npu()
-b = torch.randn(K, N).half().npu()
-d = torch.randn(M, N).half().npu()
-print("init successful!")
+    M = args.m
+    N = args.n
+    K = args.k
 
-c = func(a, b, d)
+    func = matmul_add(M, N, K, 128, 256, 64)
 
-ref_c = a @ b + d
+    torch.manual_seed(0)
 
-torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
-print("Kernel Output Match!")
+    a = torch.randn(M, K).half().npu()
+    b = torch.randn(K, N).half().npu()
+    d = torch.randn(M, N).half().npu()
+    print("init successful!")
+
+    c = func(a, b, d)
+
+    ref_c = a @ b + d
+
+    torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
+    print("Kernel Output Match!")

--- a/src/transform/ascend_combinecv.cc
+++ b/src/transform/ascend_combinecv.cc
@@ -637,6 +637,58 @@ public:
   //     current_proccess_switch_ = false; // turn off
   //     return StmtMutator::VisitStmt_(op);
   // }
+  Stmt VisitStmt_(const ForNode *op) final {
+    Stmt new_stmt = StmtMutator::VisitStmt_(op);
+
+    const ForNode *new_for = new_stmt.as<ForNode>();
+    if (!new_for) {
+      return new_stmt;
+    }
+
+    Stmt new_body = new_for->body;
+    // Recursively check if the body is effectively empty
+    // (e.g., BlockRealize with only alloc_buffers and Evaluate(0))
+    if (IsEmptyBody(new_body)) {
+      return Evaluate(0);
+    }
+
+    return new_stmt;
+  }
+
+  bool IsEmptyBody(const Stmt &stmt) {
+    if (const auto *eval = stmt.as<EvaluateNode>()) {
+      if (const auto *int_imm = eval->value.as<IntImmNode>()) {
+        return int_imm->value == 0;
+      }
+    }
+    if (const auto *alloc = stmt.as<AllocateNode>()) {
+      return IsEmptyBody(alloc->body);
+    }
+    if (const auto *realize = stmt.as<BlockRealizeNode>()) {
+      // Check if block only has allocations and no actual statements
+      return IsEmptyBody(realize->block->body);
+    }
+    if (const auto *block = stmt.as<BlockNode>()) {
+      // Block may have alloc_buffers, but we only care about the body
+      return IsEmptyBody(block->body);
+    }
+    if (const auto *if_then_else = stmt.as<IfThenElseNode>()) {
+      bool then_empty = IsEmptyBody(if_then_else->then_case);
+      bool else_empty = if_then_else->else_case.defined()
+                            ? IsEmptyBody(if_then_else->else_case.value())
+                            : true;
+      return then_empty && else_empty;
+    }
+    if (const auto *seq = stmt.as<SeqStmtNode>()) {
+      for (const auto &s : seq->seq) {
+        if (!IsEmptyBody(s)) {
+          return false;
+        }
+      }
+      return true;
+    }
+    return false;
+  }
 
   Stmt VisitStmt_(const EvaluateNode *op) final {
     auto call_node_ = op->value.as<CallNode>();


### PR DESCRIPTION
## Summary

Remove empty loops generated by CombineCV PASS when `TL_ASCEND_AUTO_CV_COMBINE` is enabled.

Fixes #162

## Problem

When `TL_ASCEND_AUTO_CV_COMBINE` is enabled, CombineCV PASS generates empty loops with loop bodies that are not `SeqStmt` or `IfThenElse`, causing PipelinePlanning PASS to fail with:
```
Pipeline_Planning: Can't handle the body of the loop because it is not a SeqStmt or IfThenElse
```

## Changes

- Add `VisitStmt_(ForNode)` to detect and remove empty loops after processing
- Add `IsEmptyBody()` helper method to recursively check if loop body is effectively empty
- Support detection in various IR structures: BlockRealize, Block, Allocate, IfThenElse, SeqStmt

## Testing

```bash
cd examples/pipeline
python matmul_add_pipeline.py
```

Expected output: `Kernel Output Match!`