### PR TITLE
[Fix] Ensure `MAKE_JOBS` is at least 1 in `install_ascend.sh` 🤖

### DIFF
--- a/install_ascend.sh
+++ b/install_ascend.sh
@@ -137,11 +137,14 @@ fi
 
 echo "Building TileLang with make..."
 
-# Calculate 50% of available CPU cores
+# Calculate 50% of available CPU cores (ensure at least 1)
 # Other wise, make will use all available cores
 # and it may cause the system to be unresponsive
 CORES=$(nproc)
 MAKE_JOBS=$(( CORES * 50 / 100 ))
+if [ $MAKE_JOBS -lt 1 ]; then
+    MAKE_JOBS=1
+fi
 make -j${MAKE_JOBS}
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
## Summary

Fix the MAKE_JOBS calculation in install_ascend.sh to ensure it's at least 1, preventing build failures on systems with fewer CPU cores.

## Changes

- Add a check to ensure MAKE_JOBS is at least 1 when calculated from CPU cores
- This fixes the issue where `make -j0` would fail on low-core systems

## Testing

```bash
OMP_NUM_THREADS=1 bash install_ascend.sh
```

> ref: [cann/cann-recipes-infer #167](https://gitcode.com/cann/cann-recipes-infer/issues/167)