### PR TITLE
[AscendNPU-IR][A5] Support bitwise ops

### DIFF
--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -86,7 +86,9 @@
 
 #include "bishengir/Dialect/HACC/IR/HACC.h"
 #include "bishengir/Dialect/Utils/Util.h"
+#include "mlir/IR/TypeUtilities.h"
 #include "tvm/runtime/logging.h"
+#include "llvm/Support/Debug.h"
 
 using namespace mlir;
 
@@ -2842,6 +2844,16 @@ Value CodeGenTileLangNPUIRDEV::broadcastOrTranspose(Value input, Value output,
   return result;
 }
 
+template<typename T, typename = void>
+struct has_hivm_operation_name {
+    static constexpr bool value = false;
+};
+template<typename T>
+struct has_hivm_operation_name<T, std::void_t<decltype(T::getOperationName())>> {
+    static constexpr bool value = startsWith(T::getOperationName(), mlir::hivm::HIVMDialect::getDialectNamespace());
+};
+
+
 /// Generate hivm.hir.vadd for tl.npuir_add.
 /// Generate hivm.hir.vcmp for tl.npuir_cmp.
 /// Generate hivm.hir.vdiv for tl.npuir_div.
@@ -2945,63 +2957,76 @@ void CodeGenTileLangNPUIRDEV::CreateHIVMBinaryVectorOp(const CallNode *op) {
   auto loc = builder.getUnknownLoc();
   mlir::Value newOpValue;
 
-  if constexpr (std::is_same_v<T, mlir::hivm::VCmpOp>) {
-    mlir::hivm::CompareMode mode =
+  if constexpr (has_hivm_operation_name<T>::value) {
+    static_assert(
+        std::is_void_v<U> && std::is_void_v<V>,
+        "Dispatch logic is not applied for hivm ops. U and V should be void");
+    if constexpr (std::is_same_v<T, mlir::hivm::VCmpOp>) {
+      mlir::hivm::CompareMode mode =
           COMPARE_MODE[op->args[3].as<StringImm>().value()->value];
-    auto cmp_attr =
-        mlir::hivm::CompareModeAttr::get(builder.getContext(), mode);
-    auto newOp = builder.create<T>(loc, insertBase.getType(), mlir::ValueRange{src0, src1},
-        mlir::ValueRange{insertBase}, cmp_attr, transpose, broadcast);
-    newOpValue = newOp->getResult(0);
-  } else if constexpr (std::is_same_v<T, mlir::hivm::VPowOp>) {
-    auto newOp = builder.create<T>(loc, insertBase.getType(), mlir::ValueRange{src0, src1},
-        mlir::ValueRange{insertBase}, mlir::Value(), transpose, broadcast);
-    newOpValue = newOp->getResult(0);
-  } else if constexpr (std::is_same_v<T, mlir::hivm::VShROp>) {
-    auto round_attr = mlir::BoolAttr::get(
-        builder.getContext(), op->args[3].as<Bool>().value());
-    auto newOp = builder.create<T>(loc, insertBase.getType(), mlir::ValueRange{src0, src1},
-        mlir::ValueRange{insertBase}, round_attr, transpose, broadcast);
-    newOpValue = newOp->getResult(0);
+      auto cmp_attr =
+          mlir::hivm::CompareModeAttr::get(builder.getContext(), mode);
+      auto newOp = builder.create<T>(
+          loc, insertBase.getType(), mlir::ValueRange{src0, src1},
+          mlir::ValueRange{insertBase}, cmp_attr, transpose, broadcast);
+      newOpValue = newOp->getResult(0);
+    } else if constexpr (std::is_same_v<T, mlir::hivm::VPowOp>) {
+      auto newOp = builder.create<T>(
+          loc, insertBase.getType(), mlir::ValueRange{src0, src1},
+          mlir::ValueRange{insertBase}, mlir::Value(), transpose, broadcast);
+      newOpValue = newOp->getResult(0);
     } else if constexpr (std::is_same_v<T, mlir::hivm::VDivOp>) {
-    auto newOp = builder.create<T>(loc, insertBase.getType(), mlir::ValueRange{src0, src1},
-        mlir::ValueRange{insertBase}, true, transpose, broadcast);
-    newOpValue = newOp->getResult(0);
-    } else if constexpr (startsWith(
-                             T::getOperationName(),
-                             mlir::hivm::HIVMDialect::getDialectNamespace())) {
+      auto newOp = builder.create<T>(
+          loc, insertBase.getType(), mlir::ValueRange{src0, src1},
+          mlir::ValueRange{insertBase}, true, transpose, broadcast);
+      newOpValue = newOp->getResult(0);
+    } else {
       auto newOp = builder.create<T>(
           loc, insertBase.getType(), mlir::ValueRange{src0, src1},
           mlir::ValueRange{insertBase}, transpose, broadcast);
       newOpValue = newOp->getResult(0);
-    } else {
-      src0 = broadcastOrTranspose(src0, insertBase, brc0, transpose, builder);
-      src1 = broadcastOrTranspose(src1, insertBase, brc1, transpose, builder);
-
-      const auto dstElemType =
-          insertBase.getType().cast<ShapedType>().getElementType();
-      if (std::is_same_v<U, void> || dstElemType.isa<FloatType>())
-        newOpValue = builder.create<T>(loc, insertBase.getType(), src0, src1)
-                         .getResult();
-      else {
-        // NOTE: The logic is done in this way to avoid code repitition because
-        // of the else branch
-        bool usedV = false;
-        if constexpr (!std::is_same_v<V, void>) {
-          if (dstElemType.cast<IntegerType>().isUnsigned()) {
-            newOpValue =
-                builder.create<V>(loc, insertBase.getType(), src0, src1)
-                    .getResult();
-            usedV = true;
-          }
+    }
+  } else {
+    src0 = broadcastOrTranspose(src0, insertBase, brc0, transpose, builder);
+    src1 = broadcastOrTranspose(src1, insertBase, brc1, transpose, builder);
+    // FIXME: The dispatch logic is currently based on the dst element type.
+    // However, signed and unsigned int types are both converted to signless int
+    // type in npuir. We need to find a better way to dispatch different int
+    // types to the correct op
+    mlir::Type srcType = getElementTypeOrSelf(src0.getType());
+    do {
+      if constexpr (!std::is_void_v<T>)
+        // If only T is provided, always build T
+        // If not only T is provided, T will be float op, check if dst element
+        // type is float, if yes, build T
+        if ((std::is_void_v<U> && std::is_void_v<V>) ||
+            isa<FloatType>(srcType)) {
+          newOpValue = builder.create<T>(loc, insertBase.getType(), src0, src1)
+                           .getResult();
+          break;
         }
-
-        if (!usedV) {
+      if constexpr (!std::is_void_v<U>)
+        // If only T, U are provided, U will be int op, check if dst element
+        // type is int, if yes, build U If T, U, V are provided, U will be int
+        // signed op, check if dst element type is int unsigned (or signless),
+        // if yes, build U
+        if (auto maybeIntType = dyn_cast<IntegerType>(srcType);
+            maybeIntType && (std::is_void_v<V> || !maybeIntType.isUnsigned())) {
           newOpValue = builder.create<U>(loc, insertBase.getType(), src0, src1)
                            .getResult();
+          break;
         }
-      }
-    }
+      if constexpr (!std::is_void_v<V>)
+        // V will be int unsigned op, check if dst element type is int unsigned
+        // (or signless), if yes, build V
+        if (srcType.isUnsignedInteger() || srcType.isSignlessInteger()) {
+          newOpValue = builder.create<V>(loc, insertBase.getType(), src0, src1)
+                           .getResult();
+          break;
+        }
+      assert(false && "Unsupported dst element type for binary op");
+    } while (false);
+  }
 
   mlir::Value result = needInsertSlice
     ? ReshapeCastAndInsertSlice(newOpValue, GetVarValue(region_node_dst), dst_range)
@@ -3537,17 +3562,17 @@ mlir::Value CodeGenTileLangNPUIRDEV::VisitExpr_(const CallNode *op) {
     CreateHIVMBinaryVectorOp<mlir::arith::MinimumFOp, mlir::arith::MinSIOp,
                              mlir::arith::MinUIOp>(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_or"))) {
-    CreateHIVMBinaryVectorOp<mlir::hivm::VOrOp>(op);
+    CreateHIVMBinaryVectorOp<void, mlir::arith::OrIOp>(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_and"))) {
-    CreateHIVMBinaryVectorOp<mlir::hivm::VAndOp>(op);
+    CreateHIVMBinaryVectorOp<void, mlir::arith::AndIOp>(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_xor"))) {
-    CreateHIVMBinaryVectorOp<mlir::hivm::VXorOp>(op);
+    CreateHIVMBinaryVectorOp<void, mlir::arith::XOrIOp>(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_pow"))) {
     CreateHIVMBinaryVectorOp<mlir::hivm::VPowOp>(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_shl"))) {
-    CreateHIVMBinaryVectorOp<mlir::hivm::VShLOp>(op);
+    CreateHIVMBinaryVectorOp<void, mlir::arith::ShLIOp>(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_shr"))) {
-    CreateHIVMBinaryVectorOp<mlir::hivm::VShROp>(op);
+    CreateHIVMBinaryVectorOp<void, mlir::arith::ShRSIOp, mlir::arith::ShRUIOp>(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_brc"))) {
     VbrcCodegen(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_cast"))) {

--- a/testing/npuir/arith_ops/test_binary_arith_op_dev.py
+++ b/testing/npuir/arith_ops/test_binary_arith_op_dev.py
@@ -4,14 +4,14 @@ import tilelang
 import tilelang.language as T
 import pytest
 import os
-
+import numpy as np
 import testcommon as tc
 
 tilelang.cache.clear_cache()
 
 pytestmark = pytest.mark.mode("Developer")
 
-BITWISE_DTYPE_CASES = ["int32", "int16", "uint32", "uint16"]
+BITWISE_DTYPE_CASES = ["int32", "int16", "uint32", "uint16"]  # also works for int16, int8 if needed
 DTYPE_CASES = ["float16", "float32"] + BITWISE_DTYPE_CASES
 
 M, N = 4, 64
@@ -91,56 +91,6 @@ def binary_partial_kernel(M, N, block_M, op, dtype="float16"):
             T.copy(out_ub, Out)
 
     return binaryArithPartialDev
-
-
-def make_integer_tensor(shape, dtype, *, low, high):
-    return torch.randint(low, high, shape, dtype=tc.DTYPE_MAP[dtype]).npu()
-
-
-def compute_uint_reference(lhs, rhs, op):
-    lhs_u = lhs.to(torch.int64)
-    rhs_u = rhs.to(torch.int64)
-    if op == "add":
-        return lhs_u + rhs_u
-    if op == "sub":
-        return lhs_u - rhs_u
-    if op == "mul":
-        return lhs_u * rhs_u
-    if op == "div":
-        return lhs_u // rhs_u
-    if op == "and":
-        return lhs_u & rhs_u
-    if op == "or":
-        return lhs_u | rhs_u
-    if op == "xor":
-        return lhs_u ^ rhs_u
-    if op == "shl":
-        return lhs_u << rhs_u
-    if op == "shr":
-        return lhs_u >> rhs_u
-    raise ValueError(op)
-
-
-def compute_int_reference(lhs, rhs, op):
-    if op == "add":
-        return lhs + rhs
-    if op == "sub":
-        return lhs - rhs
-    if op == "mul":
-        return lhs * rhs
-    if op == "div":
-        return lhs / rhs
-    if op == "and":
-        return lhs & rhs
-    if op == "or":
-        return lhs | rhs
-    if op == "xor":
-        return lhs ^ rhs
-    if op == "shl":
-        return lhs << rhs
-    if op == "shr":
-        return lhs >> rhs
-    raise ValueError(op)
 
 # ---------- New: Bitwise Kernels (AND, OR, XOR) ----------
 def bitwise_kernel(M, N, block_M, op, dtype="int32"):
@@ -267,56 +217,57 @@ def shift_partial_kernel(M, N, block_M, op, dtype="int32"):
 # ---------- Reference functions ----------
 def reference_arith(A, B, M, op):
     if op == "add":
-        ref = (A + B)[None, :].expand(M, -1)
+        if not (A.is_signed() or A.is_floating_point()):
+            ref = (A.to(torch.int64) + B.to(torch.int64))[None, :].expand(M, -1).to(A.dtype)
+        else:
+            ref = (A + B)[None, :].expand(M, -1)
     elif op == "sub":
-        ref = (A - B)[None, :].expand(M, -1)
+        if not (A.is_signed() or A.is_floating_point()):
+            ref = (A.to(torch.int64) - B.to(torch.int64))[None, :].expand(M, -1).to(A.dtype)
+        else:
+            ref = (A - B)[None, :].expand(M, -1)
     elif op == "mul":
-        ref = (A * B)[None, :].expand(M, -1)
+        if not (A.is_signed() or A.is_floating_point()):
+            ref = (A.to(torch.int64) * B.to(torch.int64))[None, :].expand(M, -1).to(A.dtype)
+        else:
+            ref = (A * B)[None, :].expand(M, -1)
     elif op == "div":
-        ref = (A / B)[None, :].expand(M, -1)
-    elif op == "add" and A.dtype.is_unsigned:
-        ref = (A.to(torch.int64) + B.to(torch.int64))[None, :].expand(M, -1).to(A.dtype)
-    elif op == "sub" and A.dtype.is_unsigned:
-        ref = (A.to(torch.int64) - B.to(torch.int64))[None, :].expand(M, -1).to(A.dtype)
-    elif op == "mul" and A.dtype.is_unsigned:
-        ref = (A.to(torch.int64) * B.to(torch.int64))[None, :].expand(M, -1).to(A.dtype)
-    elif op == "div" and A.dtype.is_unsigned:
-        ref = (A.to(torch.int64) // B.to(torch.int64))[None, :].expand(M, -1).to(A.dtype)
+        if not A.is_floating_point():
+            if A.is_signed():
+                ref = (A // B)[None, :].expand(M, -1)
+            else:
+                ref = (A.to(torch.int64) // B.to(torch.int64))[None, :].expand(M, -1).to(A.dtype)
+        else:
+            ref = (A / B)[None, :].expand(M, -1)
     else:
         raise ValueError(op)
     return ref
 
 def reference_bitwise(A, B, M, op):
+    A_type = A.dtype
+    if not A.is_signed():
+        A = A.to(torch.int64)
+        B = B.to(torch.int64)
     if op == "and":
         ref = torch.bitwise_and(A, B)[None, :].expand(M, -1)
     elif op == "or":
         ref = torch.bitwise_or(A, B)[None, :].expand(M, -1)
     elif op == "xor":
         ref = torch.bitwise_xor(A, B)[None, :].expand(M, -1)
-    elif op == "shl":
-        ref = (A << B)[None, :].expand(M, -1)
-    elif op == "shr":
-        ref = (A >> B)[None, :].expand(M, -1)
     else:
         raise ValueError(op)
-    return ref
+    return ref.to(A_type)
 
 def reference_shift(A, B, M, op, bitwidth=32):
-    # B is shift amount, clamp to 0..bitwidth-1 to avoid undefined behavior
-    B_clamped = B.clamp(0, bitwidth - 1)
     if op == "shl":
-        ref = (A << B_clamped)[None, :].expand(M, -1)
+        ref = torch.from_numpy(np.left_shift(A.cpu().numpy(), B.cpu().numpy()))
+        ref = ref[None, :].expand(M, -1)
     elif op == "shr":
-        ref = (A >> B_clamped)[None, :].expand(M, -1)
+        ref = torch.from_numpy(np.right_shift(A.cpu().numpy(), B.cpu().numpy()))
+        ref = ref[None, :].expand(M, -1)
     else:
         raise ValueError(op)
     return ref
-
-
-def reference_integer(A, B, M, op):
-    if A.dtype.is_unsigned:
-        return compute_uint_reference(A, B, op)[None, :].expand(M, -1).to(A.dtype)
-    return compute_int_reference(A, B, op)[None, :].expand(M, -1)
 
 # ---------- Arithmetic Tests (unchanged) ----------
 @pytest.mark.op("vadd")
@@ -340,11 +291,7 @@ def test_vadd(dtype):
         ref = (A.long() + B.long()).to(datatype)
     else:
         ref = A + B
-    if dtype in BITWISE_DTYPE_CASES:
-        # For bitwise ops, expect exact match
-        assert(torch.equal(Out.cpu(), ref.cpu()))
-    else:
-        tc.assert_close(Out.cpu(), ref.cpu(), rtol=1e-2, atol=1e-2, equal_nan=True)
+    tc.assert_close(Out.cpu(), ref.cpu(), rtol=1e-2, atol=1e-2, equal_nan=True)
 
 @pytest.mark.op("vsub")
 @pytest.mark.parametrize("dtype", DTYPE_CASES)
@@ -361,7 +308,10 @@ def test_vsub(dtype):
     func = binary_kernel(M, N, block_M, "sub", dtype)
     compiled = tilelang.compile(func, target="npuir")
     compiled(A, B, Out)
-    ref = A - B
+    if dtype.startswith("uint"):
+        ref = (A.long() - B.long()).to(datatype)
+    else:
+        ref = A - B
     tc.assert_close(Out.cpu(), ref.cpu(), rtol=1e-2, atol=1e-2, equal_nan=True)
 
 @pytest.mark.op("vmul")
@@ -379,7 +329,10 @@ def test_vmul(dtype):
     func = binary_kernel(M, N, block_M, "mul", dtype)
     compiled = tilelang.compile(func, target="npuir")
     compiled(A, B, Out)
-    ref = A * B
+    if dtype.startswith("uint"):
+        ref = (A.long() * B.long()).to(datatype)
+    else:
+        ref = A * B
     tc.assert_close(Out.cpu(), ref.cpu(), rtol=1e-2, atol=1e-2, equal_nan=True)
 
 @pytest.mark.op("vdiv")
@@ -397,7 +350,12 @@ def test_vdiv(dtype):
     func = binary_kernel(M, N, block_M, "div", dtype)
     compiled = tilelang.compile(func, target="npuir")
     compiled(A, B, Out)
-    ref = A / B
+    if dtype.startswith("uint"):
+        ref = (A.long() // B.long()).to(datatype)
+    elif dtype.startswith("int"):
+        ref = A // B
+    else:
+        ref = A / B
     tc.assert_close(Out.cpu(), ref.cpu(), rtol=1e-2, atol=1e-2, equal_nan=True)
 
 # Partial arithmetic
@@ -425,8 +383,13 @@ def test_vadd_partial(dtype):
 @pytest.mark.parametrize("dtype", DTYPE_CASES)
 def test_vsub_partial(dtype):
     datatype = tc.DTYPE_MAP[dtype]
-    A = torch.randn(N, dtype=datatype).npu()
-    B = torch.randn(N, dtype=datatype).npu()
+    if dtype in BITWISE_DTYPE_CASES:
+        # For bitwise ops, use integer inputs
+        A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+        B = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+    else:
+        A = torch.randn(N, dtype=datatype).npu()
+        B = torch.randn(N, dtype=datatype).npu()
     Out = torch.zeros((M, N), dtype=datatype).npu()
 
     func = binary_partial_kernel(M, N, block_M, "sub", dtype)
@@ -440,8 +403,13 @@ def test_vsub_partial(dtype):
 @pytest.mark.parametrize("dtype", DTYPE_CASES)
 def test_vmul_partial(dtype):
     datatype = tc.DTYPE_MAP[dtype]
-    A = torch.randn(N, dtype=datatype).npu()
-    B = torch.randn(N, dtype=datatype).npu()
+    if dtype in BITWISE_DTYPE_CASES:
+        # For bitwise ops, use integer inputs
+        A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+        B = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+    else:
+        A = torch.randn(N, dtype=datatype).npu()
+        B = torch.randn(N, dtype=datatype).npu()
     Out = torch.zeros((M, N), dtype=datatype).npu()
 
     func = binary_partial_kernel(M, N, block_M, "mul", dtype)
@@ -453,10 +421,15 @@ def test_vmul_partial(dtype):
 
 @pytest.mark.op("vdiv_partial")
 @pytest.mark.parametrize("dtype", DTYPE_CASES)
-def test_vdiv_partial(dtype):   
+def test_vdiv_partial(dtype):
     datatype = tc.DTYPE_MAP[dtype]
-    A = torch.randn(N, dtype=datatype).npu()
-    B = torch.randn(N, dtype=datatype).npu()
+    if dtype in BITWISE_DTYPE_CASES:
+        # For bitwise ops, use integer inputs
+        A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+        B = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+    else:
+        A = torch.randn(N, dtype=datatype).npu()
+        B = torch.randn(N, dtype=datatype).npu()
     Out = torch.zeros((M, N), dtype=datatype).npu()
 
     func = binary_partial_kernel(M, N, block_M, "div", dtype)
@@ -473,12 +446,8 @@ def test_vdiv_partial(dtype):
 def test_vand(dtype):
     datatype = tc.DTYPE_MAP[dtype]
     # Generate random integers within reasonable range for the dtype
-    if dtype == "int32":
-        A = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
-        B = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
-    else:  # int16, int8 fallback
-        A = torch.randint(-128, 127, (N,), dtype=datatype).npu()
-        B = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+    A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+    B = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
     Out = torch.zeros((N,), dtype=datatype).npu()
 
     func = bitwise_kernel(M, N, block_M, "and", dtype)
@@ -491,12 +460,8 @@ def test_vand(dtype):
 @pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
 def test_vor(dtype):
     datatype = tc.DTYPE_MAP[dtype]
-    if dtype == "int32":
-        A = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
-        B = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
-    else:
-        A = torch.randint(-128, 127, (N,), dtype=datatype).npu()
-        B = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+    A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+    B = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
     Out = torch.zeros((N,), dtype=datatype).npu()
 
     func = bitwise_kernel(M, N, block_M, "or", dtype)
@@ -509,12 +474,8 @@ def test_vor(dtype):
 @pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
 def test_vxor(dtype):
     datatype = tc.DTYPE_MAP[dtype]
-    if dtype == "int32":
-        A = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
-        B = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
-    else:
-        A = torch.randint(-128, 127, (N,), dtype=datatype).npu()
-        B = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+    A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+    B = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
     Out = torch.zeros((N,), dtype=datatype).npu()
 
     func = bitwise_kernel(M, N, block_M, "xor", dtype)
@@ -528,12 +489,8 @@ def test_vxor(dtype):
 @pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
 def test_vand_partial(dtype):
     datatype = tc.DTYPE_MAP[dtype]
-    if dtype == "int32":
-        A = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
-        B = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
-    else:
-        A = torch.randint(-128, 127, (N,), dtype=datatype).npu()
-        B = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+    A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+    B = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
     Out = torch.zeros((M, N), dtype=datatype).npu()
 
     func = bitwise_partial_kernel(M, N, block_M, "and", dtype)
@@ -546,12 +503,8 @@ def test_vand_partial(dtype):
 @pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
 def test_vor_partial(dtype):
     datatype = tc.DTYPE_MAP[dtype]
-    if dtype == "int32":
-        A = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
-        B = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
-    else:
-        A = torch.randint(-128, 127, (N,), dtype=datatype).npu()
-        B = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+    A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+    B = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
     Out = torch.zeros((M, N), dtype=datatype).npu()
 
     func = bitwise_partial_kernel(M, N, block_M, "or", dtype)
@@ -564,12 +517,8 @@ def test_vor_partial(dtype):
 @pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
 def test_vxor_partial(dtype):
     datatype = tc.DTYPE_MAP[dtype]
-    if dtype == "int32":
-        A = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
-        B = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
-    else:
-        A = torch.randint(-128, 127, (N,), dtype=datatype).npu()
-        B = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+    A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+    B = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
     Out = torch.zeros((M, N), dtype=datatype).npu()
 
     func = bitwise_partial_kernel(M, N, block_M, "xor", dtype)
@@ -583,34 +532,33 @@ def test_vxor_partial(dtype):
 @pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
 def test_vshl(dtype):
     datatype = tc.DTYPE_MAP[dtype]
-    bitwidth = 32 if dtype == "int32" else 16 if dtype == "int16" else 8
-    A = torch.randint(-(2**(bitwidth-1)), 2**(bitwidth-1)-1, (N,), dtype=datatype).npu()
+    bitwidth = 32 if dtype.endswith("int32") else 16 if dtype.endswith("int16") else 8
+    A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
     # shift amounts between 0 and bitwidth-1
-    B = torch.randint(0, bitwidth, (N,), dtype=torch.int32).npu()
+    B = torch.randint(0, bitwidth, (N,), dtype=datatype).npu()
     Out = torch.zeros((N,), dtype=datatype).npu()
 
     func = shift_kernel(M, N, block_M, "shl", dtype)
     compiled = tilelang.compile(func, target="npuir")
     compiled(A, B, Out)
-    # clamp shift amounts for reference
-    B_cpu = B.cpu().clamp(0, bitwidth - 1)
-    ref = (A.cpu() << B_cpu)
+    B_cpu = B.cpu().numpy()
+    ref = torch.from_numpy(np.left_shift(A.cpu().numpy(), B_cpu)).to(datatype)
     tc.assert_close(Out.cpu(), ref.cpu(), rtol=0, atol=0)
 
 @pytest.mark.op("vshr")
 @pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
 def test_vshr(dtype):
     datatype = tc.DTYPE_MAP[dtype]
-    bitwidth = 32 if dtype == "int32" else 16 if dtype == "int16" else 8
-    A = torch.randint(-(2**(bitwidth-1)), 2**(bitwidth-1)-1, (N,), dtype=datatype).npu()
-    B = torch.randint(0, bitwidth, (N,), dtype=torch.int32).npu()
+    bitwidth = 32 if dtype.endswith("int32") else 16 if dtype.endswith("int16") else 8
+    A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+    B = torch.randint(0, bitwidth, (N,), dtype=datatype).npu()
     Out = torch.zeros((N,), dtype=datatype).npu()
 
     func = shift_kernel(M, N, block_M, "shr", dtype)
     compiled = tilelang.compile(func, target="npuir")
     compiled(A, B, Out)
-    B_cpu = B.cpu().clamp(0, bitwidth - 1)
-    ref = (A.cpu() >> B_cpu)
+    B_cpu = B.cpu().numpy()
+    ref = torch.from_numpy(np.right_shift(A.cpu().numpy(), B_cpu)).to(datatype)
     tc.assert_close(Out.cpu(), ref.cpu(), rtol=0, atol=0)
 
 # Partial shift tests
@@ -618,9 +566,9 @@ def test_vshr(dtype):
 @pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
 def test_vshl_partial(dtype):
     datatype = tc.DTYPE_MAP[dtype]
-    bitwidth = 32 if dtype == "int32" else 16 if dtype == "int16" else 8
-    A = torch.randint(-(2**(bitwidth-1)), 2**(bitwidth-1)-1, (N,), dtype=datatype).npu()
-    B = torch.randint(0, bitwidth, (N,), dtype=torch.int32).npu()
+    bitwidth = 32 if dtype.endswith("int32") else 16 if dtype.endswith("int16") else 8
+    A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+    B = torch.randint(0, bitwidth, (N,), dtype=datatype).npu()
     Out = torch.zeros((M, N), dtype=datatype).npu()
 
     func = shift_partial_kernel(M, N, block_M, "shl", dtype)
@@ -633,9 +581,9 @@ def test_vshl_partial(dtype):
 @pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
 def test_vshr_partial(dtype):
     datatype = tc.DTYPE_MAP[dtype]
-    bitwidth = 32 if dtype == "int32" else 16 if dtype == "int16" else 8
-    A = torch.randint(-(2**(bitwidth-1)), 2**(bitwidth-1)-1, (N,), dtype=datatype).npu()
-    B = torch.randint(0, bitwidth, (N,), dtype=torch.int32).npu()
+    bitwidth = 32 if dtype.endswith("int32") else 16 if dtype.endswith("int16") else 8
+    A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+    B = torch.randint(0, bitwidth, (N,), dtype=datatype).npu()
     Out = torch.zeros((M, N), dtype=datatype).npu()
 
     func = shift_partial_kernel(M, N, block_M, "shr", dtype)

--- a/testing/npuir/arith_ops/test_binary_arith_op_dev.py
+++ b/testing/npuir/arith_ops/test_binary_arith_op_dev.py
@@ -11,11 +11,13 @@ tilelang.cache.clear_cache()
 
 pytestmark = pytest.mark.mode("Developer")
 
-DTYPE_CASES = ["float16", "float32"]
+BITWISE_DTYPE_CASES = ["int32", "int16", "uint32", "uint16"]
+DTYPE_CASES = ["float16", "float32"] + BITWISE_DTYPE_CASES
 
 M, N = 4, 64
 block_M = 4
 
+# ---------- Arithmetic Kernels (existing) ----------
 def binary_kernel(M, N, block_M, op, dtype="float16"):
     grid_M = (M + block_M - 1) // block_M
 
@@ -91,7 +93,179 @@ def binary_partial_kernel(M, N, block_M, op, dtype="float16"):
     return binaryArithPartialDev
 
 
-def reference(A, B, M, op):
+def make_integer_tensor(shape, dtype, *, low, high):
+    return torch.randint(low, high, shape, dtype=tc.DTYPE_MAP[dtype]).npu()
+
+
+def compute_uint_reference(lhs, rhs, op):
+    lhs_u = lhs.to(torch.int64)
+    rhs_u = rhs.to(torch.int64)
+    if op == "add":
+        return lhs_u + rhs_u
+    if op == "sub":
+        return lhs_u - rhs_u
+    if op == "mul":
+        return lhs_u * rhs_u
+    if op == "div":
+        return lhs_u // rhs_u
+    if op == "and":
+        return lhs_u & rhs_u
+    if op == "or":
+        return lhs_u | rhs_u
+    if op == "xor":
+        return lhs_u ^ rhs_u
+    if op == "shl":
+        return lhs_u << rhs_u
+    if op == "shr":
+        return lhs_u >> rhs_u
+    raise ValueError(op)
+
+
+def compute_int_reference(lhs, rhs, op):
+    if op == "add":
+        return lhs + rhs
+    if op == "sub":
+        return lhs - rhs
+    if op == "mul":
+        return lhs * rhs
+    if op == "div":
+        return lhs / rhs
+    if op == "and":
+        return lhs & rhs
+    if op == "or":
+        return lhs | rhs
+    if op == "xor":
+        return lhs ^ rhs
+    if op == "shl":
+        return lhs << rhs
+    if op == "shr":
+        return lhs >> rhs
+    raise ValueError(op)
+
+# ---------- New: Bitwise Kernels (AND, OR, XOR) ----------
+def bitwise_kernel(M, N, block_M, op, dtype="int32"):
+    grid_M = (M + block_M - 1) // block_M
+
+    @T.prim_func
+    def bitwiseFullDev(
+        A: T.Tensor((N,), dtype),
+        B: T.Tensor((N,), dtype),
+        Out: T.Tensor((N,), dtype),
+    ):
+        with T.Kernel(grid_M, is_npu=True) as (bx, _):
+            acc_A = T.alloc_shared((N,), dtype)
+            acc_B = T.alloc_shared((N,), dtype)
+            out_ub = T.alloc_shared((N,), dtype)
+
+            T.copy(A, acc_A)
+            T.copy(B, acc_B)
+
+            for i in T.serial(block_M):
+                if op == "and":
+                    T.npuir_and(acc_A, acc_B, out_ub)
+                elif op == "or":
+                    T.npuir_or(acc_A, acc_B, out_ub)
+                elif op == "xor":
+                    T.npuir_xor(acc_A, acc_B, out_ub)
+                else:
+                    T.assert_(False, "Unsupported bitwise op")
+
+            T.copy(out_ub, Out)
+
+    return bitwiseFullDev
+
+def bitwise_partial_kernel(M, N, block_M, op, dtype="int32"):
+    grid_M = (M + block_M - 1) // block_M
+
+    @T.prim_func
+    def bitwisePartialDev(
+        A: T.Tensor((N,), dtype),
+        B: T.Tensor((N,), dtype),
+        Out: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(grid_M, is_npu=True) as (bx, _):
+            acc_A = T.alloc_shared((N,), dtype)
+            acc_B = T.alloc_shared((N,), dtype)
+            out_ub = T.alloc_shared((M, N), dtype)
+
+            T.copy(A, acc_A)
+            T.copy(B, acc_B)
+
+            for i in T.serial(block_M):
+                if op == "and":
+                    T.npuir_and(acc_A, acc_B, out_ub[i, :])
+                elif op == "or":
+                    T.npuir_or(acc_A, acc_B, out_ub[i, :])
+                elif op == "xor":
+                    T.npuir_xor(acc_A, acc_B, out_ub[i, :])
+                else:
+                    T.assert_(False, "Unsupported bitwise op")
+
+            T.copy(out_ub, Out)
+
+    return bitwisePartialDev
+
+# ---------- New: Shift Kernels (SHL, SHR) ----------
+def shift_kernel(M, N, block_M, op, dtype="int32"):
+    grid_M = (M + block_M - 1) // block_M
+
+    @T.prim_func
+    def shiftFullDev(
+        A: T.Tensor((N,), dtype),
+        B: T.Tensor((N,), dtype),  # shift amounts
+        Out: T.Tensor((N,), dtype),
+    ):
+        with T.Kernel(grid_M, is_npu=True) as (bx, _):
+            acc_A = T.alloc_shared((N,), dtype)
+            acc_B = T.alloc_shared((N,), dtype)
+            out_ub = T.alloc_shared((N,), dtype)
+
+            T.copy(A, acc_A)
+            T.copy(B, acc_B)
+
+            for i in T.serial(block_M):
+                if op == "shl":
+                    T.npuir_shl(acc_A, acc_B, out_ub)
+                elif op == "shr":
+                    T.npuir_shr(acc_A, acc_B, out_ub)
+                else:
+                    T.assert_(False, "Unsupported shift op")
+
+            T.copy(out_ub, Out)
+
+    return shiftFullDev
+
+def shift_partial_kernel(M, N, block_M, op, dtype="int32"):
+    grid_M = (M + block_M - 1) // block_M
+
+    @T.prim_func
+    def shiftPartialDev(
+        A: T.Tensor((N,), dtype),
+        B: T.Tensor((N,), dtype),
+        Out: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(grid_M, is_npu=True) as (bx, _):
+            acc_A = T.alloc_shared((N,), dtype)
+            acc_B = T.alloc_shared((N,), dtype)
+            out_ub = T.alloc_shared((M, N), dtype)
+
+            T.copy(A, acc_A)
+            T.copy(B, acc_B)
+
+            for i in T.serial(block_M):
+                if op == "shl":
+                    T.npuir_shl(acc_A, acc_B, out_ub[i, :])
+                elif op == "shr":
+                    T.npuir_shr(acc_A, acc_B, out_ub[i, :])
+                else:
+                    T.assert_(False, "Unsupported shift op")
+
+            T.copy(out_ub, Out)
+
+    return shiftPartialDev
+
+# ---------- Reference functions ----------
+def reference_arith(A, B, M, op):
     if op == "add":
         ref = (A + B)[None, :].expand(M, -1)
     elif op == "sub":
@@ -100,31 +274,89 @@ def reference(A, B, M, op):
         ref = (A * B)[None, :].expand(M, -1)
     elif op == "div":
         ref = (A / B)[None, :].expand(M, -1)
+    elif op == "add" and A.dtype.is_unsigned:
+        ref = (A.to(torch.int64) + B.to(torch.int64))[None, :].expand(M, -1).to(A.dtype)
+    elif op == "sub" and A.dtype.is_unsigned:
+        ref = (A.to(torch.int64) - B.to(torch.int64))[None, :].expand(M, -1).to(A.dtype)
+    elif op == "mul" and A.dtype.is_unsigned:
+        ref = (A.to(torch.int64) * B.to(torch.int64))[None, :].expand(M, -1).to(A.dtype)
+    elif op == "div" and A.dtype.is_unsigned:
+        ref = (A.to(torch.int64) // B.to(torch.int64))[None, :].expand(M, -1).to(A.dtype)
     else:
         raise ValueError(op)
     return ref
 
+def reference_bitwise(A, B, M, op):
+    if op == "and":
+        ref = torch.bitwise_and(A, B)[None, :].expand(M, -1)
+    elif op == "or":
+        ref = torch.bitwise_or(A, B)[None, :].expand(M, -1)
+    elif op == "xor":
+        ref = torch.bitwise_xor(A, B)[None, :].expand(M, -1)
+    elif op == "shl":
+        ref = (A << B)[None, :].expand(M, -1)
+    elif op == "shr":
+        ref = (A >> B)[None, :].expand(M, -1)
+    else:
+        raise ValueError(op)
+    return ref
+
+def reference_shift(A, B, M, op, bitwidth=32):
+    # B is shift amount, clamp to 0..bitwidth-1 to avoid undefined behavior
+    B_clamped = B.clamp(0, bitwidth - 1)
+    if op == "shl":
+        ref = (A << B_clamped)[None, :].expand(M, -1)
+    elif op == "shr":
+        ref = (A >> B_clamped)[None, :].expand(M, -1)
+    else:
+        raise ValueError(op)
+    return ref
+
+
+def reference_integer(A, B, M, op):
+    if A.dtype.is_unsigned:
+        return compute_uint_reference(A, B, op)[None, :].expand(M, -1).to(A.dtype)
+    return compute_int_reference(A, B, op)[None, :].expand(M, -1)
+
+# ---------- Arithmetic Tests (unchanged) ----------
 @pytest.mark.op("vadd")
 @pytest.mark.parametrize("dtype", DTYPE_CASES)
 def test_vadd(dtype):
     datatype = tc.DTYPE_MAP[dtype]
-    A = torch.randn(N, dtype=datatype).npu()
-    B = torch.randn(N, dtype=datatype).npu()
+    if dtype in BITWISE_DTYPE_CASES:
+        # For bitwise ops, use integer inputs
+        A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+        B = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+    else:
+        A = torch.randn(N, dtype=datatype).npu()
+        B = torch.randn(N, dtype=datatype).npu()
     Out = torch.zeros((N,), dtype=datatype).npu()
 
     func = binary_kernel(M, N, block_M, "add", dtype)
     compiled = tilelang.compile(func, target="npuir")
 
     compiled(A, B, Out)
-    ref = A + B
-    tc.assert_close(Out.cpu(), ref.cpu(), rtol=1e-2, atol=1e-2, equal_nan=True)
+    if dtype.startswith("uint"):
+        ref = (A.long() + B.long()).to(datatype)
+    else:
+        ref = A + B
+    if dtype in BITWISE_DTYPE_CASES:
+        # For bitwise ops, expect exact match
+        assert(torch.equal(Out.cpu(), ref.cpu()))
+    else:
+        tc.assert_close(Out.cpu(), ref.cpu(), rtol=1e-2, atol=1e-2, equal_nan=True)
 
 @pytest.mark.op("vsub")
 @pytest.mark.parametrize("dtype", DTYPE_CASES)
 def test_vsub(dtype):
     datatype = tc.DTYPE_MAP[dtype]
-    A = torch.randn(N, dtype=datatype).npu()
-    B = torch.randn(N, dtype=datatype).npu()
+    if dtype in BITWISE_DTYPE_CASES:
+        # For bitwise ops, use integer inputs
+        A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+        B = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+    else:
+        A = torch.randn(N, dtype=datatype).npu()
+        B = torch.randn(N, dtype=datatype).npu()
     Out = torch.zeros((N,), dtype=datatype).npu()
     func = binary_kernel(M, N, block_M, "sub", dtype)
     compiled = tilelang.compile(func, target="npuir")
@@ -136,8 +368,13 @@ def test_vsub(dtype):
 @pytest.mark.parametrize("dtype", DTYPE_CASES)
 def test_vmul(dtype):
     datatype = tc.DTYPE_MAP[dtype]
-    A = torch.randn(N, dtype=datatype).npu()
-    B = torch.randn(N, dtype=datatype).npu()
+    if dtype in BITWISE_DTYPE_CASES:
+        # For bitwise ops, use integer inputs
+        A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+        B = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+    else:
+        A = torch.randn(N, dtype=datatype).npu()
+        B = torch.randn(N, dtype=datatype).npu()
     Out = torch.zeros((N,), dtype=datatype).npu()
     func = binary_kernel(M, N, block_M, "mul", dtype)
     compiled = tilelang.compile(func, target="npuir")
@@ -149,8 +386,13 @@ def test_vmul(dtype):
 @pytest.mark.parametrize("dtype", DTYPE_CASES)
 def test_vdiv(dtype):
     datatype = tc.DTYPE_MAP[dtype]
-    A = torch.randn(N, dtype=datatype).npu()
-    B = torch.randn(N, dtype=datatype).npu()
+    if dtype in BITWISE_DTYPE_CASES:
+        # For bitwise ops, use integer inputs
+        A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+        B = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+    else:
+        A = torch.randn(N, dtype=datatype).npu()
+        B = torch.randn(N, dtype=datatype).npu()
     Out = torch.zeros((N,), dtype=datatype).npu()
     func = binary_kernel(M, N, block_M, "div", dtype)
     compiled = tilelang.compile(func, target="npuir")
@@ -158,21 +400,25 @@ def test_vdiv(dtype):
     ref = A / B
     tc.assert_close(Out.cpu(), ref.cpu(), rtol=1e-2, atol=1e-2, equal_nan=True)
 
-# Partial binary op tests
-
+# Partial arithmetic
 @pytest.mark.op("vadd_partial")
 @pytest.mark.parametrize("dtype", DTYPE_CASES)
 def test_vadd_partial(dtype):
     datatype = tc.DTYPE_MAP[dtype]
-    A = torch.randn(N, dtype=datatype).npu()
-    B = torch.randn(N, dtype=datatype).npu()
+    if dtype in BITWISE_DTYPE_CASES:
+        # For bitwise ops, use integer inputs
+        A = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+        B = torch.randint(torch.iinfo(datatype).min, torch.iinfo(datatype).max, (N,), dtype=datatype).npu()
+    else:
+        A = torch.randn(N, dtype=datatype).npu()
+        B = torch.randn(N, dtype=datatype).npu()
     Out = torch.zeros((M, N), dtype=datatype).npu()
 
     func = binary_partial_kernel(M, N, block_M, "add", dtype)
     compiled = tilelang.compile(func, target="npuir")
 
     compiled(A, B, Out)
-    ref = reference(A.cpu(), B.cpu(), M, "add")
+    ref = reference_arith(A.cpu(), B.cpu(), M, "add")
     tc.assert_close(Out.cpu(), ref.cpu(), rtol=1e-2, atol=1e-2, equal_nan=True)
 
 @pytest.mark.op("vsub_partial")
@@ -187,7 +433,7 @@ def test_vsub_partial(dtype):
     compiled = tilelang.compile(func, target="npuir")
 
     compiled(A, B, Out)
-    ref = reference(A.cpu(), B.cpu(), M, "sub")
+    ref = reference_arith(A.cpu(), B.cpu(), M, "sub")
     tc.assert_close(Out.cpu(), ref.cpu(), rtol=1e-2, atol=1e-2, equal_nan=True)
 
 @pytest.mark.op("vmul_partial")
@@ -202,7 +448,7 @@ def test_vmul_partial(dtype):
     compiled = tilelang.compile(func, target="npuir")
 
     compiled(A, B, Out)
-    ref = reference(A.cpu(), B.cpu(), M, "mul")
+    ref = reference_arith(A.cpu(), B.cpu(), M, "mul")
     tc.assert_close(Out.cpu(), ref.cpu(), rtol=1e-2, atol=1e-2, equal_nan=True)
 
 @pytest.mark.op("vdiv_partial")
@@ -217,6 +463,183 @@ def test_vdiv_partial(dtype):
     compiled = tilelang.compile(func, target="npuir")
 
     compiled(A, B, Out)
-    ref = reference(A.cpu(), B.cpu(), M, "div")
+    ref = reference_arith(A.cpu(), B.cpu(), M, "div")
     tc.assert_close(Out.cpu(), ref.cpu(), rtol=1e-2, atol=1e-2, equal_nan=True)
 
+
+# ---------- New Tests: Bitwise AND, OR, XOR ----------
+@pytest.mark.op("vand")
+@pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
+def test_vand(dtype):
+    datatype = tc.DTYPE_MAP[dtype]
+    # Generate random integers within reasonable range for the dtype
+    if dtype == "int32":
+        A = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
+        B = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
+    else:  # int16, int8 fallback
+        A = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+        B = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+    Out = torch.zeros((N,), dtype=datatype).npu()
+
+    func = bitwise_kernel(M, N, block_M, "and", dtype)
+    compiled = tilelang.compile(func, target="npuir")
+    compiled(A, B, Out)
+    ref = torch.bitwise_and(A.cpu(), B.cpu())
+    tc.assert_close(Out.cpu(), ref.cpu(), rtol=0, atol=0)
+
+@pytest.mark.op("vor")
+@pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
+def test_vor(dtype):
+    datatype = tc.DTYPE_MAP[dtype]
+    if dtype == "int32":
+        A = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
+        B = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
+    else:
+        A = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+        B = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+    Out = torch.zeros((N,), dtype=datatype).npu()
+
+    func = bitwise_kernel(M, N, block_M, "or", dtype)
+    compiled = tilelang.compile(func, target="npuir")
+    compiled(A, B, Out)
+    ref = torch.bitwise_or(A.cpu(), B.cpu())
+    tc.assert_close(Out.cpu(), ref.cpu(), rtol=0, atol=0)
+
+@pytest.mark.op("vxor")
+@pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
+def test_vxor(dtype):
+    datatype = tc.DTYPE_MAP[dtype]
+    if dtype == "int32":
+        A = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
+        B = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
+    else:
+        A = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+        B = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+    Out = torch.zeros((N,), dtype=datatype).npu()
+
+    func = bitwise_kernel(M, N, block_M, "xor", dtype)
+    compiled = tilelang.compile(func, target="npuir")
+    compiled(A, B, Out)
+    ref = torch.bitwise_xor(A.cpu(), B.cpu())
+    tc.assert_close(Out.cpu(), ref.cpu(), rtol=0, atol=0)
+
+# Partial bitwise tests
+@pytest.mark.op("vand_partial")
+@pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
+def test_vand_partial(dtype):
+    datatype = tc.DTYPE_MAP[dtype]
+    if dtype == "int32":
+        A = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
+        B = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
+    else:
+        A = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+        B = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+    Out = torch.zeros((M, N), dtype=datatype).npu()
+
+    func = bitwise_partial_kernel(M, N, block_M, "and", dtype)
+    compiled = tilelang.compile(func, target="npuir")
+    compiled(A, B, Out)
+    ref = reference_bitwise(A.cpu(), B.cpu(), M, "and")
+    tc.assert_close(Out.cpu(), ref.cpu(), rtol=0, atol=0)
+
+@pytest.mark.op("vor_partial")
+@pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
+def test_vor_partial(dtype):
+    datatype = tc.DTYPE_MAP[dtype]
+    if dtype == "int32":
+        A = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
+        B = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
+    else:
+        A = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+        B = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+    Out = torch.zeros((M, N), dtype=datatype).npu()
+
+    func = bitwise_partial_kernel(M, N, block_M, "or", dtype)
+    compiled = tilelang.compile(func, target="npuir")
+    compiled(A, B, Out)
+    ref = reference_bitwise(A.cpu(), B.cpu(), M, "or")
+    tc.assert_close(Out.cpu(), ref.cpu(), rtol=0, atol=0)
+
+@pytest.mark.op("vxor_partial")
+@pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
+def test_vxor_partial(dtype):
+    datatype = tc.DTYPE_MAP[dtype]
+    if dtype == "int32":
+        A = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
+        B = torch.randint(-(2**31), 2**31-1, (N,), dtype=datatype).npu()
+    else:
+        A = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+        B = torch.randint(-128, 127, (N,), dtype=datatype).npu()
+    Out = torch.zeros((M, N), dtype=datatype).npu()
+
+    func = bitwise_partial_kernel(M, N, block_M, "xor", dtype)
+    compiled = tilelang.compile(func, target="npuir")
+    compiled(A, B, Out)
+    ref = reference_bitwise(A.cpu(), B.cpu(), M, "xor")
+    tc.assert_close(Out.cpu(), ref.cpu(), rtol=0, atol=0)
+
+# ---------- New Tests: Shift Left and Shift Right ----------
+@pytest.mark.op("vshl")
+@pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
+def test_vshl(dtype):
+    datatype = tc.DTYPE_MAP[dtype]
+    bitwidth = 32 if dtype == "int32" else 16 if dtype == "int16" else 8
+    A = torch.randint(-(2**(bitwidth-1)), 2**(bitwidth-1)-1, (N,), dtype=datatype).npu()
+    # shift amounts between 0 and bitwidth-1
+    B = torch.randint(0, bitwidth, (N,), dtype=torch.int32).npu()
+    Out = torch.zeros((N,), dtype=datatype).npu()
+
+    func = shift_kernel(M, N, block_M, "shl", dtype)
+    compiled = tilelang.compile(func, target="npuir")
+    compiled(A, B, Out)
+    # clamp shift amounts for reference
+    B_cpu = B.cpu().clamp(0, bitwidth - 1)
+    ref = (A.cpu() << B_cpu)
+    tc.assert_close(Out.cpu(), ref.cpu(), rtol=0, atol=0)
+
+@pytest.mark.op("vshr")
+@pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
+def test_vshr(dtype):
+    datatype = tc.DTYPE_MAP[dtype]
+    bitwidth = 32 if dtype == "int32" else 16 if dtype == "int16" else 8
+    A = torch.randint(-(2**(bitwidth-1)), 2**(bitwidth-1)-1, (N,), dtype=datatype).npu()
+    B = torch.randint(0, bitwidth, (N,), dtype=torch.int32).npu()
+    Out = torch.zeros((N,), dtype=datatype).npu()
+
+    func = shift_kernel(M, N, block_M, "shr", dtype)
+    compiled = tilelang.compile(func, target="npuir")
+    compiled(A, B, Out)
+    B_cpu = B.cpu().clamp(0, bitwidth - 1)
+    ref = (A.cpu() >> B_cpu)
+    tc.assert_close(Out.cpu(), ref.cpu(), rtol=0, atol=0)
+
+# Partial shift tests
+@pytest.mark.op("vshl_partial")
+@pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
+def test_vshl_partial(dtype):
+    datatype = tc.DTYPE_MAP[dtype]
+    bitwidth = 32 if dtype == "int32" else 16 if dtype == "int16" else 8
+    A = torch.randint(-(2**(bitwidth-1)), 2**(bitwidth-1)-1, (N,), dtype=datatype).npu()
+    B = torch.randint(0, bitwidth, (N,), dtype=torch.int32).npu()
+    Out = torch.zeros((M, N), dtype=datatype).npu()
+
+    func = shift_partial_kernel(M, N, block_M, "shl", dtype)
+    compiled = tilelang.compile(func, target="npuir")
+    compiled(A, B, Out)
+    ref = reference_shift(A.cpu(), B.cpu(), M, "shl", bitwidth)
+    tc.assert_close(Out.cpu(), ref.cpu(), rtol=0, atol=0)
+
+@pytest.mark.op("vshr_partial")
+@pytest.mark.parametrize("dtype", BITWISE_DTYPE_CASES)
+def test_vshr_partial(dtype):
+    datatype = tc.DTYPE_MAP[dtype]
+    bitwidth = 32 if dtype == "int32" else 16 if dtype == "int16" else 8
+    A = torch.randint(-(2**(bitwidth-1)), 2**(bitwidth-1)-1, (N,), dtype=datatype).npu()
+    B = torch.randint(0, bitwidth, (N,), dtype=torch.int32).npu()
+    Out = torch.zeros((M, N), dtype=datatype).npu()
+
+    func = shift_partial_kernel(M, N, block_M, "shr", dtype)
+    compiled = tilelang.compile(func, target="npuir")
+    compiled(A, B, Out)
+    ref = reference_shift(A.cpu(), B.cpu(), M, "shr", bitwidth)
+    tc.assert_close(Out.cpu(), ref.cpu(), rtol=0, atol=0)

--- a/testing/npuir/testcommon.py
+++ b/testing/npuir/testcommon.py
@@ -16,6 +16,9 @@ DTYPE_MAP = {
     "int8": torch.int8,
     "int16": torch.int16,
     "int32": torch.int32,
+    "uint8": torch.uint8,
+    "uint16": torch.uint16,
+    "uint32": torch.uint32,
     "int64": torch.int64,
     "bool": torch.bool,
 }
@@ -113,6 +116,11 @@ def assert_close(
     if dtype is None:
         dtype = actual.dtype
     name = dtype_name(dtype)
+
+    if not expected.is_floating_point():
+        assert torch.equal(actual, expected)
+        return
+
     default_rtol, default_atol = DEFAULT_TOLERANCE[name]
     torch.testing.assert_close(
         actual,


### PR DESCRIPTION
Support and, or, xor, shl, shr for A5. These ops are lowered into to arith dialect ops instead of hivm dialect ops.

Fix small issue in CreateHIVMBinaryVectorOp.

Add test cases.

**Known Issue:** Add proper checks for int/uint/float types.