### PR TITLE
fix(bench_test): exclude non-test scripts and handle special directories

### DIFF
--- a/examples/bench_test.sh
+++ b/examples/bench_test.sh
@@ -56,16 +56,58 @@ collect_test_scripts() {
     local dir="$1"
     local scripts=()
     
+    # 特殊目录处理
+    case "$dir" in
+        "./torch_tl_ascend")
+            # 只收集 test_example.sh，不收集 py 文件（需要安装 torch_tl_ascend 模块）
+            scripts+=("./torch_tl_ascend/test_example.sh")
+            echo "${scripts[@]}"
+            return
+            ;;
+        "./gemm_aot")
+            # 只收集 run_example_gemm_aot.sh，不收集 py 文件（需要 AOT 编译）
+            scripts+=("./gemm_aot/run_example_gemm_aot.sh")
+            echo "${scripts[@]}"
+            return
+            ;;
+        "./sparse_flash_attention")
+            # 收集 example_*.py，不收集 bench_sfa 下的文件（已在 EXTRA_TASKS）
+            local py_files=$(find "$dir" -maxdepth 2 -name "*.py" \
+                -not -name "__init__.py" \
+                -not -name "sfa_golden.py" \
+                -not -path "*/bench_sfa/*" \
+                | sort)
+            for f in $py_files; do scripts+=("$f"); done
+            echo "${scripts[@]}"
+            return
+            ;;
+        "./flash_attention")
+            # 收集 flash_attn*.py 和 paged_flash_attn*.py，排除 fa_opt 下的 plot.py run.py
+            local py_files=$(find "$dir" -maxdepth 2 -name "*.py" \
+                -not -name "__init__.py" \
+                -not -name "plot.py" \
+                -not -name "run.py" \
+                | sort)
+            for f in $py_files; do scripts+=("$f"); done
+            echo "${scripts[@]}"
+            return
+            ;;
+    esac
+    
     # 搜索 maxdepth 2 的 py 文件（排除特殊文件）
     local py_files=$(find "$dir" -maxdepth 2 -name "*.py" \
         -not -name "__init__.py" \
         -not -name "*_golden.py" \
         -not -name "sfa_golden.py" \
+        -not -name "plot.py" \
+        -not -name "run.py" \
+        -not -name "setup.py" \
+        -not -name "prepare.py" \
         | sort)
     for f in $py_files; do scripts+=("$f"); done
     
     # 搜索 bash 脚本（特定命名模式）
-    local sh_files=$(find "$dir" -maxdepth 2 -name "run_*.sh" -o -name "test_*.sh" | sort)
+    local sh_files=$(find "$dir" -maxdepth 2 \( -name "run_*.sh" -o -name "test_*.sh" \) | sort)
     for f in $sh_files; do scripts+=("$f"); done
     
     echo "${scripts[@]}"


### PR DESCRIPTION
## Summary

修复 bench_test.sh 收集非测试脚本的问题

## Problems

1. 非测试脚本被错误收集：
   - `plot.py` - 绘图脚本
   - `run.py` - 运行/对比脚本
   - `setup.py` - 安装脚本
   - `prepare.py` - 准备脚本

2. 特殊目录处理不当：
   - `torch_tl_ascend/*.py` 需要先安装模块
   - `gemm_aot/*.py` 需要先 AOT 编译
   - `bench_sfa/*.py` 已在 EXTRA_TASKS 中处理

## Solution

在 `collect_test_scripts()` 中添加特殊目录处理：

| 目录 | 处理方式 |
|------|---------|
| torch_tl_ascend | 只收集 test_example.sh |
| gemm_aot | 只收集 run_example_gemm_aot.sh |
| sparse_flash_attention | 排除 bench_sfa/ |
| flash_attention | 排除 plot.py, run.py |

通用排除规则：
- `plot.py`, `run.py`, `setup.py`, `prepare.py`

## Result

测试脚本数量从 130 减少到 116，排除了 14 个非测试脚本

## Test

```bash
cd examples
bash bench_test.sh
# Total scripts to run: 116 (之前是 130)
```