### PR TITLE
[AscendNPU IR][A5] feat: support transpose, gather, print

### DIFF
--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -2526,8 +2526,10 @@ void CodeGenTileLangNPUIRDEV::VgatherCodegen(const CallNode *op) {
   Value dst = GenSubviewFromRegion(npuirop.dst, npuirop.dst_range);
   Value indices = GenSubviewFromRegion(npuirop.indices, npuirop.indices_range);
 
-  builder.create<mlir::hivm::VGatherOp>(builder.getUnknownLoc(), TypeRange{},
-                                        src, indices, dst);
+  auto newGatherOp = builder.create<hfusion::GatherOp>(
+      builder.getUnknownLoc(), src, indices, dst,
+      src.getType().cast<ShapedType>().getRank() - 1);
+  SetVarValue(npuirop.dst, newGatherOp->getResult(0));
 }
 
 void CodeGenTileLangNPUIRDEV::VtransposeCodegen(const CallNode *op) {
@@ -2535,9 +2537,8 @@ void CodeGenTileLangNPUIRDEV::VtransposeCodegen(const CallNode *op) {
   Value src = GenExtractSliceFromRegion(npuirop.src, npuirop.src_range);
   Value dst = GenExtractSliceFromRegion(npuirop.dst, npuirop.dst_range);
   auto permutation = builder.getDenseI64ArrayAttr(npuirop.permutation);
-  mlir::Type dstType = dst.getType();
-  auto transposeOp = builder.create<mlir::hivm::VTransposeOp>(
-      builder.getUnknownLoc(), mlir::TypeRange{dstType}, src, dst, permutation);
+  auto newOp = transpose(src, dst, permutation, builder);
+  SetVarValue(npuirop.dst, newOp);
 }
 
 void CodeGenTileLangNPUIRDEV::VinterleaveCodegen(const CallNode *op) {
@@ -3153,8 +3154,7 @@ void CodeGenTileLangNPUIRDEV::DebugPrintCodegen(const CallNode *op) {
   }
 
   mlir::Location unknown_loc = builder.getUnknownLoc();
-  builder.create<mlir::hivm::DebugOp>(unknown_loc, "print", prefix, hex, arg,
-                                       mlir::hivm::TCoreTypeAttr{});
+  builder.create<hfusion::PrintOp>(unknown_loc, StringRef(prefix), hex, arg);
 }
 
 //Generate vector cosine approximation using polynomial expansion in codegen.

--- a/testing/npuir/debug_ops/test_print_dev.py
+++ b/testing/npuir/debug_ops/test_print_dev.py
@@ -1,0 +1,58 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+"""Developer-mode npuir debug print on shared memory does not affect numeric results."""
+import os
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+import tilelang
+import tilelang.language as T
+
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("print"),
+    pytest.mark.mode("Developer"),
+]
+
+DTYPES = ["float16"]
+PRINT_SHAPES = [(32, 32)]
+
+
+def vec_add_with_print_dev(M, N, dtype="float16"):
+    block_size = 1
+
+    @T.prim_func
+    def add_print_kernel_dev(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, N), dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(block_size, is_npu=True) as _:
+            A_VEC = T.alloc_shared((M, N), dtype)
+            B_VEC = T.alloc_shared((M, N), dtype)
+            C_VEC = T.alloc_shared((M, N), dtype)
+            T.copy(A, A_VEC)
+            T.copy(B, B_VEC)
+            T.npuir_add(A_VEC, B_VEC, C_VEC)
+            T.print(C_VEC[:4, :4], msg="tile_dbg")
+            T.copy(C_VEC, C)
+
+    return add_print_kernel_dev
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("M, N", PRINT_SHAPES)
+def test_print_dev_numeric(dtype, M, N):
+    a = gen_tensor((M, N), dtype, kind="randn")
+    b = gen_tensor((M, N), dtype, kind="randn")
+    c = gen_tensor((M, N), dtype, kind="zeros")
+    expected = a.cpu() + b.cpu()
+
+    func = vec_add_with_print_dev(M, N, dtype=dtype)
+    compiled = tilelang.compile(func, target="npuir")
+    compiled(a, b, c)
+
+    assert_close(c.cpu(), expected, dtype=dtype, rtol=1e-2, atol=1e-2)

--- a/testing/npuir/indexing_ops/test_gather_dev.py
+++ b/testing/npuir/indexing_ops/test_gather_dev.py
@@ -1,0 +1,65 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+"""Gather (npuir_gather) in Ascend Developer mode vs torch.gather."""
+import os
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+import tilelang
+import tilelang.language as T
+
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("gather"),
+    pytest.mark.mode("Developer"),
+]
+
+GATHER_CASES = [(32, 32)]
+DTYPES = ["float16"]
+IndicesType = "int64"
+
+
+def vec_gather_dev(block_M, block_N, dtype="float16"):
+    block_size = 1
+
+    @T.prim_func
+    def gather_kernel_dev(
+        A: T.Tensor((block_M, block_N), dtype),
+        B: T.Tensor((block_M, block_N), IndicesType),
+        C: T.Tensor((block_M, block_N), dtype),
+    ):
+        with T.Kernel(block_size, is_npu=True) as _:
+            A_VEC = T.alloc_shared((block_M, block_N), dtype)
+            index_VEC = T.alloc_shared((block_M, block_N), IndicesType)
+            C_VEC = T.alloc_shared((block_M, block_N), dtype)
+
+            T.copy(A, A_VEC)
+            T.copy(B, index_VEC)
+            T.npuir_gather(
+                A_VEC[:block_M, :block_N],
+                C_VEC[:block_M, :block_N],
+                index_VEC,
+            )
+            T.copy(C_VEC, C)
+
+    return gather_kernel_dev
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("M, N", GATHER_CASES)
+def test_gather_dev(dtype, M, N):
+    compile_kernel = vec_gather_dev(M, N, dtype=dtype)
+    kernel = tilelang.compile(compile_kernel, target="npuir")
+
+    a = gen_tensor((M, N), dtype, kind="randn")
+    b = gen_tensor((M, N), IndicesType, kind="randint", low=0, high=N - 1)
+    c = gen_tensor((M, N), dtype, kind="zeros")
+
+    ref_c = torch.gather(a.cpu(), dim=1, index=b.cpu())
+    kernel(a, b, c)
+
+    assert_close(c.cpu(), ref_c, dtype=dtype, rtol=1e-2, atol=1e-2)
+

--- a/testing/npuir/shape_manipulation_ops/test_transpose_dev.py
+++ b/testing/npuir/shape_manipulation_ops/test_transpose_dev.py
@@ -1,0 +1,56 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025.
+"""Transpose (npuir_transpose) in Ascend Developer mode vs torch.transpose."""
+import os
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+import tilelang
+import tilelang.language as T
+
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("transpose"),
+    pytest.mark.mode("Developer"),
+]
+
+DTYPES = ["float16"]
+TRANSPOSE_SHAPES = [(32, 32)]
+
+
+def vec_transpose_dev(block_M, block_N, dtype="float16"):
+    block_size = 1
+
+    @T.prim_func
+    def transpose_kernel_dev(
+        A: T.Tensor((block_M, block_N), dtype),
+        C: T.Tensor((block_N, block_M), dtype),
+    ):
+        with T.Kernel(block_size, is_npu=True) as _:
+            A_VEC = T.alloc_shared((block_M, block_N), dtype)
+            C_VEC = T.alloc_shared((block_N, block_M), dtype)
+            T.copy(A, A_VEC)
+            T.npuir_transpose(
+                A_VEC[:block_M, :block_N],
+                C_VEC[:block_N, :block_M],
+                (1, 0),
+            )
+            T.copy(C_VEC, C)
+
+    return transpose_kernel_dev
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("M, N", TRANSPOSE_SHAPES)
+def test_transpose_dev(dtype, M, N):
+    A = gen_tensor((M, N), dtype, kind="randn")
+    C = gen_tensor((N, M), dtype, kind="zeros")
+    ref_C = torch.transpose(A.cpu(), 0, 1)
+
+    func = vec_transpose_dev(M, N, dtype=dtype)
+    compiled = tilelang.compile(func, target="npuir")
+    compiled(A, C)
+
+    assert_close(C.cpu(), ref_C, dtype=dtype, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
This pull request updates the NPUIR developer mode codegen to use the hfusion dialect for gather, transpose, and print operations, and adds corresponding unit tests. Feedback identifies a runtime casting error in VgatherCodegen where mlir::RankedTensorType should be replaced with mlir::ShapedType to avoid failures with MemRef types, and a bug in the gather test script due to an undefined variable itype.