### PR TITLE
[Fix] Rerun original PR checks for re-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
-on: [pull_request]
+on:
+  workflow_dispatch:
 
 jobs:
   format-check:

--- a/.github/workflows/ci_ascend.yml
+++ b/.github/workflows/ci_ascend.yml
@@ -1,6 +1,14 @@
 name: AscendC-PTO CI
 
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.png'
+      - 'docs/**'
+      - 'images/**'
+      - '.agents/**'
+      - '.gitignore'
 
 jobs:
   format-check:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -221,7 +221,7 @@ jobs:
         with:
           submodules: false
           fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || '' }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
 
       - name: Detect changed files
         if: github.event_name == 'pull_request'
@@ -412,7 +412,7 @@ jobs:
         with:
           submodules: false
           fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || '' }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
 
       - name: Check if skip pytest
         id: check_skip_pytest

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -12,6 +12,7 @@ on:
       - 'docs/**'                              # 文档目录
       - 'images/**'                            # 图片目录
       - '.agents/**'                           # Agent skill 目录
+      - '.gitignore'
 
   pull_request:
     branches:
@@ -22,6 +23,7 @@ on:
       - 'docs/**'
       - 'images/**'
       - '.agents/**'
+      - '.gitignore'
 
   # 手动触发（通过 GitHub Actions 页面点击）
   workflow_dispatch:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -46,8 +46,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  statuses: write
-  checks: write
   actions: write
   issues: write
 
@@ -69,8 +67,6 @@ jobs:
       run_examples: ${{ steps.detect_changes.outputs.run_examples || steps.default_changes.outputs.run_examples }}
       run_pytest_only: ${{ steps.detect_changes.outputs.run_pytest_only || steps.default_changes.outputs.run_pytest_only }}
       should_skip: ${{ steps.detect_changes.outputs.should_skip || steps.default_changes.outputs.should_skip }}
-      status_comment_id: ${{ steps.post_queued_status.outputs.comment_id }}
-      retest_check_run_id: ${{ steps.post_queued_status.outputs.check_run_id }}
       head_sha: ${{ steps.pr_info.outputs.head_sha }}
     steps:
       - name: Set default changes for full test events
@@ -126,58 +122,110 @@ jobs:
               body: '⚠️ This PR has been merged. Skipping tests.'
             });
 
-      - name: Post queued status for /re-test
+      - name: Submit /re-test rerun
         if: github.event_name == 'issue_comment' && github.event.issue.pull_request && steps.pr_info.outputs.merged != 'true' && contains(github.event.comment.body, '/re-test')
         id: post_queued_status
         uses: actions/github-script@v7
         with:
           script: |
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const statusContext = `${context.workflow} / Re-test Benchmark Tests (Ascend NPU)`;
-            const checkRun = await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'Re-test Benchmark Tests (Ascend NPU)',
-              head_sha: '${{ steps.pr_info.outputs.head_sha }}',
-              status: 'queued',
-              details_url: runUrl,
-              output: {
-                title: 'Re-test queued',
-                summary: `Re-test workflow run: [View details](${runUrl})`
-              }
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const headSha = '${{ steps.pr_info.outputs.head_sha }}';
+            const workflowName = context.workflow;
+            const workflowPath = '.github/workflows/ci_cd.yml';
+
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+              owner,
+              repo,
+              event: 'pull_request',
+              head_sha: headSha,
+              per_page: 100
             });
-            core.setOutput('check_run_id', checkRun.data.id);
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: '${{ steps.pr_info.outputs.head_sha }}',
-              state: 'pending',
-              context: statusContext,
-              description: 'Re-test queued',
-              target_url: runUrl
+
+            const workflowRuns = runs
+              .filter((run) =>
+                run.name === workflowName &&
+                run.path === workflowPath
+              )
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+            const latestRun = workflowRuns[0];
+
+            const currentRunUrl = `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${context.runId}`;
+            if (!latestRun) {
+              const body = `No pull_request run found for /re-test.\n\nHead SHA: \`${headSha}\`\nWorkflow run: [View details](<${currentRunUrl}>)`;
+              const comment = await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: context.issue.number,
+                body
+              });
+              core.setOutput('comment_id', comment.data.id);
+              return;
+            }
+
+            const latestRunUrl = `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${latestRun.id}`;
+            if (latestRun.status !== 'completed') {
+              const body = `Re-test is already ${latestRun.status} for the latest pull_request workflow run: [View details](<${latestRunUrl}>)`;
+              const comment = await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: context.issue.number,
+                body
+              });
+              core.setOutput('comment_id', comment.data.id);
+              return;
+            }
+
+            const rerunnableConclusions = new Set(['failure', 'cancelled', 'timed_out']);
+            if (!rerunnableConclusions.has(latestRun.conclusion)) {
+              const body = `No failed pull_request run found for /re-test.\n\nLatest run conclusion: \`${latestRun.conclusion}\`\nWorkflow run: [View details](<${latestRunUrl}>)`;
+              const comment = await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: context.issue.number,
+                body
+              });
+              core.setOutput('comment_id', comment.data.id);
+              return;
+            }
+
+            const targetRun = latestRun;
+
+            await github.rest.actions.reRunWorkflowFailedJobs({
+              owner,
+              repo,
+              run_id: targetRun.id
             });
-            const body = `⏳ **Task submitted and queued**\n\nWorkflow run: [View details](<${runUrl}>)\n\n_This message will be updated when the task starts._`;
+
+            await github.rest.reactions.createForIssueComment({
+              owner,
+              repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            });
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${targetRun.id}`;
+            const body = `Re-test submitted. Re-running failed jobs from the original pull_request workflow run: [View details](<${runUrl}>)`;
             const comment = await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner,
+              repo,
               issue_number: context.issue.number,
-              body: body
+              body
             });
             core.setOutput('comment_id', comment.data.id);
 
       - name: Checkout code
-        if: (github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)) && (steps.pr_info.outputs.merged != 'true' || github.event_name == 'pull_request')
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v4
         with:
           submodules: false
           fetch-depth: 0
-          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || '' }}
 
       - name: Detect changed files
-        if: (github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)) && (steps.pr_info.outputs.merged != 'true' || github.event_name == 'pull_request')
+        if: github.event_name == 'pull_request'
         id: detect_changes
         run: |
-          BASE_REF="${{ github.event_name == 'issue_comment' && steps.pr_info.outputs.base_ref || github.base_ref }}"
+          BASE_REF="${{ github.base_ref }}"
           git fetch origin $BASE_REF --depth=1
           changed_files=$(git diff --name-only origin/$BASE_REF HEAD)
           echo "Changed files:"
@@ -348,8 +396,7 @@ jobs:
           (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         ) ||
         (
-          (github.event_name == 'pull_request' || github.event_name == 'issue_comment') &&
-          (github.event_name != 'issue_comment' || (github.event.issue.pull_request && contains(github.event.comment.body, '/re-test'))) &&
+          github.event_name == 'pull_request' &&
           needs.check_changes.outputs.merged != 'true' &&
           needs.check_changes.outputs.should_skip != 'true'
         )
@@ -358,108 +405,18 @@ jobs:
     env:
       FULL_BUILD: ${{ github.event_name == 'schedule' || github.event.inputs.full_build == 'true' }}
     steps:
-      - name: Get PR info and check merged status
-        if: github.event_name == 'issue_comment'
-        id: pr_info
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-            core.setOutput('head_ref', pr.data.head.ref);
-            core.setOutput('head_sha', pr.data.head.sha);
-            core.setOutput('base_ref', pr.data.base.ref);
-            core.setOutput('merged', pr.data.merged);
-            core.setOutput('state', pr.data.state);
-
-      - name: React to /re-test comment
-        if: github.event_name == 'issue_comment' && steps.pr_info.outputs.merged != 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'rocket'
-            });
-
-      - name: Update status comment to running
-        if: github.event_name == 'issue_comment' && needs.check_changes.outputs.status_comment_id != ''
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const commentId = '${{ needs.check_changes.outputs.status_comment_id }}';
-            if (!commentId || commentId === '') {
-              console.log('No status comment ID, skipping update');
-              return;
-            }
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const statusContext = `${context.workflow} / Re-test Benchmark Tests (Ascend NPU)`;
-            const checkRunId = '${{ needs.check_changes.outputs.retest_check_run_id }}';
-            if (checkRunId) {
-              await github.rest.checks.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                check_run_id: parseInt(checkRunId, 10),
-                status: 'in_progress',
-                details_url: runUrl,
-                output: {
-                  title: 'Re-test running',
-                  summary: `Re-test workflow run: [View details](${runUrl})`
-                }
-              });
-            }
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: '${{ steps.pr_info.outputs.head_sha }}',
-              state: 'pending',
-              context: statusContext,
-              description: 'Re-test running',
-              target_url: runUrl
-            });
-            const body = `🚀 **Task is now running**\n\nWorkflow run: [View details](<${runUrl}>)\n\n_This message will be updated when the task completes._`;
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: parseInt(commentId),
-              body: body
-            });
-
-      - name: React to merged PR comment
-        if: github.event_name == 'issue_comment' && steps.pr_info.outputs.merged == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'confused'
-            });
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: '⚠️ This PR has been merged. Skipping tests.'
-            });
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           submodules: false
           fetch-depth: 0
-          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || '' }}
 
       - name: Check if skip pytest
         id: check_skip_pytest
-        if: github.event_name == 'pull_request' || github.event_name == 'issue_comment'
+        if: github.event_name == 'pull_request'
         run: |
-          BASE_REF="${{ github.event_name == 'issue_comment' && steps.pr_info.outputs.base_ref || github.base_ref }}"
+          BASE_REF="${{ github.base_ref }}"
           git fetch origin $BASE_REF
           changed_files=$(git diff --name-only origin/$BASE_REF HEAD)
           
@@ -492,7 +449,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: build-cache/
-          key: tilelang-build-${{ github.event_name == 'issue_comment' && steps.pr_info.outputs.base_ref || github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
+          key: tilelang-build-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
       
       # 全量编译，清理所有残留编译产物
       - name: Clean build artifacts for full build
@@ -521,7 +478,7 @@ jobs:
           
           # 确定 TEST_DIRS 参数和测试策略
           # push/schedule/workflow_dispatch 事件：全量测试
-          # PR/issue_comment 事件：根据 check_changes outputs
+          # PR 事件：根据 check_changes outputs
           if [[ "$GITHUB_EVENT_NAME" == "push" ]] || [[ "$GITHUB_EVENT_NAME" == "schedule" ]] || [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
             TEST_DIRS_ARG=""
             PYTEST_FILES_ARG=""
@@ -651,7 +608,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: build-cache/
-          key: tilelang-build-${{ github.event_name == 'issue_comment' && steps.pr_info.outputs.base_ref || github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
+          key: tilelang-build-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
           
       - name: Check pass rate
         id: check_results
@@ -785,124 +742,6 @@ jobs:
             examples/*.log
             examples/*.json
           retention-days: 30
-
-      - name: Update PR commit status (for /re-test)
-        if: always() && github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const sha = '${{ steps.pr_info.outputs.head_sha }}';
-            const jobStatus = '${{ job.status }}';
-            const status = jobStatus === 'success' ? 'success' : 'failure';
-            const statusContext = `${context.workflow} / Re-test Benchmark Tests (Ascend NPU)`;
-            const checkRunId = '${{ needs.check_changes.outputs.retest_check_run_id }}';
-            if (checkRunId) {
-              await github.rest.checks.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                check_run_id: parseInt(checkRunId, 10),
-                status: 'completed',
-                conclusion: status,
-                completed_at: new Date().toISOString(),
-                details_url: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`,
-                output: {
-                  title: `Re-test: ${status}`,
-                  summary: `Re-test workflow run: [View details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})`
-                }
-              });
-            }
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: sha,
-              state: status,
-              context: statusContext,
-              description: `Re-test: ${status}`,
-              target_url: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
-            });
-
-      - name: Update status comment with final results
-        if: always() && github.event_name == 'issue_comment' && needs.check_changes.outputs.status_comment_id != ''
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const jobStatus = '${{ job.status }}';
-            const passRate = '${{ steps.check_results.outputs.pass_rate }}' || '0';
-            const testSummary = '${{ steps.check_results.outputs.test_summary }}' || 'No summary available';
-            const commentId = '${{ needs.check_changes.outputs.status_comment_id }}';
-            
-            if (!commentId || commentId === '') {
-              console.log('No status comment ID, skipping final update');
-              return;
-            }
-            
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            
-            const statusEmoji = jobStatus === 'success' ? '✅' : (jobStatus === 'failure' ? '❌' : '⚠️');
-            const statusText = jobStatus === 'success' ? 'Completed successfully' : (jobStatus === 'failure' ? 'Failed' : 'Completed with issues');
-            
-            const body = `${statusEmoji} **Task ${statusText}**\n\n**Summary:** ${testSummary}\n\nWorkflow run: [View details](<${runUrl}>)`;
-            
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: parseInt(commentId),
-              body: body
-            });
-
-  finalize_skipped_retest:
-    name: Finalize Skipped Re-test
-    runs-on: ubuntu-latest
-    needs: check_changes
-    if: |
-      github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/re-test') &&
-      needs.check_changes.outputs.should_skip == 'true' &&
-      needs.check_changes.outputs.retest_check_run_id != ''
-    steps:
-      - name: Mark skipped re-test complete
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const statusContext = `${context.workflow} / Re-test Benchmark Tests (Ascend NPU)`;
-            const checkRunId = '${{ needs.check_changes.outputs.retest_check_run_id }}';
-            await github.rest.checks.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              check_run_id: parseInt(checkRunId, 10),
-              status: 'completed',
-              conclusion: 'skipped',
-              completed_at: new Date().toISOString(),
-              details_url: runUrl,
-              output: {
-                title: 'Re-test skipped',
-                summary: 'No testable files were modified, so the re-test was skipped.'
-              }
-            });
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: '${{ needs.check_changes.outputs.head_sha }}',
-              state: 'success',
-              context: statusContext,
-              description: 'Re-test skipped: no testable changes',
-              target_url: runUrl
-            });
-
-      - name: Update skipped re-test comment
-        if: needs.check_changes.outputs.status_comment_id != ''
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const commentId = '${{ needs.check_changes.outputs.status_comment_id }}';
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: parseInt(commentId, 10),
-              body: 'ℹ️ **Re-test skipped**\n\nNo testable files were modified.'
-            });
 
   notify:
     name: Notify Daily Test Results

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,9 +1,6 @@
 name: documentation
 
 on:
-  pull_request_target:
-    types:
-      - closed
   workflow_dispatch:
 
 permissions:
@@ -11,7 +8,7 @@ permissions:
 
 jobs:
   docs:
-    if: ${{ ((github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main') || github.event_name == 'workflow_dispatch') && false }}
+    if: ${{ false }}
     runs-on: [self-hosted]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

This follow-up changes `/re-test` from creating a separate synthetic check/status to rerunning the original `pull_request` workflow run's failed jobs directly.

Changes:
- Find the latest `TileLang-Ascend CI` `pull_request` run for the PR head SHA.
- If the latest run is still queued/in progress, report that it is already running instead of submitting a duplicate rerun.
- If the latest run is successful or otherwise not rerunnable, report that no failed PR run needs rerun.
- If the latest run failed/cancelled/timed out, call `actions.reRunWorkflowFailedJobs` so the existing PR Checks row updates through GitHub's native rerun flow.
- Remove the separate `Re-test Benchmark Tests (Ascend NPU)` check run, commit status, and skipped finalizer logic.

Redundant CI cleanup:
- Disable the old `CI` workflow on PRs because its format job is permanently skipped and the build job depends on it.
- Add path filters to `AscendC-PTO CI` for docs/images/agent metadata and `.gitignore`-only changes.
- Stop the disabled documentation workflow from triggering on closed PRs.
- Add `.gitignore` to `TileLang-Ascend CI` path ignores so harmless ignore-rule changes do not run benchmarks.

## Validation

- Ran `git diff --check` for the modified workflow files.
- Verified the workflow no longer contains `checks: write`, `statuses: write`, `retest_check_run_id`, or the old re-test status update/finalizer steps.
- Queried PR #969's head SHA through the Actions API and confirmed the latest `TileLang-Ascend CI` pull_request run is the failed run this logic would rerun.