### PR TITLE
[codex] Remove invalid daily test assignee

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -793,7 +793,7 @@ jobs:
             ---
             
             *This issue was automatically created by the daily scheduled test.*
-            *Assignees: @benyang0506, @fuhouyu-hw, @z00520135, @lwwangcgz*`;
+            *Assignees: @benyang0506, @fuhouyu-hw, @z00520135*`;
             
             const title = `[Daily Test] ${statusEmoji} ${testSummary} - ${runDate}`;
             
@@ -802,6 +802,6 @@ jobs:
               repo: context.repo.repo,
               title: title,
               body: body,
-              assignees: ['benyang0506', 'fuhouyu-hw', 'z00520135', 'lwwangcgz'],
+              assignees: ['benyang0506', 'fuhouyu-hw', 'z00520135'],
               labels: ['daily-test', testStatus === 'passed' ? 'test-passed' : 'test-failed']
             });


### PR DESCRIPTION
﻿## Summary
- remove `lwwangcgz` from the daily scheduled test issue assignee list
- keep the generated issue body aligned with the actual assignees

## Why
The scheduled CI notification failed to create an issue because GitHub rejected `lwwangcgz` as an assignee with a 422 validation error. Removing the invalid assignee lets the daily report issue be created successfully.

## Validation
- `git diff --check HEAD~1 HEAD`
