### PR TITLE
[Feat] Support L0C -> GM atomic add 🤖

### DIFF
--- a/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-compute.md
+++ b/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-compute.md
@@ -305,15 +305,21 @@ T.tile.cast(b_ub, a_ub, "CAST_RINT", 4096)
 **V1 支持范围**：
 
 - `dst` 必须是 GM/global buffer、buffer load 或 region
-- `src` 必须是本地 tensor，当前主要面向 UB/shared buffer
+- `src` 必须是本地 tensor，当前主要面向 UB/shared buffer 和 L0C/fragment buffer
 - `src` 与 `dst` dtype 必须一致
 - 支持 1D 和 2D tile region 的 local -> GM 原子累加
 - 不支持 `return_prev`、`memory_order`、`use_tma`、常量 src 或任意表达式 src
+
+**支持的数据类型**：
+
+int8, int16, float16, bfloat16, int32, float32
 
 **使用建议**：
 
 - 如果业务语义是从 0 开始累加，调用 kernel 前或 kernel 内需要显式清零 GM 输出。
 - 在混合模式下可配合自动同步和内存规划使用，不要求手写 `T.Scope("V")` 或 `T.barrier_all()`。
+
+**UB -> GM 示例**：
 
 ```python
 pass_configs = {
@@ -326,6 +332,18 @@ T.tile.fill(src_ub, 1.0)
 T.tile.atomic_add(C[0], src_ub)
 ```
 示例中的pass_config只是最小用法。在混合模式或需要自动 C/V 分离时，可以同时开启 `TL_ASCEND_AUTO_CV_COMBINE`；如果存在 C/V 核间依赖，再配合 `TL_ASCEND_AUTO_CV_SYNC`。
+
+**L0C -> GM 示例**：
+
+适用于矩阵计算结果需要原子累加到 GM 的场景，如多 block/core 的 GEMM 累加。
+
+```python
+src_l0c = T.alloc_L0C((block_M, block_N), dtype)
+T.gemm_v0(..., ..., src_l0c, init=True)
+T.tile.atomic_add(C[..., ...], src_l0c)
+```
+
+**底层实现**：
 
 底层会生成 Ascend C 的 DMA atomic add 语义：开启 `SetAtomicAdd<T>()`，执行 local -> GM 的 `DataCopyPad`，再通过兼容 helper 关闭 atomic 状态。
 ### 4.11 排序操作

--- a/docs/TileLang-Ascend Programming Guide.md
+++ b/docs/TileLang-Ascend Programming Guide.md
@@ -1285,7 +1285,7 @@ Expert编程模式可以复用Developer模式的Reduce类计算原语。
 | 异或       | T.tile.bitwise_xor(dst, src0, src1)      | element-wise bitwise XOR，dst = src0 ^ src1                  |
 | 左移       | T.tile.bitwise_lshift(dst, src0, scalar) | element-wise 左移操作                                        |
 | 右移       | T.tile.bitwise_rshift(dst, src0, scalar) | element-wise 右移操作                                        |
-| 原子累加   | T.tile.atomic_add(dst, src)              | 将本地 tensor 原子累加到 GM，V1 支持 local/UB → GM           |
+| 原子累加   | T.tile.atomic_add(dst, src)              | 将本地 tensor 原子累加到 GM，V1 支持 UB → GM 和 L0C -> GM        |
 
 **(1) 基础算术**
 
@@ -2010,7 +2010,7 @@ Expert编程模式可以复用Developer模式的Reduce类计算原语。
   **参数**：
 
   - dst：GM 目标 buffer、buffer load 或 region
-  - src：本地 tensor，当前主要支持 UB/shared buffer
+  - src：本地 tensor，当前支持 UB/shared buffer 和 L0C/fragment buffer 
 
   **功能**：将本地 tensor tile 原子累加到 GM 目标区域。该接口是 Ascend 专属的 `T.tile` 原语，不等价于主仓 GPU 风格的全局 `T.atomic_add`。V1 只支持 local/UB 到 GM 的原子累加，不支持 `return_prev`、`memory_order`、`use_tma`、常量 src 或任意表达式 src。
 
@@ -2018,6 +2018,7 @@ Expert编程模式可以复用Developer模式的Reduce类计算原语。
 
   **举例**：
 
+  - UB -> GM
   ```python
   pass_configs = {
       tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
@@ -2027,6 +2028,13 @@ Expert编程模式可以复用Developer模式的Reduce类计算原语。
   src_ub = T.alloc_ub((tile_n,), "float32")
   T.tile.fill(src_ub, 1.0)
   T.tile.atomic_add(C[0], src_ub)
+  ```
+  
+  - L0C -> GM
+  ```python
+  src_l0c = T.alloc_L0C((block_M, block_N), dtype)
+  T.gemm_v0(..., ..., src_l0c, init=True)
+  T.tile.atomic_add(C[..., ...], src_l0c)
   ```
 
   **注意事项**：

--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -602,7 +602,9 @@ Stmt AscendAtomicAdd::Lower(const LowerArgs &T,
     ss << ">";
   } else if (src.scope() == "wmma.accumulator") {
     ss << "tl::ascend::atomic_add_l0c_to_gm<";
-    ss << get_dtype(src) << ", " << get_dtype(dst) << ", layout::RowMajor";
+    ss << get_dtype(src) << ", " << get_dtype(dst) << ", "
+       << (T.layout_map.count(src) ? T.layout_map[src]->AscendLayoutStr()
+                                   : "layout::RowMajor");
     if (src->shape.size() > 1) {
       ss << ", " << compute_blocklen(src, src_extents) << ", "
          << src_extents[src->shape.size() - 1];

--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -574,8 +574,10 @@ Stmt AscendAtomicAdd::Lower(const LowerArgs &T,
 
   ICHECK(dst.scope() == "global")
       << "tl.ascend_atomic_add V1 requires global dst, got " << dst.scope();
-  ICHECK(src.scope() == "shared")
-      << "tl.ascend_atomic_add V1 requires UB/shared src, got " << src.scope();
+  ICHECK(src.scope() == "shared" || src.scope() == "wmma.accumulator")
+      << "tl.ascend_atomic_add V1 requires UB/shared or L0C/wmma.accumulator "
+         "src, got "
+      << src.scope();
   ICHECK(src->dtype == dst->dtype)
       << "tl.ascend_atomic_add requires src and dst dtype to match, got src "
       << src->dtype << " and dst " << dst->dtype;
@@ -591,12 +593,24 @@ Stmt AscendAtomicAdd::Lower(const LowerArgs &T,
       << src_extents.size() << " and dst " << dst_extents.size();
 
   std::stringstream ss;
-  ss << "tl::ascend::atomic_add_ub_to_gm<";
-  ss << get_dtype(dst) << ", " << src_extents[src->shape.size() - 1];
-  if (src->shape.size() > 1) {
-    ss << ", " << compute_blocklen(src, src_extents);
+  if (src.scope() == "shared") {
+    ss << "tl::ascend::atomic_add_ub_to_gm<";
+    ss << get_dtype(dst) << ", " << src_extents[src->shape.size() - 1];
+    if (src->shape.size() > 1) {
+      ss << ", " << compute_blocklen(src, src_extents);
+    }
+    ss << ">";
+  } else if (src.scope() == "wmma.accumulator") {
+    ss << "tl::ascend::atomic_add_l0c_to_gm<";
+    ss << get_dtype(src) << ", " << get_dtype(dst) << ", layout::RowMajor";
+    if (src->shape.size() > 1) {
+      ss << ", " << compute_blocklen(src, src_extents) << ", "
+         << src_extents[src->shape.size() - 1];
+    } else {
+      ss << ", 1, " << src_extents[src->shape.size() - 1];
+    }
+    ss << ">";
   }
-  ss << ">";
 
   auto src_indices = build_indices(src_range);
   auto dst_indices = build_indices(dst_range);

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -439,7 +439,8 @@ void CodeGenTileLangAscend::VisitExpr_(const CallNode *op, std::ostream &os) {
   if (op->op.same_as(builtin::call_extern())) {
     std::string op_name = Downcast<StringImm>(op->args[0])->value;
     if (op_name.find("tl::ascend::copy") != std::string::npos ||
-        op_name.find("tl::ascend::atomic_add_ub_to_gm") != std::string::npos) {
+        op_name.find("tl::ascend::atomic_add_ub_to_gm") != std::string::npos ||
+        op_name.find("tl::ascend::atomic_add_l0c_to_gm") != std::string::npos) {
       CopyCodegen(op);
     } else if (op_name == "npu.fill") {
       this->PrintIndent();
@@ -2258,9 +2259,11 @@ void CodeGenTileLangAscend::CopyCodegen(const CallNode *op) {
   auto dst_type = GetAccessPtrDtype(op->args[2].as<CallNode>());
 
   static const std::unordered_map<std::string, int> kCopyOpExtraArgs = {
-      {"copy_l0c_to_gm", 3},      {"copy_gm_to_l1", 3}, {"copy_l1_to_l0a", 2},
-      {"copy_l1_to_l0b", 2},      {"copy_gm_to_ub", 4}, {"copy_ub_to_gm", 3},
-      {"atomic_add_ub_to_gm", 3}, {"copy_ub_to_ub", 0}};
+      {"copy_l0c_to_gm", 3},      {"copy_gm_to_l1", 3},
+      {"copy_l1_to_l0a", 2},      {"copy_l1_to_l0b", 2},
+      {"copy_gm_to_ub", 4},       {"copy_ub_to_gm", 3},
+      {"atomic_add_ub_to_gm", 3}, {"atomic_add_l0c_to_gm", 3},
+      {"copy_ub_to_ub", 0}};
 
   bool found = false;
   int extra_args = 0;

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -240,6 +240,18 @@ atomic_add_ub_to_gm(GlobalTensor<T> dstTensor, LocalTensor<T> srcTensor,
   disable_dma_atomic_compat();
 }
 
+template <typename T1, typename T2, typename LayoutGM, uint32_t srcM,
+          uint32_t srcN, bool enRelu = false>
+CATLASS_DEVICE void
+atomic_add_l0c_to_gm(GlobalTensor<T2> dstTensor, LocalTensor<T1> srcTensor,
+                     uint32_t realDstN = 1, uint32_t realTailM = 0,
+                     uint32_t realTailN = 0) {
+  AscendC::SetAtomicAdd<T2>();
+  copy_l0c_to_gm<T1, T2, LayoutGM, srcM, srcN, enRelu>(
+      dstTensor, srcTensor, realDstN, realTailM, realTailN);
+  disable_dma_atomic_compat();
+}
+
 template <typename T1, typename T2, uint32_t len>
 CATLASS_DEVICE void copy_ub_to_ub(LocalTensor<T1> dstTensor,
                                   LocalTensor<T2> srcTensor) {

--- a/src/transform/ascend_combinecv.cc
+++ b/src/transform/ascend_combinecv.cc
@@ -171,6 +171,7 @@ private:
           {"copy_gm_to_ub", {false, "MTE2"}},
           {"copy_ub_to_gm", {true, "MTE3"}},
           {"atomic_add_ub_to_gm", {true, "MTE3"}},
+          {"atomic_add_l0c_to_gm", {true, "FIX"}},
       };
 
   std::optional<std::pair<bool, std::string>>
@@ -787,13 +788,21 @@ private:
   bool current_proccess_switch_ = false;
   Map<Var, String> &location_map_;
   std::unordered_map<std::string, std::string> callnodeMapPos_ = {
-      {"copy_gm_to_l1", "cube"},  {"gemm_v0", "cube"},
-      {"copy_11_to_l0a", "cube"}, {"copy_11_to_l0b", "cube"},
-      {"copy_l0c_to_gm", "cube"}, {"copy_gm_to_ub", "vec"},
-      {"copy_ub_to_gm", "vec"},   {"atomic_add_ub_to_gm", "vec"},
-      {"copy_ub_to_ub", "vec"},   {"wmma.matrix_a", "cube"},
-      {"wmma.matrix_b", "cube"},  {"wmma.accumulator", "cube"},
-      {"shared.dyn", "cube"},     {"shared", "vec"}};
+      {"copy_gm_to_l1", "cube"},
+      {"gemm_v0", "cube"},
+      {"copy_11_to_l0a", "cube"},
+      {"copy_11_to_l0b", "cube"},
+      {"copy_l0c_to_gm", "cube"},
+      {"copy_gm_to_ub", "vec"},
+      {"copy_ub_to_gm", "vec"},
+      {"atomic_add_ub_to_gm", "vec"},
+      {"atomic_add_l0c_to_gm", "cube"},
+      {"copy_ub_to_ub", "vec"},
+      {"wmma.matrix_a", "cube"},
+      {"wmma.matrix_b", "cube"},
+      {"wmma.accumulator", "cube"},
+      {"shared.dyn", "cube"},
+      {"shared", "vec"}};
 };
 
 class CombineCV : public arith::IRMutatorWithAnalyzer {

--- a/src/transform/ascend_combinecv.cc
+++ b/src/transform/ascend_combinecv.cc
@@ -790,8 +790,8 @@ private:
   std::unordered_map<std::string, std::string> callnodeMapPos_ = {
       {"copy_gm_to_l1", "cube"},
       {"gemm_v0", "cube"},
-      {"copy_11_to_l0a", "cube"},
-      {"copy_11_to_l0b", "cube"},
+      {"copy_l1_to_l0a", "cube"},
+      {"copy_l1_to_l0b", "cube"},
       {"copy_l0c_to_gm", "cube"},
       {"copy_gm_to_ub", "vec"},
       {"copy_ub_to_gm", "vec"},

--- a/src/transform/common/operation_config.h
+++ b/src/transform/common/operation_config.h
@@ -51,6 +51,7 @@ GetOperationConfig() {
       {"copy_l1_to_l0b", {{{0, "read"}, {1, "write"}}, "PIPE_MTE1"}},
       {"copy_ub_to_gm", {{{0, "read"}, {1, "write"}}, "PIPE_MTE3"}},
       {"atomic_add_ub_to_gm", {{{0, "read"}, {1, "write"}}, "PIPE_MTE3"}},
+      {"atomic_add_l0c_to_gm", {{{0, "read"}, {1, "write"}}, "PIPE_FIX"}},
       {"copy_ub_to_l1", {{{0, "read"}, {1, "write"}}, "PIPE_MTE3"}},
       {"copy_l0c_to_gm", {{{0, "read"}, {1, "write"}}, "PIPE_FIX"}},
       {"copy_l0c_to_l1", {{{0, "read"}, {1, "write"}}, "PIPE_FIX"}},

--- a/src/transform/cross_core_pipeline.cc
+++ b/src/transform/cross_core_pipeline.cc
@@ -210,7 +210,8 @@ public:
   };
 
   const std::vector<std::string> IS_WRITE_GM = {
-      "copy_l0c_to_gm", "copy_ub_to_gm", "atomic_add_ub_to_gm"};
+      "copy_l0c_to_gm", "copy_ub_to_gm", "atomic_add_l0c_to_gm",
+      "atomic_add_ub_to_gm"};
 
   LoopAnalyzer(const ForNode *pipeline_loop,
                const Map<Var, String> location_map)

--- a/testing/python/language/test_tilelang_ascend_language_tile_atomic_add.py
+++ b/testing/python/language/test_tilelang_ascend_language_tile_atomic_add.py
@@ -8,6 +8,7 @@ import tilelang.language as T
 PASS_CONFIGS = {
     tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
     tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
 }
 
 VEC_NUM = 2
@@ -15,7 +16,7 @@ VEC_NUM = 2
 
 @pytest.fixture(scope="session", autouse=True)
 def clear_cache():
-    tilelang.cache.clear_cache()
+    tilelang.disable_cache()
     yield
 
 
@@ -104,3 +105,72 @@ def test_tile_atomic_add_2d_region_accumulates_multiple_blocks_after_zeroing_gm(
         dtype=dtype,
     )
     _run_atomic_add_case(program, (tile_m, tile_n), dtype, num_blocks)
+
+
+def _tile_atomic_add_l0c_gemm_kernel(num_blocks=4, block_M=16, block_N=16, block_K=16, dtype="float16", accum_dtype="float"):
+    """Test L0C atomic_add with GEMM"""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((block_M, block_K), dtype),  # type: ignore
+        B: T.Tensor((block_K, block_N), dtype),  # type: ignore
+        C: T.Tensor((block_M, block_N), accum_dtype),  # type: ignore
+    ):
+        with T.Kernel(num_blocks, is_npu=True) as (cid, vid):
+            A_L1 = T.alloc_L1((block_M, block_K), dtype)
+            B_L1 = T.alloc_L1((block_K, block_N), dtype)
+            C_L0 = T.alloc_L0C((block_M, block_N), accum_dtype)
+
+            T.copy(A, A_L1)
+            T.copy(B, B_L1)
+
+            T.gemm_v0(A_L1, B_L1, C_L0, init=True)
+
+            T.tile.atomic_add(C, C_L0)
+
+    return main
+
+
+def _run_atomic_add_l0c_gemm_case(program, block_M, block_N, block_K, dtype, accum_dtype, num_blocks):
+    kernel = _compile(program)
+    torch_dtype = _torch_dtype(dtype)
+    torch_accum_dtype = _torch_dtype(accum_dtype)
+
+    # all-one matrix
+    a = torch.ones((block_M, block_K), dtype=torch_dtype, device="npu")
+    b = torch.ones((block_K, block_N), dtype=torch_dtype, device="npu")
+
+    c = torch.empty((block_M, block_N), dtype=torch_accum_dtype, device="npu")
+    c.zero_()
+    torch.npu.synchronize()
+
+    kernel(a, b, c)
+    torch.npu.synchronize()
+
+    expected_value = num_blocks * block_K  # for every value in c
+    expected = torch.full((block_M, block_N), expected_value, dtype=torch_accum_dtype, device="npu")
+
+    torch.testing.assert_close(c, expected, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="tile atomic_add correctness requires an Ascend NPU runtime",
+)
+@pytest.mark.parametrize("dtype", ["float16"])
+def test_tile_atomic_add_l0c_gemm_accumulates_multiple_blocks(dtype):
+    num_blocks = 4
+    block_M = 16
+    block_N = 16
+    block_K = 16
+    accum_dtype = "float"
+
+    program = _tile_atomic_add_l0c_gemm_kernel(
+        num_blocks=num_blocks,
+        block_M=block_M,
+        block_N=block_N,
+        block_K=block_K,
+        dtype=dtype,
+        accum_dtype=accum_dtype,
+    )
+    _run_atomic_add_l0c_gemm_case(program, block_M, block_N, block_K, dtype, accum_dtype, num_blocks)


### PR DESCRIPTION
## Summary

Extend T.tile.atomic_add to support L0C/fragment buffer as source, enabling atomic accumulation from matrix computation results to GM.

## Changes

- Add atomic_add_l0c_to_gm helper function
- Update lowering and codegen for L0C atomic add
- Add test case for L0C atomic add with GEMM
- Update documentation

## Testing

Run: `pytest testing/python/language/test_tilelang_ascend_language_tile_atomic_add.py::test_tile_atomic_add_l0c_gemm_accumulates_multiple_blocks`