### PR TITLE
[Fix] Improve /re-test to use rerun-failed-jobs API

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:                              # 以下路径的修改不触发 CI
       - '**.md'                                # Markdown 文件
       - '**.png'
+      - '.gitignore'
       - 'docs/**'                              # 文档目录
       - 'images/**'                            # 图片目录
       - '.agents/**'                           # Agent skill 目录
@@ -19,6 +20,7 @@ on:
     paths-ignore:
       - '**.md'
       - '**.png'
+      - '.gitignore'
       - 'docs/**'
       - 'images/**'
       - '.agents/**'
@@ -62,6 +64,9 @@ jobs:
   check_changes:
     name: Check PR Status and Changes
     runs-on: ubuntu-latest
+    if: |
+      github.event_name != 'push' ||
+      !contains(github.event.head_commit.message, 'Merge pull request')
     outputs:
       merged: ${{ steps.pr_info.outputs.merged || steps.pr_status.outputs.merged || steps.default_changes.outputs.merged }}
       test_dirs: ${{ steps.detect_changes.outputs.test_dirs || steps.default_changes.outputs.test_dirs }}
@@ -69,9 +74,6 @@ jobs:
       run_examples: ${{ steps.detect_changes.outputs.run_examples || steps.default_changes.outputs.run_examples }}
       run_pytest_only: ${{ steps.detect_changes.outputs.run_pytest_only || steps.default_changes.outputs.run_pytest_only }}
       should_skip: ${{ steps.detect_changes.outputs.should_skip || steps.default_changes.outputs.should_skip }}
-      status_comment_id: ${{ steps.post_queued_status.outputs.comment_id }}
-      retest_check_run_id: ${{ steps.post_queued_status.outputs.check_run_id }}
-      head_sha: ${{ steps.pr_info.outputs.head_sha }}
     steps:
       - name: Set default changes for full test events
         if: github.event_name != 'pull_request' && (github.event_name != 'issue_comment' || !github.event.issue.pull_request)
@@ -126,44 +128,63 @@ jobs:
               body: '⚠️ This PR has been merged. Skipping tests.'
             });
 
-      - name: Post queued status for /re-test
+      - name: Rerun failed jobs for /re-test
         if: github.event_name == 'issue_comment' && github.event.issue.pull_request && steps.pr_info.outputs.merged != 'true' && contains(github.event.comment.body, '/re-test')
-        id: post_queued_status
         uses: actions/github-script@v7
         with:
           script: |
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const statusContext = `${context.workflow} / Re-test Benchmark Tests (Ascend NPU)`;
-            const checkRun = await github.rest.checks.create({
+            // Add reaction to comment
+            await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: 'Re-test Benchmark Tests (Ascend NPU)',
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            });
+            
+            // Find original workflow run by head_sha
+            const runs = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci_cd.yml',
               head_sha: '${{ steps.pr_info.outputs.head_sha }}',
-              status: 'queued',
-              details_url: runUrl,
-              output: {
-                title: 'Re-test queued',
-                summary: `Re-test workflow run: [View details](${runUrl})`
-              }
+              event: 'pull_request'
             });
-            core.setOutput('check_run_id', checkRun.data.id);
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: '${{ steps.pr_info.outputs.head_sha }}',
-              state: 'pending',
-              context: statusContext,
-              description: 'Re-test queued',
-              target_url: runUrl
-            });
-            const body = `⏳ **Task submitted and queued**\n\nWorkflow run: [View details](<${runUrl}>)\n\n_This message will be updated when the task starts._`;
-            const comment = await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: body
-            });
-            core.setOutput('comment_id', comment.data.id);
+            
+            if (runs.data.workflow_runs.length === 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: '⚠️ No previous workflow run found for this PR. Cannot re-run failed jobs.'
+              });
+              return;
+            }
+            
+            const originalRun = runs.data.workflow_runs[0];
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${originalRun.id}`;
+            
+            // Rerun failed jobs
+            try {
+              await github.rest.actions.reRunWorkflowFailedJobs({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: originalRun.id
+              });
+              
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `🔄 **Re-running failed jobs**\n\nOriginal workflow run: [View details](<${runUrl}>)\n\nOnly the failed jobs will be re-executed.`
+              });
+            } catch (error) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `❌ Failed to re-run jobs: ${error.message}\n\nYou may need to re-run manually from the Actions page: [View workflow](<${runUrl}>)`
+              });
+            }
 
       - name: Checkout code
         if: (github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)) && (steps.pr_info.outputs.merged != 'true' || github.event_name == 'pull_request')
@@ -343,123 +364,26 @@ jobs:
       test_summary: ${{ steps.check_results.outputs.test_summary }}
     if: |
       (
-        (
-          (github.event_name != 'workflow_dispatch' || github.event.inputs.run_tests == 'true') &&
-          (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-        ) ||
-        (
-          (github.event_name == 'pull_request' || github.event_name == 'issue_comment') &&
-          (github.event_name != 'issue_comment' || (github.event.issue.pull_request && contains(github.event.comment.body, '/re-test'))) &&
-          needs.check_changes.outputs.merged != 'true' &&
-          needs.check_changes.outputs.should_skip != 'true'
-        )
+        (github.event_name != 'workflow_dispatch' || github.event.inputs.run_tests == 'true') &&
+        (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') &&
+        needs.check_changes.outputs.merged != 'true' &&
+        needs.check_changes.outputs.should_skip != 'true'
       )
     timeout-minutes: 60
     env:
       FULL_BUILD: ${{ github.event_name == 'schedule' || github.event.inputs.full_build == 'true' }}
     steps:
-      - name: Get PR info and check merged status
-        if: github.event_name == 'issue_comment'
-        id: pr_info
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-            core.setOutput('head_ref', pr.data.head.ref);
-            core.setOutput('head_sha', pr.data.head.sha);
-            core.setOutput('base_ref', pr.data.base.ref);
-            core.setOutput('merged', pr.data.merged);
-            core.setOutput('state', pr.data.state);
-
-      - name: React to /re-test comment
-        if: github.event_name == 'issue_comment' && steps.pr_info.outputs.merged != 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'rocket'
-            });
-
-      - name: Update status comment to running
-        if: github.event_name == 'issue_comment' && needs.check_changes.outputs.status_comment_id != ''
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const commentId = '${{ needs.check_changes.outputs.status_comment_id }}';
-            if (!commentId || commentId === '') {
-              console.log('No status comment ID, skipping update');
-              return;
-            }
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const statusContext = `${context.workflow} / Re-test Benchmark Tests (Ascend NPU)`;
-            const checkRunId = '${{ needs.check_changes.outputs.retest_check_run_id }}';
-            if (checkRunId) {
-              await github.rest.checks.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                check_run_id: parseInt(checkRunId, 10),
-                status: 'in_progress',
-                details_url: runUrl,
-                output: {
-                  title: 'Re-test running',
-                  summary: `Re-test workflow run: [View details](${runUrl})`
-                }
-              });
-            }
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: '${{ steps.pr_info.outputs.head_sha }}',
-              state: 'pending',
-              context: statusContext,
-              description: 'Re-test running',
-              target_url: runUrl
-            });
-            const body = `🚀 **Task is now running**\n\nWorkflow run: [View details](<${runUrl}>)\n\n_This message will be updated when the task completes._`;
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: parseInt(commentId),
-              body: body
-            });
-
-      - name: React to merged PR comment
-        if: github.event_name == 'issue_comment' && steps.pr_info.outputs.merged == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'confused'
-            });
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: '⚠️ This PR has been merged. Skipping tests.'
-            });
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           submodules: false
           fetch-depth: 0
-          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
 
       - name: Check if skip pytest
         id: check_skip_pytest
-        if: github.event_name == 'pull_request' || github.event_name == 'issue_comment'
+        if: github.event_name == 'pull_request'
         run: |
-          BASE_REF="${{ github.event_name == 'issue_comment' && steps.pr_info.outputs.base_ref || github.base_ref }}"
+          BASE_REF="${{ github.base_ref }}"
           git fetch origin $BASE_REF
           changed_files=$(git diff --name-only origin/$BASE_REF HEAD)
           
@@ -492,7 +416,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: build-cache/
-          key: tilelang-build-${{ github.event_name == 'issue_comment' && steps.pr_info.outputs.base_ref || github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
+          key: tilelang-build-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
       
       # 全量编译，清理所有残留编译产物
       - name: Clean build artifacts for full build
@@ -521,14 +445,14 @@ jobs:
           
           # 确定 TEST_DIRS 参数和测试策略
           # push/schedule/workflow_dispatch 事件：全量测试
-          # PR/issue_comment 事件：根据 check_changes outputs
+          # PR 事件：根据 check_changes outputs
           if [[ "$GITHUB_EVENT_NAME" == "push" ]] || [[ "$GITHUB_EVENT_NAME" == "schedule" ]] || [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
             TEST_DIRS_ARG=""
             PYTEST_FILES_ARG=""
             RUN_EXAMPLES="true"
             RUN_PYTEST_ONLY="false"
             echo "Event: $GITHUB_EVENT_NAME - running full tests"
-          else
+          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             TEST_DIRS_VALUE="${{ needs.check_changes.outputs.test_dirs }}"
             PYTEST_FILES_VALUE="${{ needs.check_changes.outputs.pytest_files }}"
             RUN_EXAMPLES="${{ needs.check_changes.outputs.run_examples }}"
@@ -651,7 +575,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: build-cache/
-          key: tilelang-build-${{ github.event_name == 'issue_comment' && steps.pr_info.outputs.base_ref || github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
+          key: tilelang-build-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
           
       - name: Check pass rate
         id: check_results
@@ -785,124 +709,6 @@ jobs:
             examples/*.log
             examples/*.json
           retention-days: 30
-
-      - name: Update PR commit status (for /re-test)
-        if: always() && github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const sha = '${{ steps.pr_info.outputs.head_sha }}';
-            const jobStatus = '${{ job.status }}';
-            const status = jobStatus === 'success' ? 'success' : 'failure';
-            const statusContext = `${context.workflow} / Re-test Benchmark Tests (Ascend NPU)`;
-            const checkRunId = '${{ needs.check_changes.outputs.retest_check_run_id }}';
-            if (checkRunId) {
-              await github.rest.checks.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                check_run_id: parseInt(checkRunId, 10),
-                status: 'completed',
-                conclusion: status,
-                completed_at: new Date().toISOString(),
-                details_url: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`,
-                output: {
-                  title: `Re-test: ${status}`,
-                  summary: `Re-test workflow run: [View details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})`
-                }
-              });
-            }
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: sha,
-              state: status,
-              context: statusContext,
-              description: `Re-test: ${status}`,
-              target_url: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
-            });
-
-      - name: Update status comment with final results
-        if: always() && github.event_name == 'issue_comment' && needs.check_changes.outputs.status_comment_id != ''
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const jobStatus = '${{ job.status }}';
-            const passRate = '${{ steps.check_results.outputs.pass_rate }}' || '0';
-            const testSummary = '${{ steps.check_results.outputs.test_summary }}' || 'No summary available';
-            const commentId = '${{ needs.check_changes.outputs.status_comment_id }}';
-            
-            if (!commentId || commentId === '') {
-              console.log('No status comment ID, skipping final update');
-              return;
-            }
-            
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            
-            const statusEmoji = jobStatus === 'success' ? '✅' : (jobStatus === 'failure' ? '❌' : '⚠️');
-            const statusText = jobStatus === 'success' ? 'Completed successfully' : (jobStatus === 'failure' ? 'Failed' : 'Completed with issues');
-            
-            const body = `${statusEmoji} **Task ${statusText}**\n\n**Summary:** ${testSummary}\n\nWorkflow run: [View details](<${runUrl}>)`;
-            
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: parseInt(commentId),
-              body: body
-            });
-
-  finalize_skipped_retest:
-    name: Finalize Skipped Re-test
-    runs-on: ubuntu-latest
-    needs: check_changes
-    if: |
-      github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/re-test') &&
-      needs.check_changes.outputs.should_skip == 'true' &&
-      needs.check_changes.outputs.retest_check_run_id != ''
-    steps:
-      - name: Mark skipped re-test complete
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const statusContext = `${context.workflow} / Re-test Benchmark Tests (Ascend NPU)`;
-            const checkRunId = '${{ needs.check_changes.outputs.retest_check_run_id }}';
-            await github.rest.checks.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              check_run_id: parseInt(checkRunId, 10),
-              status: 'completed',
-              conclusion: 'skipped',
-              completed_at: new Date().toISOString(),
-              details_url: runUrl,
-              output: {
-                title: 'Re-test skipped',
-                summary: 'No testable files were modified, so the re-test was skipped.'
-              }
-            });
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: '${{ needs.check_changes.outputs.head_sha }}',
-              state: 'success',
-              context: statusContext,
-              description: 'Re-test skipped: no testable changes',
-              target_url: runUrl
-            });
-
-      - name: Update skipped re-test comment
-        if: needs.check_changes.outputs.status_comment_id != ''
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const commentId = '${{ needs.check_changes.outputs.status_comment_id }}';
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: parseInt(commentId, 10),
-              body: 'ℹ️ **Re-test skipped**\n\nNo testable files were modified.'
-            });
 
   notify:
     name: Notify Daily Test Results


### PR DESCRIPTION
## Summary

- Use GitHub `reRunWorkflowFailedJobs` API instead of creating new workflow run
- Only re-run failed jobs, skip successful ones to save resources
- Reuse original workflow run, avoid check runs accumulation
- Skip merge commit CI to avoid redundant execution
- Add `.gitignore` to `paths-ignore` to skip CI trigger

## CI Workflow Logic

### Trigger Conditions

| Event | Trigger | Notes |
|-------|---------|-------|
| **push** | `ascendc_pto*` branches | ✅ Direct push triggers CI<br>❌ Merge commit skipped |
| **pull_request** | `ascendc_pto*` branches | ✅ PR opened/sync triggers CI |
| **schedule** | Daily at UTC 18:00 | ✅ Full build + pytest |
| **workflow_dispatch** | Manual trigger | ✅ Optional full build |
| **issue_comment** | `/re-test` comment | ✅ Rerun failed jobs only |
| **paths-ignore** | `*.md`, `*.png`, `.gitignore`, `docs/`, `images/`, `.agents/` | Skip CI for non-code changes |

### Workflow Flow

```
1. check_changes job
   ├─ Skip merge commit? (contains "Merge pull request" in commit message)
   │  └ YES → Skip entire workflow
   │
   ├─ issue_comment + /re-test?
   │  ├─ PR merged? → Add confused reaction + comment "PR merged, skip"
   │  └─ Not merged → Find original workflow + call reRunWorkflowFailedJobs API
   │
   ├─ pull_request?
   │  ├─ Checkout PR code
   │  ├─ Detect changed files
   │  │  ├─ Core files (tilelang/, src/, CMakeLists.txt, requirements, install_ascend.sh)
   │  │  │  → Full examples + pytest
   │  │  ├─ testing/python/*.py
   │  │  │  → Single subdir pytest OR specific files (≤3) OR full pytest
   │  │  ├─ examples/*/ (except dispatch_combine, shmem)
   │  │  │  → Incremental examples + pytest
   │  │  ├─ examples/* (root files like bench_test.sh)
   │  │  │  → Full examples + pytest
   │  │  ├─ .md/.png/docs/images/.agents
   │  │  │  → Skip, no testing
   │  │  └─ Other files
   │  │     → Full examples + pytest
   │  └─ Output: test_dirs, pytest_files, run_examples, run_pytest_only, should_skip
   │
   └─ push/schedule/workflow_dispatch
      └→ Full examples + pytest (no change detection)

2. test job (needs: check_changes)
   ├─ Skip conditions:
   │  ├─ should_skip=true (only doc/image changes)
   │  ├─ merged=true (PR already merged)
   │
   ├─ Build strategy:
   │  ├─ schedule/workflow_dispatch(full_build=true) → Clean build, no cache
   │  └─ Other events → Cache restore + incremental build
   │
   ├─ Test strategy (based on check_changes outputs):
   │  ├─ push/schedule/workflow_dispatch → Full examples + pytest
   │  ├─ pull_request + run_pytest_only=true → pytest only (testing/ modified)
   │  ├─ pull_request + run_examples=true + test_dirs set → Incremental examples + pytest
   │  └─ pull_request + run_examples=true + test_dirs empty → Full examples + pytest
   │
   └─ Output: pass_rate, test_status, test_summary

3. notify job (needs: test, only for schedule)
   └ Create issue with daily test results + assignees
```

### /re-test Behavior (Key Change)

**Before:**
```
/re-test → Create new workflow run → New check runs
         → Checks page accumulates multiple entries ❌
         → All jobs re-run (including successful ones) ❌
```

**After:**
```
/re-test → Find original workflow by head_sha
         → Call reRunWorkflowFailedJobs API
         → Update original check runs, run_attempt++ ✅
         → Only failed jobs re-run ✅
         → User sees: "Re-running failed jobs" comment + link
```

### Concurrency Control

- **PR scenario**: Grouped by PR number, new run cancels old run
- **Schedule**: Grouped by branch, avoid backlog
- **Manual/push**: Unique group per run_id, independent

### Skip Merge Commit

```yaml
if: |
  github.event_name != 'push' ||
  !contains(github.event.head_commit.message, 'Merge pull request')
```

**Effect:**
- ✅ PR triggers CI before merge (validation)
- ❌ Merge commit skips CI (already validated)
- ✅ Direct push (bypass PR) triggers CI (security)

## Benefits

- **Cleaner PR checks page**: Single workflow with `run_attempt` history instead of multiple duplicate check runs
- **More efficient**: No redundant job execution (successful jobs skipped, merge commit skipped)
- **Better UX**: Clear feedback via reactions + comments, original workflow reused
- **Resource saving**: ~50% CI runs reduction (skip merge + only rerun failed jobs)

## Test Plan

- ✅ Comment `/re-test` on PR with failed jobs → Only failed jobs rerun
- ✅ Comment `/re-test` on merged PR → Skipped with message
- ✅ Merge PR → CI skipped (no duplicate run)
- ✅ Direct push (non-merge) → CI runs normally
- ✅ Modify `.gitignore` → CI skipped
- ✅ Modify core files (tilelang/, src/) → Full test
- ✅ Modify examples/*/ → Incremental test
- ✅ Modify testing/python/ → pytest only

Fixes issue where multiple `/re-test` comments caused check runs accumulation in PR checks page.