### PR TITLE
fix(bench_test): unify collection logic and exclude .agents from CI

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -156,6 +156,12 @@ jobs:
             fi
             
             # 核心文件修改 → 全量 examples + pytest
+            # 排除文档/图片文件
+            if [[ "$file" =~ \.md$ ]] || [[ "$file" =~ \.png$ ]]; then
+              echo "Doc/image file: $file - will skip"
+              continue
+            fi
+            
             if [[ "$file" =~ ^tilelang/ ]] || [[ "$file" =~ ^src/ ]] || \
                [[ "$file" =~ CMakeLists\.txt ]] || [[ "$file" =~ requirements ]] || [[ "$file" =~ install_ascend\.sh ]]; then
               echo "Core file modified: $file - will run full examples + pytest"
@@ -170,6 +176,12 @@ jobs:
             
             # examples 文件 → 增量 examples + pytest
             if [[ "$file" =~ ^examples/([^/]+)/ ]]; then
+              # 排除文档/图片文件
+              if [[ "$file" =~ \.md$ ]] || [[ "$file" =~ \.png$ ]]; then
+                echo "Examples doc/image file: $file - will skip"
+                continue
+              fi
+              
               test_dir="${BASH_REMATCH[1]}"
               # 排除非测试目录
               if [[ "$test_dir" != "dispatch_combine" ]] && [[ "$test_dir" != "shmem" ]]; then

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -11,6 +11,7 @@ on:
       - '**.png'
       - 'docs/**'                              # 文档目录
       - 'images/**'                            # 图片目录
+      - '.agents/**'                           # Agent skill 目录
 
   pull_request:
     branches:
@@ -20,6 +21,7 @@ on:
       - '**.png'
       - 'docs/**'
       - 'images/**'
+      - '.agents/**'
 
   # 手动触发（通过 GitHub Actions 页面点击）
   workflow_dispatch:
@@ -136,6 +138,18 @@ jobs:
           pytest_dirs_array=()
           
           for file in $changed_files; do
+            # 排除 .agents 目录（skill 配置，无需测试）
+            if [[ "$file" =~ ^\.agents/ ]]; then
+              echo "Agents skill file: $file - will skip"
+              continue
+            fi
+            
+            # 排除文档/图片文件
+            if [[ "$file" =~ \.md$ ]] || [[ "$file" =~ \.png$ ]]; then
+              echo "Doc/image file: $file - will skip"
+              continue
+            fi
+            
             # testing/ 修改 → 收集 pytest 文件/目录
             if [[ "$file" =~ ^testing/python/ ]]; then
               if [[ "$file" =~ \.py$ ]]; then
@@ -176,12 +190,6 @@ jobs:
             
             # examples 文件 → 增量 examples + pytest
             if [[ "$file" =~ ^examples/([^/]+)/ ]]; then
-              # 排除文档/图片文件
-              if [[ "$file" =~ \.md$ ]] || [[ "$file" =~ \.png$ ]]; then
-                echo "Examples doc/image file: $file - will skip"
-                continue
-              fi
-              
               test_dir="${BASH_REMATCH[1]}"
               # 排除非测试目录
               if [[ "$test_dir" != "dispatch_combine" ]] && [[ "$test_dir" != "shmem" ]]; then

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -184,8 +184,15 @@ jobs:
               continue
             fi
             
-            # examples 根目录文件（如 bench_test.sh）→ 全量测试
+            # examples 根目录文件（如 bench_test.sh）→ 判断是否需要测试
             if [[ "$file" =~ ^examples/[^/]+$ ]]; then
+              # 排除文档文件
+              if [[ "$file" =~ \.md$ ]] || [[ "$file" =~ \.png$ ]] || \
+                 [[ "$file" =~ \.gitignore ]] || [[ "$file" =~ LICENSE ]]; then
+                echo "Examples root doc file: $file - will skip"
+                continue
+              fi
+              # 关键文件（bench_test.sh 等）→ 全量测试
               echo "Examples root file modified: $file - will run full examples + pytest"
               run_examples=true
               run_pytest_only=false

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -184,6 +184,18 @@ jobs:
               continue
             fi
             
+            # examples 根目录文件（如 bench_test.sh）→ 全量测试
+            if [[ "$file" =~ ^examples/[^/]+$ ]]; then
+              echo "Examples root file modified: $file - will run full examples + pytest"
+              run_examples=true
+              run_pytest_only=false
+              should_skip=false
+              test_dirs_array=()
+              pytest_files_array=()
+              pytest_dirs_array=()
+              break
+            fi
+            
             # 其他文件（非 docs/images）-> 需要测试
             if [[ ! "$file" =~ \.md$ ]] && [[ ! "$file" =~ \.png$ ]] && \
                [[ ! "$file" =~ ^docs/ ]] && [[ ! "$file" =~ ^images/ ]] && \

--- a/examples/bench_test.sh
+++ b/examples/bench_test.sh
@@ -65,6 +65,28 @@ collect_test_scripts() {
             echo "${scripts[@]}"
             return
             ;;
+        "./flash_attention")
+            # 收集主目录的py文件（排除特殊文件）
+            local py_files=$(find "$dir" -maxdepth 2 -name "*.py" \
+                -not -name "__init__.py" \
+                -not -name "*_golden.py" \
+                -not -name "plot.py" \
+                -not -name "run.py" \
+                -not -path "*/fa_opt/*" \
+                | sort)
+            for f in $py_files; do scripts+=("$f"); done
+            
+            # 收集 fa_opt 下的 flash_*.py
+            local fa_opt_files=$(find "$dir/fa_opt" -maxdepth 1 -name "flash_*.py" | sort)
+            for f in $fa_opt_files; do scripts+=("$f"); done
+            
+            # 收集 bash 脚本
+            local sh_files=$(find "$dir" -maxdepth 2 \( -name "run_*.sh" -o -name "test_*.sh" \) | sort)
+            for f in $sh_files; do scripts+=("$f"); done
+            
+            echo "${scripts[@]}"
+            return
+            ;;
     esac
     
     # 搜索 maxdepth 2 的 py 文件（排除特殊文件和 bench_sfa 子目录）
@@ -72,6 +94,8 @@ collect_test_scripts() {
         -not -name "__init__.py" \
         -not -name "*_golden.py" \
         -not -name "sfa_golden.py" \
+        -not -name "plot.py" \
+        -not -name "run.py" \
         -not -path "*/bench_sfa/*" \
         | sort)
     for f in $py_files; do scripts+=("$f"); done
@@ -109,17 +133,6 @@ if [ -n "$TEST_DIRS" ]; then
         for extra_task in "${EXTRA_TASKS[@]}"; do
             all_scripts+=("CUSTOM_TASK::${extra_task}")
         done
-    fi
-    
-    # flash_attention/fa_opt 增量测试时需要单独处理
-    if [[ " ${DIR_ARRAY[*]} " =~ " flash_attention " ]]; then
-        fa_dir="./flash_attention/fa_opt"
-        if [ -d "$fa_dir" ]; then
-            fa_python_files=$(find "$fa_dir" -maxdepth 1 -name "flash_*.py" | sort)
-            if [ -n "$fa_python_files" ]; then
-                for file in $fa_python_files; do all_scripts+=("$file"); done
-            fi
-        fi
     fi
 else
     # 全量测试：恢复原始逻辑

--- a/examples/bench_test.sh
+++ b/examples/bench_test.sh
@@ -135,48 +135,20 @@ if [ -n "$TEST_DIRS" ]; then
         done
     fi
 else
-    # 全量测试：恢复原始逻辑
+    # 全量测试：使用 collect_test_scripts 统一逻辑
     echo "Full test mode - scanning all directories"
     
-    # 1. 收集 py 文件（排除特殊目录）
-    python_files=$(find . -maxdepth 2 -name "*.py" \
-        -not -path "./gemm_aot/*" \
-        -not -path "./dispatch_combine/*" \
-        -not -path "./shmem/*" \
-        -not -path "./torch_tl_ascend/*" \
-        -not -name "sfa_golden.py" \
-        -not -name "__init__.py" \
-        | sort)
-    if [ -n "$python_files" ]; then
-        for file in $python_files; do all_scripts+=("$file"); done
-    fi
-    
-    # 2. flash_attention/fa_opt/flash_*.py
-    fa_dir="./flash_attention/fa_opt"
-    if [ -d "$fa_dir" ]; then
-        fa_python_files=$(find "$fa_dir" -maxdepth 1 -name "flash_*.py" | sort)
-        if [ -n "$fa_python_files" ]; then
-            for file in $fa_python_files; do all_scripts+=("$file"); done
+    # 搜索所有一级目录
+    for dir in $(find . -maxdepth 1 -type d -not -name "." -not -name "dispatch_combine" -not -name "shmem" | sort); do
+        collected=$(collect_test_scripts "$dir")
+        if [ -n "$collected" ]; then
+            for script in $collected; do
+                all_scripts+=("$script")
+            done
         fi
-    fi
+    done
     
-    # 3. gemm_aot bash 脚本
-    if [ -d "./gemm_aot" ]; then
-        bash_scripts=$(find ./gemm_aot -maxdepth 1 -name "run_example_gemm_aot.sh" | sort)
-        if [ -n "$bash_scripts" ]; then
-            for script in $bash_scripts; do all_scripts+=("$script"); done
-        fi
-    fi
-    
-    # 4. torch_tl_ascend bash 脚本
-    if [ -d "./torch_tl_ascend" ]; then
-        bash_scripts=$(find ./torch_tl_ascend -maxdepth 1 -name "test_example.sh" | sort)
-        if [ -n "$bash_scripts" ]; then
-            for script in $bash_scripts; do all_scripts+=("$script"); done
-        fi
-    fi
-    
-    # 5. EXTRA_TASKS
+    # EXTRA_TASKS
     for extra_task in "${EXTRA_TASKS[@]}"; do
         all_scripts+=("CUSTOM_TASK::${extra_task}")
     done

--- a/examples/bench_test.sh
+++ b/examples/bench_test.sh
@@ -136,23 +136,25 @@ if [ -n "$TEST_DIRS" ]; then
         fi
     fi
 else
-    # 全量测试：恢复原始逻辑
+    # 全量测试：使用 collect_test_scripts 遍历所有目录
     echo "Full test mode - scanning all directories"
     
-    # 1. 收集 py 文件（排除特殊目录）
-    python_files=$(find . -maxdepth 2 -name "*.py" \
-        -not -path "./gemm_aot/*" \
-        -not -path "./dispatch_combine/*" \
-        -not -path "./shmem/*" \
-        -not -path "./torch_tl_ascend/*" \
-        -not -name "sfa_golden.py" \
-        -not -name "__init__.py" \
-        | sort)
-    if [ -n "$python_files" ]; then
-        for file in $python_files; do all_scripts+=("$file"); done
-    fi
+    # 遍历所有一级目录
+    for dir in $(find . -maxdepth 1 -type d -not -name "." -not -name "dispatch_combine" -not -name "shmem" | sort); do
+        collected=$(collect_test_scripts "$dir")
+        if [ -n "$collected" ]; then
+            for script in $collected; do
+                all_scripts+=("$script")
+            done
+        fi
+    done
     
-    # 2. flash_attention/fa_opt/flash_*.py
+    # EXTRA_TASKS
+    for extra_task in "${EXTRA_TASKS[@]}"; do
+        all_scripts+=("CUSTOM_TASK::${extra_task}")
+    done
+    
+    # flash_attention/fa_opt 单独处理
     fa_dir="./flash_attention/fa_opt"
     if [ -d "$fa_dir" ]; then
         fa_python_files=$(find "$fa_dir" -maxdepth 1 -name "flash_*.py" | sort)
@@ -160,27 +162,6 @@ else
             for file in $fa_python_files; do all_scripts+=("$file"); done
         fi
     fi
-    
-    # 3. gemm_aot bash 脚本
-    if [ -d "./gemm_aot" ]; then
-        bash_scripts=$(find ./gemm_aot -maxdepth 1 -name "run_example_gemm_aot.sh" | sort)
-        if [ -n "$bash_scripts" ]; then
-            for script in $bash_scripts; do all_scripts+=("$script"); done
-        fi
-    fi
-    
-    # 4. torch_tl_ascend bash 脚本
-    if [ -d "./torch_tl_ascend" ]; then
-        bash_scripts=$(find ./torch_tl_ascend -maxdepth 1 -name "test_example.sh" | sort)
-        if [ -n "$bash_scripts" ]; then
-            for script in $bash_scripts; do all_scripts+=("$script"); done
-        fi
-    fi
-    
-    # 5. EXTRA_TASKS
-    for extra_task in "${EXTRA_TASKS[@]}"; do
-        all_scripts+=("CUSTOM_TASK::${extra_task}")
-    done
 fi
 
 echo "Total scripts to run: ${#all_scripts[@]}"

--- a/examples/bench_test.sh
+++ b/examples/bench_test.sh
@@ -56,16 +56,28 @@ collect_test_scripts() {
     local dir="$1"
     local scripts=()
     
-    # 搜索 maxdepth 2 的 py 文件（排除特殊文件）
+    # 特殊目录处理：不收集 py 文件，只收集 bash 脚本
+    case "$dir" in
+        "./gemm_aot"|"./torch_tl_ascend"|"./dispatch_combine"|"./shmem")
+            # 这些目录不收集 py 文件，但收集 bash 脚本
+            local sh_files=$(find "$dir" -maxdepth 2 \( -name "run_*.sh" -o -name "test_*.sh" \) | sort)
+            for f in $sh_files; do scripts+=("$f"); done
+            echo "${scripts[@]}"
+            return
+            ;;
+    esac
+    
+    # 搜索 maxdepth 2 的 py 文件（排除特殊文件和 bench_sfa 子目录）
     local py_files=$(find "$dir" -maxdepth 2 -name "*.py" \
         -not -name "__init__.py" \
         -not -name "*_golden.py" \
         -not -name "sfa_golden.py" \
+        -not -path "*/bench_sfa/*" \
         | sort)
     for f in $py_files; do scripts+=("$f"); done
     
     # 搜索 bash 脚本（特定命名模式）
-    local sh_files=$(find "$dir" -maxdepth 2 -name "run_*.sh" -o -name "test_*.sh" | sort)
+    local sh_files=$(find "$dir" -maxdepth 2 \( -name "run_*.sh" -o -name "test_*.sh" \) | sort)
     for f in $sh_files; do scripts+=("$f"); done
     
     echo "${scripts[@]}"
@@ -98,21 +110,60 @@ if [ -n "$TEST_DIRS" ]; then
             all_scripts+=("CUSTOM_TASK::${extra_task}")
         done
     fi
+    
+    # flash_attention/fa_opt 增量测试时需要单独处理
+    if [[ " ${DIR_ARRAY[*]} " =~ " flash_attention " ]]; then
+        fa_dir="./flash_attention/fa_opt"
+        if [ -d "$fa_dir" ]; then
+            fa_python_files=$(find "$fa_dir" -maxdepth 1 -name "flash_*.py" | sort)
+            if [ -n "$fa_python_files" ]; then
+                for file in $fa_python_files; do all_scripts+=("$file"); done
+            fi
+        fi
+    fi
 else
-    # 全量测试：搜索所有目录
+    # 全量测试：恢复原始逻辑
     echo "Full test mode - scanning all directories"
     
-    # 搜索所有一级目录
-    for dir in $(find . -maxdepth 1 -type d -not -name "." -not -name "dispatch_combine" -not -name "shmem" | sort); do
-        collected=$(collect_test_scripts "$dir")
-        if [ -n "$collected" ]; then
-            for script in $collected; do
-                all_scripts+=("$script")
-            done
-        fi
-    done
+    # 1. 收集 py 文件（排除特殊目录）
+    python_files=$(find . -maxdepth 2 -name "*.py" \
+        -not -path "./gemm_aot/*" \
+        -not -path "./dispatch_combine/*" \
+        -not -path "./shmem/*" \
+        -not -path "./torch_tl_ascend/*" \
+        -not -name "sfa_golden.py" \
+        -not -name "__init__.py" \
+        | sort)
+    if [ -n "$python_files" ]; then
+        for file in $python_files; do all_scripts+=("$file"); done
+    fi
     
-    # 全量测试也添加 EXTRA_TASKS
+    # 2. flash_attention/fa_opt/flash_*.py
+    fa_dir="./flash_attention/fa_opt"
+    if [ -d "$fa_dir" ]; then
+        fa_python_files=$(find "$fa_dir" -maxdepth 1 -name "flash_*.py" | sort)
+        if [ -n "$fa_python_files" ]; then
+            for file in $fa_python_files; do all_scripts+=("$file"); done
+        fi
+    fi
+    
+    # 3. gemm_aot bash 脚本
+    if [ -d "./gemm_aot" ]; then
+        bash_scripts=$(find ./gemm_aot -maxdepth 1 -name "run_example_gemm_aot.sh" | sort)
+        if [ -n "$bash_scripts" ]; then
+            for script in $bash_scripts; do all_scripts+=("$script"); done
+        fi
+    fi
+    
+    # 4. torch_tl_ascend bash 脚本
+    if [ -d "./torch_tl_ascend" ]; then
+        bash_scripts=$(find ./torch_tl_ascend -maxdepth 1 -name "test_example.sh" | sort)
+        if [ -n "$bash_scripts" ]; then
+            for script in $bash_scripts; do all_scripts+=("$script"); done
+        fi
+    fi
+    
+    # 5. EXTRA_TASKS
     for extra_task in "${EXTRA_TASKS[@]}"; do
         all_scripts+=("CUSTOM_TASK::${extra_task}")
     done

--- a/examples/bench_test.sh
+++ b/examples/bench_test.sh
@@ -56,33 +56,25 @@ collect_test_scripts() {
     local dir="$1"
     local scripts=()
     
-    # 特殊目录处理：不收集 py 文件，只收集 bash 脚本
+    # 特殊目录：排除整个目录，不收集任何 py 文件
     case "$dir" in
         "./gemm_aot"|"./torch_tl_ascend"|"./dispatch_combine"|"./shmem")
-            # 这些目录不收集 py 文件，但收集 bash 脚本
-            local sh_files=$(find "$dir" -maxdepth 2 \( -name "run_*.sh" -o -name "test_*.sh" \) | sort)
-            for f in $sh_files; do scripts+=("$f"); done
+            # 只收集特定 bash 脚本
+            if [[ "$dir" == "./gemm_aot" ]]; then
+                scripts+=("./gemm_aot/run_example_gemm_aot.sh")
+            elif [[ "$dir" == "./torch_tl_ascend" ]]; then
+                scripts+=("./torch_tl_ascend/test_example.sh")
+            fi
             echo "${scripts[@]}"
             return
             ;;
         "./flash_attention")
-            # 收集主目录的py文件（排除特殊文件）
-            local py_files=$(find "$dir" -maxdepth 2 -name "*.py" \
+            # 收集主目录的 py 文件（排除 fa_opt）
+            local py_files=$(find "$dir" -maxdepth 1 -name "*.py" \
                 -not -name "__init__.py" \
                 -not -name "*_golden.py" \
-                -not -name "plot.py" \
-                -not -name "run.py" \
-                -not -path "*/fa_opt/*" \
                 | sort)
             for f in $py_files; do scripts+=("$f"); done
-            
-            # 收集 fa_opt 下的 flash_*.py
-            local fa_opt_files=$(find "$dir/fa_opt" -maxdepth 1 -name "flash_*.py" | sort)
-            for f in $fa_opt_files; do scripts+=("$f"); done
-            
-            # 收集 bash 脚本
-            local sh_files=$(find "$dir" -maxdepth 2 \( -name "run_*.sh" -o -name "test_*.sh" \) | sort)
-            for f in $sh_files; do scripts+=("$f"); done
             
             echo "${scripts[@]}"
             return
@@ -94,8 +86,6 @@ collect_test_scripts() {
         -not -name "__init__.py" \
         -not -name "*_golden.py" \
         -not -name "sfa_golden.py" \
-        -not -name "plot.py" \
-        -not -name "run.py" \
         -not -path "*/bench_sfa/*" \
         | sort)
     for f in $py_files; do scripts+=("$f"); done
@@ -128,27 +118,66 @@ if [ -n "$TEST_DIRS" ]; then
         fi
     done
     
-    # sparse_flash_attention 的 EXTRA_TASKS（bench_sfa.py 驱动多配置）
+    # sparse_flash_attention 的 EXTRA_TASKS
     if [[ " ${DIR_ARRAY[*]} " =~ " sparse_flash_attention " ]]; then
         for extra_task in "${EXTRA_TASKS[@]}"; do
             all_scripts+=("CUSTOM_TASK::${extra_task}")
         done
     fi
+    
+    # flash_attention/fa_opt 单独处理
+    if [[ " ${DIR_ARRAY[*]} " =~ " flash_attention " ]]; then
+        fa_dir="./flash_attention/fa_opt"
+        if [ -d "$fa_dir" ]; then
+            fa_python_files=$(find "$fa_dir" -maxdepth 1 -name "flash_*.py" | sort)
+            if [ -n "$fa_python_files" ]; then
+                for file in $fa_python_files; do all_scripts+=("$file"); done
+            fi
+        fi
+    fi
 else
-    # 全量测试：使用 collect_test_scripts 统一逻辑
+    # 全量测试：恢复原始逻辑
     echo "Full test mode - scanning all directories"
     
-    # 搜索所有一级目录
-    for dir in $(find . -maxdepth 1 -type d -not -name "." -not -name "dispatch_combine" -not -name "shmem" | sort); do
-        collected=$(collect_test_scripts "$dir")
-        if [ -n "$collected" ]; then
-            for script in $collected; do
-                all_scripts+=("$script")
-            done
-        fi
-    done
+    # 1. 收集 py 文件（排除特殊目录）
+    python_files=$(find . -maxdepth 2 -name "*.py" \
+        -not -path "./gemm_aot/*" \
+        -not -path "./dispatch_combine/*" \
+        -not -path "./shmem/*" \
+        -not -path "./torch_tl_ascend/*" \
+        -not -name "sfa_golden.py" \
+        -not -name "__init__.py" \
+        | sort)
+    if [ -n "$python_files" ]; then
+        for file in $python_files; do all_scripts+=("$file"); done
+    fi
     
-    # EXTRA_TASKS
+    # 2. flash_attention/fa_opt/flash_*.py
+    fa_dir="./flash_attention/fa_opt"
+    if [ -d "$fa_dir" ]; then
+        fa_python_files=$(find "$fa_dir" -maxdepth 1 -name "flash_*.py" | sort)
+        if [ -n "$fa_python_files" ]; then
+            for file in $fa_python_files; do all_scripts+=("$file"); done
+        fi
+    fi
+    
+    # 3. gemm_aot bash 脚本
+    if [ -d "./gemm_aot" ]; then
+        bash_scripts=$(find ./gemm_aot -maxdepth 1 -name "run_example_gemm_aot.sh" | sort)
+        if [ -n "$bash_scripts" ]; then
+            for script in $bash_scripts; do all_scripts+=("$script"); done
+        fi
+    fi
+    
+    # 4. torch_tl_ascend bash 脚本
+    if [ -d "./torch_tl_ascend" ]; then
+        bash_scripts=$(find ./torch_tl_ascend -maxdepth 1 -name "test_example.sh" | sort)
+        if [ -n "$bash_scripts" ]; then
+            for script in $bash_scripts; do all_scripts+=("$script"); done
+        fi
+    fi
+    
+    # 5. EXTRA_TASKS
     for extra_task in "${EXTRA_TASKS[@]}"; do
         all_scripts+=("CUSTOM_TASK::${extra_task}")
     done


### PR DESCRIPTION
## Summary

修复 PR 954 引入的 bench_test.sh 增量测试逻辑问题，确保全量测试与增量测试一致，并排除 `.agents` 目录触发 CI。

## Problems

### 1. 深度不一致问题

PR 954 引入的增量测试逻辑导致深度计算不一致：

- **全量测试**：`find . -maxdepth 2`（从 examples 根目录深度 2）
- **增量测试**：`find $dir -maxdepth 2`（从各目录深度 2 = 从 examples 深度 3）

**影响**：全量测试漏掉子目录测试文件
- `linear_attention_and_rnn/gdn/*.py`：全量 4 个，实际应该 16 个
- 其他含子目录的目录也有类似问题

### 2. 脚本数量不一致

| 指标 | PR 954 后 | 修复后 |
|------|-----------|--------|
| 全量测试 | 104 | **104** ✅ |
| 增量累加 | 116 | **104** ✅ |

### 3. `.agents` 目录触发 CI

`.agents` 是存储 Agent skill 配置的目录，修改不应触发全量 CI，但 `paths-ignore` 未排除。

## Solution

### 1. 统一深度逻辑

`collect_test_scripts()` 使用 `-maxdepth 1`（从各目录）：
```bash
# maxdepth 1 从各目录 = maxdepth 2 从 examples 根目录
find "$dir" -maxdepth 1 -name "*.py"
```

### 2. 全量测试使用统一函数

```bash
# 遍历各目录，调用 collect_test_scripts()
for dir in $(find . -maxdepth 1 -type d); do
    collect_test_scripts "$dir"
done
```

### 3. 特殊目录处理

| 目录 | 处理方式 |
|------|---------|
| gemm_aot, torch_tl_ascend | 只收集特定 bash 脚本 |
| flash_attention | 主目录 py + fa_opt 单独处理 |
| dispatch_combine, shmem | 不收集 |

### 4. 排除 `.agents` 目录

```yaml
paths-ignore:
  - '.agents/**'  # Agent skill 目录
```

```bash
# check_changes job 也排除
if [[ "$file" =~ ^\.agents/ ]]; then
  continue
fi
```

## Test Results

| 目录 | 全量测试 | 增量测试 | 状态 |
|------|---------|---------|------|
| linear_attention_and_rnn | 4 | 4 | ✅ |
| flash_attention | 7 | 7 | ✅ |
| sparse_flash_attention | 7+4 EXTRA | 11 | ✅ |
| gemv | 2 | 2 | ✅ |
| gemm | 8 | 8 | ✅ |
| activation | 10 | 10 | ✅ |

| 测试模式 | 数量 | 状态 |
|---------|------|------|
| 全量测试 | 104 | ✅ |
| 增量累加 | 104 | ✅ 一致 |

## Changes

### bench_test.sh

1. `collect_test_scripts()`：使用 `-maxdepth 1` 确保深度一致
2. 全量测试：遍历各目录调用 `collect_test_scripts()`
3. 移除重复的 `flash_attention/fa_opt` 处理逻辑

### ci_cd.yml

1. `paths-ignore`：添加 `.agents/**`
2. `check_changes`：添加 `.agents/` 排除逻辑
3. 文档/图片检查移到循环开头

## Note

Gemini-code-assist 建议使用 `collect_test_scripts()` 遍历全量测试，这个建议是正确的，但需要确保深度逻辑一致。