### PR TITLE
[AscendNPU-IR][A5] support min in reduce op

### DIFF
--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -2403,6 +2403,20 @@ void CodeGenTileLangNPUIRDEV::VreduceCodegen(const CallNode *op) {
               builder.create<mlir::arith::MaxUIOp>(loc, inputElem, accumElem);
         }
       }
+    } else if (npuirop.reduce_mode == "min") {
+      if (elemTy.isa<mlir::FloatType>()) {
+        result =
+            builder.create<mlir::arith::MinimumFOp>(loc, inputElem, accumElem);
+      } else {
+        auto intTy = elemTy.cast<mlir::IntegerType>();
+        if (intTy.isSigned()) {
+          result =
+              builder.create<mlir::arith::MinSIOp>(loc, inputElem, accumElem);
+        } else {
+          result =
+              builder.create<mlir::arith::MinUIOp>(loc, inputElem, accumElem);
+        }
+      }
     }
 
     builder.create<mlir::linalg::YieldOp>(loc, result);

--- a/testing/npuir/linalg_ops/test_reduce_dev.py
+++ b/testing/npuir/linalg_ops/test_reduce_dev.py
@@ -52,6 +52,23 @@ def vec_reduce_3d_to_2d_sum(M, K, N, dtype="float32"):
     return main_sum
 
 
+def vec_reduce_3d_to_2d_min(M, K, N, dtype="float32"):
+    @T.prim_func
+    def main_min(A: T.Tensor((M, K, N), dtype),
+             B: T.Tensor((M, K, 1), dtype),
+             ):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a = T.alloc_shared((M, K, N), dtype)
+            s = T.alloc_shared((M, K, 1), dtype)
+
+            T.copy(A, a)
+            T.reduce(a, s, dims=2, reduce_mode="min", clear=True)
+
+            T.copy(s, B)
+
+    return main_min
+
+
 def test_vec_reduce_max():
     torch.npu.set_device(0)
     os.environ['TILELANG_ASCEND_MODE'] = 'Developer'
@@ -90,7 +107,27 @@ def test_vec_reduce_sum():
     print("Sum Reduce 校验通过")
 
 
+def test_vec_reduce_min():
+    torch.npu.set_device(0)
+    os.environ['TILELANG_ASCEND_MODE'] = 'Developer'
+
+    func = vec_reduce_3d_to_2d_min(M, K, N)
+    compiled_kernel = tilelang.compile(func, target="npuir")
+
+    v1 = torch.randn(size=[M, K, N], dtype=eval("torch." + dtype)).npu()
+    v2 = torch.randn(size=[M, K, 1], dtype=eval("torch." + dtype)).npu()
+
+    v_ref = torch.min(v1, dim=2).values.reshape(M, K, 1)
+    compiled_kernel(v1, v2)
+
+    print("Min 参考结果 shape:", v_ref.shape)
+    print("Min 计算结果 shape:", v2.shape)
+    torch.testing.assert_close(v_ref, v2, rtol=1e-2, atol=1e-2)
+    print("Min Reduce 校验通过")
+
+
 if __name__ == "__main__":
     test_vec_reduce_max()
     test_vec_reduce_sum()
+    test_vec_reduce_min()
     print("所有测试全部通过！")


### PR DESCRIPTION
### Summary

This PR adds `min` operation support to the NPUIR Developer mode codegen, bringing it to parity with `max` which already uses upstream arith dialect ops.

### Changes

**1. `tl.npuir_min` lowering → arith dialect (codegen_npuir_dev.cc)**

Changed the lowering of `tl.npuir_min` from `hivm::VMinOp` to upstream arith dialect operations, matching the existing pattern used by `tl.npuir_max`:
- `arith::MinimumFOp` for floating-point types
- `arith::MinSIOp` for signed integer types
- `arith::MinUIOp` for unsigned integer types

**2. `min` reduce mode in `VreduceCodegen` (codegen_npuir_dev.cc)**

`VreduceCodegen` previously only handled `"sum"` and `"max"` reduction modes. Added a `"min"` branch that emits the corresponding arith min ops (`MinimumFOp` / `MinSIOp` / `MinUIOp`) inside the `linalg.reduce` combiner region.

**3. Test cases**

- Added `testing/npuir/linalg_ops/test_min_dev.py` — element-wise `T.vmin` test, validates against `torch.min(v1, v2)`.
- Updated test_reduce_dev.py — added `test_vec_reduce_min` that performs a 3D→2D min reduction and validates against `torch.min(v1, dim=2)`.

### Motivation

The Developer mode codegen emits upstream MLIR dialects (arith, linalg) instead of HIVM-specific ops, enabling better optimization through standard MLIR passes. `max` was already migrated to arith; `min` was still using `hivm::VMinOp`. This PR closes that gap.

---