### PR TITLE
fix(ci): add permissions for issue_comment event to enable /re-test

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -41,6 +41,12 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+  actions: write
+
 concurrency:
   # PR 场景（含 pull_request 和 /re-test）：统一按 PR 号分组，新运行自动取消旧运行
   # 手动/定时/push 场景：退化为 github.run_id（每次唯一），互不干扰


### PR DESCRIPTION
## Summary

修复 `/re-test` 评论无响应的问题。

## Problem

`issue_comment` 事件触发的 workflow 默认 GITHUB_TOKEN 权限是 read-only，导致以下操作静默失败：
- 创建 emoji reaction
- 更新 commit status

## Solution

在 workflow 级别添加显式权限声明：
- `pull-requests: write` - 创建 reactions
- `statuses: write` - 更新 commit status
- `actions: write` - 管理 workflow runs

## Test

合并后，在 PR 中评论 `/re-test` 应该能看到：
1. 评论出现 🚀 reaction
2. commit status 更新为运行状态