### PR TITLE
[Add] Support unordered tmp buffer allocate for tmp-remove pass.

### DIFF
--- a/src/transform/ascend_memory_planning.cc
+++ b/src/transform/ascend_memory_planning.cc
@@ -534,7 +534,12 @@ private:
           alloc_buffer(buffer, current_offset,
                        "Linear memory allocation failed!");
           max_offset = std::max(max_offset, current_offset);
-        } else if (scope == "shared") {
+        }
+      }
+      // Allocate tmp buffer/default buffer after origin buffer to avoid
+      // fragmention in shared memory
+      if (scope == "shared") {
+        for (const VarNode *buffer : origin_buffer) {
           if (std::find(tmp_buffers.begin(), tmp_buffers.end(), buffer) !=
                   tmp_buffers.end() &&
               !address_map_.count(buffer)) {


### PR DESCRIPTION
The order of temporary buffer allocation has been modified to support normal allocation of tmp buffer in the case of out-of-order conditions, and it is a prerequisite function for supporting the removal of tmp buffer.