### PR TITLE
[Fix] Align pytest skip ignores 🤖

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -392,6 +392,14 @@ jobs:
           skip_pytest=true
           
           for file in $changed_files; do
+            if [[ "$file" =~ ^\.agents/ ]]; then
+              echo "Agents skill file: $file - ignored for pytest skip check"
+              continue
+            fi
+            if [[ "$file" =~ \.md$ ]] || [[ "$file" =~ \.png$ ]]; then
+              echo "Doc/image file: $file - ignored for pytest skip check"
+              continue
+            fi
             if [[ ! "$file" =~ ^examples/ ]]; then
               echo "File outside examples/: $file"
               skip_pytest=false


### PR DESCRIPTION
## Summary

Align the pytest skip check with the existing changed-file ignore rules.

## Changes

- Ignore `.agents/` files when deciding whether `bench_test.sh` can use `--skip-pytest`.
- Ignore `.md` and `.png` files in the same skip check.

## Root Cause

PR #957 added `.agents/` and docs/image ignores to workflow triggers and `check_changes`, but `Check if skip pytest` had a separate `git diff` loop that still treated `.agents/` files as outside `examples/`, which forced `skip_pytest=false`.

## Testing

- `git diff --check upstream/ascendc_pto...HEAD`