### PR TITLE
[Fix] Fix infinite loop in the auto CV sync pass🤖

### DIFF
--- a/src/transform/ascend_combinecv.cc
+++ b/src/transform/ascend_combinecv.cc
@@ -504,6 +504,7 @@ private:
     // once
     while (cube_loop_idx < cube_sp.parent_for_nodes.size() ||
            vec_loop_idx < vec_sp.parent_for_nodes.size()) {
+      bool cube_idx_updated = false;
       while (
           cube_loop_idx < cube_sp.parent_for_nodes.size() &&
           (cube_loop_times <= vec_loop_times ||
@@ -518,6 +519,7 @@ private:
         const ForNode *cube_loop = cube_sp.parent_for_nodes.at(cube_loop_idx);
         cube_loop_times *= GetLoopIterTimesWithSkip(cube_loop, skip_loop_ids);
         cube_loop_idx++;
+        cube_idx_updated = true;
       }
 
       if (cube_loop_times < vec_loop_times) {
@@ -530,6 +532,7 @@ private:
                      << vec_sp.ToString() << "\n";
       }
 
+      bool vec_idx_updated = false;
       while (vec_loop_idx < vec_sp.parent_for_nodes.size() &&
              (vec_loop_times <= cube_loop_times ||
               GetLoopIterTimesWithSkip(vec_sp.parent_for_nodes.at(vec_loop_idx),
@@ -543,6 +546,7 @@ private:
         const ForNode *vec_loop = vec_sp.parent_for_nodes.at(vec_loop_idx);
         vec_loop_times *= GetLoopIterTimesWithSkip(vec_loop, skip_loop_ids);
         vec_loop_idx++;
+        vec_idx_updated = true;
 
         if (vec_loop_times == last_pair_loop_times) {
           // cube_loop_times steps beyond last_pair_loop_times && vec_loop_times
@@ -559,6 +563,10 @@ private:
                      << vec_sp.ToString() << "\n"
                      << "Cube Sync Point:\n"
                      << cube_sp.ToString() << "\n";
+      }
+
+      if (!(cube_idx_updated || vec_idx_updated)) {
+        break;
       }
     }
 


### PR DESCRIPTION
## Summary

Fix infinite loop bug in `FindTargetLoopDepth` function of `ascend_combinecv.cc`, which caused warning messages to be printed millions of times.

## Problem

When running `example_dequant_gemm_w4a8.py`, the kernel compilation printed 4.5 million identical warning messages, causing the process to hang.

## Root Cause

In `FindTargetLoopDepth`, the outer while loop condition remains true when:
- `cube_loop_idx >= cube_sp.parent_for_nodes.size()` (cube loops exhausted)
- `vec_loop_times > cube_loop_times` (vec has more iterations)
- Vec's next loop is not skipped

In the rare implementation of `example_dequant_gemm_w4a8.py`:
1. Cube inner while loop doesn't execute (condition fails)
2. Vec inner while loop doesn't execute (condition fails)
3. But outer loop continues because `vec_loop_idx < vec_sp.parent_for_nodes.size()`
4. `cube_loop_idx` and `vec_loop_idx` never increase → **infinite loop**
5. Warning printed every iteration

## Changes

- Add `cube_idx_updated` and `vec_idx_updated` flags to track progress
- Break outer loop when both flags are false (no progress made)
- Warning now printed exactly once

## Testing

```bash
python examples/dequantize_gemm/example_dequant_gemm_w4a8.py
```

Before fix: 4,512,629 warnings, 60s timeout
After fix: 1 warning, test passes in <1s