### PR TITLE
[Add] Add .clangd and compile_flags.txt for C++ IDE support 🤖

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,65 @@
+# ============================================================================
+# TileLang-Ascend .clangd configuration
+#
+# Provides IDE support for the C++ backend (src/**).
+# Compile flags (-I, -D, -std) live in compile_flags.txt (project root)
+# so that relative paths resolve correctly from the project root.
+#
+# This file controls: compiler driver, diagnostics, and indexing.
+#
+# Platform SDKs (CANN, CUDA, HIP) are NOT modeled here — their headers
+# are suppressed in the SDK-dependent fragments below.
+# When a cmake build/ directory with compile_commands.json exists,
+# clangd will prefer it over compile_flags.txt.
+# ============================================================================
+
+# --- Fragment 1: TileLang host backend code (src/**) ---
+If:
+  PathMatch: src/.*
+CompileFlags:
+  Compiler: clang++
+Diagnostics:
+  UnusedIncludes: None
+Index:
+  Background: Build
+
+---
+# --- Fragment 2: SDK-dependent tl_templates (CANN/CUDA/HIP/PTO) ---
+# These template headers rely heavily on platform SDK types and intrinsics
+# (AscendC, CUDA, HIP, PTO) that are unavailable on macOS.
+# Suppress all diagnostics to reduce noise. The cpp/ and cpu/ subtrees
+# are NOT suppressed so genuine errors remain visible there.
+If:
+  PathMatch:
+    - src/tl_templates/ascend/.*
+    - src/tl_templates/cuda/.*
+    - src/tl_templates/hip/.*
+    - src/tl_templates/pto/.*
+Diagnostics:
+  Suppress:
+    - "*"
+
+---
+# --- Fragment 3: SDK-dependent .cc files (HIP runtime module) ---
+# rt_mod_hip.cc directly includes <hip/hip_runtime.h> and <hip/hiprtc.h>
+# which are unavailable without the HIP SDK. The missing header causes a
+# fatal parse error that clangd cannot suppress (Suppress only filters
+# diagnostics after successful parsing). This fragment is retained for
+# documentation and will take effect if the HIP SDK is partially installed.
+# This is the only .cc file affected (1 of 71).
+If:
+  PathMatch: src/target/rt_mod_hip\.cc
+Diagnostics:
+  Suppress:
+    - "*"
+
+---
+# --- Fragment 4: Vendored third-party code ---
+# Reduce indexing cost and diagnostic noise from vendored submodules.
+If:
+  PathMatch: 3rdparty/.*
+Index:
+  Background: Skip
+Diagnostics:
+  Suppress:
+    - "*"

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,0 +1,27 @@
+# TileLang-Ascend compile flags for clangd fallback.
+# Used when compile_commands.json is absent (no cmake build/ directory).
+# Relative -I paths resolve from this file's directory (project root).
+# Derived from root CMakeLists.txt.
+-std=c++17
+-fPIC
+# TVM core includes (CMakeLists.txt lines 153-158)
+-I3rdparty/tvm/include
+-I3rdparty/tvm/src
+-I3rdparty/tvm/3rdparty/dlpack/include
+-I3rdparty/tvm/3rdparty/dmlc-core/include
+# Third-party includes for tl_templates browsing
+-I3rdparty/catlass/include
+-I3rdparty/shmem/include
+-I3rdparty/pto-isa/include
+-I3rdparty/cutlass/include
+-I3rdparty/composable_kernel/include
+# Compile definitions (CMakeLists.txt lines 195-204)
+-DDMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h>
+-D__STDC_FORMAT_MACROS=1
+-DPICOJSON_USE_INT64
+-DTILE_LANG_EXPORTS
+# Note: CMake conditionally adds CUDA_MAJOR_VERSION (USE_CUDA),
+# __HIP_PLATFORM_AMD__ and __HIP_PLATFORM_HCC__ (USE_ROCM).
+# These are intentionally omitted here because this file is a
+# fallback for when no cmake build/ exists. Files requiring those
+# defines (rt_mod_hip.cc) are already suppressed in .clangd.


### PR DESCRIPTION
## Summary

Add clangd configuration files to provide out-of-the-box C++ IDE support (code completion, navigation, diagnostics) for the `src/` backend without requiring a cmake build directory.

## Changes

- **`compile_flags.txt`**: All `-I`, `-D`, `-std=c++17` flags derived from `CMakeLists.txt`. Placed at project root so relative include paths resolve correctly. When a `build/compile_commands.json` exists, clangd automatically prefers it over this fallback.

- **`.clangd`**: Compiler driver, diagnostics, and indexing configuration with 4 path-scoped fragments:
  1. `src/.*` — compiler driver (`clang++`), background indexing, disable unused-includes noise
  2. `src/tl_templates/{ascend,cuda,hip,pto}/.*` — suppress all diagnostics for SDK-dependent template headers (CANN/CUDA/HIP/PTO); `cpp/` and `cpu/` subtrees remain visible
  3. `src/target/rt_mod_hip.cc` — suppress diagnostics (requires HIP SDK headers unavailable on most dev machines)
  4. `3rdparty/.*` — skip indexing and suppress diagnostics for vendored submodules

## Verification

- All 9 include directories from `CMakeLists.txt` verified to exist
- 70/71 `.cc` files parse with 0 compile errors via `clangd --check` and LSP diagnostics
- Only `rt_mod_hip.cc` fails (missing `<hip/hip_runtime.h>` — requires HIP SDK)