### PR TITLE
causal_conv1d_pto

### DIFF
--- a/examples/causal_conv1d/causal_conv1d.py
+++ b/examples/causal_conv1d/causal_conv1d.py
@@ -24,7 +24,7 @@ _kernel_cache = {}
 # ======================== Kernel ========================
 
 
-@tilelang.jit(out_idx=[-1], pass_configs=pass_configs_config)
+@tilelang.jit(out_idx=[-1], pass_configs=pass_configs_config, target="pto")
 def _build_kernel(
     width: int,
     dim_num: int,

--- a/examples/causal_conv1d/causal_conv1d_pto.py
+++ b/examples/causal_conv1d/causal_conv1d_pto.py
@@ -24,7 +24,7 @@ _kernel_cache = {}
 # ======================== Kernel ========================
 
 
-@tilelang.jit(out_idx=[-1], pass_configs=pass_configs_config)
+@tilelang.jit(out_idx=[-1], pass_configs=pass_configs_config, target="pto")
 def _build_kernel(
     width: int,
     dim_num: int,

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -829,6 +829,10 @@ void CodeGenTileLangAscendPto::VisitExpr_(const CallNode *op,
     BinaryVecClampOpsCodegen(op, "TCLAMP");
   } else if (op->op.same_as(tl::ascend_sigmoid())) {
     SigmoidCodegen(op, "TSIGMOID");
+  } else if (op->op.same_as(tl::ascend_silu())) {
+    SiluCodegen(op);
+  } else if (op->op.same_as(tl::ascend_mul_add_dst())) {
+    MulAddDstCodegen(op);
   } else if (op->op.same_as(tl::ascend_gather_mask())) {
     GatherMaskCodegen(op, "TGATHER");
   } else if (op->op.same_as(tl::ascend_round())) {
@@ -2326,6 +2330,94 @@ void CodeGenTileLangAscendPto::SigmoidCodegen(const CallNode *op,
   }
 }
 
+void CodeGenTileLangAscendPto::SiluCodegen(const CallNode *op) {
+  ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
+  ShapeInfo src_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+
+  std::string dst_name = PrintBufferOffset(op->args[0].as<CallNode>());
+  std::string src_name = PrintBufferOffset(op->args[1].as<CallNode>());
+
+  std::string tmp_name = GetTempVarName(dst_shape_info.ub_name) + "_silu_tmp";
+  int32_t row =
+      dst_shape_info.is_slice ? dst_shape_info.slice_row : dst_shape_info.row;
+  int32_t col =
+      dst_shape_info.is_slice ? dst_shape_info.slice_col : dst_shape_info.col;
+
+  if (dst_shape_info.is_slice || src_shape_info.is_slice) {
+    std::string dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
+    std::string src_temp_name = GetTempVarName(src_shape_info.ub_name);
+    CreateUbVariableND(dst_temp_name, dst_shape_info);
+    CreateUbVariableND(src_temp_name, src_shape_info);
+    this->PrintIndent();
+    this->stream << "tl::ascend_pto::TileUbDataND<" << dst_shape_info.type
+                 << ", " << row << ", " << col << "> " << tmp_name << ";\n";
+    this->PrintIndent();
+    this->stream << "TASSIGN(" << tmp_name << ", " << max_ub_addr_ << ");\n";
+    this->PrintIndent();
+    this->stream << kAscendPtoScope << "TSILU<" << dst_shape_info.type << ", "
+                 << row << ", " << col << ">(" << dst_temp_name << ", "
+                 << src_temp_name << ", " << tmp_name << ");\n";
+  } else {
+    this->PrintIndent();
+    this->stream << "tl::ascend_pto::TileUbDataND<" << dst_shape_info.type
+                 << ", " << row << ", " << col << "> " << tmp_name << ";\n";
+    this->PrintIndent();
+    this->stream << "TASSIGN(" << tmp_name << ", " << max_ub_addr_ << ");\n";
+    this->PrintIndent();
+    this->stream << kAscendPtoScope << "TSILU<" << dst_shape_info.type << ", "
+                 << row << ", " << col << ">(" << dst_name << ", " << src_name
+                 << ", " << tmp_name << ");\n";
+  }
+}
+
+void CodeGenTileLangAscendPto::MulAddDstCodegen(const CallNode *op) {
+  ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
+  ShapeInfo src0_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+  ShapeInfo src1_shape_info = GetSliceInfo(op->args[2].as<CallNode>());
+
+  std::string dst_name = PrintBufferOffset(op->args[0].as<CallNode>());
+  std::string src0_name = PrintBufferOffset(op->args[1].as<CallNode>());
+  std::string src1_name = PrintBufferOffset(op->args[2].as<CallNode>());
+
+  std::string tmp_name =
+      GetTempVarName(dst_shape_info.ub_name) + "_muladddst_tmp";
+  int32_t row =
+      dst_shape_info.is_slice ? dst_shape_info.slice_row : dst_shape_info.row;
+  int32_t col =
+      dst_shape_info.is_slice ? dst_shape_info.slice_col : dst_shape_info.col;
+
+  if (dst_shape_info.is_slice || src0_shape_info.is_slice ||
+      src1_shape_info.is_slice) {
+    std::string dst_temp_name = GetTempVarName(dst_shape_info.ub_name);
+    std::string src0_temp_name = GetTempVarName(src0_shape_info.ub_name);
+    std::string src1_temp_name = GetTempVarName(src1_shape_info.ub_name);
+    CreateUbVariableND(dst_temp_name, dst_shape_info);
+    CreateUbVariableND(src0_temp_name, src0_shape_info);
+    CreateUbVariableND(src1_temp_name, src1_shape_info);
+    this->PrintIndent();
+    this->stream << "tl::ascend_pto::TileUbDataND<" << dst_shape_info.type
+                 << ", " << row << ", " << col << "> " << tmp_name << ";\n";
+    this->PrintIndent();
+    this->stream << "TASSIGN(" << tmp_name << ", " << max_ub_addr_ << ");\n";
+    this->PrintIndent();
+    this->stream << kAscendPtoScope << "MulAddDst<" << dst_shape_info.type
+                 << ", " << row << ", " << col << ">(" << dst_temp_name << ", "
+                 << src0_temp_name << ", " << src1_temp_name << ", " << tmp_name
+                 << ");\n";
+  } else {
+    this->PrintIndent();
+    this->stream << "tl::ascend_pto::TileUbDataND<" << dst_shape_info.type
+                 << ", " << row << ", " << col << "> " << tmp_name << ";\n";
+    this->PrintIndent();
+    this->stream << "TASSIGN(" << tmp_name << ", " << max_ub_addr_ << ");\n";
+    this->PrintIndent();
+    this->stream << kAscendPtoScope << "MulAddDst<" << dst_shape_info.type
+                 << ", " << row << ", " << col << ">(" << dst_name << ", "
+                 << src0_name << ", " << src1_name << ", " << tmp_name
+                 << ");\n";
+  }
+}
+
 void CodeGenTileLangAscendPto::CastCodegen(const CallNode *op,
                                            const std::string &op_type) {
   std::vector<std::string> var_names;
@@ -2758,6 +2850,17 @@ void CodeGenTileLangAscendPto::VisitStmt_(const AllocateNode *op) {
     address_offset_.Set(String(scope), current_offset + Integer(alloc_bytes));
   }
   buffer_address_map_.Set(op->buffer_var, target_address);
+
+  // Track max UB end address for internal scratch buffer allocation
+  if (scope == "shared") {
+    if (auto *addr_int = target_address.as<IntImmNode>()) {
+      int64_t size = op->ConstantAllocationSize() * op->dtype.bytes();
+      int64_t end_addr = addr_int->value + size;
+      end_addr = ((end_addr + 31) / 32) * 32;
+      if (end_addr > max_ub_addr_)
+        max_ub_addr_ = end_addr;
+    }
+  }
 
   // Print the address assignment (TASSIGN)
   this->PrintIndent();

--- a/src/target/codegen_ascend_pto.h
+++ b/src/target/codegen_ascend_pto.h
@@ -62,6 +62,8 @@ public:
                                       const std::string &op_name);
   void BinaryVecClampOpsCodegen(const CallNode *op, const std::string &op_name);
   void SigmoidCodegen(const CallNode *op, const std::string &op_type);
+  void SiluCodegen(const CallNode *op);
+  void MulAddDstCodegen(const CallNode *op);
   void CastCodegen(const CallNode *op, const std::string &op_type);
   void ReduceOpCodegen(const CallNode *op);
 
@@ -261,6 +263,7 @@ private:
 
   Map<String, PrimExpr> address_offset_;
   Map<Var, PrimExpr> buffer_address_map_;
+  int64_t max_ub_addr_{0};
 
   Map<String, String> copy_tmplte_map_;
   Map<String, String> copy_base_addr_map_;

--- a/src/tl_templates/pto/common.h
+++ b/src/tl_templates/pto/common.h
@@ -633,6 +633,27 @@ TSIGMOID(TileUbDataND<T, row, col, row, col> &dst_addr,
 }
 
 template <typename T, int32_t row, int32_t col>
+AICORE PTO_INLINE void TSILU(TileUbDataND<T, row, col, row, col> &dst,
+                             TileUbDataND<T, row, col, row, col> &src,
+                             TileUbDataND<T, row, col, row, col> &tmp) {
+  TMOV(tmp, src);
+  pipe_barrier(PIPE_V);
+  TSIGMOID(dst, src);
+  pipe_barrier(PIPE_V);
+  TMUL(dst, tmp, dst);
+}
+
+template <typename T, int32_t row, int32_t col>
+AICORE PTO_INLINE void MulAddDst(TileUbDataND<T, row, col, row, col> &dst,
+                                 TileUbDataND<T, row, col, row, col> &src0,
+                                 TileUbDataND<T, row, col, row, col> &src1,
+                                 TileUbDataND<T, row, col, row, col> &tmp) {
+  TMUL(tmp, src0, src1);
+  pipe_barrier(PIPE_V);
+  TADD(dst, dst, tmp);
+}
+
+template <typename T, int32_t row, int32_t col>
 AICORE PTO_INLINE void axpy(TileUbDataND<T, row, col, row, col> &dst,
                             TileUbDataND<T, row, col, row, col> &src0,
                             float scalar_value) {


### PR DESCRIPTION
To enable successful execution of the causal_conv1d operator, add adaptations for SiLU and MulAddDst in the PTOAS source code.The causal_conv1d operator has been successfully enabled.

后端类型 | float16 耗时 (μs) | bfloat16 耗时 (μs)
-- | -- | --
PTO | 74.9 | 72.3
AscendC | 79.2 | 70.46
