### PR TITLE
[Fix] Rename block_num/BlockNum to avoid A5 platform identifier conflict && Add TL_PTO_DEBUG env var to enable debug print for tensor dump

### DIFF
--- a/docs/TileLang-Ascend Programming Guide.md
+++ b/docs/TileLang-Ascend Programming Guide.md
@@ -2126,6 +2126,14 @@ Expert编程模式可以复用Developer模式的Reduce类计算原语。
 TileLang-ascend 引入了新的调试接口：T.printf 和 T.dump_tensor。目前支持 Ascend 端的全量转储功能。基本类型、指针、ub_buffer、l1_buffer、l0c_buffer 和 global_buffer 均可打印。
 注意：T.printf 和 T.dump_tensor 是设备端的调试工具；对于主机端，请直接使用 Python 内置的 print 即可。
 
+**环境配置**：要使 T.printf 和 T.dump_tensor 的输出在运行时生效，需要在编译时启用调试打印支持。设置环境变量 `TL_PTO_DEBUG=1` 后，编译器会追加 `-D_DEBUG` 和 `--cce-enable-print` 编译选项，开启设备端 printf 功能：
+
+```bash
+TL_PTO_DEBUG=1 python your_script.py
+```
+
+> **注意**：`TL_PTO_DEBUG` 常态不开启。开启后设备端 printf/PRINTF/DumpTensor 等调试接口会对算子的实际运行性能产生明显影响（每条打印/断言都会引入额外的硬件交互开销），同时每个核上所有 dump 接口使用的总空间上限为 1 MB。因此该选项仅建议在调测阶段使用，调测完成后应关闭以恢复正常性能。
+
 #### 5.1.1 T.printf
 
 **接口定义**：

--- a/src/tl_templates/pto/common.h
+++ b/src/tl_templates/pto/common.h
@@ -1096,9 +1096,9 @@ AICORE constexpr int32_t next_full_size(int32_t num_segs, int32_t full_size,
   return 4 * full_size;
 }
 
-// Number of merge-tree levels needed to reduce BlockNum segments to 1.
-AICORE constexpr int32_t compute_levels(int32_t block_num) {
-  int32_t n = block_num;
+// Number of merge-tree levels needed to reduce N blocks to 1.
+AICORE constexpr int32_t compute_levels(int32_t blk_num) {
+  int32_t n = blk_num;
   int32_t levels = 0;
   while (n > 1) {
     n = (n + 3) / 4;
@@ -1109,9 +1109,9 @@ AICORE constexpr int32_t compute_levels(int32_t block_num) {
 
 // Whether the final result lives in bufA after the merge tree finishes.
 // read_from_a starts true and toggles every level, so result_in_bufA equals
-// (levels % 2 == 0). For BlockNum == 1 (zero levels) this is also true.
-template <int32_t BlockNum>
-constexpr bool result_in_bufA_v = (compute_levels(BlockNum) % 2 == 0);
+// (levels % 2 == 0). For kBlockNum == 1 (zero levels) this is also true.
+template <int32_t kBlockNum>
+constexpr bool result_in_bufA_v = (compute_levels(kBlockNum) % 2 == 0);
 
 // Number of float pair-elements the finalize step has to copy. For full sort
 // it's 2*N; for topk it's 2*K rounded up to user_T's block alignment so the

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -138,6 +138,8 @@ class LibraryGenerator:
                 "--shared",
                 src.name,
             ]
+            if os.environ.get("TL_PTO_DEBUG") == "1":
+                command += ["-D_DEBUG", "--cce-enable-print"]
         command += ["-o", libpath]
 
         src.write(self.lib_code)


### PR DESCRIPTION
[Fix] Rename block_num/BlockNum to avoid A5 platform identifier conflict
[PTO] Add TL_PTO_DEBUG env var to enable debug print for tensor dump