### PR TITLE
[Add] add PTO backend codegen for T.tile.gather

### DIFF
--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -831,6 +831,8 @@ void CodeGenTileLangAscendPto::VisitExpr_(const CallNode *op,
     SigmoidCodegen(op, "TSIGMOID");
   } else if (op->op.same_as(tl::ascend_gather_mask())) {
     GatherMaskCodegen(op, "TGATHER");
+  } else if (op->op.same_as(tl::ascend_gather())) {
+    GatherCodegen(op, "TGATHERB");
   } else if (op->op.same_as(tl::ascend_round())) {
     CastCodegen(op, "RoundMode::CAST_ROUND");
   } else if (op->op.same_as(tl::ascend_cast())) {
@@ -1432,6 +1434,29 @@ void CodeGenTileLangAscendPto::GatherbCodegen(const CallNode *op,
   std::string idx_name = PrintExpr(op->args[3].as<CallNode>()->args[1]);
   this->stream << op_name << "(" << dst_name << ", " << src_name << ", "
                << idx_name << ");\n";
+}
+
+void CodeGenTileLangAscendPto::GatherCodegen(const CallNode *op,
+                                             const std::string &op_name) {
+  ShapeInfo dst_info = GetSliceInfo(op->args[0].as<CallNode>());
+  ShapeInfo src_info = GetSliceInfo(op->args[1].as<CallNode>());
+  ShapeInfo idx_info = GetSliceInfo(op->args[2].as<CallNode>());
+
+  if (dst_info.is_slice || src_info.is_slice || idx_info.is_slice) {
+    auto dst_temp_name = GetTempVarName(dst_info.ub_name);
+    auto src_temp_name = GetTempVarName(src_info.ub_name);
+    auto idx_temp_name = GetTempVarName(idx_info.ub_name);
+    CreateUbVariableND(dst_temp_name, dst_info);
+    CreateUbVariableND(src_temp_name, src_info);
+    CreateUbVariableND(idx_temp_name, idx_info);
+    this->PrintIndent();
+    this->stream << op_name << "(" << dst_temp_name << ", " << src_temp_name << ", "
+                 << idx_temp_name << ");\n";
+  } else {
+    this->PrintIndent();
+    this->stream << op_name << "(" << dst_info.ub_name << ", " << src_info.ub_name
+                 << ", " << idx_info.ub_name << ");\n";
+  }
 }
 
 void CodeGenTileLangAscendPto::GatherMaskCodegen(const CallNode *op,

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -1134,8 +1134,8 @@ void CodeGenTileLangAscendPto::GMCopyCall(const CallNode *call,
   stream << copy_base_addr_map_.at(gm_info.id) << " + " << gm_offset_string;
 
   if (is_dynamic) {
-    stream << ", pto::Shape<" << shape_tmpl << ">()"
-           << ", pto::Stride<" << stride_tmpl << ">(" << stride_param << ")";
+    stream << ", pto::Shape<" << shape_tmpl << ">()" << ", pto::Stride<"
+           << stride_tmpl << ">(" << stride_param << ")";
   }
 
   stream << ", " << PrintExpr(buffer_address_map_.at(local_info.var)) << ", "
@@ -1419,8 +1419,8 @@ void CodeGenTileLangAscendPto::CreateVecIndexCodegen(
 
   this->PrintIndent();
   this->stream << kAscendPtoScope << "tci" << "<" << getType(dst_info.dtype)
-               << ", " << PrintExpr(M) << ", " << PrintExpr(N) << ">"
-               << "(" << PrintExpr(dst_slice_info.first_addr) << ", "
+               << ", " << PrintExpr(M) << ", " << PrintExpr(N) << ">" << "("
+               << PrintExpr(dst_slice_info.first_addr) << ", "
                << dst_slice_info.offset << ", "
                << GetTypeLen(dst_slice_info.type) << ", " << first_value
                << ");\n";
@@ -1450,12 +1450,12 @@ void CodeGenTileLangAscendPto::GatherCodegen(const CallNode *op,
     CreateUbVariableND(src_temp_name, src_info);
     CreateUbVariableND(idx_temp_name, idx_info);
     this->PrintIndent();
-    this->stream << op_name << "(" << dst_temp_name << ", " << src_temp_name << ", "
-                 << idx_temp_name << ");\n";
+    this->stream << op_name << "(" << dst_temp_name << ", " << src_temp_name
+                 << ", " << idx_temp_name << ");\n";
   } else {
     this->PrintIndent();
-    this->stream << op_name << "(" << dst_info.ub_name << ", " << src_info.ub_name
-                 << ", " << idx_info.ub_name << ");\n";
+    this->stream << op_name << "(" << dst_info.ub_name << ", "
+                 << src_info.ub_name << ", " << idx_info.ub_name << ");\n";
   }
 }
 
@@ -1500,15 +1500,13 @@ void CodeGenTileLangAscendPto::PowCodegen(const CallNode *op) {
     this->PrintIndent();
     this->stream << kAscendPtoScope << "pow" << "<" << dst_shape_info.type
                  << ", " << dst_shape_info.slice_row << ", "
-                 << dst_shape_info.slice_col << ">"
-                 << "(" << dst_temp_name << ", " << src0_temp_name << ", "
-                 << src1_temp_name << ");\n";
+                 << dst_shape_info.slice_col << ">" << "(" << dst_temp_name
+                 << ", " << src0_temp_name << ", " << src1_temp_name << ");\n";
   } else {
     this->PrintIndent();
     this->stream << kAscendPtoScope << "pow" << "<" << dst_shape_info.type
                  << ", " << dst_shape_info.row << ", " << dst_shape_info.col
-                 << ">"
-                 << "(" << dst_shape_info.ub_name << ", "
+                 << ">" << "(" << dst_shape_info.ub_name << ", "
                  << src0_shape_info.ub_name << ", " << src1_shape_info.ub_name
                  << ");\n";
   }
@@ -1888,8 +1886,7 @@ void CodeGenTileLangAscendPto::CodegenColBroadcast(const ShapeInfo &dst,
   }
 
   this->PrintIndent();
-  this->stream << "TCOLEXPAND"
-               << "(" << dst_name << ", " << src_name << ");\n";
+  this->stream << "TCOLEXPAND" << "(" << dst_name << ", " << src_name << ");\n";
 }
 
 void CodeGenTileLangAscendPto::BroadcastOpCodegen(const CallNode *op) {
@@ -2101,8 +2098,7 @@ void CodeGenTileLangAscendPto::AxpyCodegen(const CallNode *op) {
     this->PrintIndent();
     this->stream << kAscendPtoScope << "axpy" << "<" << dst_shape_info.type
                  << ", " << dst_shape_info.row << ", " << dst_shape_info.col
-                 << ">"
-                 << "(" << dst_shape_info.ub_name << ", "
+                 << ">" << "(" << dst_shape_info.ub_name << ", "
                  << src_shape_info.ub_name << ", " << scalar << ");\n";
   }
 }
@@ -2747,8 +2743,8 @@ void CodeGenTileLangAscendPto::VisitExpr_(const SelectNode *op,
   auto true_value = PrintExpr(op->true_value);
   auto false_value = PrintExpr(op->false_value);
 
-  os << "(" << condition << " ? "
-     << "" << true_value << " : " << false_value << ")";
+  os << "(" << condition << " ? " << "" << true_value << " : " << false_value
+     << ")";
 }
 
 static void ProcessHostInput(std::ostream &os,
@@ -2756,8 +2752,7 @@ static void ProcessHostInput(std::ostream &os,
                              std::vector<const tir::VarNode *> &shape_vars,
                              bool add_args = true) {
   for (auto shape_var : shape_vars) {
-    os << ", "
-       << "int64_t " << shape_var->name_hint;
+    os << ", " << "int64_t " << shape_var->name_hint;
     if (add_args) {
       arg_names.push_back(shape_var->name_hint);
     }

--- a/src/target/codegen_ascend_pto.h
+++ b/src/target/codegen_ascend_pto.h
@@ -145,6 +145,8 @@ private:
 
   void GatherbCodegen(const CallNode *op, const std::string &op_name);
 
+  void GatherCodegen(const CallNode *op, const std::string &op_name);
+
   void GatherMaskCodegen(const CallNode *op, const std::string &op_name);
 
   void PowCodegen(const CallNode *op);

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -704,6 +704,7 @@ def binary_op(
     src0: Buffer | BufferRegion,
     src1: Buffer | BufferRegion | BufferLoad | PrimExpr | float,
     op: str,
+    count: PrimExpr | None = None,
 ):
     if isinstance(dst, BufferRegion):
         dst_ptr, dst_extent = _handle_buffer_region(dst, "w")
@@ -716,8 +717,8 @@ def binary_op(
         src0_ptr = src0.access_ptr("r")
         src0_extent = src0.shape
 
-    size_0 = math.prod(dst_extent)
-    size_1 = math.prod(src0_extent)
+    size_0 = math.prod(dst_extent) if count is None else count
+    size_1 = math.prod(src0_extent) if count is None else count
     assert size_0 == size_1, "size must be same"
     if isinstance(src1, BufferLoad):
         buffer_1 = src1.buffer
@@ -736,7 +737,7 @@ def binary_op(
         return T.call_intrin("handle", tir.op.Op.get(f"tl.ascend_{op}s"), dst_ptr, src0_ptr, src1, size_0)
     elif isinstance(src1, BufferRegion):
         src1_ptr, src1_extent = _handle_buffer_region(src1, "r")
-        size_2 = math.prod(src1_extent)
+        size_2 = math.prod(src1_extent) if count is None else count
         assert size_0 == size_2, "size must be same"
 
         return T.call_intrin(
@@ -1382,7 +1383,7 @@ def gather(dst: Buffer | BufferRegion, src: Buffer | BufferRegion, src_offset: B
         src_ptr = src.access_ptr("r")
         size = math.prod(src.shape)
 
-    if isinstance(src, BufferRegion):
+    if isinstance(src_offset, BufferRegion):
         src_offset_ptr, _ = _handle_buffer_region(src_offset, "r")
     else:
         src_offset_ptr = src_offset.access_ptr("r")


### PR DESCRIPTION
PTO Backend Add gather operation support for PTO
---
## Description
### Changes
- Fixed `gather` frontend parameter handling bug
- Added PTO backend codegen for `ascend_gather` → `TGATHERB`
- Implemented slice handling in `GatherCodegen`
### Limitations
| Parameter | AscendC | PTO |
|-----------|---------|-----|
| `dst` | ✅ | ✅ |
| `src` | ✅ | ✅ |
| `src_offset` | ✅ | ✅ |
| `src_base_addr` | ✅ | ❌ |
| `size` | ✅ | ❌ |
`TGATHERB` only supports 3 parameters, missing `base_addr` and `size`.
**Recommendation:** Use `src_base_addr = 0` for PTO backend.
### Files Changed
tilelang/language/ascend_tile.py    (bug fix)
src/target/codegen_ascend_pto.h     (method declaration)
src/target/codegen_ascend_pto.cc    (codegen implementation)