### PR TITLE
[AscendNPU-IR][A5] Feature sigmoid a5

### DIFF
--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -2470,30 +2470,28 @@ void CodeGenTileLangNPUIRDEV::VsigmoidCodegen(const tvm::tir::CallNode* op) {
   auto elem_type = dst_type.getElementType();
   mlir::Location loc = builder.getUnknownLoc();
   mlir::TypeRange result_tensors(&dst_type, 1);
-  // mlir::DenseI64ArrayAttr transpose = builder.getDenseI64ArrayAttr({});
-  // mlir::DenseI64ArrayAttr broadcast = builder.getDenseI64ArrayAttr({});
-  auto zero = builder.create<mlir::arith::ConstantOp>(
-      loc, mlir::FloatAttr::get(elem_type, 0.0)).getResult();
-  auto one = builder.create<mlir::arith::ConstantOp>(
-      loc, mlir::FloatAttr::get(elem_type, 1.0)).getResult();
 
-  // Step 1 src = 0 - src
-  auto subOp = builder.create<mlir::hivm::VSubOp>(loc, result_tensors, 
-      mlir::ValueRange{zero, src}, mlir::ValueRange{dst});
-  mlir::Value subOpValue = subOp->getResult(0);
-  // Step 2: src = exp(src)
-  auto expOp = builder.create<mlir::hivm::VExpOp>(loc, result_tensors,
-      mlir::ValueRange{subOpValue}, mlir::ValueRange{dst});
-  mlir::Value expOpValue = expOp->getResult(0);
-  // Step 3: src = src + 1
-  auto onePlusOp = builder.create<mlir::hivm::VAddOp>(loc, result_tensors, 
-      mlir::ValueRange{expOpValue, one}, mlir::ValueRange{dst});
-  mlir::Value onePlusOpValue = onePlusOp->getResult(0);
-  // Step 4: dst = 1 / src
-  auto divOp = builder.create<mlir::hivm::VDivOp>(loc, result_tensors, 
-      mlir::ValueRange{one, onePlusOpValue}, mlir::ValueRange{dst});
-  mlir::Value divOpValue = divOp->getResult(0);
-  SetVarValue(npuirop.dst, divOpValue);
+  auto zero = builder.create<mlir::arith::ConstantOp>(
+    loc, mlir::FloatAttr::get(elem_type, 0.0)).getResult();
+  auto one = builder.create<mlir::arith::ConstantOp>(
+    loc, mlir::FloatAttr::get(elem_type, 1.0)).getResult();
+
+  auto broadcast = [&](mlir::Value value) -> mlir::Value {
+  auto empty = builder.create<mlir::tensor::EmptyOp>(
+    loc, dst_type.getShape(), elem_type);
+  auto fill = builder.create<mlir::linalg::FillOp>(loc, value, empty.getResult());
+  return fill.getResult(0);
+  };
+
+  auto zeroTensor = broadcast(zero);
+  auto oneTensor = broadcast(one);
+
+  auto negOp = builder.create<mlir::arith::SubFOp>(loc, zeroTensor, src);
+  auto expOp = builder.create<mlir::math::ExpOp>(loc, negOp.getResult());
+  auto addOp = builder.create<mlir::arith::AddFOp>(loc, expOp.getResult(), oneTensor);
+  auto divOp = builder.create<mlir::arith::DivFOp>(loc, oneTensor, addOp.getResult());
+
+  SetVarValue(npuirop.dst, divOp.getResult());
 }
 
 void CodeGenTileLangNPUIRDEV::VAtomicAddCodegen(const CallNode *op) {

--- a/testing/npuir/arith_ops/test_sigmoid_dev.py
+++ b/testing/npuir/arith_ops/test_sigmoid_dev.py
@@ -1,0 +1,73 @@
+import os
+
+import pytest
+import torch
+import torch_npu
+
+import tilelang
+import tilelang.language as T
+
+tilelang.cache.clear_cache()
+os.environ["TILELANG_ASCEND_MODE"] = "Developer"
+
+
+
+@pytest.fixture(
+    params=[
+        # ((1, 1), "float16"),    # FIXME: (X, 1) shape will have compilation error in hfusion-flatten-ops pass in NPUIR. Skip them for now.
+        ((1, 4), "float16"),
+        ((1, 15), "float16"),
+        # ((4, 1), "float16"),
+        ((4, 4), "float16"),
+        ((4, 15), "float16"),
+        # ((15, 1), "float16"),
+        ((15, 4), "float16"),
+        ((15, 15), "float16"),
+    ]
+)
+def sigmoid_case(request):
+    return request.param
+
+
+def sigmoid_kernel(M, N, dtype):
+    BLOCK_SIZE = 1
+
+    @T.prim_func
+    def sigmoidKernel(src: T.Tensor((M, N), dtype), dst: T.Tensor((M, N), dtype)):
+        with T.Kernel(BLOCK_SIZE, is_npu=True):
+            src_ub = T.alloc_ub((M, N), dtype)
+            dst_ub = T.alloc_ub((M, N), dtype)
+
+            T.copy(src, src_ub)
+            T.npuir_sigmoid(src_ub, dst_ub)
+            T.copy(dst_ub, dst)
+
+    return sigmoidKernel
+
+
+def generate_tensor(shape, dtype, clear=False):
+    if clear:
+        return torch.zeros(shape, dtype=eval("torch." + dtype))
+    if dtype in ("float32", "float16", "bfloat16"):
+        return torch.randn(size=shape, dtype=eval("torch." + dtype))
+    if dtype in ("int32", "int64", "int16"):
+        return torch.randint(low=0, high=2000, size=shape, dtype=eval("torch." + dtype))
+    if dtype == "int8":
+        return torch.randint(low=0, high=127, size=shape, dtype=eval("torch." + dtype))
+    if dtype == "bool":
+        return torch.randint(low=0, high=2, size=shape).bool()
+    raise ValueError('Invalid parameter "dtype" is found : {}'.format(dtype))
+
+def test_sigmoid_dev(sigmoid_case):
+    shape, dtype = sigmoid_case
+
+    func = sigmoid_kernel(*shape, dtype)
+    compiled_kernel = tilelang.compile(func, target="npuir")
+
+    src = generate_tensor(shape, dtype).npu()
+    dst = generate_tensor(shape, dtype, clear=True).npu()
+
+    ref = torch.sigmoid(src.cpu())
+    compiled_kernel(src, dst)
+
+    assert torch.allclose(dst.cpu(), ref, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
This pull request refactors the NPUIR code generation to utilize standard MLIR arith and math dialects for sigmoid, bitwise, and shift operations, replacing previous HIVM dialect implementations. It introduces a more robust dispatch mechanism for binary vector operations and expands the test suite with comprehensive bitwise and shift test cases. Feedback focuses on improving test utility safety by avoiding eval(), optimizing reference functions with native PyTorch operators, and reducing code duplication in the test suite through parametrization.