### PR TITLE
[Fix] Fix PTO row-reduce temporary buffer size and type mismatch for TROWSUM

### DIFF
--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -1445,7 +1445,6 @@ void CodeGenTileLangAscendPto::GatherbCodegen(const CallNode *op,
                << idx_name << ");\n";
 }
 
-
 void CodeGenTileLangAscendPto::GatherMaskCodegen(const CallNode *op,
                                                  const std::string &op_name) {
   BufferInfo dst_info = GetBufferInfo(op->args[1]);
@@ -2365,10 +2364,18 @@ void CodeGenTileLangAscendPto::CodegenRowReduce(const ReduceOpInfo &op_info,
   if (src.type != tmp.type) {
     temp_name = GetTempVarName(temp_name);
     int tmp_col = GetRowReduceTmpCol(src.slice_valid_col, src.type);
-    ShapeInfo tmp_cast =
-        ShapeInfo{src.slice_valid_row, tmp_col, src.slice_valid_row, tmp_col,
-                  src.slice_valid_row, tmp_col, tmp.extent, tmp.first_addr,
-                  "0", src.type, tmp.ub_name, false};
+    ShapeInfo tmp_cast = ShapeInfo{src.slice_valid_row,
+                                   tmp_col,
+                                   src.slice_valid_row,
+                                   tmp_col,
+                                   src.slice_valid_row,
+                                   tmp_col,
+                                   tmp.extent,
+                                   tmp.first_addr,
+                                   "0",
+                                   src.type,
+                                   tmp.ub_name,
+                                   false};
     CreateUbVariableND(temp_name, tmp_cast);
   }
 

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -11,6 +11,7 @@
 #include <tvm/tir/index_map.h>
 #include <tvm/tir/op.h>
 
+#include <algorithm>
 #include <cmath>
 #include <iomanip>
 #include <sstream>
@@ -159,6 +160,16 @@ int GetValidShape(int shape, const std::string &dtype) {
     return shape;
   }
   return shape + (32 - shape_mod) / dtype_len;
+}
+
+int GetRowReduceTmpCol(int valid_col, const std::string &dtype) {
+  constexpr int kVectorRepeatBytes = 256;
+  int dtype_len = GetTypeLen(dtype);
+  int elem_per_repeat = kVectorRepeatBytes / dtype_len;
+  int tmp_col = valid_col <= elem_per_repeat
+                    ? 1
+                    : std::max(valid_col / 2, elem_per_repeat);
+  return GetValidShape(tmp_col, dtype);
 }
 
 std::string CodeGenTileLangAscendPto::GetVarId(const Var &var) const {
@@ -1132,8 +1143,8 @@ void CodeGenTileLangAscendPto::GMCopyCall(const CallNode *call,
   stream << copy_base_addr_map_.at(gm_info.id) << " + " << gm_offset_string;
 
   if (is_dynamic) {
-    stream << ", pto::Shape<" << shape_tmpl << ">()"
-           << ", pto::Stride<" << stride_tmpl << ">(" << stride_param << ")";
+    stream << ", pto::Shape<" << shape_tmpl << ">()" << ", pto::Stride<"
+           << stride_tmpl << ">(" << stride_param << ")";
   }
 
   stream << ", " << PrintExpr(buffer_address_map_.at(local_info.var)) << ", "
@@ -1417,8 +1428,8 @@ void CodeGenTileLangAscendPto::CreateVecIndexCodegen(
 
   this->PrintIndent();
   this->stream << kAscendPtoScope << "tci" << "<" << getType(dst_info.dtype)
-               << ", " << PrintExpr(M) << ", " << PrintExpr(N) << ">"
-               << "(" << PrintExpr(dst_slice_info.first_addr) << ", "
+               << ", " << PrintExpr(M) << ", " << PrintExpr(N) << ">" << "("
+               << PrintExpr(dst_slice_info.first_addr) << ", "
                << dst_slice_info.offset << ", "
                << GetTypeLen(dst_slice_info.type) << ", " << first_value
                << ");\n";
@@ -1433,6 +1444,7 @@ void CodeGenTileLangAscendPto::GatherbCodegen(const CallNode *op,
   this->stream << op_name << "(" << dst_name << ", " << src_name << ", "
                << idx_name << ");\n";
 }
+
 
 void CodeGenTileLangAscendPto::GatherMaskCodegen(const CallNode *op,
                                                  const std::string &op_name) {
@@ -1475,15 +1487,13 @@ void CodeGenTileLangAscendPto::PowCodegen(const CallNode *op) {
     this->PrintIndent();
     this->stream << kAscendPtoScope << "pow" << "<" << dst_shape_info.type
                  << ", " << dst_shape_info.slice_row << ", "
-                 << dst_shape_info.slice_col << ">"
-                 << "(" << dst_temp_name << ", " << src0_temp_name << ", "
-                 << src1_temp_name << ");\n";
+                 << dst_shape_info.slice_col << ">" << "(" << dst_temp_name
+                 << ", " << src0_temp_name << ", " << src1_temp_name << ");\n";
   } else {
     this->PrintIndent();
     this->stream << kAscendPtoScope << "pow" << "<" << dst_shape_info.type
                  << ", " << dst_shape_info.row << ", " << dst_shape_info.col
-                 << ">"
-                 << "(" << dst_shape_info.ub_name << ", "
+                 << ">" << "(" << dst_shape_info.ub_name << ", "
                  << src0_shape_info.ub_name << ", " << src1_shape_info.ub_name
                  << ");\n";
   }
@@ -1863,8 +1873,7 @@ void CodeGenTileLangAscendPto::CodegenColBroadcast(const ShapeInfo &dst,
   }
 
   this->PrintIndent();
-  this->stream << "TCOLEXPAND"
-               << "(" << dst_name << ", " << src_name << ");\n";
+  this->stream << "TCOLEXPAND" << "(" << dst_name << ", " << src_name << ");\n";
 }
 
 void CodeGenTileLangAscendPto::BroadcastOpCodegen(const CallNode *op) {
@@ -2076,8 +2085,7 @@ void CodeGenTileLangAscendPto::AxpyCodegen(const CallNode *op) {
     this->PrintIndent();
     this->stream << kAscendPtoScope << "axpy" << "<" << dst_shape_info.type
                  << ", " << dst_shape_info.row << ", " << dst_shape_info.col
-                 << ">"
-                 << "(" << dst_shape_info.ub_name << ", "
+                 << ">" << "(" << dst_shape_info.ub_name << ", "
                  << src_shape_info.ub_name << ", " << scalar << ");\n";
   }
 }
@@ -2350,9 +2358,23 @@ void CodeGenTileLangAscendPto::CodegenRowReduce(const ReduceOpInfo &op_info,
     CreateUbVariableND(src_name, src);
   }
 
+  ICHECK(dst.type == src.type)
+      << "Row reduce input dtype must be consistent with the output dtype.";
+
+  std::string temp_name = tmp.ub_name;
+  if (src.type != tmp.type) {
+    temp_name = GetTempVarName(temp_name);
+    int tmp_col = GetRowReduceTmpCol(src.slice_valid_col, src.type);
+    ShapeInfo tmp_cast =
+        ShapeInfo{src.slice_valid_row, tmp_col, src.slice_valid_row, tmp_col,
+                  src.slice_valid_row, tmp_col, tmp.extent, tmp.first_addr,
+                  "0", src.type, tmp.ub_name, false};
+    CreateUbVariableND(temp_name, tmp_cast);
+  }
+
   this->PrintIndent();
   this->stream << op_name << "(" << dst_name << ", " << src_name << ", "
-               << tmp.ub_name << ");\n";
+               << temp_name << ");\n";
 }
 
 void CodeGenTileLangAscendPto::CodegenColReduce(const ReduceOpInfo &op_info,
@@ -2722,8 +2744,8 @@ void CodeGenTileLangAscendPto::VisitExpr_(const SelectNode *op,
   auto true_value = PrintExpr(op->true_value);
   auto false_value = PrintExpr(op->false_value);
 
-  os << "(" << condition << " ? "
-     << "" << true_value << " : " << false_value << ")";
+  os << "(" << condition << " ? " << "" << true_value << " : " << false_value
+     << ")";
 }
 
 static void ProcessHostInput(std::ostream &os,
@@ -2731,8 +2753,7 @@ static void ProcessHostInput(std::ostream &os,
                              std::vector<const tir::VarNode *> &shape_vars,
                              bool add_args = true) {
   for (auto shape_var : shape_vars) {
-    os << ", "
-       << "int64_t " << shape_var->name_hint;
+    os << ", " << "int64_t " << shape_var->name_hint;
     if (add_args) {
       arg_names.push_back(shape_var->name_hint);
     }

--- a/src/transform/allocate_tmp_buffer.cc
+++ b/src/transform/allocate_tmp_buffer.cc
@@ -36,6 +36,15 @@ int64_t AlignReduceOutputCols(int64_t valid_col, int64_t dtype_bytes) {
   return aligned_bytes / dtype_bytes;
 }
 
+int64_t GetPtoRowReduceTmpCols(int64_t valid_col, int64_t dtype_bytes) {
+  constexpr int64_t kVectorRepeatBytes = 256;
+  const int64_t elem_per_repeat = kVectorRepeatBytes / dtype_bytes;
+  const int64_t tmp_col = valid_col <= elem_per_repeat
+                              ? 1
+                              : std::max(valid_col / 2, elem_per_repeat);
+  return AlignReduceOutputCols(tmp_col, dtype_bytes);
+}
+
 } // namespace
 
 class CallNodeCollector : public ExprVisitor, public StmtVisitor {
@@ -807,14 +816,20 @@ private:
           valid_row = src_buffer_node->shape[1].as<IntImmNode>()->value;
           valid_col = src_buffer_node->shape[2].as<IntImmNode>()->value;
         }
-        if (op_name == "TROWMAX" || op_name == "TROWMIN") {
-          int64_t tmp_shape_size = valid_row;
-          if (valid_row > shape_size) {
-            Array<PrimExpr> tmp_shape = {IntImm(DataType::Int(32), valid_row)};
+        if (op_name == "TROWMAX" || op_name == "TROWMIN" ||
+            op_name == "TROWSUM") {
+          const int64_t dtype_bytes = src_buffer_node->dtype.bytes();
+          const int64_t tmp_col =
+              GetPtoRowReduceTmpCols(valid_col, dtype_bytes);
+          const int64_t tmp_shape_size = valid_row * tmp_col * dtype_bytes;
+          if (tmp_shape_size > shape_size) {
+            Array<PrimExpr> tmp_shape = {
+                IntImm(DataType::Int(32), tmp_shape_size),
+            };
             shape = tmp_shape;
             shape_size = tmp_shape_size;
           }
-        } else if (op_name == "TROWSUM" || op_name == "TCOLSUM") {
+        } else if (op_name == "TCOLSUM") {
           int64_t tmp_shape_size = valid_row * valid_col / 2;
           if (tmp_shape_size > shape_size) {
             Array<PrimExpr> tmp_shape = {

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1382,7 +1382,7 @@ def gather(dst: Buffer | BufferRegion, src: Buffer | BufferRegion, src_offset: B
         src_ptr = src.access_ptr("r")
         size = math.prod(src.shape)
 
-    if isinstance(src, BufferRegion):
+    if isinstance(src_offset, BufferRegion):
         src_offset_ptr, _ = _handle_buffer_region(src_offset, "r")
     else:
         src_offset_ptr = src_offset.access_ptr("r")


### PR DESCRIPTION
## 问题

  在 PTO 后端使用 `T.reduce_sum(dim=-1)` 的内核在运行时会崩溃，报错：

      VEC instruction error: the ub address out of bounds
      CCU instruction address check error

  以xllm中的 `split_qkv_rmsnorm_mrope`算子（head_size=256）复现：第一个编译变体
  （q_heads=32, kv_heads=2）表面通过，但后续变体在
  `npuSynchronizeDevice` 时崩溃。

  ## 根因

  PTO 后端将 reduce 操作的临时buffer以 `uint8`（裸字节）类型分配。
  旧代码存在两个耦合的 bug，导致 TROWSUM 无法正确使用这块缓冲区：

  1. **缓冲区太小**（`allocate_tmp_buffer.cc`）：
     TROWSUM 与 TCOLSUM 共用同一公式：
     `tmp_shape_size = valid_row × valid_col / 2`（单位为元素个数）。

     由于缓冲区类型是 `uint8`，实际字节数为：
     `valid_row × valid_col / 2` 字节。

     但 TROWSUM 内部需要以源数据的类型（如 float32，每元素 4 字节）
     来使用这块 scratch 空间。正确的字节数应为：
     `valid_row × tmp_col × 4`，其中 `tmp_col` 基于 NPU 向量单元宽度
     （每次处理 256 字节）计算得出。

     以 head_size=256 为例：`valid_col / 2 = 128`，`tmp_col = 128`。
     旧分配：32 × 128 = 4096 字节。
     实际需要：32 × 128 × 4 = 16384 字节（差了 4 倍）。

  2. **缓冲区以错误类型传给硬件**（`codegen_ascend_pto.cc`）：
     `CodegenRowReduce` 将 `uint8` 类型的临时缓冲区直接传给 TROWSUM
     硬件指令。硬件内部以 float32 的步长（4 字节）访问该缓冲区，
     偏移量远超 `uint8` 声明的边界，触发 CCU 地址检查异常。

  ## 修改

  ### `src/transform/allocate_tmp_buffer.cc`

  - 新增 `GetPtoRowReduceTmpCols(valid_col, dtype_bytes)` —— 根据
    NPU 向量单元宽度（256 字节/次）和 32 字节对齐要求，计算行归约
    临时缓冲区的正确列数。
  - 将 TROWSUM 从 TCOLSUM 分组中移出，与 TROWMAX/TROWMIN 归入同一分组。
    新公式计入源数据元素字节数：
    `tmp_shape_size = valid_row × tmp_col × dtype_bytes`。

  ### `src/target/codegen_ascend_pto.cc`

  - 新增 `GetRowReduceTmpCol(valid_col, dtype)` —— codegen 层对应逻辑，
    基于 dtype 字符串计算列数。
  - 在 `CodegenRowReduce` 中新增 `ICHECK(dst.type == src.type)` ——
    在编译期捕获 dtype 不匹配，避免静默生成错误代码。
  - 当 `src.type != tmp.type`（即 uint8 缓冲区 vs float32 源数据）时，
    通过 `CreateUbVariableND` 在临时缓冲区上创建正确类型和维度的 ND 视图。
    确保 TROWSUM 以 float32 类型、正确列数访问缓冲区。

  ## 验证

  - `split_qkv_rmsnorm_mrope` 内核对测试套件中所有 head 配置
    （32×2、24×4、16×4、16×2 等）均通过 `torch.testing.assert_close`
    与 PyTorch 参考实现对比。
  - 此前崩溃的算例现在正常运行，无硬件异常。