### PR TITLE
feat: enhance broadcast API with axis param and shape validation

### DIFF
--- a/examples/chunk_gated_delta_rule/chunk_gated_delta_rule_varlen.py
+++ b/examples/chunk_gated_delta_rule/chunk_gated_delta_rule_varlen.py
@@ -135,7 +135,6 @@ def chunk_gated_delta_rule_fwd_kernel_unified(
                         g_last_scalar = T.alloc_ub([1], accum_dtype)
                         g_exp_ub = T.alloc_ub([BT // 2], accum_dtype)
                         g_exp_ub_pad = T.alloc_ub([BT], accum_dtype)
-                        g_exp_ub_dim = T.alloc_ub([1, BT // 2], accum_dtype)
                         g_exp_ub_broc = T.alloc_ub([BT // 2, V], accum_dtype)
                         g_mask_ub_pad = T.alloc_ub([BT // 8], "uint8")
 
@@ -158,8 +157,7 @@ def chunk_gated_delta_rule_fwd_kernel_unified(
                         T.tile.exp(g_exp_ub, g_exp_ub)
 
                         # v_new = v_new * exp(g_last - g)
-                        T.copy(g_exp_ub, g_exp_ub_dim[0, :])
-                        T.tile.broadcast(g_exp_ub_broc, g_exp_ub_dim)
+                        T.tile.broadcast(g_exp_ub_broc, g_exp_ub, axis=1)
                         T.tile.mul(v_new_ub_float, v_new_ub_float, g_exp_ub_broc)
 
                         # 4. h = h * exp(g_last)

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1708,80 +1708,96 @@ def round(out: Buffer | BufferRegion, buffer: Buffer | BufferRegion, count: Prim
 
 
 def broadcast(
-    dst: Buffer | BufferRegion,  # noqa: F821, FA100
-    src: Buffer | BufferRegion,  # noqa: F821, FA100
-):  # noqa: F821, FA100
-    """Generates a TIR intrinsic call for the AscendC `Broadcast` operation.
+    dst: Buffer | BufferRegion,
+    src: Buffer | BufferRegion,
+    axis: int | None = None,
+):
+    """Generates a TIR intrinsic call for the Ascend `Broadcast` operation.
 
     This function performs a broadcast copy from the source buffer (`src`) to the
     destination buffer (`dst`). It automatically infers the broadcasting axis
-    based on the shapes of the input buffers.
+    based on the shapes of the input buffers, or uses the explicitly provided axis.
 
     Args:
-        dst (tvm.tir.Buffer): The destination buffer. Must be allocated in the
-            Unified Buffer (UB). Its shape determines the output size.
-        src (tvm.tir.Buffer): The source buffer. Must be allocated in the
-            Unified Buffer (UB). Its shape must be compatible with `dst` for broadcasting.
+        dst: Destination buffer (must be in UB).
+        src: Source buffer (must be in UB).
+        axis: Broadcasting axis (0 or 1). If None, auto-inferred.
 
     Returns:
-        tvm.tir.Call: A TIR intrinsic call node that maps to the C++ `AscendC::Broadcast` API.
+        tvm.tir.Call: Intrinsic call for AscendC Broadcast API.
 
     Raises:
-        AssertionError: If the input shapes violate the dimension constraints.
-
-    Constraints:
-        1. **Rank Consistency**: The number of dimensions (rank) of `src` and `dst` must be identical.
-        2. **Supported Dimensions**: Only 1D and 2D tensors are supported. The rank must be 1 or 2.
-        3. **Broadcasting Logic**:
-            - **Axis 0 (Row Broadcast)**: Inferred if `src.shape[0] == 1` and `dst.shape[0] > 1`.
-              The source row is replicated `dst.shape[0]` times.
-            - **Axis 1 (Column Broadcast)**: Inferred if `src.shape[1] == 1` and `dst.shape[1] > 1`.
-              The source column is replicated `dst.shape[1]` times.
-            - **No Broadcast (Copy)**: If shapes are identical, the axis defaults to 0.
+        ValueError: If shapes are incompatible for broadcasting.
     """
-    if isinstance(dst, BufferRegion):
-        dst_ptr, dst_extent = _handle_buffer_region(dst, "w")
-    else:
-        dst_ptr = dst.access_ptr("w")
-        dst_extent = dst.shape
-
-    if isinstance(src, BufferRegion):
-        src_ptr, src_extent = _handle_buffer_region(src, "r")
-    else:
-        src_ptr = src.access_ptr("r")
-        src_extent = src.shape
-
+    # --- 1. Extract pointers and shapes ---
+    dst_ptr, dst_extent = _handle_buffer_region(dst, "w") if isinstance(dst, BufferRegion) else (dst.access_ptr("w"), dst.shape)
+    src_ptr, src_extent = _handle_buffer_region(src, "r") if isinstance(src, BufferRegion) else (src.access_ptr("r"), src.shape)
     dtype = _dtype(src)
+    # 3D to 2D conversion
+    dst_extent = list(dst_extent)[-2:]
+    src_extent = list(src_extent)[-2:]
 
-    if len(dst_extent) == 3:
-        dst_extent = [dst_extent[1], dst_extent[2]]
-    if len(src_extent) == 3:
-        src_extent = [src_extent[1], src_extent[2]]
-    dim = len(dst_extent)
-    assert dim in [1, 2], "Ascend Broadcast only supports dim=1 or dim=2."
-    assert len(src_extent) == dim, "Source and Dest dimension must match."
+    dst_dim, src_dim = len(dst_extent), len(src_extent)
+    if dst_dim not in [1, 2] or src_dim not in [1, 2]:
+        raise ValueError(f"Ascend Broadcast only supports 1D or 2D: dst_dim={dst_dim}, src_dim={src_dim}")
 
-    axis = 0
-    if dim == 2:
-        if src_extent[0] == 1 and dst_extent[0] != 1:
-            axis = 0
-        elif src_extent[1] == 1 and dst_extent[1] != 1:
-            axis = 1
+    # --- 2. Normalize 1D src to 2D ---
+    if src_dim == 1 and dst_dim == 2:
+        if axis == 0 or (axis is None and dst_extent[1] == src_extent[0]):
+            src_extent, axis = [1, src_extent[0]], 0
+        elif axis == 1 or (axis is None and dst_extent[0] == src_extent[0]):
+            src_extent, axis = [src_extent[0], 1], 1
         else:
-            axis = 0
-    else:  # dim == 1
-        axis = 0
+            raise ValueError(f"Cannot broadcast 1D src {src_extent} to 2D dst {dst_extent}, axis={axis}")
+        src_dim = 2
 
-    op_name = "tl.ascend_broadcast"
-    template_args = f"{dtype}, {dim}, {axis}, false"
+    if src_dim != dst_dim:
+        raise ValueError(f"Dimension mismatch: dst_dim={dst_dim} != src_dim={src_dim}")
 
+    # --- 3. Auto-infer axis (2D case) ---
+    if axis is None:
+        if dst_dim == 2:
+            if src_extent[0] == 1 and dst_extent[0] != 1:
+                axis = 0
+            elif src_extent[1] == 1 and dst_extent[1] != 1:
+                axis = 1
+            else:
+                axis = 0  # No broadcast, default axis=0
+        else:
+            axis = 0  # 1D case
+
+    # --- 4. Shape validation ---
+    if dst_dim == 2:
+        if axis not in [0, 1]:
+            raise ValueError(f"axis must be 0 or 1, got {axis}")
+
+        if src_extent[axis] == 1:
+            # Broadcast case: validate non-broadcast dimension matches
+            other_axis = 1 - axis
+            if src_extent[other_axis] != dst_extent[other_axis]:
+                raise ValueError(
+                    f"Broadcast dimension mismatch: src[{other_axis}]={src_extent[other_axis]} "
+                    f"!= dst[{other_axis}]={dst_extent[other_axis]}"
+                )
+        elif src_extent != dst_extent:
+            # No broadcast: shapes must match exactly
+            raise ValueError(f"Shapes must match when src[{axis}] != 1: src={src_extent}, dst={dst_extent}")
+    elif dst_dim == 1:
+        # 1D case: axis must be 0
+        if axis != 0:
+            raise ValueError(f"1D broadcast requires axis=0, got axis={axis}")
+        # broadcast requires src[0] == 1, otherwise shapes must match
+        if src_extent[0] != 1 and src_extent != dst_extent:
+            raise ValueError(f"1D broadcast requires src[0]=1 or shapes must match: src={src_extent}, dst={dst_extent}")
+
+    # --- 5. Generate TIR intrinsic call ---
     return tir.call_intrin(
         "handle",
-        tir.op.Op.get(op_name),
-        f"Broadcast<{template_args}>",
+        tir.op.Op.get("tl.ascend_broadcast"),
+        f"Broadcast<{dtype}, {dst_dim}, {axis}, false>",
         dst_ptr,
         src_ptr,
-        dim,
+        dst_dim,
         *dst_extent,
         *src_extent,
     )


### PR DESCRIPTION
- Add optional axis parameter for explicit broadcast direction
- Support 1D→2D cross-dimension broadcasting
- Add comprehensive shape validation for all broadcast cases
- Replace assert with ValueError for production error handling

## Feature Comparison

| Feature | HEAD (Old) | New Implementation |
|---------|------------|-------------------|
| **axis parameter** | ❌ Not supported | ✅ Supports explicit specification |
| **1D → 2D cross-dimension** | ❌ assert fails | ✅ Supported with auto-inference |
| **Shape validation** | ❌ No validation (silent errors) | ✅ Comprehensive validation |
| **Error handling** | `assert` (may be optimized away) | `ValueError` (production standard) |
| **Backward compatibility** | - | ✅ Fully compatible with old API |

## Supported Scenarios

| Scenario | dst | src | axis | HEAD (Old) | New | Notes |
|----------|-----|-----|------|------------|-----|-------|
| **1D → 1D same shape** | `[64]` | `[64]` | - | ✅ axis=0 | ✅ axis=0 | No broadcast, direct copy |
| **1D → 1D broadcast** | `[64]` | `[1]` | - | ✅ axis=0 | ✅ axis=0 | Single element copied 64 times |
| **1D → 1D invalid** | `[64]` | `[32]` | - | ❌ Silent error | ✅ ValueError | New validation added |
| **1D → 2D row broadcast** | `[64,128]` | `[128]` | 0 | ❌ assert fails | ✅ Auto-inferred | **New feature** |
| **1D → 2D column broadcast** | `[64,128]` | `[64]` | 1 | ❌ assert fails | ✅ Auto-inferred | **New feature** |
| **1D → 2D explicit axis** | `[64,128]` | `[128]` | 0 | ❌ axis not supported | ✅ Supported | **New feature** |
| **1D → 2D mismatch** | `[64,128]` | `[64]` | 0 | - | ✅ ValueError | New validation added |
| **2D → 2D same shape** | `[64,128]` | `[64,128]` | - | ✅ axis=0 | ✅ axis=0 | No broadcast |
| **2D → 2D row broadcast** | `[64,128]` | `[1,128]` | - | ✅ axis=0 auto | ✅ axis=0 auto | Row copied 64 times |
| **2D → 2D column broadcast** | `[64,128]` | `[64,1]` | - | ✅ axis=1 auto | ✅ axis=1 auto | Column copied 128 times |
| **2D → 2D explicit axis** | `[64,128]` | `[1,128]` | 0 | ❌ axis not supported | ✅ Supported | **New feature** |
| **2D → 2D axis mismatch** | `[64,128]` | `[1,64]` | 0 | ❌ Silent error | ✅ ValueError | src[1]=64 ≠ dst[1]=128 |
| **2D → 2D non-broadcast invalid** | `[64,128]` | `[32,128]` | - | ❌ Silent error | ✅ ValueError | New validation added |
| **2D → 2D both dims broadcast** | `[64,128]` | `[1,1]` | - | ❌ Silent error | ❌ ValueError | AscendC不支持双维度广播，需分两步 |
| **3D → 2D** | `[B,M,N]` | `[B,M,N]` | - | ✅ Last 2 dims | ✅ Last 2 dims | Dimension reduction |