### PR TITLE
[Fix] Preserve non-written buffer history across if-blocks in sync insertion

### DIFF
--- a/src/transform/ascend_sync_insert.cc
+++ b/src/transform/ascend_sync_insert.cc
@@ -254,19 +254,47 @@ private:
     std::vector<Stmt> stmts;
     InsertSynchronization("PipeBarrier_ALL", stmts);
 
+    // Save access history before entering the if-block.
+    // Only buffers written inside the if-block should have their
+    // history cleared; buffers untouched by the conditional code
+    // must retain their history so that cross-iteration dependencies
+    // (e.g. V -> MTE2 on s_ub) can still be detected.
+    auto saved_history = current_access_history_;
     current_access_history_.clear();
     Stmt then_case = VisitStmt(op->then_case);
+
+    // Collect buffers written inside the then-branch.
+    std::unordered_set<std::string> written_in_if;
+    for (const auto &pair : current_access_history_) {
+      if (pair.second.is_write) {
+        written_in_if.insert(pair.first);
+      }
+    }
 
     Optional<Stmt> else_case;
     if (op->else_case.defined()) {
       current_access_history_.clear();
       else_case = VisitStmt(op->else_case.value());
+      // Collect buffers written inside the else-branch.
+      for (const auto &pair : current_access_history_) {
+        if (pair.second.is_write) {
+          written_in_if.insert(pair.first);
+        }
+      }
     }
 
     stmts.push_back(IfThenElse(op->condition, then_case, else_case));
 
     InsertSynchronization("PipeBarrier_ALL", stmts);
-    current_access_history_.clear();
+
+    // Restore history for buffers NOT written inside the if-block.
+    // Buffers written inside the if-block have uncertain state
+    // (conditional write) and are covered by PipeBarrier_ALL.
+    current_access_history_ = saved_history;
+    for (const auto &buf_name : written_in_if) {
+      current_access_history_.erase(buf_name);
+    }
+
     return SeqStmt(stmts);
   }
 


### PR DESCRIPTION
When the AscendSyncInsert pass encounters an if-else block, it previously cleared all access history after the block. This caused cross-iteration data dependencies (e.g. V -> MTE2 on s_ub) to go undetected when the if-block touched only a subset of buffers, leading to missing synchronizations between loop iterations.

Fix: save the access history before entering the if-block, collect which buffers were written inside the then/else branches, and after the block restore history only for buffers that were NOT written. Buffers written inside the conditional are covered by the surrounding PipeBarrier_ALL.