### PR TITLE
[Fix] Support pip install -e . without requiring TL_ROOT or set_env.sh 🤖

### DIFF
--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -72,7 +72,7 @@ COMPOSABLE_KERNEL_INCLUDE_DIR: str | None = os.environ.get("TL_COMPOSABLE_KERNEL
 TVM_PYTHON_PATH: str | None = os.environ.get("TVM_IMPORT_PYTHON_PATH", None)
 TVM_LIBRARY_PATH: str | None = os.environ.get("TVM_LIBRARY_PATH", None)
 TILELANG_TEMPLATE_PATH: str | None = os.environ.get("TL_TEMPLATE_PATH", None)
-TILELANG_PACKAGE_PATH: str = pathlib.Path(__file__).resolve().parents[0]
+TILELANG_PACKAGE_PATH = pathlib.Path(__file__).resolve().parents[0]
 
 TILELANG_CACHE_DIR: str = os.environ.get("TILELANG_CACHE_DIR", os.path.expanduser("~/.tilelang/cache"))
 

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -72,7 +72,7 @@ COMPOSABLE_KERNEL_INCLUDE_DIR: str | None = os.environ.get("TL_COMPOSABLE_KERNEL
 TVM_PYTHON_PATH: str | None = os.environ.get("TVM_IMPORT_PYTHON_PATH", None)
 TVM_LIBRARY_PATH: str | None = os.environ.get("TVM_LIBRARY_PATH", None)
 TILELANG_TEMPLATE_PATH: str | None = os.environ.get("TL_TEMPLATE_PATH", None)
-TILELANG_PACKAGE_PATH = pathlib.Path(__file__).resolve().parents[0]
+TILELANG_PACKAGE_PATH: pathlib.Path = pathlib.Path(__file__).resolve().parent
 
 TILELANG_CACHE_DIR: str = os.environ.get("TILELANG_CACHE_DIR", os.path.expanduser("~/.tilelang/cache"))
 

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -1,6 +1,7 @@
 # Copyright (c) Tile-AI Corporation.
 # Licensed under the MIT License.
 
+from __future__ import annotations
 import sys
 import os
 import pathlib

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -12,12 +12,27 @@ from tilelang.env import TILELANG_TEMPLATE_PATH, TILELANG_PACKAGE_PATH
 logger = logging.getLogger(__name__)
 
 
-def _get_tl_root() -> str:
+def _get_tl_root(third_party_name="3rdparty") -> str:
     """Get TL_ROOT path, fallback to package path if not set."""
     tl_root = os.environ.get("TL_ROOT")
-    if tl_root is None:
-        tl_root = str(TILELANG_PACKAGE_PATH)
-    return tl_root
+    if tl_root is not None:
+        return tl_root
+
+    tl_root = TILELANG_PACKAGE_PATH
+    third_party_root = tl_root / third_party_name
+    if third_party_root.exists():
+        return str(tl_root)
+
+    tl_root = tl_root.parent
+    third_party_root = tl_root / third_party_name
+    if not third_party_root.exists():
+        # In most situations, third_party_root should exists. Otherwise, "import tvm" will fail before
+        # reaching this point.
+        raise ValueError(
+            f"TL_ROOT is not set and {third_party_name}/ directory not found in {TILELANG_PACKAGE_PATH} and {tl_root}. "
+            "Please set the TL_ROOT environment variable."
+        )
+    return str(tl_root)
 
 
 def _get_ascend_home_path() -> str:
@@ -59,6 +74,8 @@ class LibraryGenerator:
         libpath = src.name.replace(".cpp", ".so")
         ASCEND_HOME_PATH = _get_ascend_home_path()
         TL_ROOT = _get_tl_root()
+        if not os.path.exists(os.path.join(TL_ROOT, "3rdparty")):
+            raise ValueError(f"3rdparty dependencies not found. {TL_ROOT = }")
         if self.target == "ascendc" or self.target == "auto":
             command = [
                 "bisheng",

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 import subprocess
 import logging
+from pathlib import Path
 from tilelang.env import TILELANG_TEMPLATE_PATH, TILELANG_PACKAGE_PATH
 
 logger = logging.getLogger(__name__)
@@ -16,23 +17,20 @@ def _get_tl_root(third_party_name="3rdparty") -> str:
     """Get TL_ROOT path, fallback to package path if not set."""
     tl_root = os.environ.get("TL_ROOT")
     if tl_root is not None:
+        if not (Path(tl_root) / third_party_name).exists():
+            raise ValueError(f"3rdparty dependencies not found. TL_ROOT is {tl_root!r}")
         return tl_root
 
-    tl_root = TILELANG_PACKAGE_PATH
-    third_party_root = tl_root / third_party_name
-    if third_party_root.exists():
-        return str(tl_root)
-
-    tl_root = tl_root.parent
-    third_party_root = tl_root / third_party_name
-    if not third_party_root.exists():
-        # In most situations, third_party_root should exists. Otherwise, "import tvm" will fail before
-        # reaching this point.
-        raise ValueError(
-            f"TL_ROOT is not set and {third_party_name}/ directory not found in {TILELANG_PACKAGE_PATH} and {tl_root}. "
-            "Please set the TL_ROOT environment variable."
-        )
-    return str(tl_root)
+    for path in [TILELANG_PACKAGE_PATH, TILELANG_PACKAGE_PATH.parent]:
+        if (path / third_party_name).exists():
+            return str(path)
+    # In most situations, (path / third_party_name) should exists.
+    # Otherwise, "import tvm" will fail before reaching this point.
+    raise ValueError(
+        f"TL_ROOT is not set and {third_party_name}/ directory not found in "
+        f"{TILELANG_PACKAGE_PATH} or {TILELANG_PACKAGE_PATH.parent}. "
+        "Please set the TL_ROOT environment variable."
+    )
 
 
 def _get_ascend_home_path() -> str:
@@ -74,8 +72,6 @@ class LibraryGenerator:
         libpath = src.name.replace(".cpp", ".so")
         ASCEND_HOME_PATH = _get_ascend_home_path()
         TL_ROOT = _get_tl_root()
-        if not os.path.exists(os.path.join(TL_ROOT, "3rdparty")):
-            raise ValueError(f"3rdparty dependencies not found. {TL_ROOT = }")
         if self.target == "ascendc" or self.target == "auto":
             command = [
                 "bisheng",


### PR DESCRIPTION
## Summary

Make the framework work correctly under `USE_ASCEND=true pip install -e .` without requiring `TL_ROOT` environment variable or `source set_env.sh`. Previously, when `TL_ROOT` was not set, the framework would fail to locate `3rdparty/` directory, preventing operator compilation (e.g., `cd examples/gemm && python example_gemm.py` would fail).

## Changes

- **`tilelang/env.py`**: Change `TILELANG_PACKAGE_PATH` from `str` type annotation to `Path` object, enabling path traversal operations (`.parent`, `/ operator`)
- **`tilelang/jit/adapter/libgen.py`**: Rewrite `_get_tl_root()` to search upward from `TILELANG_PACKAGE_PATH` for a directory containing `3rdparty/` when `TL_ROOT` is not set, instead of blindly using the package path itself. Also add a runtime check to ensure `3rdparty/` exists at the resolved `TL_ROOT`

## Supported Installation Scenarios

After this change, all three installation methods work correctly:

1. **`install_ascend.sh` + `source set_env.sh`** — `TL_ROOT` set via environment variable (existing behavior, unchanged)
2. **`USE_ASCEND=true pip install -e .` (editable install)** — `3rdparty/` auto-detected by traversing upward from the package directory (new behavior)
3. **`pip install .whl`** — `3rdparty/` found via the package path hierarchy (existing behavior, unchanged)

## Testing

Verified that `cd examples/gemm && python example_gemm.py` works correctly under `USE_ASCEND=true pip install -e .` without `TL_ROOT` or `PYTHONPATH` set.

> ref: [tile-ai/tilelang - tilelang/env.py](https://github.com/tile-ai/tilelang/blob/main/tilelang/env.py#L29)