### PR TITLE
[Feature] Add workspace reduction pass for Ascend NPU

### DIFF
--- a/examples/developer_mode/flash_attn_bshd_developer.py
+++ b/examples/developer_mode/flash_attn_bshd_developer.py
@@ -18,7 +18,7 @@ pass_configs = {
 }
 
 
-@tilelang.jit(out_idx=[3], workspace_idx=[4, 5, 6], pass_configs=pass_configs)
+@tilelang.jit(out_idx=[3], pass_configs=pass_configs)
 def flash_attention_fwd(
     heads,
     dim,
@@ -43,9 +43,6 @@ def flash_attention_fwd(
         K: T.Tensor(shape, dtype),  # type: ignore
         V: T.Tensor(shape, dtype),  # type: ignore
         Output: T.Tensor(shape, dtype),  # type: ignore
-        workspace_1: T.Tensor([block_num, block_M, block_N], accum_dtype),
-        workspace_2: T.Tensor([block_num, block_M, block_N], dtype),
-        workspace_3: T.Tensor([block_num, block_M, dim], accum_dtype),
     ):
         with T.Kernel(block_num, threads=2, is_npu=True) as (cid):
             bx = cid % (seq_len // block_M)
@@ -82,11 +79,10 @@ def flash_attention_fwd(
                 # acc_s_l0c = Q @ K^T
                 T.copy(K[bz, by, k * block_N : (k + 1) * block_N, :], k_l1)
                 T.gemm_v0(q_l1, k_l1, acc_s_l0c, transpose_B=True, init=True)
-                T.copy(acc_s_l0c, workspace_1[cid, :, :])
+                T.copy(acc_s_l0c, acc_s_ub_)
 
                 T.tile.fill(acc_s_ub, 0.0)
                 T.copy(m_i, m_i_prev)
-                T.copy(workspace_1[cid, 0:block_M, :], acc_s_ub_)
                 T.tile.add(acc_s_ub, acc_s_ub, acc_s_ub_)
                 # scale
                 T.tile.mul(acc_s_ub, acc_s_ub, sm_scale)
@@ -107,17 +103,15 @@ def flash_attention_fwd(
 
                 # softmax(S_scaled) @ V
                 T.copy(acc_s_ub, acc_s_half)
-                T.copy(acc_s_half, workspace_2[cid, 0:block_M, :])
+                T.copy(acc_s_half, acc_s_l1)
 
-                T.copy(workspace_2[cid, :, :], acc_s_l1)
                 T.copy(V[bz, by, k * block_N : (k + 1) * block_N, :], v_l1)
                 T.gemm_v0(acc_s_l1, v_l1, acc_o_l0c, init=True)
-                T.copy(acc_o_l0c, workspace_3[cid, :, :])
+                T.copy(acc_o_l0c, acc_o_ub)
 
                 # update history acc_o
                 for h_i in range(block_M):
                     T.tile.mul(acc_o[h_i, :], acc_o[h_i, :], m_i_prev[h_i])
-                T.copy(workspace_3[cid, 0:block_M, :], acc_o_ub)
                 T.tile.add(acc_o, acc_o, acc_o_ub)
 
             # normalization

--- a/examples/developer_mode/matmul_add_developer.py
+++ b/examples/developer_mode/matmul_add_developer.py
@@ -24,7 +24,7 @@ N = args.n
 K = args.k
 
 
-@tilelang.jit(out_idx=[2], workspace_idx=4, pass_configs=pass_configs)
+@tilelang.jit(out_idx=[2], pass_configs=pass_configs)
 def matmul_add(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="float"):
     m_num = M // block_M
     n_num = N // block_N
@@ -35,7 +35,6 @@ def matmul_add(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype=
         B: T.Tensor((K, N), dtype),
         C: T.Tensor((M, N), dtype),
         D: T.Tensor((M, N), dtype),
-        workspace: T.Tensor((M, N), dtype),
     ):
         with T.Kernel(m_num * n_num, threads=2, is_npu=True) as (cid):
             bx = cid // n_num
@@ -58,9 +57,7 @@ def matmul_add(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype=
                 else:
                     T.gemm_v0(A_L1, B_L1, C_L0)
 
-            T.copy(C_L0, workspace[bx * block_M, by * block_N])
-
-            T.copy(workspace[bx * block_M, by * block_N], c_ub)
+            T.copy(C_L0, c_ub)
             T.copy(D[bx * block_M, by * block_N], d_ub)
 
             T.tile.add(c_ub, c_ub, d_ub)

--- a/examples/developer_mode/sparse_flash_attn_developer_vid_reduce.py
+++ b/examples/developer_mode/sparse_flash_attn_developer_vid_reduce.py
@@ -15,7 +15,7 @@ pass_configs = {
 }
 
 
-@tilelang.jit(out_idx=[3], workspace_idx=[4, 5, 6, 7, 8], pass_configs=pass_configs)
+@tilelang.jit(out_idx=[3], pass_configs=pass_configs)
 def sparse_attention_fwd(
     heads,
     dim,
@@ -80,12 +80,6 @@ def sparse_attention_fwd(
         KV: T.Tensor(kv_shape, dtype),  # type: ignore
         Indices: T.Tensor(indices_shape, indices_dtype),  # type: ignore
         Output: T.Tensor(o_shape, dtype),  # type: ignore
-        # TODO: implement automatically
-        workspace_1: T.Tensor([block_num, BI, D], dtype),
-        workspace_2: T.Tensor([block_num, BI, D_tail], dtype),
-        workspace_3: T.Tensor([block_num, H_per_block, BI], accum_dtype),
-        workspace_4: T.Tensor([block_num, H_per_block, BI], dtype),
-        workspace_5: T.Tensor([block_num, H_per_block, D], accum_dtype),
     ):
         with T.Kernel(block_num, threads=2, is_npu=True) as (cid):
             bx = cid % (seq_len * REPLICATE_H)
@@ -130,32 +124,27 @@ def sparse_attention_fwd(
             T.tile.fill(sumexp, 0.0)
             T.tile.fill(m_i, -(2.0**30))
             for i_i in T.serial(NI):
-                T.copy(workspace_1[cid, 0:BI, 0:D], kv_l1)
-                T.copy(workspace_2[cid, 0:BI, 0:D_tail], kv_tail_l1)
-
                 T.gemm_v0(q_l1, kv_l1, acc_s_l0c, transpose_B=True, init=True)
                 T.gemm_v0(q_tail_l1, kv_tail_l1, acc_s_l0c, transpose_B=True)
 
-                T.copy(acc_s_l0c, workspace_3[cid, 0:H_per_block, 0:BI])
-                T.copy(workspace_4[cid, 0:H_per_block, 0:BI], acc_s_l1)
+                T.copy(acc_s_l0c, acc_s_ub_)
 
                 T.gemm_v0(acc_s_l1, kv_l1, acc_o_l0c, init=True)
 
-                T.copy(acc_o_l0c, workspace_5[cid, 0:H_per_block, 0:D])
+                T.copy(acc_o_l0c, acc_o_ub)
 
                 T.copy(Indices[b_i, s_i, g_i, i_i * BI : i_i * BI + BI], indices_ub_)
 
                 for bi_i in range(BI):
                     T.copy(KV[b_i, indices_ub_[bi_i], g_i, :D], kv_ub)
                     T.copy(KV[b_i, indices_ub_[bi_i], g_i, D:], kv_tail_ub)
-                    T.copy(kv_ub, workspace_1[cid, bi_i, :])
-                    T.copy(kv_tail_ub, workspace_2[cid, bi_i, :])
+                    T.copy(kv_ub, kv_l1[bi_i, :])
+                    T.copy(kv_tail_ub, kv_tail_l1[bi_i, :])
 
                 T.tile.fill(acc_s_ub, 0.0)
 
                 T.copy(m_i, m_i_prev)
 
-                T.copy(workspace_3[cid, 0:v_block, :], acc_s_ub_)
 
                 for i, j in T.Parallel(v_block, BI):
                     acc_s_ub[i, j] = acc_s_ub[i, j] + acc_s_ub_[i, j]
@@ -185,9 +174,7 @@ def sparse_attention_fwd(
 
                 T.copy(acc_s_ub, acc_s_half)
 
-                T.copy(acc_s_half, workspace_4[cid, 0:v_block, :])
-
-                T.copy(workspace_5[cid, 0:v_block, :], acc_o_ub)
+                T.copy(acc_s_half, acc_s_l1)
 
                 for i, j in T.Parallel(v_block, D):
                     acc_o[i, j] += acc_o_ub[i, j]

--- a/examples/developer_mode/sparse_flash_attn_developer_vid_reduce.py
+++ b/examples/developer_mode/sparse_flash_attn_developer_vid_reduce.py
@@ -145,7 +145,6 @@ def sparse_attention_fwd(
 
                 T.copy(m_i, m_i_prev)
 
-
                 for i, j in T.Parallel(v_block, BI):
                     acc_s_ub[i, j] = acc_s_ub[i, j] + acc_s_ub_[i, j]
 

--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -166,6 +166,7 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     bool print_dst_layout = false;
     bool print_ub = false;
     bool l0_dst_split = false;
+    bool virtual_channel = false;
     bool gm2ub = false;
     bool ub2gm = false;
   } config;
@@ -220,6 +221,24 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
         ss << ", " << compute_blocklen(src, src_extents);
       }
       ss << ">";
+    } else if (dst.scope() == "shared.dyn") {
+      config.virtual_channel = true;
+      ss << "copy_ub_to_l1<"; // real channel is "ub -> gm -> l1"
+      ss << get_dtype(dst) << ", ";
+      ss << src->shape[src->shape.size() - 1];
+      if (src->shape.size() > 1) {
+        ss << ", " << src->shape[src->shape.size() - 2];
+      }
+      ss << ">";
+    } else if (src.scope() == "wmma.accumulator") {
+      config.virtual_channel = true;
+      ss << "copy_l0c_to_ub<";
+      ss << get_dtype(src) << ", " << get_dtype(dst) << ", ";
+      ss << "layout::RowMajor, "; // real channel is "ub -> gm -> l1", so gm is
+                                  // always row major
+      ss << src->shape[src->shape.size() - 2] << ", "
+         << src->shape[src->shape.size() - 1];
+      ss << ", " << enRelu << ">";
     } else {
       PrimExpr len = 1;
       for (auto &shape : dst_extents) {
@@ -446,6 +465,12 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     new_args.push_back(src->shape[src->shape.size() - 1]);
   }
 
+  if (config.virtual_channel) {
+    new_args.push_back(
+        src->shape[src->shape.size() -
+                   1]); // ub/l0c -> gm need realdstN which is equal to srcN in
+                        // virtural channel scenario
+  }
   // if (config.l12l0) {
   //   ICHECK(src->shape.size() == dst->shape.size());
   //   bool is_extract = false;

--- a/src/transform/ascend_workspace_reduction.cc
+++ b/src/transform/ascend_workspace_reduction.cc
@@ -1,0 +1,898 @@
+#include "../op/builtin.h"
+#include "arith/ir_mutator_with_analyzer.h"
+#include <tvm/tir/builtin.h>
+#include <tvm/tir/transform.h>
+
+namespace tvm {
+namespace tl {
+
+enum class DstBufferScope { L1, Ub };
+
+enum class CopyDirection { None, UbToL1, L0cToUb };
+
+struct WorkspaceInfo {
+  DataType dtype;
+  std::string dtype_str;
+  std::string workspace_name;
+  std::string associated_dst_buffer_name;
+  Buffer workspace_buffer;
+  Array<PrimExpr> shapes;
+  PrimExpr offset;
+  PrimExpr extent;
+  PrimExpr dim;
+  int64_t per_block_ele_nums = 0;
+  PrimExpr dst_l1_row_offset; // Only used for skip UB scenario to store the row
+                              // offset for in-place UB to workspace copy
+                              // transformation
+};
+
+struct CoreMetaInfo {
+  Var cid_var;
+  Var vid_var;
+  PrimExpr total_core_nums;
+  int vector_cnt = 1;
+};
+
+struct CopyGlobalContext {
+  // Maps workspace name to the corresponding detailed workspace information
+  std::map<std::string, WorkspaceInfo> workspace_map_;
+  // Tracks the total number of existing workspaces
+  size_t workspace_num_ = 0;
+  // Maps source buffer name to the associated workspace name
+  std::unordered_map<std::string, std::string> src_to_workspace_map_;
+  // Maps destination buffer name to the associated workspace name
+  std::unordered_map<std::string, std::string> dst_to_workspace_map_;
+  // Maps destination buffer name to its corresponding access Call object
+  std::unordered_map<std::string, Call> dst_to_access_map_;
+  // Stores the set of all buffers that are currently being tracked
+  std::unordered_set<std::string> tracked_buffers_;
+  // Maps source buffer name to its corresponding destination buffer name
+  std::unordered_map<std::string, std::string> src_to_dst_map_;
+  // Maps destination buffer name to its corresponding scope information
+  std::unordered_map<std::string, DstBufferScope> dst_to_scope_map_;
+  // Core meta info for vid offset calculation (threads=2 scenario)
+  CoreMetaInfo core_meta_info_;
+  // UB buffers that skipped VidReduction (from PrimFunc attrs)
+  std::unordered_set<std::string> buffers_skip_vid_reduction_;
+  // Buffer shapes (from PrimFunc attrs)
+  std::unordered_map<std::string, Array<PrimExpr>> buffer_shapes_;
+};
+
+class CopyInfoCollector : public StmtExprVisitor {
+private:
+  CopyGlobalContext context_;
+
+  static const std::unordered_map<std::string, DataType> type_map_;
+
+  std::unordered_set<std::string> target_copy_stmts_ = {"copy_ub_to_l1",
+                                                        "copy_l0c_to_ub"};
+  std::unordered_map<std::string, DstBufferScope> scope_table_ = {
+      {"copy_ub_to_l1", DstBufferScope::L1},
+      {"copy_l0c_to_ub", DstBufferScope::Ub}};
+
+public:
+  const CopyGlobalContext &GetCopyGlobalContext() const { return context_; }
+
+  explicit CopyInfoCollector(
+      const std::unordered_set<std::string> &target_copy_stmts = {},
+      const std::unordered_map<std::string, DstBufferScope> &scope_table = {}) {
+    if (!target_copy_stmts.empty()) {
+      this->target_copy_stmts_ = target_copy_stmts;
+    }
+    if (!scope_table.empty()) {
+      this->scope_table_ = scope_table;
+    }
+  }
+
+  void SetSkipBuffers(const std::unordered_set<std::string> &skip_buffers) {
+    context_.buffers_skip_vid_reduction_ = skip_buffers;
+  }
+
+  void SetBufferShapes(
+      const std::unordered_map<std::string, Array<PrimExpr>> &shapes) {
+    context_.buffer_shapes_ = shapes;
+  }
+
+  DataType ConvertStringToDataType(const std::string &type_str) {
+    auto it = type_map_.find(type_str);
+
+    ICHECK(it != type_map_.end())
+        << "[Error]<WorkspaceReduction>: Not supported type: " << type_str
+        << ", maybe you need to update type_map_.";
+
+    return it->second;
+  }
+
+  std::string IsTargetCopyExpr(const CallNode *call_node) {
+    if (!call_node || call_node->op != tir::builtin::call_extern()) {
+      return "";
+    }
+
+    if (call_node->args.empty() || !call_node->args[0].as<StringImmNode>()) {
+      return "";
+    }
+    std::string copy_stmt = Downcast<StringImm>(call_node->args[0])->value;
+    for (const auto &target_substr : target_copy_stmts_) {
+      size_t pos = copy_stmt.find(target_substr);
+      if (pos != std::string::npos) {
+        return copy_stmt;
+      }
+    }
+    return "";
+  }
+
+  void WorkspaceInfoCollector(const std::string &copy_stmt,
+                              const CallNode *src_access_ptr,
+                              const CallNode *dst_access_ptr) {
+    ICHECK(src_access_ptr != nullptr && dst_access_ptr != nullptr)
+        << "[Error]<WorkspaceReduction>: src_access_ptr or "
+           "dst_access_ptr is nullptr!";
+    for (auto &target_copy_stmt : target_copy_stmts_) {
+      std::vector<std::string> params_vec;
+      if (copy_stmt.find(target_copy_stmt) != std::string::npos) {
+        CopyDirection copy_direction = CopyDirection::None;
+        std::string current_param;
+        std::string src_buffer_name =
+            src_access_ptr->args[1].as<VarNode>()->name_hint;
+        std::string dst_buffer_name =
+            dst_access_ptr->args[1].as<VarNode>()->name_hint;
+        if (target_copy_stmt == "copy_ub_to_l1") {
+          copy_direction = CopyDirection::UbToL1;
+        } else if (target_copy_stmt == "copy_l0c_to_ub") {
+          copy_direction = CopyDirection::L0cToUb;
+        }
+        size_t left_bracket = copy_stmt.find('<');
+        size_t right_bracket = copy_stmt.rfind('>');
+        ICHECK(left_bracket != std::string::npos &&
+               right_bracket != std::string::npos &&
+               left_bracket < right_bracket)
+            << "[Error]<WorkspaceReduction>: illegal template "
+               "parameters scope!"
+            << std::endl;
+        std::string template_content = copy_stmt.substr(
+            left_bracket + 1, right_bracket - left_bracket - 1);
+        for (auto &c : template_content) {
+          if (c == ',') {
+            ICHECK(!current_param.empty())
+                << "[Error]<WorkspaceReduction>: Empty parameter found in "
+                   "template!";
+            params_vec.push_back(current_param); // [type N M] or [type1 type2
+                                                 // LayoutGM M N enRelu]
+            current_param = "";
+            continue;
+          }
+          if (std::isspace(c)) {
+            continue;
+          }
+          current_param.push_back(c);
+        }
+        params_vec.push_back(current_param);
+        // Only swap for normal UbToL1 with 3+ params (skip UB has only 2
+        // params)
+        if (copy_direction == CopyDirection::UbToL1 && params_vec.size() >= 3) {
+          std::swap(params_vec[1], params_vec[2]);
+        }
+        ++context_.workspace_num_;
+        WorkspaceInfo ws_info;
+        std::stringstream ss;
+        ss << "workspace_" << context_.workspace_num_;
+        ws_info.workspace_name = ss.str();
+
+        ws_info.associated_dst_buffer_name = dst_buffer_name;
+
+        // Check if src_buffer is in skip set (must be defined before switch)
+        bool is_skip_ub =
+            context_.buffers_skip_vid_reduction_.count(src_buffer_name) > 0;
+
+        switch (copy_direction) {
+        case CopyDirection::UbToL1:
+          ws_info.dtype_str = params_vec[0]; // UbToL1: [dtype, M, N]
+          ws_info.dtype = ConvertStringToDataType(ws_info.dtype_str);
+
+          if (is_skip_ub) {
+            // Skip UB scenario: use full L1 shape from buffer_shapess
+            // Template params for skip UB: [dtype, size] (no M, N)
+
+            // dst_access_ptr args: [type_annotation, var, offset, extent, ...]
+            // args.size() should be at least 4
+
+            // Check args size before accessing
+            ICHECK(dst_access_ptr->args.size() >= 4)
+                << "[ERROR]<WorkspaceReduction>: dst_access_ptr args size "
+                   "should be at least 4, got "
+                << dst_access_ptr->args.size();
+
+            PrimExpr dst_offset = dst_access_ptr->args[2]; // row offset
+
+            // Get dst buffer full shape from buffer_shapes_
+            auto shape_it = context_.buffer_shapes_.find(dst_buffer_name);
+            ICHECK(shape_it != context_.buffer_shapes_.end())
+                << "[ERROR]<WorkspaceReduction>: dst_buffer " << dst_buffer_name
+                << " not found in buffer_shapes_";
+            Array<PrimExpr> dst_full_shape = shape_it->second;
+
+            // Shape must be 2D [M, N] for current Skip UB UbToL1 scenario
+            // Future: Extend to support multi-dimensional shapes based on
+            // buffer scope
+            ICHECK(dst_full_shape.size() == 2)
+                << "[ERROR]<WorkspaceReduction>: Skip UB UbToL1 expects "
+                   "dst_full_shape to be 2D, "
+                   "got "
+                << dst_full_shape.size();
+
+            PrimExpr M = dst_full_shape[0]; // rows
+            PrimExpr N = dst_full_shape[1]; // cols
+
+            ws_info.shapes.push_back(M);
+            ws_info.shapes.push_back(N);
+
+            // per_block_ele_nums = M * N
+            int64_t M_val = 0, N_val = 0;
+            if (const IntImmNode *M_imm = M.as<IntImmNode>()) {
+              M_val = M_imm->value;
+            }
+            if (const IntImmNode *N_imm = N.as<IntImmNode>()) {
+              N_val = N_imm->value;
+            }
+            ws_info.per_block_ele_nums = M_val * N_val;
+
+            // dst_extent for workspace = M * N (full L1 size)
+            PrimExpr dst_full_extent = M * N;
+
+            // base offset: cid * dst_full_extent (for workspace declaration,
+            // excludes dst_offset) workspace declaration)
+            ws_info.offset = context_.core_meta_info_.cid_var * dst_full_extent;
+
+            // Store row offset separately, added during UbToL1 in-place
+            // transform
+            ws_info.dst_l1_row_offset = dst_offset;
+
+            // extent: total_core_nums * dst_full_extent - base_offset
+            ws_info.extent =
+                context_.core_meta_info_.total_core_nums * dst_full_extent -
+                ws_info.offset;
+
+          } else {
+            // Normal UB scenario: use M, N from template params
+            for (int i = 1; i < params_vec.size(); ++i) {
+              int shapeI = std::stoi(params_vec[i]);
+              // UbToL1 scenario: UB is halved by VidReduction (due to two
+              // vector cores), but GM workspace needs to store complete data,
+              // first dim needs to multiply vector_cnt
+              if (i == 1 && context_.core_meta_info_.vid_var.defined() &&
+                  context_.core_meta_info_.vector_cnt > 1) {
+                shapeI *= context_.core_meta_info_.vector_cnt;
+              }
+              ws_info.shapes.push_back(IntImm(DataType::Int(32), shapeI));
+            }
+
+            ws_info.per_block_ele_nums = 1;
+            for (auto &i : ws_info.shapes) {
+              const IntImmNode *i_node = i.as<IntImmNode>();
+              ICHECK(i_node != nullptr)
+                  << "[Error]<WorkspaceReduction>: Shape dimension is not "
+                     "a "
+                     "valid IntImm, cannot extract value\n";
+              ws_info.per_block_ele_nums *= i_node->value;
+            }
+
+            ws_info.offset =
+                context_.core_meta_info_.cid_var *
+                IntImm(DataType::Int(64), ws_info.per_block_ele_nums);
+
+            ws_info.extent =
+                context_.core_meta_info_.total_core_nums *
+                    IntImm(DataType::Int(64), ws_info.per_block_ele_nums) -
+                ws_info.offset;
+          }
+          break;
+        case CopyDirection::L0cToUb:
+          ws_info.dtype_str = params_vec[1]; // L0cToUb: [src_dtype, dst_dtype,
+                                             // LayoutGM, M, N, enRelu]
+          ws_info.dtype = ConvertStringToDataType(ws_info.dtype_str);
+          int shapeM = std::stoi(params_vec[3]);
+          int shapeN = std::stoi(params_vec[4]);
+          ws_info.shapes.push_back(IntImm(DataType::Int(32), shapeM));
+          ws_info.shapes.push_back(IntImm(DataType::Int(32), shapeN));
+
+          ws_info.per_block_ele_nums = shapeM * shapeN;
+
+          ws_info.offset =
+              context_.core_meta_info_.cid_var *
+              IntImm(DataType::Int(64), ws_info.per_block_ele_nums);
+
+          ws_info.extent =
+              context_.core_meta_info_.total_core_nums *
+                  IntImm(DataType::Int(64), ws_info.per_block_ele_nums) -
+              ws_info.offset;
+          break;
+        }
+
+        ws_info.dim = IntImm(DataType::Int(64), ws_info.shapes.size());
+
+        Array<PrimExpr> real_shapes{context_.core_meta_info_.total_core_nums};
+        for (const auto &shape : ws_info.shapes) {
+          real_shapes.push_back(shape);
+        }
+        ws_info.workspace_buffer = decl_buffer(
+            real_shapes, ws_info.dtype, ws_info.workspace_name, "global");
+
+        context_.workspace_map_[ws_info.workspace_name] = ws_info;
+        context_.src_to_workspace_map_[src_buffer_name] =
+            ws_info.workspace_name;
+        context_.dst_to_workspace_map_[dst_buffer_name] =
+            ws_info.workspace_name;
+      }
+    }
+  }
+
+  void VisitStmt(const Stmt &stmt) final { StmtExprVisitor::VisitStmt(stmt); }
+
+  void VisitStmt_(const EvaluateNode *op) final {
+    const CallNode *call_node = op->value.as<CallNode>();
+    if (!call_node) {
+      return StmtExprVisitor::VisitStmt_(op);
+    }
+
+    std::string copy_stmt_name = IsTargetCopyExpr(call_node);
+    if (!copy_stmt_name.empty()) {
+      Array<PrimExpr> call_node_args = call_node->args;
+
+      const CallNode *src_ptr = call_node_args[1].as<CallNode>();
+      const CallNode *dst_ptr = call_node_args[2].as<CallNode>();
+      ICHECK(src_ptr != nullptr && dst_ptr != nullptr)
+          << "[Error]<WorkspaceReduction>: src_ptr or dst_ptr is nullptr!";
+      ICHECK(src_ptr->op.same_as(tvm::tir::builtin::tvm_access_ptr()) &&
+             src_ptr->args.size() >= 2)
+          << "[Error]<WorkspaceReduction>: src is not access ptr or its "
+             "size of args is too small";
+      ICHECK(dst_ptr->op.same_as(tvm::tir::builtin::tvm_access_ptr()) &&
+             dst_ptr->args.size() >= 2)
+          << "[Error]<WorkspaceReduction>: dst is not access ptr or its "
+             "size of args is too small";
+      const VarNode *src_name_var_node = (src_ptr->args[1].as<VarNode>());
+      const VarNode *dst_name_var_node = (dst_ptr->args[1].as<VarNode>());
+      ICHECK(src_name_var_node != nullptr && dst_name_var_node != nullptr)
+          << "[Error]<WorkspaceReduction>: src or dst args[1] is not VarNode!";
+
+      WorkspaceInfoCollector(copy_stmt_name, src_ptr, dst_ptr);
+
+      const std::string src_buffer_name = src_name_var_node->name_hint;
+      const std::string dst_buffer_name = dst_name_var_node->name_hint;
+      context_.tracked_buffers_.insert(src_buffer_name);
+      context_.src_to_dst_map_[src_buffer_name] = dst_buffer_name;
+
+      // skip UB + UbToL1: reconstruct dst_access_ptr
+      bool is_skip_ub =
+          context_.buffers_skip_vid_reduction_.count(src_buffer_name) > 0;
+      bool is_ub_to_l1 =
+          (copy_stmt_name.find("copy_ub_to_l1") != std::string::npos);
+
+      if (is_skip_ub && is_ub_to_l1) {
+        // Get dst full shape [M, N] from buffer_shapes_
+        auto shape_it = context_.buffer_shapes_.find(dst_buffer_name);
+        if (shape_it != context_.buffer_shapes_.end()) {
+          Array<PrimExpr> dst_full_shape = shape_it->second;
+          PrimExpr M = dst_full_shape[0]; // rows
+          PrimExpr N = dst_full_shape[1]; // cols
+          PrimExpr full_extent = M * N;
+
+          // Construct new dst_access_ptr: offset=0, extent=M*N
+          Array<PrimExpr> new_args = {
+              dst_ptr->args[0],             // type_annotation
+              dst_ptr->args[1],             // var
+              IntImm(DataType::Int(64), 0), // offset = 0
+              full_extent,                  // extent = M * N
+              dst_ptr->args[4]              // rw_mask
+          };
+
+          Call new_dst_access(dst_ptr->dtype, dst_ptr->op, new_args);
+          context_.dst_to_access_map_[dst_buffer_name] = new_dst_access;
+        } else {
+          context_.dst_to_access_map_[dst_buffer_name] = GetRef<Call>(dst_ptr);
+        }
+      } else {
+        context_.dst_to_access_map_[dst_buffer_name] = GetRef<Call>(dst_ptr);
+      }
+
+      std::string copy_func_name = call_node_args[0].as<StringImmNode>()->value;
+      for (auto &target_copy_stmt : target_copy_stmts_) {
+        if (copy_func_name.find(target_copy_stmt) != std::string::npos) {
+          context_.dst_to_scope_map_[dst_buffer_name] =
+              scope_table_[target_copy_stmt];
+        }
+      }
+    }
+  }
+
+  void VisitStmt_(const AttrStmtNode *op) override {
+
+    if (op->attr_key == tvm::tir::attr::thread_extent) {
+      if (const IterVarNode *iter_var_node = op->node.as<IterVarNode>()) {
+        IterVar iter_var = GetRef<IterVar>(iter_var_node);
+        if (/*!context_.core_meta_info_.is_valid &&*/
+            iter_var->thread_tag == "blockIdx.x") {
+          context_.core_meta_info_.cid_var = iter_var->var;
+          context_.core_meta_info_.total_core_nums = op->value;
+          // context_.core_meta_info_.is_valid = true;
+        }
+        if (iter_var->thread_tag == "threadIdx.x") {
+          context_.core_meta_info_.vid_var = iter_var->var;
+          context_.core_meta_info_.vector_cnt =
+              Downcast<IntImm>(op->value)->value;
+        }
+      }
+    }
+
+    StmtVisitor::VisitStmt_(op);
+  }
+};
+
+const std::unordered_map<std::string, DataType> CopyInfoCollector::type_map_ = {
+    {"half", tvm::runtime::DataType::Float(16)},
+    {"float16", tvm::runtime::DataType::Float(16)},
+    {"float", tvm::runtime::DataType::Float(32)},
+    {"float32", tvm::runtime::DataType::Float(32)},
+    {"float64", tvm::runtime::DataType::Float(64)},
+    {"int8", tvm::runtime::DataType::Int(8)},
+    {"int16", tvm::runtime::DataType::Int(16)},
+    {"int", tvm::runtime::DataType::Int(32)},
+    {"int32", tvm::runtime::DataType::Int(32)},
+    {"int64", tvm::runtime::DataType::Int(64)},
+    {"uint8", tvm::runtime::DataType::UInt(8)},
+    {"uint16", tvm::runtime::DataType::UInt(16)},
+    {"uint32", tvm::runtime::DataType::UInt(32)},
+    {"uint64", tvm::runtime::DataType::UInt(64)}};
+
+class AscendWorkspaceReductionPass : public arith::IRMutatorWithAnalyzer {
+public:
+  static PrimFunc Substitute(PrimFunc f) {
+    arith::Analyzer analyzer;
+
+    // Read buffers_skip_vid_reduction from PrimFunc attrs
+    std::unordered_set<std::string> skip_buffer_names;
+    std::unordered_map<std::string, Array<PrimExpr>> buffer_shapes;
+    if (f->attrs.defined()) {
+      auto attrs_dict = f->attrs->dict;
+
+      // Read buffers_skip_vid_reduction
+      auto it_skip = attrs_dict.find("buffers_skip_vid_reduction");
+      if (it_skip != attrs_dict.end()) {
+        auto skip_array = Downcast<Array<String>>((*it_skip).second);
+        for (const auto &name : skip_array) {
+          skip_buffer_names.insert(name);
+        }
+      }
+
+      // Read buffer_shapess for skip UB scenario
+      auto it_shapes = attrs_dict.find("buffer_shapess");
+      if (it_shapes != attrs_dict.end()) {
+        auto shapes_map =
+            Downcast<Map<Var, Array<PrimExpr>>>((*it_shapes).second);
+        for (const auto &pair : shapes_map) {
+          std::string buf_name = pair.first->name_hint;
+          buffer_shapes[buf_name] = pair.second;
+        }
+      }
+    }
+
+    CopyInfoCollector info_collector;
+    info_collector.SetSkipBuffers(skip_buffer_names);
+    info_collector.SetBufferShapes(buffer_shapes);
+    info_collector.VisitStmt(f->body);
+    const CopyGlobalContext &context = info_collector.GetCopyGlobalContext();
+    AscendWorkspaceReductionPass substituter(&analyzer, context);
+
+    auto *f_mut = f.CopyOnWrite();
+    f_mut->body = substituter.VisitStmt(f->body);
+
+    Array<Var> new_params = f_mut->params;
+    Array<IntImm> auto_gm_idx;
+    for (const auto &[ws_name, ws_info] : context.workspace_map_) {
+      if (ws_info.workspace_buffer.defined()) {
+        Var ws_handle(ws_name + "_handle", DataType::Handle());
+        if (!f_mut->buffer_map.count(ws_handle)) {
+          f_mut->buffer_map.Set(ws_handle, ws_info.workspace_buffer);
+          new_params.push_back(ws_handle);
+          auto_gm_idx.push_back(
+              IntImm(DataType::UInt(32), new_params.size() - 1));
+        }
+      }
+    }
+
+    f_mut->params = new_params;
+    tvm::tir::PrimFunc prim_func_with_new_attr =
+        GetRef<tvm::tir::PrimFunc>(f_mut);
+    prim_func_with_new_attr = tvm::WithAttr(std::move(prim_func_with_new_attr),
+                                            "auto_gm_indices", auto_gm_idx);
+
+    return prim_func_with_new_attr;
+  }
+
+private:
+  AscendWorkspaceReductionPass(arith::Analyzer *analyzer,
+                               const CopyGlobalContext &context)
+      : arith::IRMutatorWithAnalyzer(analyzer), context_(context),
+        core_meta_info__(context.core_meta_info_) {}
+
+  const CopyGlobalContext &context_;
+  const CoreMetaInfo core_meta_info__; // For vid offset calculation
+
+  std::unordered_set<std::string> inserted_buffers_;
+
+  std::unordered_set<std::string> copy_stmt_table_ = {
+      "copy_gm_to_l1",  "copy_l1_to_l0a", "copy_l1_to_l0b",
+      "copy_l0c_to_gm", "copy_gm_to_ub",  "copy_ub_to_gm",
+      "copy_ub_to_l1",  "copy_l0c_to_ub", "copy_ub_to_ub"};
+
+  std::unordered_map<std::string, std::string> copy_replace_table_ = {
+      {"copy_ub_to_l1", "copy_ub_to_gm"}, {"copy_l0c_to_ub", "copy_l0c_to_gm"}};
+
+  std::string PrintDstScope(const DstBufferScope &dst_scope) {
+    switch (dst_scope) {
+    case DstBufferScope::L1:
+      return "l1";
+      break;
+    case DstBufferScope::Ub:
+      return "ub";
+      break;
+    default:
+      return "UnknownScope";
+    }
+  }
+
+  bool IsTargetCopyExpr(const CallNode *call_node) {
+
+    if (!call_node || call_node->op != tir::builtin::call_extern()) {
+      return false;
+    }
+
+    if (call_node->args.empty() || !call_node->args[0].as<StringImmNode>()) {
+      return false;
+    }
+    std::string func_name = Downcast<StringImm>(call_node->args[0])->value;
+    for (const auto &[target_substr, replace_substr] : copy_replace_table_) {
+      size_t pos = func_name.find(target_substr);
+      if (pos != std::string::npos) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  StringImm ReplaceCopyFuncName(const StringImm &orig_name) {
+    std::string new_name = orig_name->value;
+    std::string original_name = new_name;
+
+    for (const auto &[target_substr, replace_substr] : copy_replace_table_) {
+      size_t pos = new_name.find(target_substr);
+      if (pos != std::string::npos) {
+        new_name.replace(pos, target_substr.length(), replace_substr);
+        break;
+      }
+    }
+
+    return StringImm(new_name);
+  }
+
+  std::vector<std::string> IsTargetAccessNode(const CallNode *call_node) {
+
+    static const std::vector<std::string> EMPTY_BUFFER_LIST;
+    std::vector<std::string> dst_buffers_vec;
+    if (!call_node) {
+      return EMPTY_BUFFER_LIST;
+    }
+
+    if (call_node->args.empty()) {
+      return EMPTY_BUFFER_LIST;
+    }
+
+    Array<PrimExpr> call_node_args = call_node->args;
+    if (call_node_args.empty()) {
+      return EMPTY_BUFFER_LIST;
+    }
+
+    const StringImmNode *call_node_name = call_node_args[0].as<StringImmNode>();
+    if (call_node_name != nullptr) {
+      const std::string call_node_name_str = call_node_name->value;
+      for (const auto &copy_stmt : copy_stmt_table_) {
+        // Skip copy statements: only insert copy-back before data consumers,
+        // not producers(copy stmts).
+        if (call_node_name_str.find(copy_stmt) != std::string::npos) {
+          return EMPTY_BUFFER_LIST;
+        }
+      }
+    }
+
+    for (int i = 0; i < call_node_args.size(); ++i) {
+      const PrimExpr &arg = call_node_args[i];
+      const CallNode *access_ptr = arg.as<CallNode>();
+
+      if (!access_ptr || !access_ptr->op.same_as(builtin::tvm_access_ptr())) {
+        continue;
+      }
+
+      Array<PrimExpr> access_args = access_ptr->args;
+      ICHECK(!access_args.empty())
+          << "[Error]<WorkspaceReduction>: access ptr args is empty!";
+      ICHECK(access_args.size() >= 2)
+          << "[Error]<WorkspaceReduction>: access ptr args size too small!";
+
+      const VarNode *buffer_var = access_args[1].as<VarNode>();
+      ICHECK(buffer_var != nullptr)
+          << "[Error]<WorkspaceReduction>: access ptr args[1] is not VarNode!";
+
+      std::string buffer_name = buffer_var->name_hint;
+
+      for (const auto &[src_buffer_name, dst_buffer_name] :
+           context_.src_to_dst_map_) {
+        if (!inserted_buffers_.count(buffer_name) &&
+            buffer_name == dst_buffer_name) {
+          dst_buffers_vec.push_back(buffer_name);
+          inserted_buffers_.insert(buffer_name);
+        } else if (inserted_buffers_.count(buffer_name) &&
+                   buffer_name == dst_buffer_name) {
+          continue;
+        }
+      }
+    }
+    return dst_buffers_vec;
+  }
+
+  Call CreateWorkspaceAccessPtr(const WorkspaceInfo &ws_info, int rw_mask,
+                                bool other_side_is_ub) {
+    DataType dtype = DataType::Handle();
+    const Op &op = builtin::tvm_access_ptr();
+
+    PrimExpr offset = ws_info.offset; // Base offset: cid * M * N
+
+    // skip UB UbToL1 in-place: add row offset
+    // Condition: dst_l1_row_offset exists and workspace as dst (rw_mask=2,
+    // write) workspace restore (rw_mask=1, read) doesn't need this
+    if (ws_info.dst_l1_row_offset.defined() && rw_mask == 2) {
+      offset = offset + ws_info.dst_l1_row_offset;
+    }
+
+    // Check if vid offset needed: GM's other side is UB (UB halved by
+    // VidReduction)
+    bool need_vid_offset = other_side_is_ub &&
+                           core_meta_info__.vid_var.defined() &&
+                           core_meta_info__.vector_cnt > 1;
+
+    if (need_vid_offset) {
+      // vid offset: vid * per_block_ele_nums / vector_cnt
+      PrimExpr vid_offset =
+          core_meta_info__.vid_var *
+          IntImm(DataType::Int(64), ws_info.per_block_ele_nums) /
+          IntImm(DataType::Int(64), core_meta_info__.vector_cnt);
+      offset = offset + vid_offset;
+    }
+
+    Array<PrimExpr> args = {TypeAnnotation(ws_info.dtype),
+                            ws_info.workspace_buffer->data, offset,
+                            ws_info.extent, IntImm(DataType::Int(32), rw_mask)};
+
+    Call access_ptr_call(dtype, op, args);
+    return access_ptr_call;
+  }
+
+  Stmt CreateGmToDstStmt(const Call &src_access, const Call &dst_access,
+                         const DstBufferScope &buffer_scope,
+                         PrimExpr &strideN) {
+    Array<PrimExpr> args;
+    const CallNode *gm_access_ptr = src_access.as<CallNode>();
+    const VarNode *gm_var = gm_access_ptr->args[1].as<VarNode>();
+    std::string gm_name = gm_var->name_hint;
+    WorkspaceInfo ws_info = context_.workspace_map_.at(gm_name);
+
+    std::stringstream ss;
+    ss << "tl::ascend::copy_gm_to_" << PrintDstScope(buffer_scope) << "<"
+       << ws_info.dtype_str;
+    if (buffer_scope == DstBufferScope::L1) {
+      for (auto &shape : ws_info.shapes) {
+        // gm_to_l1 : M N
+        ss << ", " << shape.as<IntImmNode>()->value;
+      }
+      ss << ">";
+    } else if (buffer_scope == DstBufferScope::Ub) {
+      // gm_to_ub: N M (reversed order)
+      // threads=2: first dim (M) divided by vector_cnt, each vidcopieshalf
+      int idx = 0;
+      for (auto it = ws_info.shapes.rbegin(); it != ws_info.shapes.rend();
+           ++it, ++idx) {
+        int shape_val = (*it).as<IntImmNode>()->value;
+        // Last element is original shapes[0] (M), needs division by vector_cnt
+        if (idx == ws_info.shapes.size() - 1 &&
+            core_meta_info__.vid_var.defined() &&
+            core_meta_info__.vector_cnt > 1) {
+          shape_val /= core_meta_info__.vector_cnt;
+        }
+        ss << ", " << shape_val;
+      }
+      ss << ">";
+    }
+
+    std::string stmt_name_str = ss.str();
+
+    StringImm stmt_name(stmt_name_str);
+    args.push_back(stmt_name);
+    args.push_back(src_access);
+    args.push_back(dst_access);
+    args.push_back(strideN);
+
+    // Add extra parameters for codegen
+    if (buffer_scope == DstBufferScope::L1) {
+      // copy_gm_to_l1: add realTailM=0, realTailN=0
+      args.push_back(IntImm(DataType::Int(32), 0));
+      args.push_back(IntImm(DataType::Int(32), 0));
+    } else if (buffer_scope == DstBufferScope::Ub) {
+      // copy_gm_to_ub: add maskShapeM, maskShapeN, padValue=0
+      // ws_info.shapes = [M, N] (workspace shape, M includes vector_cnt)
+      // Template params: dstN=N, dstM=M/vector_cnt (from reversed shapes)
+      // So maskShapeM=M/vector_cnt, maskShapeN=N
+      ICHECK(ws_info.shapes.size() >= 2);
+      // Extract M and N from ws_info.shapes
+      int M_val = ws_info.shapes[0].as<IntImmNode>()->value;
+      int N_val = ws_info.shapes[1].as<IntImmNode>()->value;
+      // maskShapeM considers vector_cnt (threads=2 scenario)
+      if (core_meta_info__.vid_var.defined() &&
+          core_meta_info__.vector_cnt > 1) {
+        M_val /= core_meta_info__.vector_cnt;
+      }
+      args.push_back(IntImm(DataType::Int(32), M_val)); // maskShapeM
+      args.push_back(IntImm(DataType::Int(32), N_val)); // maskShapeN
+      args.push_back(IntImm(DataType::Int(32), 0));     // padValue
+    }
+
+    Call new_call_node(DataType::Handle(), tvm::tir::builtin::call_extern(),
+                       args);
+
+    return Evaluate(new_call_node);
+  }
+
+  Stmt VisitStmt_(const EvaluateNode *op) final {
+    Stmt orig_stmt = arith::IRMutatorWithAnalyzer::VisitStmt_(op);
+    const EvaluateNode *orig_eval_node = orig_stmt.as<EvaluateNode>();
+    if (!orig_eval_node) {
+      return orig_stmt;
+    }
+
+    const CallNode *orig_call = orig_eval_node->value.as<CallNode>();
+    if (!orig_call) {
+      return orig_stmt;
+    }
+
+    // In-place transform
+    if (IsTargetCopyExpr(orig_call)) {
+      Array<PrimExpr> new_args = orig_call->args;
+      StringImm orig_func_name = Downcast<StringImm>(new_args[0]);
+      const CallNode *src_access_ptr = new_args[1].as<CallNode>();
+      std::string src_buffer_name =
+          (src_access_ptr->args[1]).as<VarNode>()->name_hint;
+
+      // copyA (in-place): GM's other side is source, check if source is UB
+      // ub_to_l1 source is UB; l0c_to_ub source is L0C
+      std::string orig_func_name_str = orig_func_name->value;
+      bool other_side_is_ub =
+          (orig_func_name_str.find("copy_ub_to_l1") != std::string::npos);
+
+      StringImm new_func_name = ReplaceCopyFuncName(orig_func_name);
+      new_args.Set(0, new_func_name);
+      std::string ws_name = context_.src_to_workspace_map_.at(src_buffer_name);
+      WorkspaceInfo ws_info = context_.workspace_map_.at(ws_name);
+      new_args.Set(2, CreateWorkspaceAccessPtr(ws_info, 2, other_side_is_ub));
+
+      // Add extra parameters for codegen
+      if (orig_func_name_str.find("copy_ub_to_l1") != std::string::npos) {
+        // copy_ub_to_gm: add maskShapeM, maskShapeN
+
+        // Check if src_buffer is in skip_vid_reduction set
+        bool is_skip_ub =
+            context_.buffers_skip_vid_reduction_.count(src_buffer_name) > 0;
+
+        if (is_skip_ub) {
+          // Skip UB: use original UB shape from buffer_shapes_
+          // These UB buffers not processed by VidReduction, vector split in
+          // index array
+
+          auto shape_it = context_.buffer_shapes_.find(src_buffer_name);
+          ICHECK(shape_it != context_.buffer_shapes_.end());
+
+          // buffer_shapes_ can be 1D [N] or 2D [M, N]
+          int M_val = 1; // colsefault value
+          int N_val = 1;
+          if (shape_it->second.size() >= 1) {
+            N_val = shape_it->second[shape_it->second.size() - 1]
+                        .as<IntImmNode>()
+                        ->value;
+          }
+          if (shape_it->second.size() >= 2) {
+            M_val = shape_it->second[shape_it->second.size() - 2]
+                        .as<IntImmNode>()
+                        ->value;
+          }
+
+          new_args.push_back(IntImm(DataType::Int(32), M_val)); // maskShapeM
+          new_args.push_back(IntImm(DataType::Int(32), N_val)); // maskShapeN
+        } else {
+          // Normal UB: use ws_info.shapes, considering vector_cnt
+          // ws_info.shapes = [M * vector_cnt, N] (workspace stores complete
+          // data) maskShapeM = M = ws_info.shapes[0] / vector_cnt (each
+          // vidcopieshalf maskShapeN = N = ws_info.shapes[1]
+          ICHECK(ws_info.shapes.size() >= 2);
+          int M_val = ws_info.shapes[0].as<IntImmNode>()->value;
+          int N_val = ws_info.shapes[1].as<IntImmNode>()->value;
+          // threads=2: each vidcopies M/vector_cnt
+          if (core_meta_info__.vid_var.defined() &&
+              core_meta_info__.vector_cnt > 1) {
+            M_val /= core_meta_info__.vector_cnt;
+          }
+          new_args.push_back(IntImm(DataType::Int(32), M_val)); // maskShapeM
+          new_args.push_back(IntImm(DataType::Int(32), N_val)); // maskShapeN
+        }
+      } else if (orig_func_name_str.find("copy_l0c_to_ub") !=
+                 std::string::npos) {
+        // copy_l0c_to_gm: add realTailM=0, realTailN=0
+        new_args.push_back(IntImm(DataType::Int(32), 0));
+        new_args.push_back(IntImm(DataType::Int(32), 0));
+      }
+
+      Call new_call =
+          Call(orig_call->dtype, orig_call->op, new_args, orig_call->span);
+      return Evaluate(new_call);
+    }
+
+    // Insert copy-back statements
+    std::vector<std::string> buffer_names_vec = IsTargetAccessNode(orig_call);
+    if (!buffer_names_vec.empty()) {
+      Array<Stmt> seq_stmts_array;
+      for (const auto &buffer_name : buffer_names_vec) {
+
+        auto buffer_scope_it = context_.dst_to_scope_map_.find(buffer_name);
+
+        ICHECK(buffer_scope_it != context_.dst_to_scope_map_.end())
+            << "[Error]<WorkspaceReduction>: Dst scope is not found for "
+               "buffer: "
+            << buffer_name << "\n";
+
+        DstBufferScope buffer_scope =
+            context_.dst_to_scope_map_.at(buffer_name);
+        const std::string workspace_name =
+            context_.dst_to_workspace_map_.at(buffer_name);
+        WorkspaceInfo ws_info = context_.workspace_map_.at(workspace_name);
+
+        // copyB (copy-back): GM's other side is destination, check if dst is UB
+        // gm_to_ub destination is UB; gm_to_l1 destination is L1
+        bool other_side_is_ub = (buffer_scope == DstBufferScope::Ub);
+        Call workspace_access =
+            CreateWorkspaceAccessPtr(ws_info, 1, other_side_is_ub);
+        PrimExpr strideN = ws_info.shapes[ws_info.shapes.size() - 1];
+        Stmt insert_eval_stmt = this->CreateGmToDstStmt(
+            workspace_access, context_.dst_to_access_map_.at(buffer_name),
+            buffer_scope, strideN);
+        seq_stmts_array.push_back(insert_eval_stmt);
+      }
+      seq_stmts_array.push_back(orig_stmt);
+      return SeqStmt(seq_stmts_array);
+    }
+    return orig_stmt;
+  }
+};
+
+namespace transform {
+
+using namespace tir::transform;
+
+tvm::transform::Pass AscendWorkspaceReduction() {
+  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+    return AscendWorkspaceReductionPass::Substitute(std::move(f));
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.AscendWorkspaceReduction", {});
+}
+
+TVM_REGISTER_GLOBAL("tl.transform.AscendWorkspaceReduction")
+    .set_body_typed(AscendWorkspaceReduction);
+} // namespace transform
+
+} // namespace tl
+} // namespace tvm

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -2,12 +2,14 @@
 # Licensed under the MIT License.
 """The cache utils with class and database persistence - KernelCache Class"""
 
+from __future__ import annotations
+
 import os
 import json
 import shutil
 from pathlib import Path
 from hashlib import sha256
-from typing import Callable, List, Literal, Union, Optional
+from typing import Callable, Literal
 from tvm.target import Target
 from tvm.tir import PrimFunc
 from tilelang.jit import JITKernel
@@ -68,13 +70,13 @@ class KernelCache:
     def _generate_key(
         self,
         func: Callable,
-        out_idx: List[int],
-        workspace_idx: List[int],
-        auto_gm_idx: List[int],
+        out_idx: list[int],
+        workspace_idx: list[int],
+        auto_gm_idx: list[int],
         execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
         args=None,
-        target: Union[str, Target] = "auto",
-        target_host: Union[str, Target] = None,
+        target: str | Target = "auto",
+        target_host: str | Target = None,
         platform: str = "auto",
         pass_configs: dict = None,
     ) -> str:
@@ -103,9 +105,7 @@ class KernelCache:
             "out_idx": (tuple(out_idx) if isinstance(out_idx, (list, tuple)) else [out_idx]),
             "workspace_idx": (tuple(workspace_idx) if isinstance(workspace_idx, (list, tuple)) else [workspace_idx]),
             "auto_gm_idx": (tuple(auto_gm_idx) if isinstance(auto_gm_idx, (list, tuple)) else [auto_gm_idx]),
-            "args_repr": tuple(
-                repr(arg) for arg in args
-            ),  # Use repr to serialize arguments, may need more robust serialization
+            "args_repr": tuple(repr(arg) for arg in args),  # Use repr to serialize arguments, may need more robust serialization
             "target": str(target),
             "target_host": str(target_host) if target_host else None,
             "platform": str(platform),
@@ -118,12 +118,12 @@ class KernelCache:
     def cached(
         self,
         func: PrimFunc = None,
-        out_idx: List[int] = None,
-        workspace_idx: List[int] = None,
-        auto_gm_idx: List[int] = None,
+        out_idx: list[int] = None,
+        workspace_idx: list[int] = None,
+        auto_gm_idx: list[int] = None,
         *args,
-        target: Union[str, Target] = "auto",
-        target_host: Union[str, Target] = None,
+        target: str | Target = "auto",
+        target_host: str | Target = None,
         platform: str = "auto",
         execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
         verbose: bool = False,
@@ -175,13 +175,15 @@ class KernelCache:
         with self._lock:
             # First check in-memory cache
             if key in self._memory_cache:
-                self.logger.warning("Found kernel in memory cache. For better performance," \
-                                    " consider using `@tilelang.jit` instead of direct kernel caching.")
+                self.logger.warning(
+                    "Found kernel in memory cache. For better performance, consider using `@tilelang.jit` instead of direct kernel caching."
+                )
                 return self._memory_cache[key]
 
             # Then check disk cache
-            kernel = self._load_kernel_from_disk(key, target, target_host, platform, out_idx, workspace_idx,
-                                                 auto_gm_idx, execution_backend, pass_configs, func)
+            kernel = self._load_kernel_from_disk(
+                key, target, target_host, platform, out_idx, workspace_idx, auto_gm_idx, execution_backend, pass_configs, func
+            )
             if kernel is not None:
                 # Populate memory cache with disk result
                 self._memory_cache[key] = kernel
@@ -296,12 +298,12 @@ class KernelCache:
     def _load_kernel_from_disk(
         self,
         key: str,
-        target: Union[str, Target] = "auto",
-        target_host: Union[str, Target] = None,
+        target: str | Target = "auto",
+        target_host: str | Target = None,
         platform: str = "auto",
-        out_idx: List[int] = None,
-        workspace_idx: List[int] = None,
-        auto_gm_idx: List[int] = None,
+        out_idx: list[int] = None,
+        workspace_idx: list[int] = None,
+        auto_gm_idx: list[int] = None,
         execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
         pass_configs: dict = None,
         func: Callable = None,
@@ -329,12 +331,12 @@ class KernelCache:
         if not os.path.exists(cache_path):
             return None
 
-        kernel_global_source: Optional[str] = None
-        kernel_params: Optional[List[KernelParam]] = None
+        kernel_global_source: str | None = None
+        kernel_params: list[KernelParam] | None = None
 
         try:
             wrapped_kernel_path = os.path.join(cache_path, WRAPPED_KERNEL_PATH)
-            with open(wrapped_kernel_path, "r") as f:
+            with open(wrapped_kernel_path) as f:
                 kernel_global_source = f.read()
         except Exception as e:
             self.logger.error(f"Error loading wrapped kernel source code from disk: {e}")
@@ -370,7 +372,7 @@ class KernelCache:
     def _clear_disk_cache(self):
         """
         Removes all cached kernels from disk.
-        
+
         Note:
             This operation will delete the entire cache directory and recreate it empty.
             Use with caution as this operation cannot be undone.

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -70,6 +70,7 @@ class KernelCache:
         func: Callable,
         out_idx: List[int],
         workspace_idx: List[int],
+        auto_gm_idx: List[int],
         execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
         args=None,
         target: Union[str, Target] = "auto",
@@ -84,6 +85,7 @@ class KernelCache:
             func (Callable): The function to be compiled.
             out_idx (List[int]): Indices specifying which outputs to return.
             workspace_idx (List[int]): Indices specifying auto-allocated workspace tensors.
+            auto_gm_idx (List[int]): Indices specifying workspace tensors which virtual channels(ub/l0c->l1/ub) need.
             execution_backend (Literal): Backend type for execution. Defaults to "cython".
             args: Arguments passed to the function.
             target (Union[str, Target]): Compilation target platform. Defaults to "auto".
@@ -100,6 +102,7 @@ class KernelCache:
             "func": sha256(func_binary).hexdigest(),  # Use SHA256 to generate hash key
             "out_idx": (tuple(out_idx) if isinstance(out_idx, (list, tuple)) else [out_idx]),
             "workspace_idx": (tuple(workspace_idx) if isinstance(workspace_idx, (list, tuple)) else [workspace_idx]),
+            "auto_gm_idx": (tuple(auto_gm_idx) if isinstance(auto_gm_idx, (list, tuple)) else [auto_gm_idx]),
             "args_repr": tuple(
                 repr(arg) for arg in args
             ),  # Use repr to serialize arguments, may need more robust serialization
@@ -117,6 +120,7 @@ class KernelCache:
         func: PrimFunc = None,
         out_idx: List[int] = None,
         workspace_idx: List[int] = None,
+        auto_gm_idx: List[int] = None,
         *args,
         target: Union[str, Target] = "auto",
         target_host: Union[str, Target] = None,
@@ -132,6 +136,7 @@ class KernelCache:
             func: Function to be compiled or a prepared PrimFunc
             out_idx: Indices specifying which outputs to return
             workspace_idx: Indices specifying auto-allocated workspace tensors
+            auto_gm_idx: Indices specifying workspace tensors which virtual channels(ub/l0c->l1/ub) need
             target: Compilation target platform
             target_host: Host target platform
             platform: Specifies the target hardware platform generation. Defaults to "A3".
@@ -159,6 +164,7 @@ class KernelCache:
             func=func,
             out_idx=out_idx,
             workspace_idx=workspace_idx,
+            auto_gm_idx=auto_gm_idx,
             execution_backend=execution_backend,
             args=args,
             target=target,
@@ -175,7 +181,7 @@ class KernelCache:
 
             # Then check disk cache
             kernel = self._load_kernel_from_disk(key, target, target_host, platform, out_idx, workspace_idx,
-                                                 execution_backend, pass_configs, func)
+                                                 auto_gm_idx, execution_backend, pass_configs, func)
             if kernel is not None:
                 # Populate memory cache with disk result
                 self._memory_cache[key] = kernel
@@ -295,6 +301,7 @@ class KernelCache:
         platform: str = "auto",
         out_idx: List[int] = None,
         workspace_idx: List[int] = None,
+        auto_gm_idx: List[int] = None,
         execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
         pass_configs: dict = None,
         func: Callable = None,
@@ -309,6 +316,7 @@ class KernelCache:
             platform (Literal): Specifies the target hardware platform generation. Defaults to "A3".
             out_idx (List[int], optional): Indices specifying which outputs to return.
             workspace_idx (List[int], optional): Indices specifying auto-allocated workspace tensors.
+            auto_gm_idx (List[int], optional): Indices specifying workspace tensors which virtual channels(ub/l0c->l1/ub) need.
             execution_backend (Literal): Backend type for execution. Defaults to "cython".
             pass_configs (dict, optional): Configuration for compiler passes.
             func (Callable, optional): The original function.
@@ -352,6 +360,7 @@ class KernelCache:
                 platform=platform,
                 out_idx=out_idx,
                 workspace_idx=workspace_idx,
+                auto_gm_idx=auto_gm_idx,
                 execution_backend=execution_backend,
                 pass_configs=pass_configs,
             )

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -235,4 +235,4 @@ def lower(
     func = mod.functions_items()[0][1]
     params = extrac_params(func)
 
-    return CompiledArtifact(None, None, params, codegen_mod.get_source())
+    return CompiledArtifact(None, mod, params, codegen_mod.get_source())

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -2,11 +2,12 @@
 # Licensed under the MIT License.
 """The compiler for TL programs."""
 
-from typing import Literal
+from __future__ import annotations
+
 
 import os
 import os.path as osp
-from typing import Union, Optional, Callable, List
+from typing import Callable
 import tilelang.transform
 from tilelang import tvm as tvm
 from tvm import tir
@@ -27,8 +28,7 @@ def is_cpu_device_backend(target: Target):
 
 def has_device_kernel_launch(attrs) -> bool:
     """Check if the attributes indicate a device kernel launch."""
-    return bool(attrs and "calling_conv" in attrs and
-                attrs["calling_conv"] == CallingConv.DEVICE_KERNEL_LAUNCH)
+    return bool(attrs and "calling_conv" in attrs and attrs["calling_conv"] == CallingConv.DEVICE_KERNEL_LAUNCH)
 
 
 def is_device_call_c_device(func: tir.PrimFunc):
@@ -121,7 +121,7 @@ def tilelang_callback_hip_compile(code, target):
     return hsaco
 
 
-def extrac_params(func: tir.PrimFunc) -> List[KernelParam]:
+def extrac_params(func: tir.PrimFunc) -> list[KernelParam]:
     tensor_types = []
     for var in func.params:
         if var in func.buffer_map:
@@ -131,8 +131,7 @@ def extrac_params(func: tir.PrimFunc) -> List[KernelParam]:
     return tensor_types
 
 
-def canon_target_host(target: Union[str, Target], target_host: Optional[Union[str, Target]]):
-
+def canon_target_host(target: str | Target, target_host: str | Target | None):
     if not target_host:
         target_host = "llvm" if tvm.runtime.enabled("llvm") else "stackvm"
 
@@ -176,11 +175,9 @@ def device_codegen_without_compile(device_mod: tvm.IRModule, target: Target) -> 
     device_mod = tir.transform.LowerIntrin()(device_mod)
     device_mod = tir.transform.Simplify()(device_mod)
     if target.kind.name == "cuda":
-        device_mod = tvm._ffi.get_global_func("target.build.tilelang_cuda_without_compile")(
-            device_mod, target)
+        device_mod = tvm._ffi.get_global_func("target.build.tilelang_cuda_without_compile")(device_mod, target)
     elif target.kind.name == "hip":
-        device_mod = tvm._ffi.get_global_func("target.build.tilelang_hip_without_compile")(
-            device_mod, target)
+        device_mod = tvm._ffi.get_global_func("target.build.tilelang_hip_without_compile")(device_mod, target)
     elif target.kind.name == "c":
         device_mod = tvm._ffi.get_global_func("target.build.tilelang_cpp")(device_mod, target)
     elif target.kind.name == "llvm":
@@ -194,22 +191,23 @@ def device_codegen_without_compile(device_mod: tvm.IRModule, target: Target) -> 
 
 
 def lower(
-    func_or_mod: Union[tir.PrimFunc, tvm.IRModule],
-    target: Union[str, Target] = "auto",
-    target_host: Optional[Union[str, Target]] = None,
+    func_or_mod: tir.PrimFunc | tvm.IRModule,
+    target: str | Target = "auto",
+    target_host: str | Target | None = None,
     platform: str = "auto",
     runtime_only=False,
     enable_host_codegen=False,
     enable_device_compile=False,
 ) -> CompiledArtifact:
-    '''
-        enable_host_codegen: whether to enable host codegen, default is False, as we have our
-        own host codegen implementation in jit.
-        enable_device_compile: whether to enable device codegen, default is False, as we have our
-        own device codegen implementation in jit.
-    '''
-    
+    """
+    enable_host_codegen: whether to enable host codegen, default is False, as we have our
+    own host codegen implementation in jit.
+    enable_device_compile: whether to enable device codegen, default is False, as we have our
+    own device codegen implementation in jit.
+    """
+
     from tilelang.utils.target import determine_platform
+
     platform = determine_platform(platform)
 
     mod = func_or_mod
@@ -219,10 +217,7 @@ def lower(
         params = extrac_params(func) if not runtime_only else None
         mod = tvm.IRModule({func.attrs["global_symbol"]: func})
 
-    target = tvm.target.Target({
-        "kind": "llvm",
-        "model": target
-    })
+    target = tvm.target.Target({"kind": "llvm", "model": target})
 
     # Phase 1: Lower and legalize the IR
     mod = LowerAndLegalize(mod, target)

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -68,6 +68,8 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.CollectBufferShapes()(mod)
     # Lower high-level tile operations to low-level operations
     mod = tilelang.transform.LowerTileOp()(mod)
+    # Erase manual workspace allocations for virtual CV copy in Ascend
+    mod = tilelang.transform.AscendWorkspaceReduction()(mod)
     # Legalize vectorized loops to ensure they are valid
     mod = tilelang.transform.LegalizeVectorizedLoop()(mod)
     # Add safety checks for memory accesses
@@ -97,6 +99,8 @@ def OptimizeForTarget(mod: IRModule, target: Target, platform: str) -> IRModule:
     mod = tilelang.transform.FlattenBuffer()(mod)
     mod = tir.transform.Simplify()(mod)
     mod = tilelang.transform.VectorizeLoop(enable_vectorize=allow_vectorize(pass_ctx=pass_ctx))(mod)
+    # print("[PHASE] OptimizeForTarget - Before AscendStorageRewrite")
+    # print(mod)
     mod = tilelang.transform.AscendStorageRewrite(is_npu=check_npu_availability())(mod)
     mod = tir.transform.UnrollLoop()(mod)
     mod = tir.transform.RenormalizeSplitPattern()(mod)

--- a/tilelang/jit/adapter/cython/adapter.py
+++ b/tilelang/jit/adapter/cython/adapter.py
@@ -2,9 +2,11 @@
 # Licensed under the MIT License.
 """The profiler and convert to torch utils"""
 
+from __future__ import annotations
+
 from ..base import BaseKernelAdapter
 import ctypes
-from typing import List, Optional, Union, Callable, Dict, Tuple, Any
+from typing import Callable, Any
 from tilelang import tvm as tvm
 from tvm.target import Target
 from tilelang.engine.param import KernelParam
@@ -12,7 +14,6 @@ from tvm import tir
 from tvm.relay import TensorType
 from tilelang.jit.adapter.wrapper import TLWrapper
 from tilelang.jit.adapter.libgen import LibraryGenerator
-from tilelang.utils.target import determine_target
 from tilelang.utils.language import retrieve_func_from_module
 from tilelang.utils.tensor import map_torch_type
 from tilelang.contrib.cc import get_cplus_compiler
@@ -29,7 +30,7 @@ import site
 logger = logging.getLogger(__name__)
 
 
-def get_cython_compiler() -> Optional[str]:
+def get_cython_compiler() -> str | None:
     """Return the path to the Cython compiler.
 
     Returns
@@ -75,7 +76,7 @@ def get_cache_dir() -> Path:
     return cache_dir
 
 
-def get_cached_lib(source_code: str) -> Tuple[Optional[ctypes.CDLL], Path]:
+def get_cached_lib(source_code: str) -> tuple[ctypes.CDLL | None, Path]:
     """Try to load cached library or return None if not found."""
     code_hash = hashlib.sha256(source_code.encode()).hexdigest()
     cache_path = get_cache_dir() / f"{code_hash}.so"
@@ -101,7 +102,7 @@ def get_cached_lib(source_code: str) -> Tuple[Optional[ctypes.CDLL], Path]:
 current_dir = os.path.dirname(os.path.abspath(__file__))
 cython_wrapper_path = os.path.join(current_dir, "cython_wrapper.pyx")
 
-with open(cython_wrapper_path, "r") as f:
+with open(cython_wrapper_path) as f:
     cython_wrapper_code = f.read()
     cache_dir = get_cache_dir()
     source_path = cache_dir / "cython_wrapper.cpp"
@@ -114,7 +115,7 @@ with open(cython_wrapper_path, "r") as f:
     # Check if cached version exists and is valid
     need_compile = True
     if md5_path.exists() and library_path.exists():
-        with open(md5_path, "r") as f:
+        with open(md5_path) as f:
             cached_hash = f.read().strip()
             if cached_hash == code_hash:
                 logger.debug("Cython jit adapter is up to date, no need to compile...")
@@ -131,7 +132,7 @@ with open(cython_wrapper_path, "r") as f:
             try:
                 # After acquiring the lock, check again if the file has been compiled by another process
                 if md5_path.exists() and library_path.exists():
-                    with open(md5_path, "r") as f:
+                    with open(md5_path) as f:
                         cached_hash = f.read().strip()
                         if cached_hash == code_hash:
                             logger.info("Another process has already compiled the file, using it...")
@@ -182,43 +183,43 @@ class CythonKernelAdapter(BaseKernelAdapter):
     """
 
     # Class attributes to store compiled kernel information
-    target: Union[str, Target] = "cuda"
-    ir_module: Optional[tvm.IRModule] = None
+    target: str | Target = "cuda"
+    ir_module: tvm.IRModule | None = None
     # The global source code of the kernel -> global means the source code of the kernel
     # that is not wrapped by the wrapper code
-    kernel_global_source: Optional[str] = None
-    lib: Optional[ctypes.CDLL] = None  # Compiled library handle
-    wrapped_source: Optional[str] = None  # Generated C++ wrapper code
+    kernel_global_source: str | None = None
+    lib: ctypes.CDLL | None = None  # Compiled library handle
+    wrapped_source: str | None = None  # Generated C++ wrapper code
     # Maps symbolic variables to their corresponding buffer and shape indices
-    dynamic_symbolic_map: Optional[Dict[tir.Var, Tuple[int, int]]] = None
+    dynamic_symbolic_map: dict[tir.Var, tuple[int, int]] | None = None
     # Maps pointer arguments to their corresponding (buffer_index, shape_dimension)
-    ptr_map: Optional[Dict[int, str]] = None
+    ptr_map: dict[int, str] | None = None
     # Maps buffer variables to their corresponding dtypes
-    buffer_dtype_map: Optional[Dict[tir.Var, Tuple[int, torch.dtype]]] = None
+    buffer_dtype_map: dict[tir.Var, tuple[int, torch.dtype]] | None = None
     # Maps buffer variables to their corresponding static shapes
     # {
     #     "A": [(0, 16), (1, 16)] -> represents A.shape = (16, 16)
     # }
-    static_shape_map: Optional[Dict[tir.Var, Tuple[int, List[Tuple[int, int]]]]] = None
+    static_shape_map: dict[tir.Var, tuple[int, list[tuple[int, int]]]] | None = None
     # Maps buffer variables to their corresponding devices
-    buffer_device_map: Optional[Dict[tir.Var, Tuple[int, torch.device]]] = None
+    buffer_device_map: dict[tir.Var, tuple[int, torch.device]] | None = None
     # Pass configs for the compiler
-    pass_configs: Optional[Dict[str, Any]] = None
+    pass_configs: dict[str, Any] | None = None
 
     def __init__(
         self,
-        params: List[KernelParam],
-        result_idx: List[int],
-        workspace_idx: List[int],
-        auto_gm_idx: List[int],
-        target: Union[str, Target],
+        params: list[KernelParam],
+        result_idx: list[int],
+        workspace_idx: list[int],
+        auto_gm_idx: list[int],
+        target: str | Target,
         platform: str,
-        func_or_mod: Union[tir.PrimFunc, tvm.IRModule],
-        host_mod: Optional[tvm.IRModule] = None,
-        device_mod: Optional[tvm.IRModule] = None,
-        kernel_global_source: Optional[str] = None,
+        func_or_mod: tir.PrimFunc | tvm.IRModule,
+        host_mod: tvm.IRModule | None = None,
+        device_mod: tvm.IRModule | None = None,
+        kernel_global_source: str | None = None,
         verbose: bool = False,
-        pass_configs: Optional[Dict[str, Any]] = None,
+        pass_configs: dict[str, Any] | None = None,
     ):
         """Initialize the adapter with the given TIR function or module.
 
@@ -284,17 +285,17 @@ class CythonKernelAdapter(BaseKernelAdapter):
     @classmethod
     def from_database(
         cls,
-        params: List[TensorType],
-        result_idx: List[int],
-        workspace_idx: List[int],
-        auto_gm_idx: List[int],
+        params: list[TensorType],
+        result_idx: list[int],
+        workspace_idx: list[int],
+        auto_gm_idx: list[int],
         target: str,
         platform: str,
-        func_or_mod: Union[tir.PrimFunc, tvm.IRModule],
+        func_or_mod: tir.PrimFunc | tvm.IRModule,
         kernel_global_source: str,
         kernel_lib_path: str,
         verbose: bool = False,
-        pass_configs: Optional[Dict[str, Any]] = None,
+        pass_configs: dict[str, Any] | None = None,
     ):
         adapter = cls.__new__(cls)
         adapter.params = params
@@ -341,7 +342,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
         adapter._post_init()
         return adapter
 
-    def _process_dynamic_symbolic(self) -> Dict[tir.Var, Tuple[int, int]]:
+    def _process_dynamic_symbolic(self) -> dict[tir.Var, tuple[int, int]]:
         """Extract information about dynamic shapes from the TIR function.
 
         Maps symbolic variables to their corresponding (buffer_index, shape_dimension)
@@ -363,7 +364,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
                         dynamic_symbolic_map[shape] = (i - temp, j)
         return dynamic_symbolic_map
 
-    def _process_buffer_dtype(self) -> Dict[tir.Var, Tuple[int, torch.dtype]]:
+    def _process_buffer_dtype(self) -> dict[tir.Var, tuple[int, torch.dtype]]:
         """Extract information about buffer dtypes from the TIR function.
 
         Maps buffer variables to their corresponding dtypes.
@@ -379,7 +380,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
                 buffer_dtype_map[name] = (i, map_torch_type(dtype))
         return buffer_dtype_map
 
-    def _process_ptr_map(self) -> Dict[int, str]:
+    def _process_ptr_map(self) -> dict[int, str]:
         """Extract information about pointer arguments from the TIR function.
 
         Maps pointer arguments to their corresponding (buffer_index, shape_dimension)
@@ -393,7 +394,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
                 ptr_map[i] = param.name
         return ptr_map
 
-    def _process_static_shape(self) -> Dict[tir.Var, List[Tuple[int, int]]]:
+    def _process_static_shape(self) -> dict[tir.Var, list[tuple[int, int]]]:
         """Extract information about static shapes from the TIR function.
 
         Maps buffer variables to their corresponding static shapes.
@@ -414,7 +415,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
                 static_shape_map[name] = (i, static_shape)
         return static_shape_map
 
-    def _process_buffer_device(self) -> Dict[tir.Var, Tuple[int, torch.device]]:
+    def _process_buffer_device(self) -> dict[tir.Var, tuple[int, torch.device]]:
         """Extract information about buffer devices from the TIR function.
 
         Maps buffer variables to their corresponding devices.
@@ -432,7 +433,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
                 buffer_device_map[name] = (i, device)
         return buffer_device_map
 
-    def _forward_from_prebuild_lib(self, *args, stream: Optional[int] = None):
+    def _forward_from_prebuild_lib(self, *args, stream: int | None = None):
         """Low-level function to call the compiled CUDA kernel.
 
         Converts PyTorch tensor pointers to C void pointers for ctypes interface.

--- a/tilelang/jit/adapter/cython/adapter.py
+++ b/tilelang/jit/adapter/cython/adapter.py
@@ -79,8 +79,8 @@ def get_cached_lib(source_code: str) -> Tuple[Optional[ctypes.CDLL], Path]:
     """Try to load cached library or return None if not found."""
     code_hash = hashlib.sha256(source_code.encode()).hexdigest()
     cache_path = get_cache_dir() / f"{code_hash}.so"
-    lock_file = cache_path.with_suffix('.lock')
-    with open(lock_file, 'w') as lock:
+    lock_file = cache_path.with_suffix(".lock")
+    with open(lock_file, "w") as lock:
         fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
         try:
             if cache_path.exists():
@@ -109,7 +109,7 @@ with open(cython_wrapper_path, "r") as f:
     md5_path = cache_dir / "md5.txt"
     code_hash = hashlib.sha256(cython_wrapper_code.encode()).hexdigest()
     cache_path = cache_dir / f"{code_hash}.so"
-    lock_file = cache_path.with_suffix('.lock')
+    lock_file = cache_path.with_suffix(".lock")
 
     # Check if cached version exists and is valid
     need_compile = True
@@ -126,7 +126,7 @@ with open(cython_wrapper_path, "r") as f:
 
     if need_compile:
         logger.info("Waiting for lock to compile cython jit adapter...")
-        with open(lock_file, 'w') as lock:
+        with open(lock_file, "w") as lock:
             fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
             try:
                 # After acquiring the lock, check again if the file has been compiled by another process
@@ -134,8 +134,7 @@ with open(cython_wrapper_path, "r") as f:
                     with open(md5_path, "r") as f:
                         cached_hash = f.read().strip()
                         if cached_hash == code_hash:
-                            logger.info(
-                                "Another process has already compiled the file, using it...")
+                            logger.info("Another process has already compiled the file, using it...")
                             need_compile = False
 
                 if need_compile:
@@ -158,7 +157,7 @@ with open(cython_wrapper_path, "r") as f:
                     # rename the temp file to the library file
                     temp_path.rename(library_path)
             except Exception as e:
-                if 'temp_path' in locals() and temp_path.exists():
+                if "temp_path" in locals() and temp_path.exists():
                     temp_path.unlink()
                 raise Exception(f"Failed to compile cython jit adapter: {e}") from e
             finally:
@@ -175,7 +174,7 @@ from cython_wrapper import CythonKernelWrapper
 
 class CythonKernelAdapter(BaseKernelAdapter):
     """Adapter class that converts TVM/TIR functions to callable CUDA kernels using ctypes.
-    
+
     This adapter handles:
     1. Converting TIR functions to compiled CUDA libraries
     2. Managing dynamic shapes in tensor operations
@@ -206,20 +205,23 @@ class CythonKernelAdapter(BaseKernelAdapter):
     # Pass configs for the compiler
     pass_configs: Optional[Dict[str, Any]] = None
 
-    def __init__(self,
-                 params: List[KernelParam],
-                 result_idx: List[int],
-                 workspace_idx: List[int],
-                 target: Union[str, Target],
-                 platform: str,
-                 func_or_mod: Union[tir.PrimFunc, tvm.IRModule],
-                 host_mod: Optional[tvm.IRModule] = None,
-                 device_mod: Optional[tvm.IRModule] = None,
-                 kernel_global_source: Optional[str] = None,
-                 verbose: bool = False,
-                 pass_configs: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self,
+        params: List[KernelParam],
+        result_idx: List[int],
+        workspace_idx: List[int],
+        auto_gm_idx: List[int],
+        target: Union[str, Target],
+        platform: str,
+        func_or_mod: Union[tir.PrimFunc, tvm.IRModule],
+        host_mod: Optional[tvm.IRModule] = None,
+        device_mod: Optional[tvm.IRModule] = None,
+        kernel_global_source: Optional[str] = None,
+        verbose: bool = False,
+        pass_configs: Optional[Dict[str, Any]] = None,
+    ):
         """Initialize the adapter with the given TIR function or module.
-        
+
         Args:
             params: List of tensor types for inputs/outputs
             result_idx: Indices of output tensors
@@ -232,6 +234,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
         self.params = params
         self.result_idx = self._legalize_auto_memory_idx(result_idx, "result_idx")
         self.workspace_idx = self._legalize_auto_memory_idx(workspace_idx, "workspace_idx")
+        self.auto_gm_idx = self._legalize_auto_memory_idx(auto_gm_idx, "auto_gm_idx")
         self.kernel_global_source = kernel_global_source
 
         if isinstance(func_or_mod, tir.PrimFunc):
@@ -270,7 +273,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
         #     error_msg += f"\n{self.lib_code}"
         #     raise RuntimeError(f"Initialization failed: {error_msg}")
 
-        self.cython_wrapper = CythonKernelWrapper(self.result_idx, self.workspace_idx, self.params, self.lib)
+        self.cython_wrapper = CythonKernelWrapper(self.result_idx, self.workspace_idx, self.auto_gm_idx, self.params, self.lib)
         self.cython_wrapper.set_dynamic_symbolic_map(self.dynamic_symbolic_map)
         self.cython_wrapper.set_buffer_dtype_map(self.buffer_dtype_map)
         self.cython_wrapper.set_static_shape_map(self.static_shape_map)
@@ -279,21 +282,25 @@ class CythonKernelAdapter(BaseKernelAdapter):
         self._post_init()
 
     @classmethod
-    def from_database(cls,
-                      params: List[TensorType],
-                      result_idx: List[int],
-                      workspace_idx: List[int],
-                      target: str,
-                      platform: str,
-                      func_or_mod: Union[tir.PrimFunc, tvm.IRModule],
-                      kernel_global_source: str,
-                      kernel_lib_path: str,
-                      verbose: bool = False,
-                      pass_configs: Optional[Dict[str, Any]] = None):
+    def from_database(
+        cls,
+        params: List[TensorType],
+        result_idx: List[int],
+        workspace_idx: List[int],
+        auto_gm_idx: List[int],
+        target: str,
+        platform: str,
+        func_or_mod: Union[tir.PrimFunc, tvm.IRModule],
+        kernel_global_source: str,
+        kernel_lib_path: str,
+        verbose: bool = False,
+        pass_configs: Optional[Dict[str, Any]] = None,
+    ):
         adapter = cls.__new__(cls)
         adapter.params = params
         adapter.result_idx = adapter._legalize_auto_memory_idx(result_idx, "result_idx")
         adapter.workspace_idx = adapter._legalize_auto_memory_idx(workspace_idx, "workspace_idx")
+        adapter.auto_gm_idx = adapter._legalize_auto_memory_idx(auto_gm_idx, "auto_gm_idx")
         adapter.kernel_global_source = kernel_global_source
         adapter.wrapped_source = kernel_global_source
         adapter.pass_configs = pass_configs
@@ -322,8 +329,9 @@ class CythonKernelAdapter(BaseKernelAdapter):
         #     error_msg = adapter.lib.get_last_error().decode('utf-8')
         #     raise RuntimeError(f"Initialization failed: {error_msg}")
 
-        adapter.cython_wrapper = CythonKernelWrapper(adapter.result_idx, adapter.workspace_idx, adapter.params,
-                                                     adapter.lib)
+        adapter.cython_wrapper = CythonKernelWrapper(
+            adapter.result_idx, adapter.workspace_idx, adapter.auto_gm_idx, adapter.params, adapter.lib
+        )
         adapter.cython_wrapper.set_dynamic_symbolic_map(adapter.dynamic_symbolic_map)
         adapter.cython_wrapper.set_buffer_dtype_map(adapter.buffer_dtype_map)
         adapter.cython_wrapper.set_static_shape_map(adapter.static_shape_map)
@@ -335,7 +343,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
 
     def _process_dynamic_symbolic(self) -> Dict[tir.Var, Tuple[int, int]]:
         """Extract information about dynamic shapes from the TIR function.
-        
+
         Maps symbolic variables to their corresponding (buffer_index, shape_dimension)
         for runtime shape resolution.
         """
@@ -351,14 +359,13 @@ class CythonKernelAdapter(BaseKernelAdapter):
             if param in buffer_map:
                 buffer = buffer_map[param]
                 for j, shape in enumerate(buffer.shape):
-                    if (isinstance(shape, tir.Var) and (shape not in dynamic_symbolic_map) and
-                        (shape not in params)):
+                    if isinstance(shape, tir.Var) and (shape not in dynamic_symbolic_map) and (shape not in params):
                         dynamic_symbolic_map[shape] = (i - temp, j)
         return dynamic_symbolic_map
 
     def _process_buffer_dtype(self) -> Dict[tir.Var, Tuple[int, torch.dtype]]:
         """Extract information about buffer dtypes from the TIR function.
-        
+
         Maps buffer variables to their corresponding dtypes.
         """
         func = self.prim_func
@@ -374,7 +381,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
 
     def _process_ptr_map(self) -> Dict[int, str]:
         """Extract information about pointer arguments from the TIR function.
-        
+
         Maps pointer arguments to their corresponding (buffer_index, shape_dimension)
         for runtime shape resolution.
         """
@@ -382,13 +389,13 @@ class CythonKernelAdapter(BaseKernelAdapter):
         params = func.params
         ptr_map = {}
         for i, param in enumerate(params):
-            if param.dtype == 'handle':
+            if param.dtype == "handle":
                 ptr_map[i] = param.name
         return ptr_map
 
     def _process_static_shape(self) -> Dict[tir.Var, List[Tuple[int, int]]]:
         """Extract information about static shapes from the TIR function.
-        
+
         Maps buffer variables to their corresponding static shapes.
         """
         func = self.prim_func
@@ -409,7 +416,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
 
     def _process_buffer_device(self) -> Dict[tir.Var, Tuple[int, torch.device]]:
         """Extract information about buffer devices from the TIR function.
-        
+
         Maps buffer variables to their corresponding devices.
         """
         func = self.prim_func
@@ -427,12 +434,10 @@ class CythonKernelAdapter(BaseKernelAdapter):
 
     def _forward_from_prebuild_lib(self, *args, stream: Optional[int] = None):
         """Low-level function to call the compiled CUDA kernel.
-        
+
         Converts PyTorch tensor pointers to C void pointers for ctypes interface.
         """
-        ctypes_args = [
-            ctypes.c_void_p(arr.data_ptr()) if not isinstance(arr, int) else arr for arr in args
-        ]
+        ctypes_args = [ctypes.c_void_p(arr.data_ptr()) if not isinstance(arr, int) else arr for arr in args]
         ctypes_args.append(ctypes.c_void_p(stream))
         self.lib.call(*ctypes_args)
 
@@ -467,7 +472,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
     @property
     def is_dynamic(self):
         """Indicates whether the kernel handles dynamic shapes."""
-        return (self.dynamic_symbolic_map is not None and len(self.dynamic_symbolic_map) > 0)
+        return self.dynamic_symbolic_map is not None and len(self.dynamic_symbolic_map) > 0
 
     def get_kernel_source(self, kernel_only: bool = False):
         """Returns the source code of the compiled kernel."""

--- a/tilelang/jit/adapter/cython/cython_wrapper.pyx
+++ b/tilelang/jit/adapter/cython/cython_wrapper.pyx
@@ -21,17 +21,19 @@ cdef class CythonKernelWrapper:
         object static_shape_map     # Maps buffer variables to their corresponding static shapes
         object ptr_map              # Maps pointer arguments to their corresponding buffer indices
         list result_idx             # Indices of output tensors in the params list
-        list workspace_idx          # Indices of auto-allocated workspace tensors in the params list
+        list workspace_idx          # Indices of workspace in the params list
+        list auto_gm_idx            # Indices of auto-allocated GM workspace
         list params                 # List of parameter specifications (includes both inputs and outputs)
         object lib                  # Reference to the compiled library containing the kernel
         # Add new cache attributes
         list param_dtypes    # Cache for parameter dtypes
         list param_shapes    # Cache for parameter shapes as native Python lists
         object get_current_device
-    def __cinit__(self, result_idx, workspace_idx, params, lib):
+    def __cinit__(self, result_idx, workspace_idx, auto_gm_idx, params, lib):
         # Initialize wrapper with kernel configuration
         self.result_idx = result_idx
         self.workspace_idx = workspace_idx
+        self.auto_gm_idx = auto_gm_idx
         self.params = params
         self.lib = lib
         # Convert TVM types to native Python types during initialization
@@ -76,6 +78,7 @@ cdef class CythonKernelWrapper:
         cdef int total_inputs = len(inputs)
         cdef int total_result_idx = len(self.result_idx)
         cdef int total_workspace_idx = len(self.workspace_idx)
+        cdef int total_auto_gm_idx = len(self.auto_gm_idx)
         cdef int total_dynamic_symbolics = len(self.dynamic_symbolic_map)
 
         # Ensure the number of inputs matches expected parameter count
@@ -122,6 +125,14 @@ cdef class CythonKernelWrapper:
                     else:
                         raise TypeError(f"Unsupported shape dim type: {type(s)} ({str(s)})")
                     shape.append(res)
+                device = inputs[0].device if len(inputs) > 0 else torch.npu.current_device()
+                tensor = torch.empty(*shape, dtype=dtype, device=device)
+            elif i in self.auto_gm_idx:
+                dtype = self.param_dtypes[i]
+                shape = []
+                # Auto GM: Dynamic shape scenarios are not supported currently  
+                for dim_name in self.param_shapes[i]:
+                    shape.append(dim_name)
                 device = inputs[0].device if len(inputs) > 0 else torch.npu.current_device()
                 tensor = torch.empty(*shape, dtype=dtype, device=device)
             else:

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -1,7 +1,8 @@
 # Copyright (c) Tile-AI Corporation.
 # Licensed under the MIT License.
+from __future__ import annotations
 
-from typing import List, Union, Any, Callable, Literal, Optional, Dict
+from typing import Any, Callable, Literal
 from tvm.target import Target
 import tilelang
 from tilelang import tvm as tvm
@@ -18,7 +19,7 @@ from tilelang.profiler import Profiler, TensorSupplyType
 from tilelang.engine.param import KernelParam, CompiledArtifact
 
 
-class JITKernel(object):
+class JITKernel:
     """
     A wrapper class for compiling and invoking TileLang (TVM TIR) functions as PyTorch-compatible functions.
 
@@ -31,6 +32,7 @@ class JITKernel(object):
     torch_function : Callable
         The compiled function that can be invoked as a PyTorch-compatible function.
     """
+
     prim_func: PrimFunc = None
     artifact: CompiledArtifact = None
     adapter: BaseKernelAdapter = None
@@ -38,20 +40,20 @@ class JITKernel(object):
 
     # tuner result
     latency: float = None
-    config: Dict[str, Any] = None
+    config: dict[str, Any] = None
     ref_latency: float = None
 
     def __init__(
         self,
         func: PrimFunc = None,
-        out_idx: Union[List[int], int] = None,
-        workspace_idx: Union[List[int], int] = None,
+        out_idx: list[int] | int = None,
+        workspace_idx: list[int] | int = None,
         execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
-        target: Union[str, Target] = "auto",
-        target_host: Union[str, Target] = None,
+        target: str | Target = "auto",
+        target_host: str | Target = None,
         platform: str = "auto",
         verbose: bool = False,
-        pass_configs: Optional[Dict[str, Any]] = None,
+        pass_configs: dict[str, Any] | None = None,
         from_database: bool = False,
     ):
         """
@@ -92,7 +94,6 @@ class JITKernel(object):
         self.platform = platform
         self.verbose = verbose
 
-
         if pass_configs is None:
             pass_configs = {}
         self.pass_configs = pass_configs
@@ -106,9 +107,7 @@ class JITKernel(object):
         if execution_backend == "cython":
             from tilelang.contrib.cc import get_cplus_compiler
 
-            assert (
-                get_cplus_compiler() is not None
-            ), "Cython backend requires a C++ compiler, please install or use other backends."
+            assert get_cplus_compiler() is not None, "Cython backend requires a C++ compiler, please install or use other backends."
 
         if from_database:
             return
@@ -126,14 +125,15 @@ class JITKernel(object):
         func: PrimFunc,
         kernel_global_source: str,
         kernel_lib_path: str,
-        params: List[KernelParam],
-        target: Union[str, Target],
-        target_host: Union[str, Target],
+        params: list[KernelParam],
+        target: str | Target,
+        target_host: str | Target,
         platform: str,
-        out_idx: Union[List[int], int],
-        workspace_idx: Union[List[int], int],
+        out_idx: list[int] | int,
+        workspace_idx: list[int] | int,
+        auto_gm_idx: list[int] | int,
         execution_backend: Literal["dlpack", "ctypes", "cython"],
-        pass_configs: Optional[Dict[str, Any]] = None,
+        pass_configs: dict[str, Any] | None = None,
     ):
         """
         Alternative constructor to create a TorchFunction directly from a database.
@@ -155,6 +155,7 @@ class JITKernel(object):
             params=params,
             result_idx=out_idx,
             workspace_idx=workspace_idx,
+            auto_gm_idx=auto_gm_idx,
             target=target,
             platform=platform,
             kernel_global_source=kernel_global_source,
@@ -194,9 +195,7 @@ class JITKernel(object):
         """
         return self.torch_function(*modify_args, **kwds)
 
-    def _compile_and_create_adapter(self, tilelang_func: PrimFunc,
-                                    out_idx: List[int],
-                                    workspace_idx: List[int]) -> BaseKernelAdapter:
+    def _compile_and_create_adapter(self, tilelang_func: PrimFunc, out_idx: list[int], workspace_idx: list[int]) -> BaseKernelAdapter:
         """
         Compiles the given TileLang PrimFunc using TVM and creates a kernel adapter.
 
@@ -227,18 +226,31 @@ class JITKernel(object):
                 target_host=target_host,
                 platform=self.platform,
                 enable_host_codegen=enable_host_codegen,
-                enable_device_compile=enable_device_compile)
+                enable_device_compile=enable_device_compile,
+            )
 
         self.artifact = artifact
+
+        # Check for auto_gm_indices attribute in the compiled PrimFunc and store it if available.
+        self._auto_gm_idx = None
+        target_prim_func = None
+        mod = artifact.device_mod
+        if mod is not None and isinstance(mod, tvm.ir.module.IRModule):
+            for _global_symbol, prim_func in mod.functions_items():
+                if isinstance(prim_func, tvm.tir.PrimFunc):
+                    target_prim_func = prim_func
+                    break
+            if target_prim_func is not None and "auto_gm_indices" in target_prim_func.attrs:
+                self._auto_gm_idx = target_prim_func.attrs["auto_gm_indices"]
+                self._auto_gm_idx = [int(item.value) for item in self._auto_gm_idx]
 
         # Create an adapter based on the specified execution backend.
         if execution_backend == "dlpack":
             # Use TorchDLPackKernelAdapter for interoperability with PyTorch via DLPack.
             # But we need to ensure that the runtime is enabled and the runtime module is not None.
             assert tvm.runtime.enabled("llvm"), "DLPack backend requires LLVM runtime."
-            assert (artifact.rt_mod is not None), "DLPack backend requires a runtime module."
-            adapter = TorchDLPackKernelAdapter(
-                artifact.rt_mod, params=artifact.params, result_idx=out_idx)
+            assert artifact.rt_mod is not None, "DLPack backend requires a runtime module."
+            adapter = TorchDLPackKernelAdapter(artifact.rt_mod, params=artifact.params, result_idx=out_idx)
         elif execution_backend == "ctypes":
             adapter = CtypesKernelAdapter(
                 params=artifact.params,
@@ -256,6 +268,7 @@ class JITKernel(object):
                 params=artifact.params,
                 result_idx=out_idx,
                 workspace_idx=workspace_idx,
+                auto_gm_idx=self._auto_gm_idx,
                 target=target,
                 platform=self.platform,
                 func_or_mod=tilelang_func,
@@ -273,15 +286,16 @@ class JITKernel(object):
 
     def _create_adapter_from_database(
         self,
-        params: List[KernelParam],
-        result_idx: Union[List[int], int],
-        workspace_idx: Union[List[int], int],
-        target: Union[str, Target],
+        params: list[KernelParam],
+        result_idx: list[int] | int,
+        workspace_idx: list[int] | int,
+        auto_gm_idx: list[int] | int,
+        target: str | Target,
         platform: str,
-        func_or_mod: Union[PrimFunc, tvm.runtime.Module],
+        func_or_mod: PrimFunc | tvm.runtime.Module,
         kernel_global_source: str,
         kernel_lib_path: str,
-        pass_configs: Optional[Dict[str, Any]] = None,
+        pass_configs: dict[str, Any] | None = None,
     ) -> BaseKernelAdapter:
         target = self.target
         execution_backend = self.execution_backend
@@ -304,6 +318,7 @@ class JITKernel(object):
                 params=params,
                 result_idx=result_idx,
                 workspace_idx=workspace_idx,
+                auto_gm_idx=auto_gm_idx,
                 target=target,
                 platform=platform,
                 func_or_mod=func_or_mod,
@@ -336,8 +351,7 @@ class JITKernel(object):
         """
         return cls(func=tilelang_func, **kwargs)
 
-    def get_profiler(self,
-                     tensor_supply_type: TensorSupplyType = TensorSupplyType.Auto) -> Profiler:
+    def get_profiler(self, tensor_supply_type: TensorSupplyType = TensorSupplyType.Auto) -> Profiler:
         """
         Creates a profiler to benchmark the compiled runtime module.
 
@@ -351,8 +365,7 @@ class JITKernel(object):
         Profiler
             A Profiler instance for benchmarking the runtime module.
         """
-        return Profiler(self.params, self.out_idx, self.workspace_idx,
-                        tensor_supply_type).with_default_adapter(self.adapter)
+        return Profiler(self.params, self.out_idx, self.workspace_idx, tensor_supply_type).with_default_adapter(self.adapter)
 
     def get_kernel_source(self) -> str:
         """
@@ -373,11 +386,10 @@ class JITKernel(object):
         """
         return str(self.artifact.host_mod)
 
-    def run_once(self, func: Optional[Callable] = None) -> None:
+    def run_once(self, func: Callable | None = None) -> None:
         return self.get_profiler().run_once(func)
 
-    def update_tuner_result(self, latency: float, config: Dict[str, Any],
-                            ref_latency: float) -> "JITKernel":
+    def update_tuner_result(self, latency: float, config: dict[str, Any], ref_latency: float) -> JITKernel:
         """
         Updates the tuning results for this kernel.
 
@@ -400,7 +412,7 @@ class JITKernel(object):
 
         return self
 
-    def get_tuner_result(self) -> Dict[str, Any]:
+    def get_tuner_result(self) -> dict[str, Any]:
         """
         Gets the tuning results for this kernel.
 
@@ -422,15 +434,19 @@ class JITKernel(object):
         }
 
     @property
-    def out_idx(self) -> List[int]:
+    def out_idx(self) -> list[int]:
         return self.adapter.result_idx
-    
+
     @property
-    def workspace_idx(self) -> List[int]:
+    def workspace_idx(self) -> list[int]:
         return self.adapter.workspace_idx
 
     @property
-    def params(self) -> List[KernelParam]:
+    def auto_gm_idx(self) -> list[int]:
+        return self.adapter.auto_gm_idx
+
+    @property
+    def params(self) -> list[KernelParam]:
         return self.artifact.params if self.artifact else self.adapter.params
 
     @property

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -425,6 +425,7 @@ def AscendVidReduction():
     """
     return _ffi_api.AscendVidReduction()  # type: ignore
 
+
 def AscendWorkspaceReduction():
     """Reduction Workspace for Ascend.
 

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -425,6 +425,17 @@ def AscendVidReduction():
     """
     return _ffi_api.AscendVidReduction()  # type: ignore
 
+def AscendWorkspaceReduction():
+    """Reduction Workspace for Ascend.
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    ----
+    """
+    return _ffi_api.AscendWorkspaceReduction()  # type: ignore
+
 
 def AscendInferBufferScope():
     """Infer Buffer Scope for Ascend.


### PR DESCRIPTION
Implement AscendWorkspaceReduction pass to transform UB↔L1 and L0C↔UB operations into two-step copy via GM workspace. Core changes:
- Add AscendWorkspaceReduction pass (880 lines) in src/transform/
- Support normal UB and skip UB scenarios with vid offset calculation
- Integrate pass into compilation pipeline (after LowerTileOp)
- Add virtual channel support in AscendCopy lowering
- Support auto_gm_indices in JIT kernel and Cython adapter
- Update examples to use virtual channel for automatic workspace allocation This eliminates manual workspace buffer management in developer mode kernels.