### PR TITLE
[Tilelang][A5] Add concat support in developer mode for Tilelang

### DIFF
--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -2638,16 +2638,61 @@ void CodeGenTileLangNPUIRDEV::VarangeCodegen(const CallNode *op) {
   SetVarValue(npuirop.dst, arangeOp->getResult(0));
 }
 
+bool isIdentityRange(const Array<Range>& range, const Buffer& buffer_data){
+  Array<PrimExpr> region_shape;
+  Array<PrimExpr> region_indices;
+  for (Range r: range) {
+    region_shape.push_back(r.get()->extent);
+    region_indices.push_back(r.get()->min);
+  }
+  return (IsEqual(buffer_data->shape, region_shape) && AllZero(region_indices));
+}
+
 void CodeGenTileLangNPUIRDEV::VconcatCodegen(const CallNode *op) {
+  auto getBufferVarValue = [this](const Buffer &buffer_data) -> mlir::Value {
+    const VarNode *v = buffer_data->data.get();
+    return GetVarValue(v);
+  };
+  auto isBufferMemref = [getBufferVarValue](const Buffer &buffer_data) -> bool {
+    mlir::Value v_value = getBufferVarValue(buffer_data);
+    if (isa<TensorType>(v_value.getType()))
+      return false;
+    if (isa<MemRefType>(v_value.getType()))
+      return true;
+    llvm::dbgs() << "got v as " << v_value << "\n";
+    LOG(FATAL) << "expect value from tensor or memref dialect";
+  };
   tvm::tl::NpuirConcat npuirop(op->args, this->vmap);
-  auto dim = builder.getIntegerAttr(builder.getI64Type(), npuirop.dim);
   llvm::SmallVector<Value> srcs;
   size_t n_srcs = npuirop.srcs.size();
+  assert(n_srcs > 0 && "Concatenation must have at least one operand");
+  bool bufferIsMemref = isBufferMemref(npuirop.dst);
   for (size_t i = 0; i < n_srcs; i++) {
-    Value src = GenSubviewFromRegion(npuirop.srcs[i], npuirop.srcs_range[i]);
+    assert(isBufferMemref(npuirop.srcs[i]) == bufferIsMemref &&
+           "Concatenating a mixture of memref & tensor is not supported");
+    Value src =
+        bufferIsMemref
+            ? GenSubviewFromRegion(npuirop.srcs[i], npuirop.srcs_range[i])
+            : GenExtractSliceFromRegion(npuirop.srcs[i], npuirop.srcs_range[i]);
     srcs.push_back(src);
   }
   mlir::ValueRange srcs_vr(srcs);
+  // Value dst = GenSubviewFromRegion(npuirop.dst, npuirop.dst_range);
+  if (!bufferIsMemref) {
+    auto concatResult = builder.create<mlir::tensor::ConcatOp>(
+        builder.getUnknownLoc(), npuirop.dim, srcs_vr);
+    Value dst = GenExtractSliceFromRegion(npuirop.dst, npuirop.dst_range);
+    if (isIdentityRange(npuirop.dst_range, npuirop.dst))
+      SetVarValue(npuirop.dst, concatResult.getResult());
+    else {
+      SliceRange rg = MakeSliceRange(npuirop.dst_range);
+      Value newVal = InsertSlice(concatResult, getBufferVarValue(npuirop.dst),
+                                 rg.offs, rg.sizes, rg.strides);
+      SetVarValue(npuirop.dst, newVal);
+    }
+    return;
+  }
+  IntegerAttr dim = builder.getI64IntegerAttr(npuirop.dim);
   Value dst = GenSubviewFromRegion(npuirop.dst, npuirop.dst_range);
   builder.create<mlir::hivm::VConcatOp>(builder.getUnknownLoc(), TypeRange{},
                                         dim, srcs_vr, dst);

--- a/testing/npuir/shape_manipulation_ops/test_slice_concat_dev.py
+++ b/testing/npuir/shape_manipulation_ops/test_slice_concat_dev.py
@@ -1,0 +1,60 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+import tilelang
+import tilelang.language as T
+
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("concat"),
+    #
+    pytest.mark.mode("Developer")
+]
+
+DTYPES = ["float16", "float32"]
+
+
+def vec_concat(block_M, block_N, dim, dtype="float16"):
+    BLOCK_SIZE = 1
+
+    @T.prim_func
+    def sliceConcatExp(
+        A: T.Tensor((block_M, block_N), dtype),
+        B: T.Tensor((block_M, block_N), dtype),
+        C: T.Tensor((block_M, 2 * block_N), dtype),
+    ):
+        with T.Kernel(BLOCK_SIZE, is_npu=True) as (cid, _):
+            A_VEC = T.alloc_ub((block_M, block_N), dtype)
+            B_VEC = T.alloc_ub((block_M, block_N), dtype)
+            C_VEC = T.alloc_ub((block_M, 2 * block_N), dtype)
+            T.copy(A, A_VEC)
+            T.copy(B, B_VEC)
+            T.npuir_concat(
+                A_VEC[:block_M, :block_N],
+                B_VEC[:block_M, :block_N],
+                C_VEC[:block_M, : 2 * block_N],
+                dim,
+            )
+            T.copy(C_VEC, C)
+
+    return sliceConcatExp
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_vec_concat(dtype):
+    M, N = 32, 32
+    torch.manual_seed(42)
+    A = gen_tensor((M, N), dtype, kind="randn")
+    B = gen_tensor((M, N), dtype, kind="randn")
+    C = gen_tensor((M, 2 * N), dtype, kind="zeros")
+    ref_C = torch.cat((A.cpu(), B.cpu()), dim=1)
+
+    func = vec_concat(32, 32, dim=1, dtype=dtype)
+    compiled = tilelang.compile(func, target="npuir")
+    compiled(A, B, C)
+
+    assert_close(C.cpu(), ref_C, dtype=dtype, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
This pull request extends the VconcatCodegen implementation in the NPU IR codegen to support tensor types, utilizing mlir::tensor::ConcatOp and InsertSlice when applicable. It also introduces a helper function isIdentityRange and a new test suite for vector concatenation. 