### PR TITLE
[feat] Add topk_sum_and_topk_group_idx

### DIFF
--- a/examples/tile_kernels/moe/moe_topk_sum_and_topk_group_idx.py
+++ b/examples/tile_kernels/moe/moe_topk_sum_and_topk_group_idx.py
@@ -1,0 +1,510 @@
+import os
+import sys
+import pytest
+import numpy as np
+import torch
+import tilelang
+from tilelang import language as T
+
+
+tilelang.cache.clear_cache()
+
+# Apply pass configs to remove auto sync
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+}
+
+FLOAT32 = "float32"
+INDEX_TYPE = "int64"
+INT32 = "int32"
+
+
+@tilelang.jit(pass_configs=pass_configs)
+def get_topk_sum_and_topk_group_idx_kernel(num_groups: int, num_experts_per_group: int, num_topk_groups: int, num_topk_sum: int):
+    ALIGNMENT = 32
+    num_experts = num_experts_per_group * num_groups
+    # num_aligned_experts is not used in forward kernel, removed
+    num_aligned_groups = (num_groups + ALIGNMENT - 1) // ALIGNMENT * ALIGNMENT
+    num_aligned_epg = (num_experts_per_group + ALIGNMENT - 1) // ALIGNMENT * ALIGNMENT
+
+    # Align int64 output to 8 elements for 32 byte MTE3 alignment
+    num_aligned_topk_groups = (num_topk_groups + 7) // 8 * 8
+
+    num_tokens = T.symbolic("num_tokens")
+
+    assert num_groups <= 32, f"num_groups {num_groups} must be less than or equal to 32"
+
+    @T.prim_func
+    def topk_sum_and_topk_group_idx_kernel(
+        scores: T.Tensor[(num_tokens, num_experts), FLOAT32],
+        group_topk_idx: T.Tensor[(num_tokens, num_aligned_topk_groups), INDEX_TYPE],
+    ):
+        VEC_NUM = 2
+        num_blocks = 128
+        chunk_size = num_blocks * VEC_NUM
+        num_batches = (num_tokens + chunk_size - 1) // chunk_size
+
+        with T.Kernel(num_blocks, is_npu=True) as (cid, vid):
+            topk_group_idx_out_ub = T.alloc_ub((num_aligned_topk_groups,), INDEX_TYPE)
+
+            # Two 1D buffers for double buffering
+            group_experts_ub_ping = T.alloc_ub((num_aligned_epg,), FLOAT32)
+            group_experts_ub_pong = T.alloc_ub((num_aligned_epg,), FLOAT32)
+
+            group_scores_ub = T.alloc_ub((num_aligned_groups,), FLOAT32)
+
+            # Split topk_res_ub buffer to break compiler's data dependency analysis between ping-pong branches
+            topk_res_ub_ping = T.alloc_ub((64,), FLOAT32)
+            topk_res_ub_pong = T.alloc_ub((64,), FLOAT32)
+
+            group_topk_res_ub = T.alloc_ub(((num_topk_groups * 2 + 31) // 32 * 32,), FLOAT32)
+
+            # Temporary efficient buffer for float32 indices extracted from group_topk_res_ub
+            topk_index_f32_ub = T.alloc_ub((num_aligned_topk_groups,), FLOAT32)
+
+            for batch_idx in T.Pipelined(num_batches):
+                token_idx = (batch_idx * num_blocks + cid) * VEC_NUM + vid
+                if token_idx < num_tokens:
+                    # Process first group (group 0) outside the loop
+                    T.copy(
+                        scores[token_idx, 0:num_experts_per_group],
+                        group_experts_ub_ping,
+                        pad_value=-T.infinity(FLOAT32),
+                    )
+                    T.set_flag("MTE2", "V", 0)
+
+                    # If group 1 exists, preload to pong
+                    if num_groups > 1:
+                        T.copy(
+                            scores[token_idx, num_experts_per_group : 2 * num_experts_per_group],
+                            group_experts_ub_pong,
+                            pad_value=-T.infinity(FLOAT32),
+                        )
+                    # Perform topk on group 0 and assign
+                    T.wait_flag("MTE2", "V", 0)
+                    T.tile.topk(topk_res_ub_ping, group_experts_ub_ping, num_topk_sum, num_experts_per_group)
+                    T.pipe_barrier("V")
+
+                    # Process remaining groups (starting from group 1) in the loop
+                    for g in T.serial(1, num_groups):
+                        T.barrier_all()
+
+                        if g % 2 == 1:
+                            # Currently using data in pong, load next group to ping
+                            if g + 1 < num_groups:
+                                next_group_start_ping = (g + 1) * num_experts_per_group
+                                T.copy(
+                                    scores[token_idx, next_group_start_ping : next_group_start_ping + num_experts_per_group],
+                                    group_experts_ub_ping,
+                                    pad_value=-T.infinity(FLOAT32),
+                                )
+                            # Process current group (pong)
+                            T.tile.topk(topk_res_ub_pong, group_experts_ub_pong, num_topk_sum, num_experts_per_group)
+                            T.pipe_barrier("V")
+                            if num_topk_sum == 1:
+                                group_scores_ub[g - 1] = topk_res_ub_ping[0]
+                            else:
+                                group_scores_ub[g - 1] = topk_res_ub_ping[0] + topk_res_ub_ping[2]
+                        else:
+                            # g is even (>=2), currently using data in ping, load next group to pong
+                            if g + 1 < num_groups:
+                                next_group_start_pong = (g + 1) * num_experts_per_group
+                                T.copy(
+                                    scores[token_idx, next_group_start_pong : next_group_start_pong + num_experts_per_group],
+                                    group_experts_ub_pong,
+                                    pad_value=-T.infinity(FLOAT32),
+                                )
+                            # Process current group (ping)
+                            T.tile.topk(topk_res_ub_ping, group_experts_ub_ping, num_topk_sum, num_experts_per_group)
+                            T.pipe_barrier("V")
+                            if num_topk_sum == 1:
+                                group_scores_ub[g - 1] = topk_res_ub_pong[0]
+                            else:
+                                group_scores_ub[g - 1] = topk_res_ub_pong[0] + topk_res_ub_pong[2]
+
+                        T.barrier_all()
+
+                    if num_topk_sum == 1:
+                        group_scores_ub[num_groups - 1] = topk_res_ub_pong[0] if (num_groups - 1) % 2 == 1 else topk_res_ub_ping[0]
+                    else:
+                        if (num_groups - 1) % 2 == 1:
+                            group_scores_ub[num_groups - 1] = topk_res_ub_pong[0] + topk_res_ub_pong[2]
+                        else:
+                            group_scores_ub[num_groups - 1] = topk_res_ub_ping[0] + topk_res_ub_ping[2]
+
+                    T.pipe_barrier("V")
+
+                    T.tile.topk(group_topk_res_ub, group_scores_ub, num_topk_groups, num_groups)
+                    T.pipe_barrier("V")
+
+                    # Vectorized extraction and conversion
+                    T.tile.gather_mask(topk_index_f32_ub, group_topk_res_ub, "P1010")
+                    T.pipe_barrier("V")
+
+                    T.tile.cast(topk_group_idx_out_ub, topk_index_f32_ub, "CAST_ROUND", num_topk_groups)
+                    T.pipe_barrier("V")
+
+                    T.copy(topk_group_idx_out_ub, group_topk_idx[token_idx, 0:num_aligned_topk_groups])
+
+    return topk_sum_and_topk_group_idx_kernel
+
+
+def topk_sum_and_topk_group_idx(scores: torch.Tensor, num_topk_sum: int, num_topk_groups: int) -> torch.Tensor:
+    """Return top num topk groups group indices ranked by intra group top k sum"""
+    assert scores.dim() == 3 and scores.is_contiguous() and scores.dtype == torch.float32
+    num_tokens, num_groups, num_experts_per_group = scores.shape
+    assert num_topk_sum <= num_experts_per_group and num_topk_sum in (1, 2) and num_topk_groups <= num_groups
+
+    kernel = get_topk_sum_and_topk_group_idx_kernel(num_groups, num_experts_per_group, num_topk_groups, num_topk_sum)
+    if int(os.getenv("TK_PRINT_KERNEL_SOURCE", 0)):
+        print(kernel.get_kernel_source())
+
+    num_aligned_topk_groups = (num_topk_groups + 7) // 8 * 8
+    topk_group_idx_padded = torch.empty(num_tokens, num_aligned_topk_groups, dtype=torch.int64, device=scores.device)
+
+    if num_tokens == 0:
+        return topk_group_idx_padded[:, :num_topk_groups].contiguous()
+
+    kernel(scores.view(num_tokens, -1), topk_group_idx_padded)
+
+    # Slice to original shape after aligned writeback
+    return topk_group_idx_padded[:, :num_topk_groups].contiguous()
+
+
+@tilelang.jit(pass_configs=pass_configs)
+def get_topk_sum_and_topk_group_idx_backward_kernel(num_groups: int, num_experts_per_group: int, num_topk_groups: int, num_topk_sum: int):
+    ALIGNMENT = 32
+    num_experts = num_experts_per_group * num_groups
+    num_aligned_experts = (num_experts + ALIGNMENT - 1) // ALIGNMENT * ALIGNMENT
+    num_aligned_epg = (num_experts_per_group + ALIGNMENT - 1) // ALIGNMENT * ALIGNMENT
+    num_aligned_topk_groups = (num_topk_groups + 7) // 8 * 8
+    num_tokens = T.symbolic("num_tokens")
+
+    @T.prim_func
+    def topk_sum_and_topk_group_idx_backward_kernel(
+        grad_out: T.Tensor[(num_tokens, num_topk_groups), FLOAT32],
+        scores: T.Tensor[(num_tokens, num_experts), FLOAT32],
+        group_topk_idx: T.Tensor[(num_tokens, num_topk_groups), INDEX_TYPE],
+        grad_scores: T.Tensor[(num_tokens, num_aligned_experts), FLOAT32],
+    ):
+        VEC_NUM = 2
+        num_blocks = 128
+        chunk_size = num_blocks * VEC_NUM
+        num_batches = (num_tokens + chunk_size - 1) // chunk_size
+
+        with T.Kernel(num_blocks, is_npu=True) as (cid, vid):
+            # Token-level double buffering for base inputs
+            grad_out_ub = T.alloc_ub((2, num_aligned_topk_groups), FLOAT32)
+            group_topk_idx_ub = T.alloc_ub((2, num_aligned_topk_groups), INDEX_TYPE)
+
+            group_experts_ub_ping = T.alloc_ub((num_aligned_epg,), FLOAT32)
+            group_experts_ub_pong = T.alloc_ub((num_aligned_epg,), FLOAT32)
+            topk_res_ub_ping = T.alloc_ub((64,), FLOAT32)
+            topk_res_ub_pong = T.alloc_ub((64,), FLOAT32)
+
+            group_grad_ub_ping = T.alloc_ub((num_aligned_epg,), FLOAT32)
+            group_grad_ub_pong = T.alloc_ub((num_aligned_epg,), FLOAT32)
+
+            for batch_idx in T.Pipelined(num_batches):
+                token_idx = (batch_idx * num_blocks + cid) * VEC_NUM + vid
+                ping_pong_idx = batch_idx % 2
+
+                if token_idx < num_tokens:
+                    # Fetch token metadata
+                    T.copy(
+                        grad_out[token_idx, 0:num_topk_groups],
+                        grad_out_ub[ping_pong_idx, 0:num_topk_groups],
+                        pad_value=0.0,
+                    )
+                    T.copy(
+                        group_topk_idx[token_idx, 0:num_topk_groups],
+                        group_topk_idx_ub[ping_pong_idx, 0:num_topk_groups],
+                        pad_value=-1,
+                    )
+                    T.barrier_all()
+
+                    if num_topk_groups > 0:
+                        # Backward three-stage software pipeline: Prologue (k = 0)
+                        g_0 = T.cast(group_topk_idx_ub[ping_pong_idx, 0], INT32)
+                        if g_0 >= 0 and g_0 < num_groups:
+                            group_start_0 = g_0 * num_experts_per_group
+                            T.copy(
+                                scores[token_idx, group_start_0 : group_start_0 + num_experts_per_group],
+                                group_experts_ub_ping,
+                                pad_value=-T.infinity(FLOAT32),
+                            )
+
+                        if num_topk_groups > 1:
+                            g_1 = T.cast(group_topk_idx_ub[ping_pong_idx, 1], INT32)
+                            if g_1 >= 0 and g_1 < num_groups:
+                                group_start_1 = g_1 * num_experts_per_group
+                                T.copy(
+                                    scores[token_idx, group_start_1 : group_start_1 + num_experts_per_group],
+                                    group_experts_ub_pong,
+                                    pad_value=-T.infinity(FLOAT32),
+                                )
+
+                        T.barrier_all()
+
+                        if g_0 >= 0 and g_0 < num_groups:
+                            T.tile.topk(topk_res_ub_ping, group_experts_ub_ping, num_topk_sum, num_experts_per_group)
+                            T.barrier_all()
+                            # Zero out small UB
+                            for e in T.serial(num_aligned_epg):
+                                group_grad_ub_ping[e] = 0.0
+
+                            current_grad_0 = grad_out_ub[ping_pong_idx, 0]
+                            for step in T.serial(num_topk_sum):
+                                idx_f32 = topk_res_ub_ping[step * 2 + 1]
+                                found_e_idx = T.cast(idx_f32, INT32)
+                                if found_e_idx < num_experts_per_group:
+                                    group_grad_ub_ping[found_e_idx] += current_grad_0
+
+                        # Backward three-stage software pipeline: Main Loop
+                        for k in T.serial(1, num_topk_groups):
+                            T.pipe_barrier("V")
+                            if k % 2 == 1:
+                                g_prev = T.cast(group_topk_idx_ub[ping_pong_idx, k - 1], INT32)
+                                if g_prev >= 0 and g_prev < num_groups:
+                                    group_start_prev = g_prev * num_experts_per_group
+                                    T.copy(
+                                        group_grad_ub_ping,
+                                        grad_scores[token_idx, group_start_prev : group_start_prev + num_experts_per_group],
+                                    )
+                                    T.pipe_barrier("V")
+
+                                if k + 1 < num_topk_groups:
+                                    g_next = T.cast(group_topk_idx_ub[ping_pong_idx, k + 1], INT32)
+                                    if g_next >= 0 and g_next < num_groups:
+                                        group_start_next = g_next * num_experts_per_group
+                                        T.copy(
+                                            scores[token_idx, group_start_next : group_start_next + num_experts_per_group],
+                                            group_experts_ub_ping,
+                                            pad_value=-T.infinity(FLOAT32),
+                                        )
+
+                                g_curr = T.cast(group_topk_idx_ub[ping_pong_idx, k], INT32)
+                                if g_curr >= 0 and g_curr < num_groups:
+                                    T.tile.topk(topk_res_ub_pong, group_experts_ub_pong, num_topk_sum, num_experts_per_group)
+                                    T.barrier_all()
+                                    for e in T.serial(num_aligned_epg):
+                                        group_grad_ub_pong[e] = 0.0
+
+                                    current_grad = grad_out_ub[ping_pong_idx, k]
+                                    for step in T.serial(num_topk_sum):
+                                        idx_f32 = topk_res_ub_pong[step * 2 + 1]
+                                        found_e_idx = T.cast(idx_f32, INT32)
+                                        if found_e_idx < num_experts_per_group:
+                                            group_grad_ub_pong[found_e_idx] += current_grad
+
+                            else:
+                                g_prev = T.cast(group_topk_idx_ub[ping_pong_idx, k - 1], INT32)
+                                if g_prev >= 0 and g_prev < num_groups:
+                                    group_start_prev = g_prev * num_experts_per_group
+                                    T.copy(
+                                        group_grad_ub_pong,
+                                        grad_scores[token_idx, group_start_prev : group_start_prev + num_experts_per_group],
+                                    )
+                                    T.pipe_barrier("V")
+
+                                if k + 1 < num_topk_groups:
+                                    g_next = T.cast(group_topk_idx_ub[ping_pong_idx, k + 1], INT32)
+                                    if g_next >= 0 and g_next < num_groups:
+                                        group_start_next = g_next * num_experts_per_group
+                                        T.copy(
+                                            scores[token_idx, group_start_next : group_start_next + num_experts_per_group],
+                                            group_experts_ub_pong,
+                                            pad_value=-T.infinity(FLOAT32),
+                                        )
+
+                                g_curr = T.cast(group_topk_idx_ub[ping_pong_idx, k], INT32)
+                                if g_curr >= 0 and g_curr < num_groups:
+                                    T.tile.topk(topk_res_ub_ping, group_experts_ub_ping, num_topk_sum, num_experts_per_group)
+                                    T.barrier_all()
+                                    for e in T.serial(num_aligned_epg):
+                                        group_grad_ub_ping[e] = 0.0
+
+                                    current_grad = grad_out_ub[ping_pong_idx, k]
+                                    for step in T.serial(num_topk_sum):
+                                        idx_f32 = topk_res_ub_ping[step * 2 + 1]
+                                        found_e_idx = T.cast(idx_f32, INT32)
+                                        if found_e_idx < num_experts_per_group:
+                                            group_grad_ub_ping[found_e_idx] += current_grad
+
+                            T.barrier_all()
+
+                        # Backward three-stage software pipeline: Epilogue (handle last group write)
+                        k_last = num_topk_groups - 1
+                        g_last = T.cast(group_topk_idx_ub[ping_pong_idx, k_last], INT32)
+                        if g_last >= 0 and g_last < num_groups:
+                            group_start_last = g_last * num_experts_per_group
+                            if k_last % 2 == 0:
+                                T.copy(
+                                    group_grad_ub_ping,
+                                    grad_scores[token_idx, group_start_last : group_start_last + num_experts_per_group],
+                                )
+                            else:
+                                T.copy(
+                                    group_grad_ub_pong,
+                                    grad_scores[token_idx, group_start_last : group_start_last + num_experts_per_group],
+                                )
+
+    return topk_sum_and_topk_group_idx_backward_kernel
+
+
+def topk_sum_and_topk_group_idx_backward(
+    grad_out: torch.Tensor, scores: torch.Tensor, group_topk_idx: torch.Tensor, num_topk_sum: int
+) -> torch.Tensor:
+    """Backward pass"""
+    assert grad_out.is_contiguous() and grad_out.dtype == torch.float32
+    assert scores.is_contiguous() and scores.dtype == torch.float32
+    assert group_topk_idx.is_contiguous() and group_topk_idx.dtype == torch.int64
+
+    num_tokens, num_groups, num_experts_per_group = scores.shape
+    num_topk_groups = group_topk_idx.shape[1]
+    num_experts = num_groups * num_experts_per_group
+
+    ALIGNMENT = 32
+    num_aligned_experts = (num_experts + ALIGNMENT - 1) // ALIGNMENT * ALIGNMENT
+
+    kernel = get_topk_sum_and_topk_group_idx_backward_kernel(num_groups, num_experts_per_group, num_topk_groups, num_topk_sum)
+
+    if int(os.getenv("TK_PRINT_KERNEL_SOURCE", 0)):
+        print(kernel.get_kernel_source())
+
+    # Host-side aligned memory allocation (already initialized to zero, perfect for sparse update)
+    grad_scores_padded = torch.zeros(num_tokens, num_aligned_experts, dtype=torch.float32, device=scores.device)
+
+    if num_tokens > 0:
+        kernel(grad_out, scores.view(num_tokens, -1), group_topk_idx, grad_scores_padded)
+
+    # Slice to original shape after aligned writeback
+    return grad_scores_padded[:, :num_experts].view(num_tokens, num_groups, num_experts_per_group).contiguous()
+
+
+def ref_topk_sum_and_topk_group_idx(scores: torch.Tensor, num_topk_sum: int, num_topk_groups: int) -> torch.Tensor:
+    num_tokens, num_groups, num_experts_per_group = scores.shape
+    group_scores = torch.empty(num_tokens, num_groups, dtype=scores.dtype, device=scores.device)
+    for g in range(num_groups):
+        group_experts = scores[:, g, :]
+        if num_topk_sum == 1:
+            group_scores[:, g] = torch.topk(group_experts, 1, dim=1).values.squeeze(1)
+        else:
+            topk_vals = torch.topk(group_experts, 2, dim=1).values
+            group_scores[:, g] = topk_vals.sum(dim=1)
+    _, topk_group_idx = torch.topk(group_scores, num_topk_groups, dim=1)
+    return topk_group_idx.to(torch.int64)
+
+
+def ref_topk_sum_and_topk_group_idx_backward(
+    grad_out: torch.Tensor, scores: torch.Tensor, group_topk_idx: torch.Tensor, num_topk_sum: int
+) -> torch.Tensor:
+    num_tokens, num_groups, num_experts_per_group = scores.shape
+    num_topk_groups = group_topk_idx.shape[1]
+    grad_scores = torch.zeros_like(scores)
+    for t in range(num_tokens):
+        for k in range(num_topk_groups):
+            g = group_topk_idx[t, k].item()
+            if g < 0 or g >= num_groups:
+                continue
+            experts = scores[t, g, :]
+            if num_topk_sum == 1:
+                _, top1_idx = torch.topk(experts, 1)
+                grad_scores[t, g, top1_idx.item()] += grad_out[t, k].item()
+            else:
+                _, top2_idx = torch.topk(experts, 2)
+                for e in top2_idx.tolist():
+                    grad_scores[t, g, e] += grad_out[t, k].item()
+    return grad_scores
+
+
+def generate_test_params() -> list[dict]:
+    return [
+        {
+            "num_tokens": num_tokens,
+            "num_experts": num_experts,
+            "num_groups": num_groups,
+            "num_group_sum_topk": num_group_sum_topk,
+            "num_topk_groups": num_topk_groups,
+        }
+        for num_tokens in [1, 4001, 8001]
+        for num_experts in (72, 256)
+        for num_groups in (4, 8, 12, 16)
+        if num_experts % num_groups == 0
+        for num_group_sum_topk in (1, 2)
+        for num_topk_groups in (2, 4)
+    ]
+
+
+def make_param_id(params: dict) -> str:
+    return (
+        f"tok={params['num_tokens']}_exp={params['num_experts']}_"
+        f"grp={params['num_groups']}_sumk={params['num_group_sum_topk']}_"
+        f"topk={params['num_topk_groups']}"
+    )
+
+
+@pytest.mark.parametrize("params", generate_test_params(), ids=make_param_id)
+def test_topk_sum_and_topk_group_idx(params):
+    num_tokens = params["num_tokens"]
+    num_experts = params["num_experts"]
+    num_groups = params["num_groups"]
+    num_group_sum_topk = params["num_group_sum_topk"]
+    num_topk_groups = params["num_topk_groups"]
+    num_experts_per_group = num_experts // num_groups
+
+    torch.manual_seed(42)
+    scores = torch.randn((num_tokens, num_groups, num_experts_per_group), dtype=torch.float32)
+    topk_idx_ref = ref_topk_sum_and_topk_group_idx(scores, num_group_sum_topk, num_topk_groups)
+
+    if hasattr(torch, "npu") and torch.npu.is_available():
+        scores = scores.to("npu").contiguous()
+    elif torch.cuda.is_available():
+        scores = scores.to("cuda").contiguous()
+
+    topk_idx = topk_sum_and_topk_group_idx(scores, num_group_sum_topk, num_topk_groups)
+    np.testing.assert_equal(topk_idx.cpu().numpy(), topk_idx_ref.cpu().numpy())
+    print(f"Forward Test passed for {make_param_id(params)}")
+
+
+@pytest.mark.parametrize("params", generate_test_params(), ids=make_param_id)
+def test_topk_sum_and_topk_group_idx_backward(params):
+    num_tokens = params["num_tokens"]
+    num_experts = params["num_experts"]
+    num_groups = params["num_groups"]
+    num_group_sum_topk = params["num_group_sum_topk"]
+    num_topk_groups = params["num_topk_groups"]
+    num_experts_per_group = num_experts // num_groups
+
+    torch.manual_seed(42)
+    scores = torch.randn((num_tokens, num_groups, num_experts_per_group), dtype=torch.float32)
+    grad_out = torch.randn((num_tokens, num_topk_groups), dtype=torch.float32)
+
+    topk_idx = ref_topk_sum_and_topk_group_idx(scores, num_group_sum_topk, num_topk_groups)
+    grad_scores_ref = ref_topk_sum_and_topk_group_idx_backward(grad_out, scores, topk_idx, num_group_sum_topk)
+
+    if hasattr(torch, "npu") and torch.npu.is_available():
+        scores = scores.to("npu").contiguous()
+        grad_out = grad_out.to("npu").contiguous()
+        topk_idx = topk_idx.to("npu").contiguous()
+    elif torch.cuda.is_available():
+        scores = scores.to("cuda").contiguous()
+        grad_out = grad_out.to("cuda").contiguous()
+        topk_idx = topk_idx.to("cuda").contiguous()
+
+    grad_scores_tl = topk_sum_and_topk_group_idx_backward(grad_out, scores, topk_idx, num_group_sum_topk)
+
+    np.testing.assert_allclose(
+        grad_scores_tl.cpu().numpy(),
+        grad_scores_ref.cpu().numpy(),
+        atol=1e-5,
+        rtol=1e-5,
+    )
+    print(f"Backward Test passed for {make_param_id(params)}")
+
+
+if __name__ == "__main__":
+    exit_code = pytest.main([__file__, "-v"])
+    if exit_code == pytest.ExitCode.OK:
+        print("All topk_sum_and_topk_group_idx tests passed! Kernel Output Match!")
+    sys.exit(exit_code)

--- a/examples/topk_selector/example_topk_sum_and_topk_group_idx.py
+++ b/examples/topk_selector/example_topk_sum_and_topk_group_idx.py
@@ -1,0 +1,307 @@
+import argparse
+from typing import Literal
+from collections import Counter
+
+import tilelang
+import torch
+from tilelang import language as T
+
+tilelang.cache.clear_cache()
+
+pass_configs = {
+    tilelang.PassConfigKey.TIR_MERGE_STATIC_SMEM: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+}
+
+
+@tilelang.jit(pass_configs=pass_configs)
+def get_topk_sum_and_topk_group_idx_kernel(B: int, N: int, top_k: int, block_N: int, topk_sum: int, dtype: Literal["float32"] = "float32"):
+    INDEX_DTYPE = "int64"
+    num_threads = 32
+    total_N = N * block_N
+    aligned_total_N = (total_N + num_threads - 1) // num_threads * num_threads
+    aligned_N = (N + num_threads - 1) // num_threads * num_threads
+    aligned_block_N = (block_N + num_threads - 1) // num_threads * num_threads
+    dynamic_B = T.symbolic("B")
+    assert N <= 32, f"num_groups ({N}) must be <= 32"
+
+    @T.prim_func
+    def topk_sum_and_topk_group_idx_kernel(
+        scores: T.Tensor[(dynamic_B, total_N), dtype], group_topk_idx: T.Tensor[(dynamic_B, top_k), INDEX_DTYPE]
+    ):
+        with T.Kernel(dynamic_B, is_npu=True) as (cid, _):
+            scores_ub = T.alloc_ub((aligned_total_N,), dtype)
+            group_experts_ub = T.alloc_ub((aligned_block_N,), dtype)
+            group_scores_ub = T.alloc_ub((aligned_N,), dtype)
+            top1_ub = T.alloc_ub((1,), dtype)
+            top2_ub = T.alloc_ub((1,), dtype)
+            amax_ub = T.alloc_ub((1,), dtype)
+            tmp_calc_ub = T.alloc_ub((aligned_N,), dtype)
+            min_idx_res_ub = T.alloc_ub((1,), dtype)
+            topk_group_idx_out_ub = T.alloc_ub((top_k,), INDEX_DTYPE)
+
+            # 1. Load scores and pad
+            T.copy(scores[cid, 0:total_N], scores_ub[0:total_N])
+            for i in T.serial(aligned_total_N - total_N):
+                scores_ub[total_N + i] = -1e10
+
+            # 2. Compute group scores (topk_sum within each group)
+            for g in T.serial(N):
+                group_start = g * block_N
+                for e in T.serial(block_N):
+                    group_experts_ub[e] = scores_ub[group_start + e]
+                for e in T.serial(aligned_block_N - block_N):
+                    group_experts_ub[block_N + e] = -1e10
+
+                T.reduce_max(group_experts_ub, top1_ub, dim=0)
+                for e in T.serial(aligned_block_N):
+                    if group_experts_ub[e] == top1_ub[0]:
+                        group_experts_ub[e] = -1e10
+                T.reduce_max(group_experts_ub, top2_ub, dim=0)
+
+                if topk_sum == 1:
+                    group_scores_ub[g] = top1_ub[0]
+                else:
+                    group_scores_ub[g] = top1_ub[0] + top2_ub[0]
+
+            for g in T.serial(aligned_N - N):
+                group_scores_ub[N + g] = -1e10
+
+            # 3. Select top-k groups
+            for k in T.serial(top_k):
+                T.reduce_max(group_scores_ub, amax_ub, dim=0)
+                for i in T.serial(aligned_N):
+                    if group_scores_ub[i] == amax_ub[0]:
+                        tmp_calc_ub[i] = T.cast(i, dtype)
+                    else:
+                        tmp_calc_ub[i] = T.cast(aligned_N, dtype)
+                T.reduce_min(tmp_calc_ub, min_idx_res_ub, dim=0)
+                found_idx_int32 = T.cast(min_idx_res_ub[0], "int32")
+                topk_group_idx_out_ub[k] = T.cast(min_idx_res_ub[0], INDEX_DTYPE)
+                group_scores_ub[found_idx_int32] = -1e10
+
+            # 4. Write back results
+            T.copy(topk_group_idx_out_ub[0:top_k], group_topk_idx[cid, 0:top_k])
+
+    return topk_sum_and_topk_group_idx_kernel
+
+
+def topk_sum_and_topk_group_idx(scores: torch.Tensor, num_topk_sum: int, num_topk_groups: int) -> torch.Tensor:
+    assert scores.dim() == 3 and scores.is_contiguous() and scores.dtype == torch.float32
+    num_tokens, num_groups, num_experts_per_group = scores.shape
+    assert num_topk_sum <= num_experts_per_group and num_topk_sum in (1, 2) and num_topk_groups <= num_groups
+
+    kernel = get_topk_sum_and_topk_group_idx_kernel(
+        B=num_tokens, N=num_groups, top_k=num_topk_groups, block_N=num_experts_per_group, topk_sum=num_topk_sum, dtype="float32"
+    )
+    topk_group_idx = torch.empty(num_tokens, num_topk_groups, dtype=torch.int64, device=scores.device)
+    if num_tokens == 0:
+        return topk_group_idx
+    kernel(scores.view(num_tokens, -1), topk_group_idx)
+    return topk_group_idx
+
+
+@tilelang.jit(pass_configs=pass_configs)
+def get_topk_sum_and_topk_group_idx_backward_kernel(
+    B: int, N: int, top_k: int, block_N: int, topk_sum: int, dtype: Literal["float32"] = "float32"
+):
+    INDEX_DTYPE = "int64"
+    num_threads = 32
+    total_N = N * block_N
+    aligned_total_N = (total_N + num_threads - 1) // num_threads * num_threads
+    aligned_block_N = (block_N + num_threads - 1) // num_threads * num_threads
+    aligned_top_k = (top_k + 31) // 32 * 32
+    dynamic_B = T.symbolic("B")
+
+    @T.prim_func
+    def topk_sum_and_topk_group_idx_backward_kernel(
+        grad_out: T.Tensor[(dynamic_B, aligned_top_k), dtype],
+        scores: T.Tensor[(dynamic_B, aligned_total_N), dtype],
+        group_topk_idx: T.Tensor[(dynamic_B, aligned_top_k), INDEX_DTYPE],
+        grad_scores: T.Tensor[(dynamic_B, aligned_total_N), dtype],
+    ):
+        with T.Kernel(dynamic_B, is_npu=True) as (cid, _):
+            grad_out_ub = T.alloc_ub((aligned_top_k,), "float32")
+            scores_ub = T.alloc_ub((aligned_total_N,), "float32")
+            group_topk_idx_ub = T.alloc_ub((aligned_top_k,), INDEX_DTYPE)
+            grad_scores_ub = T.alloc_ub((aligned_total_N,), "float32")
+            group_experts_ub = T.alloc_ub((aligned_block_N,), "float32")
+            tmp_calc_ub = T.alloc_ub((aligned_block_N,), "float32")
+            top_val_ub = T.alloc_ub((1,), "float32")
+            min_idx_res_ub = T.alloc_ub((1,), "float32")
+
+            for i in T.serial(aligned_total_N):
+                grad_scores_ub[i] = 0.0
+
+            T.copy(grad_out[cid, 0:aligned_top_k], grad_out_ub[0:aligned_top_k])
+            T.copy(scores[cid, 0:aligned_total_N], scores_ub[0:aligned_total_N])
+            T.copy(group_topk_idx[cid, 0:aligned_top_k], group_topk_idx_ub[0:aligned_top_k])
+
+            for k in T.serial(top_k):
+                g_int32 = T.cast(group_topk_idx_ub[k], "int32")
+                if g_int32 >= 0 and g_int32 < N:
+                    group_start = g_int32 * block_N
+                    current_grad = grad_out_ub[k]
+
+                    for e in T.serial(block_N):
+                        group_experts_ub[e] = scores_ub[group_start + e]
+                    for e in T.serial(aligned_block_N - block_N):
+                        group_experts_ub[block_N + e] = -1e10
+
+                    for _step in T.serial(topk_sum):
+                        T.reduce_max(group_experts_ub, top_val_ub, dim=0)
+                        for i in T.serial(aligned_block_N):
+                            if group_experts_ub[i] == top_val_ub[0]:
+                                tmp_calc_ub[i] = T.cast(i, "float32")
+                            else:
+                                tmp_calc_ub[i] = T.cast(aligned_block_N, "float32")
+                        T.reduce_min(tmp_calc_ub, min_idx_res_ub, dim=0)
+                        found_e_idx = T.cast(min_idx_res_ub[0], "int32")
+                        if found_e_idx < block_N:
+                            grad_scores_ub[group_start + found_e_idx] = grad_scores_ub[group_start + found_e_idx] + current_grad
+                        group_experts_ub[found_e_idx] = -1e10
+
+            T.copy(grad_scores_ub[0:aligned_total_N], grad_scores[cid, 0:aligned_total_N])
+
+    return topk_sum_and_topk_group_idx_backward_kernel
+
+
+def topk_sum_and_topk_group_idx_backward(
+    grad_out: torch.Tensor, scores: torch.Tensor, group_topk_idx: torch.Tensor, num_topk_sum: int
+) -> torch.Tensor:
+    assert grad_out.is_contiguous() and grad_out.dtype == torch.float32
+    assert scores.is_contiguous() and scores.dtype == torch.float32
+    assert group_topk_idx.is_contiguous() and group_topk_idx.dtype == torch.int64
+
+    num_tokens, num_groups, num_experts_per_group = scores.shape
+    num_topk_groups = group_topk_idx.shape[1]
+    num_experts = num_groups * num_experts_per_group
+    num_aligned_experts = (num_experts + 31) // 32 * 32
+    num_aligned_topk_groups = (num_topk_groups + 31) // 32 * 32
+
+    if num_experts < num_aligned_experts:
+        scores_padded = torch.nn.functional.pad(
+            scores.view(num_tokens, -1), (0, num_aligned_experts - num_experts), value=-1e10
+        ).contiguous()
+    else:
+        scores_padded = scores.view(num_tokens, -1).contiguous()
+
+    if num_topk_groups < num_aligned_topk_groups:
+        grad_out_padded = torch.nn.functional.pad(grad_out, (0, num_aligned_topk_groups - num_topk_groups), value=0.0).contiguous()
+        group_topk_idx_padded = torch.nn.functional.pad(
+            group_topk_idx, (0, num_aligned_topk_groups - num_topk_groups), value=-1
+        ).contiguous()
+    else:
+        grad_out_padded = grad_out.contiguous()
+        group_topk_idx_padded = group_topk_idx.contiguous()
+
+    kernel = get_topk_sum_and_topk_group_idx_backward_kernel(
+        B=num_tokens, N=num_groups, top_k=num_topk_groups, block_N=num_experts_per_group, topk_sum=num_topk_sum, dtype="float32"
+    )
+    grad_scores_padded = torch.zeros(num_tokens, num_aligned_experts, dtype=torch.float32, device=scores.device)
+    if num_tokens > 0:
+        kernel(grad_out_padded, scores_padded, group_topk_idx_padded, grad_scores_padded)
+    return grad_scores_padded[:, :num_experts].view(num_tokens, num_groups, num_experts_per_group).contiguous()
+
+
+def stable_topk(x, top_k):
+    _, sorted_indices = torch.sort(x, dim=-1, descending=True, stable=True)
+    return sorted_indices[..., :top_k].contiguous()
+
+
+def ref_topk_sum_and_topk_group_idx(scores: torch.Tensor, num_group_sum_topk: int, num_topk_groups: int) -> torch.Tensor:
+    group_scores_ref = scores.topk(num_group_sum_topk, dim=-1, sorted=False).values.sum(-1)
+    return stable_topk(group_scores_ref, num_topk_groups)
+
+
+def count_per_row_mismatches(indices: torch.Tensor, ref_indices: torch.Tensor):
+    row_mismatches = 0
+    for i in range(indices.shape[0]):
+        ref_indices_np = ref_indices[i].to(torch.int32).numpy()
+        indices_np = indices[i].to(torch.int32).numpy()
+        ref_indices_set = set(ref_indices_np)
+        indices_set = set(indices_np)
+        intersection = ref_indices_set & indices_set
+        if len(intersection) != len(ref_indices_set):
+            row_mismatches += 1
+        indices_ratio = len(intersection) / len(indices_set)
+        ref_indices_ratio = len(intersection) / len(ref_indices_set)
+        assert indices_ratio == ref_indices_ratio and indices_ratio > 0.99, (
+            f"Row {i} check failed: {indices_ratio = }, {ref_indices_ratio = }; {row_mismatches = }"
+        )
+    return row_mismatches
+
+
+def count_total_mismatches(indices: torch.Tensor, ref_indices: torch.Tensor):
+    assert indices.shape[-1] == ref_indices.shape[-1], "last dimension must match"
+    total_mismatches = 0
+    for i in range(indices.shape[0]):
+        indices_row = indices[i].tolist()
+        ref_indices_row = ref_indices[i].tolist()
+        indices_counter = Counter(indices_row)
+        ref_indices_counter = Counter(ref_indices_row)
+        diff = (indices_counter - ref_indices_counter) + (ref_indices_counter - indices_counter)
+        total_mismatches += sum(diff.values())
+    return total_mismatches
+
+
+def check_case(B: int, N: int, block_N: int, top_k: int, topk_sum: int):
+    print(f"\n Testing Case: B={B}, N={N}, block_N={block_N}, top_k={top_k}, topk_sum={topk_sum} ")
+
+    scores = torch.randn(B, N, block_N).to(torch.float32).npu()
+    indices = topk_sum_and_topk_group_idx(scores, topk_sum, top_k)
+    ref_indices = ref_topk_sum_and_topk_group_idx(scores, topk_sum, top_k)
+
+    grad_out = torch.randn(B, top_k).to(torch.float32).npu()
+    grad_scores = topk_sum_and_topk_group_idx_backward(grad_out, scores, indices, topk_sum)
+
+    scores_ref = scores.clone().detach().requires_grad_(True)
+    group_scores = scores_ref.topk(topk_sum, dim=-1, sorted=False).values.sum(-1)
+    chosen_group_scores = group_scores.gather(1, indices)
+    chosen_group_scores.backward(grad_out)
+    ref_grad_scores = scores_ref.grad
+
+    indices_cpu = indices.cpu()
+    ref_indices_cpu = ref_indices.cpu()
+
+    row_mismatches = count_per_row_mismatches(indices_cpu, ref_indices_cpu)
+    print(f"[Forward] Row matches: {B - row_mismatches} / {B}")
+
+    total = B * top_k
+    total_mismatches = count_total_mismatches(indices_cpu, ref_indices_cpu)
+    accuracy = 1 - total_mismatches / total
+    print(f"[Forward] Total matches: {total - total_mismatches} / {total}")
+    print(f"[Forward] Accuracy: {accuracy}")
+    assert accuracy > 0.99, "Forward accuracy check failed against torch.topk!"
+
+    torch.testing.assert_close(grad_scores, ref_grad_scores, rtol=1e-5, atol=1e-5)
+    print("[Backward] Scatter Check Passed! (PyTorch Reference Match!)")
+
+
+def main(custom_args=None):
+    parser = argparse.ArgumentParser(description="topk_sum_and_topk_group_idx with Backward Test")
+    parser.add_argument("--b", type=int, default=64, help="Batch Size / num_tokens")
+    parser.add_argument("--n", type=int, default=16, help="Number of groups (N)")
+    parser.add_argument("--block_n", type=int, default=32, help="Experts per group")
+    parser.add_argument("--top_k", type=int, default=4, help="Number of selected groups")
+    args, remains = parser.parse_known_args(custom_args)
+    if remains:
+        print(f"[{parser.description}]", "Unknown args:", remains)
+
+    B, N, block_N, top_k = args.b, args.n, args.block_n, args.top_k
+
+    torch.manual_seed(0)
+    tilelang.cache.clear_cache()
+
+    check_case(B, N, block_N, top_k, topk_sum=2)
+    check_case(32, 8, 16, 2, topk_sum=1)
+    check_case(123, 14, 23, 5, topk_sum=2)
+
+    print("\ntopk_sum_and_topk_group_idx example passed!")
+    print("Kernel Output Match!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
基于开源TileKernel，实现面向NPU的topk_sum_and_topk_group_idx算子。
验证迁移后基于tilelang-ascend架构在NPU上TileKernel的用例可全部通过。
补充后向实现与对应测试用例，验证符合预期。