### PR TITLE
fix: example_merge_sort.py run failed with pto backend

### DIFF
--- a/src/transform/allocate_tmp_buffer.cc
+++ b/src/transform/allocate_tmp_buffer.cc
@@ -565,7 +565,7 @@ private:
               }
             }
             int64_t tmp_shape_size =
-                Downcast<IntImm>(dst_access_ptr->args[3])->value * 4;
+                Downcast<IntImm>(dst_access_ptr->args[3])->value;
             if (tmp_shape_size > shape_size) {
               Array<PrimExpr> tmp_shape;
               tmp_shape.push_back(IntImm(DataType::Int(32), tmp_shape_size));
@@ -575,7 +575,7 @@ private:
             Array<PrimExpr> tmp_shape;
             tmp_shape.push_back(
                 IntImm(DataType::Int(32),
-                       Downcast<IntImm>(dst_access_ptr->args[3])->value * 4));
+                       Downcast<IntImm>(dst_access_ptr->args[3])->value));
             shapes[dtype] = tmp_shape;
           }
         }


### PR DESCRIPTION
## PTO 后端 MergeSort 临时缓冲区尺寸 Bug 修复报告

### 1. 修改前的报错信息

```
/tmp/tmp0c8zm437.cpp:26:9: error: no matching function for call to 'MergeSort'
        tl::ascend_pto::MergeSort<float, 128, 256>(merge_output, tmp_ub_1, src0, src1);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
note: candidate function template not viable: no known conversion from
      'TileUbDataND<float, 1, 1024, 1, 1024>' to 'TileUbDataND<float, 1, 256, 1, 256> &'
      for 2nd argument
```

PTO `MergeSort` C++ 模板期望 `tmp` 参数类型为 `TileUbDataND<float, 1, 256, 1, 256>`，但实际传入的 `tmp_ub_1` 类型为 `TileUbDataND<float, 1, 1024, 1, 1024>`，模板参数 `DstCols` 不匹配（期望 256，实际 1024）。

### 2. 报错分析

以 2-way merge sort（N=64, ELEMENT_SIZE=2）为例，数据流追踪如下：

| 步骤 | 计算过程 | 结果 |
|------|---------|------|
| dst 缓冲区 | `N * 2 * ELEMENT_SIZE = 64 * 2 * 2` | 256 个 float32 元素 |
| `dst_access_ptr->args[3]`（extent） | dst 的元素数 | 256 |
| **Bug处：`* 4`** | `256 * 4` | **1024** |
| tmp 缓冲区分配 | `Buffer(tmp_ub_1, float32, [1024])` | 1024 个 float32 元素 |
| `Flatten2DPass` 对齐 | `[1024]` → `[1, 1024, 1, 1024]` | tmp C++ 类型为 `TileUbDataND<float, 1, 1024, 1, 1024>` |
| codegen 生成的调用 | `MergeSort<float, 128, 256>(merge_output, tmp_ub_1, src0, src1)` | dst_col=256, tmp_col=1024 |
| C++ 模板匹配 | 期望 `TileUbDataND<float, 1, 256, 1, 256>&` | 实际 `TileUbDataND<float, 1, 1024, 1, 1024>` |
| **结果** | **类型不匹配，编译失败** | |

**根因**：`src/transform/allocate_tmp_buffer.cc` 第 567-578 行，`createPTOXORAndMergeSortAndGatherMaskTmpBuffer_` 函数中，计算 PTO typed 临时缓冲区尺寸时使用了 `dst_access_ptr->args[3]->value * 4`。这个 `* 4` 将 float32 元素数乘以了 dtype 字节数（4 字节），导致 tmp 缓冲区的元素数变为 dst 的 4 倍。

PTO `MergeSort` 模板要求 `tmp` 与 `dst` 类型完全相同（`TileUbDataND<T, 1, DstCols, 1, DstCols>`），即 tmp 的元素数必须等于 dst 的元素数（256），而非 4 倍（1024）。

### 3. 修改必要性

- **PTO 后端 merge_sort 无法运行**：不修复则 PTO 后端编译必定失败，2/3/4-way merge_sort 均不可用
- **AscendC 后端不受影响**：AscendC 使用 `LocalTensor<uint8_t>` 通用缓冲区（`tmp_buf_`），走不同代码路径，`* 4` 对 AscendC 是正确的（uint8 字节级存储，`256 元素 * 4 字节/元素 = 1024 字节`）
- **PTO 后端需要元素级而非字节级**：PTO 的 tmp 是同 dtype 的 `TileUbDataND`，元素数应等于 dst 元素数

### 4. 修改前编码思路解释

原始代码 `dst_access_ptr->args[3]->value * 4` 的编码意图是：

- `args[3]` 是 `tvm_access_ptr` 的 `extent` 参数，表示访问的元素数（如 dst 有 256 个 float32 元素）
- `* 4` 是将"元素数"转换为"字节数"（`float32` 每元素 4 字节）
- 这个思路对 **AscendC 后端** 是正确的，因为 AscendC 的通用 tmp 缓冲区是 `LocalTensor<uint8_t>`（字节级存储），总大小 = 元素数 * dtype.bytes()

但这个思路被错误地复用到了 **PTO 后端** 的 typed 缓冲区分配中。PTO 的 `MergeSort` 要求 tmp 是同 dtype 的 `TileUbDataND`，其模板参数 `DstCols` 是**元素数**而非字节数。将字节级尺寸直接赋给元素级缓冲区，导致元素数膨胀 4 倍。

### 5. 对已有代码的影响分析

| 影响维度 | 分析结论 |
|---------|---------|
| **AscendC 后端** | **无影响**。AscendC merge_sort 使用 `tmp_buf_`（uint8 通用缓冲区），其尺寸由 `GetAscendcTmpBufferSize_` 计算，走独立代码路径，不经过 `createPTOXORAndMergeSortAndGatherMaskTmpBuffer_` |
| **PTO 其他算子** | **无影响**。`createPTOXORAndMergeSortAndGatherMaskTmpBuffer_` 函数中，XOR 和 GatherMask 的 tmp 尺寸计算逻辑不受此次修改影响（它们不使用 `* 4`） |
| **PTO merge_sort** | **正向修复**。tmp 元素数从 `dst_extent * 4` 改为 `dst_extent`，与 PTO `MergeSort` 模板的 `TileUbDataND<T, 1, DstCols, 1, DstCols>` 类型要求匹配 |
| **codegen 层** | **无影响**。`codegen_ascend_pto.cc` 中 `MergeSortCodegen` 的 `GetSliceInfo(tmp_call)` 逻辑不变，修复后 tmp 形状自然变为 `[1, DstCols, 1, DstCols]`，`is_slice=false` 时直接使用正确的 ub_name |
| **通用 tmp_buf_（uint8）** | **无影响**。`GetPTOTmpBufferSize_` 中 merge_sort 的 `dst_extent * dtype.bytes()` 计算仍保留（该函数计算 uint8 通用缓冲区大小，字节级是正确的），本次仅修改 typed 缓冲区的计算 |

**修改文件**：`src/transform/allocate_tmp_buffer.cc`（第 567-568 行、第 576-578 行）

**修改内容**：将 `* 4` 改为去掉该乘法，使 PTO typed tmp 缓冲区元素数等于 dst 元素数而非 dst 字节数。

