### PR TITLE
[AscendNPU-IR][Expert] Bug fix for the codegen of binary vector operators

### DIFF
--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -21,6 +21,23 @@ namespace tl {
 
 using namespace tir;
 
+NpuirOperand NpuirOperand::FromExpr(const PrimExpr &expr,
+                                    const BufferMap &vmap) {
+  if (const auto *call = expr.as<CallNode>()) {
+    // CallNode should be a tensor
+    auto region = RegionOp(call->args, vmap);
+    return NpuirOperand::Tensor(region.GetBuffer(), region.GetRanges());
+  }
+  if (expr.as<IntImm>() || expr.as<FloatImm>() || expr.as<tir::VarNode>()) {
+    // If there are other types of nodes that need to be treated as scalars,
+    // please add them here.
+    return NpuirOperand::Scalar(expr);
+  }
+  LOG(FATAL) << "NpuirOperand::FromExpr cannot handle the expr with type of \""
+             << expr->GetTypeKey() << '\"';
+  __builtin_unreachable();
+}
+
 AscendCopy::AscendCopy(Array<PrimExpr> args, BufferMap vmap) : args_(args) {
   Array<Range> rgs[2];
   Buffer bf[2];
@@ -36,39 +53,30 @@ AscendCopy::AscendCopy(Array<PrimExpr> args, BufferMap vmap) : args_(args) {
   std::tie(this->src_range, this->dst_range) = std::tie(rgs[0], rgs[1]);
 }
 
-#define NPUIR_BINARY_OP_CTOR(OPNAME, opname)                                   \
-  Npuir##OPNAME::Npuir##OPNAME(Array<PrimExpr> args, BufferMap vmap) {         \
-    Array<Range> rgs[3];                                                       \
-    Buffer bf[3];                                                              \
-    for (int i = 0; i < 3; i++) {                                              \
-      auto expr = args[i];                                                     \
-      auto call = expr.as<CallNode>();                                         \
-      ICHECK(call);                                                            \
-      auto region = RegionOp(call->args, vmap);                                \
-      rgs[i] = region.GetRanges();                                             \
-      bf[i] = region.GetBuffer();                                              \
-    }                                                                          \
-    std::tie(this->src0, this->src1, this->dst) =                              \
-        std::tie(bf[0], bf[1], bf[2]);                                         \
-    std::tie(this->src0_range, this->src1_range, this->dst_range) =            \
-        std::tie(rgs[0], rgs[1], rgs[2]);                                      \
-  }                                                                            \
+NpuirBinaryOperator::NpuirBinaryOperator(Array<PrimExpr> args, BufferMap vmap) {
+  ICHECK_GE(args.size(), 3U) << "Binary operator expects at least 3 inputs";
+  src0_ = NpuirOperand::FromExpr(args[0], vmap);
+  src1_ = NpuirOperand::FromExpr(args[1], vmap);
+  dst_ = NpuirOperand::FromExpr(args[2], vmap);
+}
+
+#define NPUIR_BINARY_OP_REGISTER(OPNAME, opname)                               \
   TIR_REGISTER_TL_OP(Npuir##OPNAME, npuir_##opname)                            \
       .set_num_inputs(3)                                                       \
       .set_attr<TCallEffectKind>("TCallEffectKind",                            \
                                  Integer(CallEffectKind::kOpaque));
 
-NPUIR_BINARY_OP_CTOR(Add, add)
-NPUIR_BINARY_OP_CTOR(Sub, sub)
-NPUIR_BINARY_OP_CTOR(Mul, mul)
-NPUIR_BINARY_OP_CTOR(Div, div)
-NPUIR_BINARY_OP_CTOR(Max, max)
-NPUIR_BINARY_OP_CTOR(Min, min)
-NPUIR_BINARY_OP_CTOR(Or, or)
-NPUIR_BINARY_OP_CTOR(And, and)
-NPUIR_BINARY_OP_CTOR(Xor, xor)
-NPUIR_BINARY_OP_CTOR(Pow, pow)
-NPUIR_BINARY_OP_CTOR(Shl, shl)
+NPUIR_BINARY_OP_REGISTER(Add, add)
+NPUIR_BINARY_OP_REGISTER(Sub, sub)
+NPUIR_BINARY_OP_REGISTER(Mul, mul)
+NPUIR_BINARY_OP_REGISTER(Div, div)
+NPUIR_BINARY_OP_REGISTER(Max, max)
+NPUIR_BINARY_OP_REGISTER(Min, min)
+NPUIR_BINARY_OP_REGISTER(Or, or)
+NPUIR_BINARY_OP_REGISTER(And, and)
+NPUIR_BINARY_OP_REGISTER(Xor, xor)
+NPUIR_BINARY_OP_REGISTER(Pow, pow)
+NPUIR_BINARY_OP_REGISTER(Shl, shl)
 
 #define NPUIR_UNARY_OP_CTOR(OPNAME, opname)                                    \
   Npuir##OPNAME::Npuir##OPNAME(Array<PrimExpr> args, BufferMap vmap) {         \
@@ -99,7 +107,7 @@ NPUIR_UNARY_OP_CTOR(Sqrt, sqrt)
 NPUIR_UNARY_OP_CTOR(Rsqrt, rsqrt)
 NPUIR_UNARY_OP_CTOR(Abs, abs)
 NPUIR_UNARY_OP_CTOR(Rec, rec)
-NPUIR_UNARY_OP_CTOR(Not, not )
+NPUIR_UNARY_OP_CTOR(Not, not)
 
 NpuirBrc::NpuirBrc(Array<PrimExpr> args, BufferMap vmap) {
   in = args[0], out = args[1];
@@ -411,10 +419,10 @@ NpuirDevicePrintBuf::NpuirDevicePrintBuf(Array<PrimExpr> args, BufferMap vmap) {
 
 #define NPUIR_LIST_PARAM(list_param, arg_pos)                                  \
   std::string str_##list_param = args[arg_pos].as<StringImmNode>()->value;     \
-  std::stringstream ss_##list_param(str_##list_param);                                      \
-  std::string num_##list_param;                                                             \
-  while (std::getline(ss_##list_param, num_##list_param, ',')) {                                         \
-    list_param.push_back(std::stoi(num_##list_param));                                      \
+  std::stringstream ss_##list_param(str_##list_param);                         \
+  std::string num_##list_param;                                                \
+  while (std::getline(ss_##list_param, num_##list_param, ',')) {               \
+    list_param.push_back(std::stoi(num_##list_param));                         \
   }
 
 NpuirGather::NpuirGather(Array<PrimExpr> args, BufferMap vmap) {
@@ -483,7 +491,7 @@ NpuirPad::NpuirPad(Array<PrimExpr> args, BufferMap vmap) {
   }
 }
 
-NpuirFlip::NpuirFlip(Array<PrimExpr> args, BufferMap vmap){
+NpuirFlip::NpuirFlip(Array<PrimExpr> args, BufferMap vmap) {
   NPUIR_SRC_DST_BUF
 
   this->axis = args[2].as<IntImm>().value()->value;
@@ -511,13 +519,12 @@ NpuirReshape::NpuirReshape(Array<PrimExpr> args, BufferMap vmap) {
   std::tie(this->src, this->dst) = std::tie(bf[0], bf[1]);
   std::tie(this->src_range, this->dst_range) = std::tie(rgs[0], rgs[1]);
 
-  for (const auto& r : this->src_range) {
+  for (const auto &r : this->src_range) {
     src_shape.push_back(r->extent);
   }
-  for (const auto& r : this->dst_range) {
+  for (const auto &r : this->dst_range) {
     dst_shape.push_back(r->extent);
   }
-
 }
 
 NpuirTranspose::NpuirTranspose(Array<PrimExpr> args, BufferMap vmap){
@@ -777,6 +784,3 @@ TIR_REGISTER_TL_OP(NpuirReshape, npuir_reshape)
                                Integer(CallEffectKind::kOpaque));
 } // namespace tl
 } // namespace tvm
-
-
-

--- a/src/op/ascend.h
+++ b/src/op/ascend.h
@@ -19,6 +19,60 @@ namespace tl {
 
 using namespace tir;
 
+class NpuirOperand {
+public:
+  NpuirOperand() = default;
+
+  static NpuirOperand Tensor(Buffer buffer, Array<Range> ranges) {
+    NpuirOperand op;
+    op.kind_ = Kind::kTensor;
+    op.buffer_ = std::move(buffer);
+    op.ranges_ = std::move(ranges);
+    return op;
+  }
+
+  static NpuirOperand Scalar(PrimExpr expr) {
+    NpuirOperand op;
+    op.kind_ = Kind::kScalar;
+    op.scalar_ = std::move(expr);
+    return op;
+  }
+
+  static NpuirOperand FromExpr(const PrimExpr &expr, const BufferMap &vmap);
+
+  bool IsValid() const { return kind_ != Kind::kInvalid; }
+  bool IsTensor() const { return kind_ == Kind::kTensor; }
+  bool IsScalar() const { return kind_ == Kind::kScalar; }
+
+  const Buffer &GetBuffer() const {
+    ICHECK(IsTensor()) << "Operand is not a tensor";
+    return buffer_;
+  }
+
+  const Array<Range> &GetRanges() const {
+    ICHECK(IsTensor()) << "Operand is not a tensor";
+    return ranges_;
+  }
+
+  const PrimExpr &GetExpr() const {
+    ICHECK(IsScalar()) << "Operand is not a scalar";
+    return scalar_;
+  }
+
+private:
+  enum class Kind {
+    kInvalid,
+    kTensor,
+    kScalar,
+  };
+
+  Kind kind_{Kind::kInvalid};
+
+  Buffer buffer_;
+  Array<Range> ranges_;
+  PrimExpr scalar_;
+};
+
 class AscendCopy : public Operator {
 public:
   AscendCopy(Array<PrimExpr> args, BufferMap vmap);
@@ -32,15 +86,25 @@ public:
   Array<Range> src_range, dst_range;
 };
 
+class NpuirBinaryOperator : public Operator {
+public:
+  const NpuirOperand &Src0() const { return src0_; }
+  const NpuirOperand &Src1() const { return src1_; }
+  const NpuirOperand &Dst() const { return dst_; }
+
+  NpuirBinaryOperator(Array<PrimExpr> args, BufferMap vmap);
+
+protected:
+  NpuirOperand src0_;
+  NpuirOperand src1_;
+  NpuirOperand dst_;
+};
+
 #define NPUIR_BINARY_OP_CLASS(OPNAME)                                          \
-  class Npuir##OPNAME : public Operator {                                      \
+  class Npuir##OPNAME : public NpuirBinaryOperator {                           \
   public:                                                                      \
-    Npuir##OPNAME(Array<PrimExpr> args, BufferMap vmap);                       \
+    using NpuirBinaryOperator::NpuirBinaryOperator;                            \
     static const Op &Get();                                                    \
-                                                                               \
-  private:                                                                     \
-    Buffer src0, src1, dst;                                                    \
-    Array<Range> src0_range, src1_range, dst_range;                            \
   };
 
 NPUIR_BINARY_OP_CLASS(Add)
@@ -155,7 +219,7 @@ public:
 };
 
 /// HIVM set flag sync.
-class NpuirSetFlag: public Operator {
+class NpuirSetFlag : public Operator {
 public:
   NpuirSetFlag(Array<PrimExpr> args, BufferMap vmap);
 
@@ -168,7 +232,7 @@ public:
 };
 
 /// HIVM wait flag sync.
-class NpuirWaitFlag: public Operator {
+class NpuirWaitFlag : public Operator {
 public:
   NpuirWaitFlag(Array<PrimExpr> args, BufferMap vmap);
 

--- a/src/target/codegen_npuir_api.cc
+++ b/src/target/codegen_npuir_api.cc
@@ -1888,25 +1888,17 @@ void CodeGenTileLangNPUIRAPI::BitcastCodegen(const CallNode *op) {
 }
 
 mlir::Value
-CodeGenTileLangNPUIRAPI::GenMemrefLoadFromRegion(const BufferLoadNode *op) {
-  auto buffer = op->buffer;
-  auto indices = op->indices;
-
-  // Check pre-conditions
-  if (op->dtype.lanes() != 1) {
-    LOG(FATAL) << "lanes not one";
-  }
-  if (op->dtype != buffer->dtype) {
-    LOG(FATAL) << "The load type and buffer element type do not match";
-  }
-
+CodeGenTileLangNPUIRAPI::GenMemrefLoadFromRegion(Buffer buffer_data,
+                                                 Array<Range> range) {
   // Convert buffer from Buffer in TIR 2 memref in MLIR
-  auto mem = GetVarValue(buffer->data.get());
+  auto mem = GetVarValue(buffer_data->data.get());
 
   // Convert index from PrimExpr in TIR 2 index type in MLIR
   SmallVector<mlir::Value> convert_inds;
-  for (auto index : indices) {
-    mlir::Value indexVal = CreateIndexCastOp(MakeValue(index));
+  for (auto r : range) {
+    ICHECK(analyzer_->CanProveEqual(r->extent, 1))
+        << "Extent of range must be 1 or the memref.load should not be used.";
+    mlir::Value indexVal = CreateIndexCastOp(MakeValue(r->min));
     convert_inds.push_back(indexVal);
   }
 
@@ -1917,59 +1909,107 @@ CodeGenTileLangNPUIRAPI::GenMemrefLoadFromRegion(const BufferLoadNode *op) {
 
 template <typename T>
 void CodeGenTileLangNPUIRAPI::CreateHIVMBinaryVectorOp(const CallNode *op) {
-  auto processImm = [&](mlir::Value &src, int arg_id,
-                        Array<PrimExpr> &buffer_shape) {
-    if (op->args[arg_id].as<IntImm>() || op->args[arg_id].as<FloatImm>() ||
-        op->args[arg_id].as<tir::VarNode>()) {
+  tvm::tl::NpuirBinaryOperator binaryOp(op->args, this->vmap);
+  ICHECK(binaryOp.Dst().IsTensor())
+      << "The dst of a binary vector operator cannot be a scalar.";
+  // `enableScaler{Name}` is a flag used to determine whether to allow
+  // optimizing a 1x1 tensor into a scalar. If the Op does not accept this
+  // operand as a scalar or another operand is already a scalar, then this
+  // flag should be set to false.
+  bool enableScalerSrc0 = binaryOp.Src1().IsTensor();
+  if constexpr (T::template hasTrait<OpTrait::VectorOnlyTrait<0>::Impl>()) {
+    ICHECK(binaryOp.Src0().IsTensor())
+        << "The first operand of \"" << T::getOperationName().str()
+        << "\" cannot be a scalar.";
+    enableScalerSrc0 = false;
+  }
+  bool enableScalerSrc1 = binaryOp.Src0().IsTensor();
+  if constexpr (T::template hasTrait<OpTrait::VectorOnlyTrait<1>::Impl>()) {
+    ICHECK(binaryOp.Src1().IsTensor())
+        << "The second operand of \"" << T::getOperationName().str()
+        << "\" cannot be a scalar.";
+    enableScalerSrc1 = false;
+  }
+  ICHECK(binaryOp.Src0().IsTensor() || binaryOp.Src1().IsTensor())
+      << "Binary Vector Ops does not support cases where both input operands "
+         "are scalars.";
+  // src_dtype is used to unify the type of input operands.
+  DataType src_dtype;
+  if (binaryOp.Src0().IsTensor()) {
+    src_dtype = binaryOp.Src0().GetBuffer()->dtype;
+    if constexpr (T::template hasTrait<OpTrait::SameOperandsElementType>()) {
+      if (binaryOp.Src1().IsTensor()) {
+        ICHECK(src_dtype == binaryOp.Src1().GetBuffer()->dtype)
+            << "The element types of two operands should be the same for \""
+            << T::getOperationName().str() << '\"';
+      }
+    }
+  } else {
+    src_dtype = binaryOp.Src1().GetBuffer()->dtype;
+  }
+
+  mlir::Value src0, src1, dst;
+  llvm::ArrayRef<long int> shapeSrc0, shapeSrc1;
+  // rank_min is used to record the minimum rank of tensor type operands.
+  size_t rank_min = binaryOp.Dst().GetRanges().size();
+  auto PreProcessInput = [this, &rank_min, &src_dtype](
+                             mlir::Value &v, const tl::NpuirOperand &operand,
+                             const bool enableScaler) -> bool {
+    if (operand.IsScalar()) {
       // Scalar case
-      const CallNode *region_node = op->args[1 - arg_id].as<CallNode>();
-      const BufferLoadNode *buffer_load_node =
-          region_node->args[0].as<BufferLoadNode>();
-      if (op->args[arg_id]->dtype != buffer_load_node->buffer->dtype) {
-        src = ScalarConvertType(op->args[arg_id],
-                                buffer_load_node->buffer->dtype);
+      auto this_dtype = operand.GetExpr()->dtype;
+      if (this_dtype != src_dtype) {
+        v = ScalarConvertType(operand.GetExpr(), src_dtype);
       } else {
-        src = MakeValue(op->args[arg_id]);
+        v = MakeValue(operand.GetExpr());
       }
     } else {
       // Vector case
-      const CallNode *region_node = op->args[arg_id].as<CallNode>();
-      auto buffer_node = region_node->args[0].as<BufferLoadNode>();
-      buffer_shape = buffer_node->buffer->shape;
-      bool is_scalar_load = true;
-      for (int i = 0; i < buffer_shape.size(); i++) {
-        const IntImmNode *int_imm = region_node->args[2 + i].as<IntImmNode>();
-        if (!int_imm || int_imm->value != 1) {
-          is_scalar_load = false;
+      bool is_scalar_load = enableScaler;
+      for (auto arrRanges = operand.GetRanges(); auto range : arrRanges) {
+        if (!is_scalar_load) {
           break;
         }
+        if (!analyzer_->CanProveEqual(range->extent, 1)) {
+          is_scalar_load = false;
+        }
       }
-      const IntImmNode *int_imm = region_node->args[2].as<IntImmNode>();
-      // If load only one element, do not use memref.subview, use memref.load as
-      // a scalar
-      if (is_scalar_load && arg_id == 1) {
-        src = GenMemrefLoadFromRegion(buffer_node);
-        // clear buffer_shape to unable broadcast
-        buffer_shape.clear();
+      if (is_scalar_load) {
+        v = GenMemrefLoadFromRegion(operand.GetBuffer(), operand.GetRanges());
       } else {
-        src = GenSubviewFromRegion(region_node);
+        rank_min = std::min(rank_min, operand.GetRanges().size());
+        return true;
       }
     }
+    return false;
   };
-  // src0 src1
-  mlir::Value src0, src1;
-  Array<PrimExpr> buffer_shape0, buffer_shape1;
-  processImm(src0, 0, buffer_shape0);
-  processImm(src1, 1, buffer_shape1);
-  // dst
-  const CallNode *region_node_dst = op->args[2].as<CallNode>();
-  // Result will always be a vector. No need to add scalar check.
-  mlir::Value dst = GenSubviewFromRegion(region_node_dst);
+  auto ProcessTensor = [this, &rank_min](mlir::Value &v,
+                                         const tl::NpuirOperand &operand) {
+    if (rank_min != operand.GetRanges().size()) {
+      v = GenRankReducedSubviewFromRegion(operand.GetBuffer(),
+                                          operand.GetRanges(), rank_min);
+    } else {
+      v = GenSubviewFromRegion(operand.GetBuffer(), operand.GetRanges());
+    }
+  };
+  auto flag_src0_is_vec =
+      PreProcessInput(src0, binaryOp.Src0(), enableScalerSrc0);
+  auto flag_src1_is_vec =
+      PreProcessInput(src1, binaryOp.Src1(), enableScalerSrc1);
+  if (flag_src0_is_vec) {
+    ProcessTensor(src0, binaryOp.Src0());
+    shapeSrc0 = src0.getType().cast<MemRefType>().getShape();
+  }
+  if (flag_src1_is_vec) {
+    ProcessTensor(src1, binaryOp.Src1());
+    shapeSrc1 = src1.getType().cast<MemRefType>().getShape();
+  }
+  ProcessTensor(dst, binaryOp.Dst());
+
   // transpose
   mlir::DenseI64ArrayAttr transpose = builder.getDenseI64ArrayAttr({});
   // broadcast
-  llvm::SmallVector<int64_t> dims =
-      getBroadcastDim(buffer_shape0, buffer_shape1);
+  llvm::SmallVector<int64_t> dims = getBroadcastDim(shapeSrc0, shapeSrc1);
   mlir::DenseI64ArrayAttr broadcast = builder.getDenseI64ArrayAttr(dims);
   // Create hivm::op
   auto loc = builder.getUnknownLoc();

--- a/src/target/codegen_npuir_api.h
+++ b/src/target/codegen_npuir_api.h
@@ -288,9 +288,10 @@ private:
     mlir::OpFoldResult viewOffset;
   };
 
-  mlir::Value GenMemrefLoadFromRegion(const BufferLoadNode *op);
+  mlir::Value GenMemrefLoadFromRegion(Buffer buffer_data, Array<Range> range);
   mlir::Value GenSubviewFromRegion(const CallNode *region_node);
   mlir::Value GenSubviewFromRegion(Buffer buffer_data, Array<Range> range);
+  bool EnableToReduceRank(Array<Range> range, int target_rank);
   // Similar to GenSubviewFromRegion but performs rank reduction by dropping
   // static-1 dimensions from the slice sizes (Region extents).
   mlir::Value GenRankReducedSubviewFromRegion(Buffer buffer_data,

--- a/testing/npuir/arith_ops/test_vadd_rank_reduce_exp.py
+++ b/testing/npuir/arith_ops/test_vadd_rank_reduce_exp.py
@@ -1,0 +1,61 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025.
+import pytest
+import tilelang
+import tilelang.language as T
+
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [pytest.mark.mode("Expert")]
+DTYPE_CASES = ["float16", "float32"]
+
+
+def ref_program(a, b):
+    k, _, _ = b.shape
+    o = a.clone().detach()
+    for i in range(k):
+        o += b[i]
+    return o
+
+
+@tilelang.jit(target="npuir", out_idx=[2])
+def reduce_add(M, N, K, block_M, block_N, dtype="float32"):
+    @T.prim_func
+    def reduceAdd(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((K, M, N), dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N) * T.ceildiv(M, block_M), is_npu=True) as (
+            cid,
+            _,
+        ):
+            mid = cid // T.ceildiv(N, block_N)
+            nid = cid % T.ceildiv(N, block_N)
+            offset_m = mid * block_M
+            offset_n = nid * block_N
+
+            a = T.alloc_ub((block_M, block_N), dtype)
+            b = T.alloc_ub((K, block_M, block_N), dtype)
+
+            T.copy(A[offset_m : offset_m + block_M, offset_n : offset_n + block_N], a)
+            T.copy(
+                B[:, offset_m : offset_m + block_M, offset_n : offset_n + block_N], b
+            )
+            for i in T.serial(K):
+                T.vadd(a, b[i, :, :], a)
+            T.copy(a, C[offset_m : offset_m + block_M, offset_n : offset_n + block_N])
+
+    return reduceAdd
+
+
+@pytest.mark.op("vadd_rank_reduce_exp")
+@pytest.mark.parametrize("dtype", DTYPE_CASES)
+def test_vadd_rank_reduce_exp(dtype):
+    M, N, K, BLOCK_M, BLOCK_N = 512, 512, 2, 64, 64
+    a = gen_tensor((M, N), dtype, kind="randn")
+    b = gen_tensor((K, M, N), dtype, kind="randn")
+
+    kernel = reduce_add(M, N, K, BLOCK_M, BLOCK_N, dtype)
+    o = kernel(a, b)
+
+    assert_close(o, ref_program(a, b), rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
- The codegen of binary operators is reconstructed.
- The operands are no longer required to have the same buffer shape, but only to have the same region shape.