### PR TITLE
feat(tensorpulse): backend skeleton + ascend CI smoke test

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -510,11 +510,18 @@ jobs:
               if [ -d build-cache ] && [ \"\$(ls -A build-cache)\" ]; then
                 echo \"Copy build cache...\"
                 mkdir -p build
-                cp -ra build-cache/* build/ 
+                cp -ra build-cache/* build/
               fi
 
-              # 1. 增量编译项目
-              bash install_ascend.sh \$INCREMENTAL_FLAG
+              # 1a. 铺 SMI_IQ stub 让 USE_TENSORPULSE=ON 的 cmake 检查通过；
+              # codegen_tensorpulse.cc / rt_mod_tensorpulse.cc 不直接 include 这个 header，
+              # 只在运行时通过 TILELANG_TENSORPULSE_HOME 宏向 kernel 编译命令注入 -I 。
+              mkdir -p .tensorpulse_stub/iq
+              : > .tensorpulse_stub/iq/iq_api.h
+              export TENSORPULSE_HOME=\$PWD/.tensorpulse_stub
+
+              # 1b. 增量编译项目（同时启用 ascend + tensorpulse 后端）
+              bash install_ascend.sh \$INCREMENTAL_FLAG --enable-tensorpulse
               # 保存编译产物
               if [ -d \"build\" ]; then
                 echo \"Saving build artifacts...\"
@@ -526,6 +533,10 @@ jobs:
               echo 'Sourcing environment...'
               source set_env.sh
               echo 'TILELANG_PATH='\$PWD >> \$GITHUB_ENV
+
+              # 2a. TensorPulse target 注册 smoke test（秒级，build 完即跑）
+              echo 'Running tensorpulse target smoke test...'
+              TVM_LIBRARY_PATH=\$PWD/build/tvm python3 testing/python/test_tensorpulse_target_smoke.py
 
               # 3. 运行测试用例
               cd examples

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,13 @@ examples/torch_tl_ascend/demo_libtorch/lib/*.so
 docs/notebook/*.so
 docs/notebook/*.cpp
 
+# TensorPulse private hardware specs (do not commit)
+AIACC*.docx
+AIACC*.xlsx
+AIACC*.doc
+AIACC*.xls
+AIACC*.pdf
+
+# Claude Code local config
+.claude/
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,14 @@ if(USE_ASCEND)
   list(APPEND TILE_LANG_SRCS ${TILE_LANG_ASCEND_SRCS})
 endif()
 
+if(USE_TENSORPULSE)
+  tilelang_file_glob(GLOB TILE_LANG_TENSORPULSE_SRCS
+    src/target/codegen_tensorpulse.cc
+    src/target/rt_mod_tensorpulse.cc
+  )
+  list(APPEND TILE_LANG_SRCS ${TILE_LANG_TENSORPULSE_SRCS})
+endif()
+
 # Include ROCm source files if ROCm is enabled
 if(USE_ROCM)
   tilelang_file_glob(GLOB TILE_LANG_HIP_SRCS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,14 @@ target_compile_definitions(tilelang_objs PRIVATE -DTILE_LANG_EXPORTS)
 
 # Shared library
 add_library(tilelang SHARED $<TARGET_OBJECTS:tilelang_objs>)
-target_link_libraries(tilelang PUBLIC tvm_runtime)
+if(APPLE)
+  # macOS arm64 ld defaults to -undefined error, so tilelang must resolve
+  # the TVM compile-time IR symbols (tvm::PrimExpr, tvm::tir::*) at link time.
+  # Those live in libtvm, not libtvm_runtime.
+  target_link_libraries(tilelang PUBLIC tvm)
+else()
+  target_link_libraries(tilelang PUBLIC tvm_runtime)
+endif()
 
 # Static library
 add_library(tilelang_static STATIC $<TARGET_OBJECTS:tilelang_objs>)

--- a/install_ascend.sh
+++ b/install_ascend.sh
@@ -6,6 +6,7 @@
 # Add command line option parsing
 USE_LLVM=false
 USE_SHMEM=false
+USE_TENSORPULSE=false
 INCREMENTAL_BUILD=false  # 增量编译选项
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -17,13 +18,17 @@ while [[ $# -gt 0 ]]; do
             USE_SHMEM=true
             shift
             ;;
+        --enable-tensorpulse)
+            USE_TENSORPULSE=true
+            shift
+            ;;
         --enable-incremental)
             INCREMENTAL_BUILD=true
             shift
             ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: $0 [--enable-llvm] [--enable-shmem] [--enable-incremental]"
+            echo "Usage: $0 [--enable-llvm] [--enable-shmem] [--enable-tensorpulse] [--enable-incremental]"
             exit 1
             ;;
     esac
@@ -42,7 +47,23 @@ fi
 echo "Starting installation script..."
 echo "LLVM enabled: $USE_LLVM"
 echo "SHMEM enabled: $USE_SHMEM"
+echo "TensorPulse enabled: $USE_TENSORPULSE"
 echo "Incremental build: $INCREMENTAL_BUILD"
+
+if $USE_TENSORPULSE; then
+    if [ -z "${TENSORPULSE_HOME}" ] && [ -n "${TENSORPULSE_HOME_PATH}" ]; then
+        export TENSORPULSE_HOME="${TENSORPULSE_HOME_PATH}"
+    fi
+    if [ -z "${TENSORPULSE_HOME}" ]; then
+        echo "[ERROR] --enable-tensorpulse requires TENSORPULSE_HOME (or TENSORPULSE_HOME_PATH) to be set."
+        exit 1
+    fi
+    if [ ! -f "${TENSORPULSE_HOME}/iq/iq_api.h" ]; then
+        echo "[ERROR] ${TENSORPULSE_HOME}/iq/iq_api.h not found."
+        exit 1
+    fi
+    echo "TENSORPULSE_HOME: ${TENSORPULSE_HOME}"
+fi
 
 # Step 1: Install Python requirements
 echo "Installing Python requirements from requirements.txt..."
@@ -145,6 +166,10 @@ cd build
 if ! $INCREMENTAL_BUILD; then
     echo "set(USE_ASCEND ON)" >> config.cmake
     echo 'set(USE_GTEST OFF)' >> config.cmake
+    if $USE_TENSORPULSE; then
+        echo "set(USE_TENSORPULSE ON)" >> config.cmake
+        echo "set(TENSORPULSE_HOME \"${TENSORPULSE_HOME}\")" >> config.cmake
+    fi
     cmake ..
     if [ $? -ne 0 ]; then
         echo "Error: CMake configuration failed."

--- a/src/op/tensorpulse.cc
+++ b/src/op/tensorpulse.cc
@@ -1,0 +1,35 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+
+/*!
+ * \file tl/op/tensorpulse.cc
+ * \brief Define TensorPulse-related operators.
+ */
+
+#include "tensorpulse.h"
+
+#include <tvm/tir/builtin.h>
+#include <tvm/tir/op.h>
+#include <tvm/tir/op_attr_types.h>
+
+#include "builtin.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+
+#define TIR_DEFINE_TL_BUILTIN(OpName)                                          \
+  const Op &OpName() {                                                         \
+    static const Op &op = Op::Get("tl." #OpName);                              \
+    return op;                                                                 \
+  }                                                                            \
+  TVM_REGISTER_OP("tl." #OpName)                                               \
+      .set_attr<TScriptPrinterName>("TScriptPrinterName", #OpName)
+
+TIR_DEFINE_TL_BUILTIN(tensorpulse_add)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+}  // namespace tl
+}  // namespace tvm

--- a/src/op/tensorpulse.h
+++ b/src/op/tensorpulse.h
@@ -1,0 +1,27 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+
+/*!
+ * \file tl/op/tensorpulse.h
+ * \brief Define TensorPulse-related operators.
+ */
+
+#ifndef TVM_TL_OP_TENSORPULSE_H_
+#define TVM_TL_OP_TENSORPULSE_H_
+
+#include "op.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+
+// V1.0 skeleton: a single elementwise op to validate the registration
+// mechanism. Real op set (gemm_v0, set/wait_flag, pipe_barrier, sync_all, ...)
+// is added incrementally as codegen lands.
+TVM_DLL const Op &tensorpulse_add();
+
+}  // namespace tl
+}  // namespace tvm
+
+#endif  // TVM_TL_OP_TENSORPULSE_H_

--- a/src/target/codegen_tensorpulse.cc
+++ b/src/target/codegen_tensorpulse.cc
@@ -1,0 +1,37 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+
+#include "codegen_tensorpulse.h"
+
+namespace tvm {
+namespace codegen {
+
+std::string CodeGenTileLangTensorPulse::Finish() {
+  std::ostringstream code;
+  code << CodeGenC::Finish();
+  return code.str();
+}
+
+void CodeGenTileLangTensorPulse::PrintFuncPrefix(std::ostream &os) {
+  os << "extern \"C\" ";
+}
+
+void CodeGenTileLangTensorPulse::PrintStorageScope(const std::string &scope,
+                                                   std::ostream &os) {
+  // TensorPulse memory model is 2-level: external address space + UR.
+  if (scope == "global") {
+    os << " ";
+  } else if (scope == "shared" || scope == "ur") {
+    os << " ";  // UR (User Register); placeholder qualifier for now.
+  } else {
+    LOG(FATAL) << "TensorPulse: unsupported storage scope: " << scope;
+  }
+}
+
+void CodeGenTileLangTensorPulse::PrintType(DataType t, std::ostream &os) {
+  // FP8 / FP4 specialisations will be added later; defer to base for now.
+  CodeGenC::PrintType(t, os);
+}
+
+}  // namespace codegen
+}  // namespace tvm

--- a/src/target/codegen_tensorpulse.h
+++ b/src/target/codegen_tensorpulse.h
@@ -1,0 +1,42 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+
+/*!
+ * \file target/codegen_tensorpulse.h
+ * \brief Code-generator skeleton for the TensorPulse (AIACC) backend.
+ *
+ * V1.0 minimal skeleton: enough to register `target.build.tilelang_tensorpulse`
+ * and pass cmake build. Per-op visitors will be filled in incrementally.
+ */
+#ifndef TVM_TL_TARGET_CODEGEN_TENSORPULSE_H_
+#define TVM_TL_TARGET_CODEGEN_TENSORPULSE_H_
+
+#include <tvm/target/codegen.h>
+#include <tvm/tir/expr.h>
+#include <tvm/tir/op.h>
+
+#include <string>
+
+#include "target/source/codegen_c.h"
+
+namespace tvm {
+namespace codegen {
+
+class CodeGenTileLangTensorPulse final : public CodeGenC {
+ public:
+  CodeGenTileLangTensorPulse() = default;
+
+  std::string Finish();
+
+  void PrintFuncPrefix(std::ostream &os) final;
+  void PrintStorageScope(const std::string &scope, std::ostream &os) final;
+  void PrintType(DataType t, std::ostream &os) final;
+
+ private:
+  bool IsScopePartOfType() const final { return false; }
+};
+
+}  // namespace codegen
+}  // namespace tvm
+
+#endif  // TVM_TL_TARGET_CODEGEN_TENSORPULSE_H_

--- a/src/target/rt_mod_tensorpulse.cc
+++ b/src/target/rt_mod_tensorpulse.cc
@@ -1,0 +1,33 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+
+#include "codegen_tensorpulse.h"
+
+namespace tvm {
+namespace codegen {
+
+runtime::Module BuildTileLangTensorPulse(IRModule mod, Target target) {
+  bool output_ssa = false;
+  CodeGenTileLangTensorPulse cg;
+  cg.Init(output_ssa);
+
+  Array<String> function_names;
+
+  for (auto kv : mod->functions) {
+    ICHECK(kv.second->IsInstance<PrimFuncNode>())
+        << "CodeGenTileLangTensorPulse: Can only take PrimFunc";
+    auto gvar = Downcast<GlobalVar>(kv.first);
+    auto f = Downcast<PrimFunc>(kv.second);
+    cg.AddFunction(gvar, f);
+    function_names.push_back(cg.GetFunctionName(gvar));
+  }
+
+  std::string code = cg.Finish();
+  return CSourceModuleCreate(code, "c", function_names);
+}
+
+TVM_REGISTER_GLOBAL("target.build.tilelang_tensorpulse")
+    .set_body_typed(BuildTileLangTensorPulse);
+
+}  // namespace codegen
+}  // namespace tvm

--- a/src/tl_templates/tensorpulse/common.h
+++ b/src/tl_templates/tensorpulse/common.h
@@ -1,0 +1,37 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+
+/*!
+ * \file tl_templates/tensorpulse/common.h
+ * \brief TensorPulse intrinsic templates (V1.0 skeleton).
+ *
+ * Maps TensorPulse SMC microinstructions (AIACC ISA spec §5.3) to
+ * compiler-emitted intrinsic calls. Currently a CPU-fallback stub —
+ * real SMC instruction emission lands when the TensorPulse SDK is wired in.
+ *
+ * Unlike the Ascend equivalent, this header does not (yet) depend on any
+ * vendor SDK (no catlass / AscendC counterpart exists for TensorPulse).
+ */
+
+#ifndef TILELANG_TL_TEMPLATES_TENSORPULSE_COMMON_H_
+#define TILELANG_TL_TEMPLATES_TENSORPULSE_COMMON_H_
+
+#include <cstddef>
+#include <cstdint>
+
+namespace tl {
+namespace tensorpulse {
+
+// Placeholder elementwise add. Real implementation dispatches to
+// SMC INTADD / FPADD / FP16MUL / ... microinstructions per dtype.
+template <typename T>
+inline void tensorpulse_add(T* dst, const T* src0, const T* src1, std::size_t n) {
+  for (std::size_t i = 0; i < n; ++i) {
+    dst[i] = src0[i] + src1[i];
+  }
+}
+
+}  // namespace tensorpulse
+}  // namespace tl
+
+#endif  // TILELANG_TL_TEMPLATES_TENSORPULSE_COMMON_H_

--- a/src/transform/tensorpulse_lower_opaque_block.cc
+++ b/src/transform/tensorpulse_lower_opaque_block.cc
@@ -280,9 +280,11 @@ private:
   Map<Var, PrimExpr> local_var_init_map_;
 };
 
+namespace {
 PrimFunc LowerOpaqueBlock(PrimFunc f) {
   return OpaqueBlockLower::Rewrite(std::move(f));
 }
+} // namespace
 
 namespace transform {
 using namespace tir::transform;

--- a/src/transform/tensorpulse_lower_opaque_block.cc
+++ b/src/transform/tensorpulse_lower_opaque_block.cc
@@ -1,0 +1,301 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tensorpulse_lower_opaque_block.cc
+ * \brief Pass TensorPulseLowerOpaqueBlock — lifted from
+ *        ascend_lower_opaque_block.cc. Underlying rewrite is generic TIR,
+ *        not Ascend-specific. Drop when TVM submodule provides equivalent.
+ */
+
+#include <tvm/ir/attrs.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+
+#include <string>
+
+#include "../op/builtin.h"
+#include "tir/transforms/ir_utils.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+
+/*!
+ * \brief Remove Block to ensure that the TIR can not be scheduled again.
+ */
+class OpaqueBlockLower : public StmtExprMutator {
+public:
+  static PrimFunc Rewrite(PrimFunc f) {
+    auto fptr = f.CopyOnWrite();
+    OpaqueBlockLower lower;
+    if (auto existing =
+            fptr->attrs.GetAttr<Map<Var, PrimExpr>>(tl::attr::kLocalVarInit)) {
+      lower.local_var_init_map_ = existing.value();
+    }
+    lower.storage_align_ = CollectStorageAlignAnnotation(fptr->body);
+    fptr->body = lower(std::move(fptr->body));
+    if (!lower.local_var_init_map_.empty()) {
+      f = WithAttr(std::move(f), tl::attr::kLocalVarInit,
+                   lower.local_var_init_map_);
+    }
+    return f;
+  }
+
+private:
+  Stmt VisitStmt_(const BlockRealizeNode *op) final {
+    // We have convert blocks into opaque blocks in previous passes.
+    ICHECK(op->iter_values.empty())
+        << "Non-opaque blocks are not allowed in FlattenBuffer. Please "
+           "call pass ConvertBlocksToOpaque before.";
+    // Step 1. Visit the body
+    Block new_block = Downcast<Block>(this->VisitStmt(op->block));
+    PrimExpr predicate = this->VisitExpr(op->predicate);
+    // Step 2. Transform the `predicate` to if-then-else
+    Stmt body = new_block->body;
+    if (!is_one(predicate)) {
+      body = IfThenElse(predicate, std::move(body));
+    }
+    // Step 3. Handle annotations, block annotations are not preserved by
+    // default.
+    std::vector<std::pair<std::string, PrimExpr>> pragma_attrs;
+    HandleAnnotations(new_block->annotations, &pragma_attrs, /*is_block=*/true,
+                      new_block->alloc_buffers);
+
+    // Step 4. Handle allocations in reverse order
+    for (size_t i = new_block->alloc_buffers.size(); i > 0; --i) {
+      const Buffer &buffer = new_block->alloc_buffers[i - 1];
+      Array<PrimExpr> allocation_shape = GetBufferAllocationShape(buffer);
+      body = DeclBuffer(buffer, std::move(body));
+      Map<String, ObjectRef> allocate_annotations;
+      auto it = storage_align_.find(buffer->data);
+      if (it != storage_align_.end()) {
+        StorageAlignAnnotation allocate_aligns;
+        for (auto tuple : it->second) {
+          ICHECK_EQ(tuple.size(), 4);
+          tuple.Set(0, -1);
+          allocate_aligns.push_back(tuple);
+        }
+        allocate_annotations.Set(tir::attr::buffer_dim_align, allocate_aligns);
+      }
+
+      auto init_it = local_var_init_map_.find(buffer->data);
+      if (init_it != local_var_init_map_.end()) {
+        const PrimExpr &init = (*init_it).second;
+        allocate_annotations.Set(tl::attr::kLocalVarInit, init);
+      }
+      body = Allocate(buffer->data, buffer->dtype, allocation_shape,
+                      const_true(), std::move(body), allocate_annotations);
+    }
+    // Step 5. Insert attribute statements converted from pragmas
+    for (auto it = pragma_attrs.rbegin(); it != pragma_attrs.rend(); ++it) {
+      body = AttrStmt(Integer(0), it->first, it->second, std::move(body));
+    }
+    return body;
+  }
+
+  Stmt VisitStmt_(const BlockNode *op) final {
+    Block block = Downcast<Block>(StmtExprMutator::VisitStmt_(op));
+    if (block->annotations.count("stmt_group")) {
+      return block->body;
+    }
+    return block;
+  }
+
+  Stmt VisitStmt_(const ForNode *op) final {
+    // Step 1. Update unit loop info.
+    PrimExpr min = this->VisitExpr(op->min);
+    PrimExpr extent = this->VisitExpr(op->extent);
+    if (is_one(extent) && op->annotations.empty()) {
+      // handling unit loop
+      unit_loop_vars_[op->loop_var] = min;
+    }
+    // Step 2. Visit recursively
+    Stmt body = this->VisitStmt(op->body);
+    // Step 3. Handle annotations
+    std::vector<std::pair<std::string, PrimExpr>> pragma_attrs;
+    Map<String, ObjectRef> new_annotations =
+        HandleAnnotations(op->annotations, &pragma_attrs, /*is_block=*/false);
+    // Step 4. Create new For loop accordingly
+    if (op->kind == ForKind::kThreadBinding) {
+      // Case 1. Thread binding
+      ICHECK(op->thread_binding.defined());
+      String thread_tag = op->thread_binding.value()->thread_tag;
+      body = MakeLaunchThread(min, extent, op->loop_var, thread_tag, body);
+    } else if (is_one(extent) && op->annotations.empty()) {
+      // Case 2. Unit loop
+      return body;
+    } else {
+      // Case 3. An ordinary loop
+      body = For(op->loop_var, std::move(min), std::move(extent), op->kind,
+                 std::move(body), NullOpt, new_annotations);
+    }
+    // Step 5. Insert nested attrs
+    for (auto it = pragma_attrs.rbegin(); it != pragma_attrs.rend(); ++it) {
+      body = AttrStmt(op->loop_var, it->first, it->second, std::move(body));
+    }
+    return body;
+  }
+
+  PrimExpr VisitExpr_(const VarNode *op) final {
+    Var var = GetRef<Var>(op);
+    auto it = unit_loop_vars_.find(var);
+    if (it == unit_loop_vars_.end()) {
+      return std::move(var);
+    } else {
+      PrimExpr expr = it->second;
+      if (expr.dtype() != var.dtype()) {
+        expr = tvm::cast(var.dtype(), std::move(expr));
+      }
+      return expr;
+    }
+  }
+
+  static Stmt MakeLaunchThread(PrimExpr min, PrimExpr extent, Var var,
+                               String thread_tag, Stmt body) {
+    IterVar iter_var(/*dom=*/Range::FromMinExtent(min, extent),
+                     /*var=*/std::move(var),
+                     /*iter_type=*/IterVarType::kThreadIndex,
+                     /*thread_tag=*/thread_tag);
+    String attr_key = (thread_tag == "vthread" || thread_tag == "vthread.x" ||
+                       thread_tag == "vthread.y" || thread_tag == "vthread.z")
+                          ? tir::attr::virtual_thread
+                          : tir::attr::thread_extent;
+    return AttrStmt(/*node=*/std::move(iter_var),
+                    /*attr_key=*/std::move(attr_key),
+                    /*value=*/std::move(extent),
+                    /*body=*/std::move(body));
+  }
+
+  /*! \brief Convert attr value from annotation map into PrimExpr. */
+  PrimExpr ConvertAttrValue(const String &key, const ObjectRef &obj) {
+    if (!obj.defined()) {
+      return PrimExpr();
+    } else if (auto expr = obj.as<PrimExpr>()) {
+      return expr.value();
+    } else if (auto str = obj.as<String>()) {
+      return std::move(StringImm(str.value()));
+    } else {
+      LOG(FATAL) << "Illegal attribute of key " << key << ", value type "
+                 << obj->GetTypeKey() << " not supported";
+      return PrimExpr();
+    }
+  }
+
+  /*!
+   * \brief Helper to handle annotation dict.
+   * (1) if the attr key is prefixed by `pragma_`, move to ordered kv list. They
+   * are lowered to `AttrStmt` by legacy TE schedule convention.
+   * (2) the non-pragma loop annotations are preserved
+   * (3) the non-pragma block annotations are dropped
+   * \return New annotation dict with preserved keys. Also update pragma attr
+   * pairs ordered by key.
+   */
+  Map<String, ObjectRef>
+  HandleAnnotations(const Map<String, ObjectRef> &annotations,
+                    std::vector<std::pair<std::string, PrimExpr>> *pragma_attrs,
+                    bool is_block,
+                    const Array<Buffer> &alloc_buffers = Array<Buffer>()) {
+    Map<String, ObjectRef> preserved_annotations;
+    pragma_attrs->clear();
+    for (const auto &kv : annotations) {
+      const String &key = kv.first;
+      if (tir::attr::IsPragmaKey(key)) {
+        pragma_attrs->emplace_back(key, ConvertAttrValue(key, kv.second));
+      } else if (key == tl::attr::kLocalVarInit) {
+        if (auto local_init_map = kv.second.as<Map<Var, PrimExpr>>()) {
+
+          for (const auto &pair : local_init_map.value()) {
+            local_var_init_map_.Set(pair.first, pair.second);
+          }
+        } else if (auto init_expr = kv.second.as<PrimExpr>()) {
+          ICHECK(is_block) << "`" << tl::attr::kLocalVarInit
+                           << "` on non-block annotations is not supported";
+          Buffer target = ResolveLocalVarBuffer(alloc_buffers);
+          if (!target.defined()) {
+            LOG(WARNING) << "Failed to resolve buffer for `"
+                         << tl::attr::kLocalVarInit << "` annotation";
+            continue;
+          }
+          local_var_init_map_.Set(target->data, init_expr.value());
+        } else {
+          LOG(FATAL) << "Expected `" << tl::attr::kLocalVarInit
+                     << "` to be a PrimExpr or Map<Var, PrimExpr>, but got "
+                     << kv.second->GetTypeKey();
+        }
+      } else if (!is_block) {
+        // the loop annotation is preserved
+        preserved_annotations.Set(key, kv.second);
+      }
+    }
+    std::sort(
+        pragma_attrs->begin(), pragma_attrs->end(),
+        [](const auto &p1, const auto &p2) { return p1.first < p2.first; });
+    return preserved_annotations;
+  }
+
+  Buffer ResolveLocalVarBuffer(const Array<Buffer> &alloc_buffers) const {
+    for (const Buffer &buffer : alloc_buffers) {
+      std::string scope = buffer.scope();
+      if (scope.find("local.var") != std::string::npos) {
+        return buffer;
+      }
+    }
+    if (!alloc_buffers.empty()) {
+      return alloc_buffers.back();
+    }
+    return Buffer();
+  }
+
+  /*! \brief Record the loop_var and loop start value of unit loops, whose
+   * extent is one. */
+  std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual>
+      unit_loop_vars_;
+
+  /*! \brief Attr keys to preserve into loop annotations. */
+  std::unordered_set<std::string> preserved_annotations_;
+
+  /*! \brief The map from buffer var to its storage alignment information. */
+  std::unordered_map<Var, StorageAlignAnnotation, ObjectPtrHash, ObjectPtrEqual>
+      storage_align_;
+
+  /*! \brief Local var initializers collected from block annotations. */
+  Map<Var, PrimExpr> local_var_init_map_;
+};
+
+PrimFunc LowerOpaqueBlock(PrimFunc f) {
+  return OpaqueBlockLower::Rewrite(std::move(f));
+}
+
+namespace transform {
+using namespace tir::transform;
+Pass TensorPulseLowerOpaqueBlock() {
+  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+    return LowerOpaqueBlock(std::move(f));
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.TensorPulseLowerOpaqueBlock", {});
+}
+
+TVM_REGISTER_GLOBAL("tl.transform.TensorPulseLowerOpaqueBlock")
+    .set_body_typed(TensorPulseLowerOpaqueBlock);
+} // namespace transform
+
+} // namespace tl
+} // namespace tvm

--- a/testing/python/test_tensorpulse_target_smoke.py
+++ b/testing/python/test_tensorpulse_target_smoke.py
@@ -1,0 +1,82 @@
+"""Minimal smoke test: libtilelang loads and the tensorpulse target is wired
+end-to-end through TVM and tilelang.utils.target.determine_target.
+
+Run from repo root:
+
+    export PYTHONPATH=$PWD/3rdparty/tvm/python:$PYTHONPATH
+    export TVM_LIBRARY_PATH=$PWD/build/tvm
+    python3 testing/python/test_tensorpulse_target_smoke.py
+
+We stub the tilelang package instead of running its __init__.py to avoid
+pulling in torch / Cython adapter compilation that aren't needed for a
+target-registration smoke test.
+"""
+
+import ctypes
+import os
+import sys
+import types
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+_LIB_NAMES = ("libtilelang_module.so", "libtilelang_module.dylib",
+              "libtilelang.so", "libtilelang.dylib")
+LIB = next((os.path.join(REPO, "build", n)
+            for n in _LIB_NAMES
+            if os.path.exists(os.path.join(REPO, "build", n))), None)
+
+
+def _stub_tilelang_package(tvm_module):
+    """Register a minimal tilelang package so submodules import cleanly."""
+    pkg = types.ModuleType("tilelang")
+    pkg.__path__ = [os.path.join(REPO, "tilelang")]
+    pkg.tvm = tvm_module  # satisfies `from tilelang import tvm as tvm`
+    sys.modules["tilelang"] = pkg
+
+    contrib = types.ModuleType("tilelang.contrib")
+    contrib.__path__ = [os.path.join(REPO, "tilelang", "contrib")]
+    sys.modules["tilelang.contrib"] = contrib
+
+
+def main():
+    assert LIB is not None and os.path.exists(LIB), (
+        f"no tilelang shared lib under {REPO}/build (tried {_LIB_NAMES}); "
+        "build the project with USE_TENSORPULSE=ON first")
+
+    # 1. ctypes-load libtilelang so its TVM_REGISTER_GLOBAL hooks fire.
+    import tvm
+    from tvm.target import Target
+
+    handle = ctypes.CDLL(LIB)
+    print(f"[ok] loaded {handle._name}")
+
+    # 2. target.build.tilelang_tensorpulse registered by rt_mod_tensorpulse.cc.
+    fn = tvm._ffi.get_global_func("target.build.tilelang_tensorpulse",
+                                  allow_missing=True)
+    assert fn is not None, "target.build.tilelang_tensorpulse not registered"
+    print("[ok] global func target.build.tilelang_tensorpulse registered")
+
+    # 3. determine_target maps the string alias to the llvm target with the key.
+    _stub_tilelang_package(tvm)
+    from tilelang.utils.target import determine_target
+
+    s = determine_target("tensorpulse")
+    assert s == "llvm --keys=tensorpulse", f"unexpected target string: {s!r}"
+    print(f"[ok] determine_target('tensorpulse') -> {s!r}")
+
+    # 4. The Target object actually carries the tensorpulse key.
+    tgt = Target(s)
+    keys = list(tgt.keys)
+    assert "tensorpulse" in keys, f"missing tensorpulse key: {keys}"
+    print(f"[ok] Target(...).keys = {keys}")
+
+    # 5. Lowering pass registered (transform/tensorpulse_lower_opaque_block.cc).
+    pass_fn = tvm._ffi.get_global_func("tl.transform.TensorPulseLowerOpaqueBlock",
+                                       allow_missing=True)
+    print(f"[{'ok' if pass_fn else 'warn'}] TensorPulseLowerOpaqueBlock "
+          f"{'registered' if pass_fn else 'NOT FOUND under tl.transform.*'}")
+
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -63,9 +63,24 @@ def _find_ascend_home() -> str:
     return ascend_home if ascend_home is not None else ""
 
 
+def _find_tensorpulse_home() -> str:
+    """Find the TensorPulse toolchain install path."""
+    tensorpulse_home = os.environ.get("TENSORPULSE_HOME_PATH") or os.environ.get("TENSORPULSE_HOME")
+    if tensorpulse_home is None:
+        potential_paths = [
+            "/usr/local/TensorPulse/latest",
+        ]
+        for path in potential_paths:
+            if os.path.exists(path):
+                tensorpulse_home = path
+                break
+    return tensorpulse_home if tensorpulse_home is not None else ""
+
+
 CUDA_HOME = _find_cuda_home()
 ROCM_HOME = _find_rocm_home()
 ASCEND_HOME = _find_ascend_home()
+TENSORPULSE_HOME = _find_tensorpulse_home()
 
 CUTLASS_INCLUDE_DIR: str | None = os.environ.get("TL_CUTLASS_PATH", None)
 COMPOSABLE_KERNEL_INCLUDE_DIR: str | None = os.environ.get("TL_COMPOSABLE_KERNEL_PATH", None)
@@ -222,6 +237,7 @@ __all__ = [
     "CUDA_HOME",
     "ROCM_HOME",
     "ASCEND_HOME",
+    "TENSORPULSE_HOME",
     "TILELANG_CACHE_DIR",
     "TILELANG_AUTO_TUNING_CPU_UTILITIES",
     "TILELANG_AUTO_TUNING_CPU_COUNTS",

--- a/tilelang/language/tensorpulse.py
+++ b/tilelang/language/tensorpulse.py
@@ -1,0 +1,27 @@
+"""TensorPulse DSL — V1.0 skeleton.
+
+Wraps ``tl.tensorpulse_*`` TIR operators registered in
+``src/op/tensorpulse.cc``. Real intrinsics (gemm_v0, set/wait_flag,
+pipe_barrier, sync_all, ...) are added incrementally as codegen lands.
+"""
+
+from __future__ import annotations
+
+from tvm import tir
+from tvm.tir import Buffer
+
+
+def add(dst: Buffer, src0: Buffer, src1: Buffer):
+    """Skeleton elementwise add: ``dst = src0 + src1``.
+
+    Emits a TIR intrinsic call to ``tl.tensorpulse_add`` that the TensorPulse
+    codegen will lower to an SMC microinstruction sequence (INTADD / FPADD /
+    FP16MUL depending on dtype).
+    """
+    return tir.call_intrin(
+        "handle",
+        tir.op.Op.get("tl.tensorpulse_add"),
+        dst.access_ptr("w"),
+        src0.access_ptr("r"),
+        src1.access_ptr("r"),
+    )

--- a/tilelang/utils/target.py
+++ b/tilelang/utils/target.py
@@ -56,47 +56,66 @@ def check_npu_availability() -> bool:
         return False
 
 
+def check_tensorpulse_availability() -> bool:
+    """
+    Check if TensorPulse hardware/toolchain is available on the system.
+
+    Detection priority:
+      1. TENSORPULSE_HOME / TENSORPULSE_HOME_PATH env var set;
+      2. torch.tensorpulse module present and reporting is_available().
+    """
+    import os
+    if os.environ.get("TENSORPULSE_HOME") or os.environ.get("TENSORPULSE_HOME_PATH"):
+        return True
+    try:
+        import torch
+        return hasattr(torch, 'tensorpulse') and torch.tensorpulse.is_available()
+    except Exception:
+        return False
+
+
 def determine_target(target: Union[str, Target, Literal["auto"]] = "auto",
                      return_object: bool = False) -> Union[str, Target]:
     """
-    Determine the appropriate target for compilation (CUDA, HIP, or manual selection).
+    Determine the appropriate target for compilation
+    (CUDA, HIP, NPU/Ascend, TensorPulse, or manual selection).
 
     Args:
         target (Union[str, Target, Literal["auto"]]): User-specified target.
-            - If "auto", the system will automatically detect whether CUDA or HIP is available.
+            - If "auto", the system will auto-detect available hardware.
             - If a string or Target, it is directly validated.
 
     Returns:
-        Union[str, Target]: The selected target ("cuda", "hip", or a valid Target object).
+        Union[str, Target]: The selected target.
 
     Raises:
-        ValueError: If no CUDA or HIP is available and the target is "auto".
+        ValueError: If no supported hardware is available and the target is "auto".
         AssertionError: If the target is invalid.
     """
 
     return_var: Union[str, Target] = target
 
     if target == "auto":
-        # Check for CUDA and HIP availability
         is_cuda_available = check_cuda_availability()
         is_hip_available = check_hip_availability()
         is_npu_available = check_npu_availability()
+        is_tensorpulse_available = check_tensorpulse_availability()
 
-        # Determine the target based on availability
         if is_cuda_available:
             return_var = "cuda"
         elif is_hip_available:
             return_var = "hip"
         elif is_npu_available:
-            # NPU (Ascend) is available, use llvm as the TVM target
-            # tilelang will handle Ascend-specific compilation internally
             return_var = "llvm --keys=ascend"
+        elif is_tensorpulse_available:
+            return_var = "llvm --keys=tensorpulse"
         else:
-            raise ValueError("No CUDA, HIP, or NPU available on this system.")
+            raise ValueError("No CUDA, HIP, NPU, or TensorPulse available on this system.")
     elif target in ["ascendc", "pto"]:
         return_var = "llvm --keys=ascend"
+    elif target == "tensorpulse":
+        return_var = "llvm --keys=tensorpulse"
     else:
-        # Validate the target if it's not "auto"
         assert isinstance(
             target, Target) or target in AVALIABLE_TARGETS, f"Target {target} is not supported"
         return_var = target


### PR DESCRIPTION
## Summary                                                                                 
  - Initial TensorPulse backend scaffold: codegen + runtime module, op registry, DSL stub,
  lowering pass, kernel-side runtime template (cc2b5f7, e2b8e8e)                             
  - macOS arm64 build fix: tilelang must link the full `tvm` library, not just `tvm_runtime`,
   to resolve `tvm::PrimExpr` / `tvm::tir::*` symbols (af6fa6d)                              
  - Hook `target.build.tilelang_tensorpulse` smoke test into the existing Ascend self-hosted
  CI runner via an opt-in `--enable-tensorpulse` flag in `install_ascend.sh`; CI lays an     
  empty `iq/iq_api.h` stub so the cmake existence check passes without shipping SMI_IQ 
  (a0ec13e)                                                                                  
                  
  ## Test plan
  - [ ] First post-merge self-hosted CI run rebuilds from scratch (cache key changed via 
  `install_ascend.sh` hash) — confirm `testing/python/test_tensorpulse_target_smoke.py`      
  passes
  - [ ] No-flag `bash install_ascend.sh` (Ascend-only path) is unchanged — no regression on  
  existing PR runs                                                                           
  - [ ] Local macOS smoke test still passes: `TVM_LIBRARY_PATH=$PWD/build/tvm python3
  testing/python/test_tensorpulse_target_smoke.py`  