### PR TITLE
[AscendNPU-IR][A5] Fix template parameter mismatch in UnaryVecOpCodeg declaration

### DIFF
--- a/src/target/codegen_npuir_dev.h
+++ b/src/target/codegen_npuir_dev.h
@@ -273,7 +273,7 @@ private:
   void ReshapeCodegen(const CallNode *op);
   template <typename T, typename U = void, typename V = void>
   void CreateHIVMBinaryVectorOp(const CallNode *op);
-  template <typename T, typename U> void UnaryVecOpCodegen(const CallNode *op);
+  template <typename T, auto fn> void UnaryVecOpCodegen(const CallNode *op);
   void BarrierCodegen(const CallNode *op);
   void VselectCodegen(const CallNode *op);
   template <typename T, typename U>


### PR DESCRIPTION
The declaration in codegen_npuir_dev.h used `typename U` (a type parameter)
while the definition in codegen_npuir_dev.cc used `auto fn` (a non-type
parameter), causing a compilation error. Updated the header to use
`template <typename T, auto fn>` to match the definition.