### PR TITLE
[fix] precision errors fix: swi_glu_grad.py & swi_glu_v2.py

### DIFF
--- a/examples/activation/swi_glu_grad.py
+++ b/examples/activation/swi_glu_grad.py
@@ -7,7 +7,7 @@ tilelang.cache.clear_cache()
 torch.set_default_device("npu")
 
 pass_configs = {
-    # tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
     # tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
     tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
     # tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
@@ -123,8 +123,7 @@ def swi_glu_backward_db(block_M, block_N, split_dim, dtype="float"):
                     T.tile.sub(temp1[cur, :, :], zero_ub, x1_ub[cur, :, :])
                     T.tile.exp(temp1[cur, :, :], temp1[cur, :, :])
                     T.tile.add(temp1[cur, :, :], temp1[cur, :, :], 1.0)
-                    T.tile.reciprocal(temp1[cur, :, :], temp1[cur, :, :])
-                    T.tile.mul(sigmoid_ub[cur, :, :], one_ub, temp1[cur, :, :])
+                    T.tile.div(sigmoid_ub[cur, :, :], one_ub, temp1[cur, :, :])
 
                     ## silu(x1) = x1 * sigmoid(x1)
                     T.tile.mul(temp1[cur, :, :], x1_ub[cur, :, :], sigmoid_ub[cur, :, :])

--- a/examples/activation/swi_glu_grad.py
+++ b/examples/activation/swi_glu_grad.py
@@ -80,8 +80,6 @@ def swi_glu_backward_db(block_M, block_N, split_dim, dtype="float"):
 
             T.tile.fill(zero_ub, 0.0)
             T.tile.fill(one_ub, 1.0)
-            for s in T.serial(stages):
-                T.set_flag("v", "mte2", s)
 
             for i in T.serial(num_iters):
                 cur = i % stages
@@ -95,17 +93,11 @@ def swi_glu_backward_db(block_M, block_N, split_dim, dtype="float"):
                     row_start = bx * block_M + vid * rows_per_vec
                     col_start = by * block_N
 
-                    T.wait_flag("v", "mte2", cur)
-
                     ## load
-                    T.set_flag("v", "mte2", 3)
-                    T.wait_flag("v", "mte2", 3)
                     if need_cast:
                         T.copy(A[row_start, col_start], tmp_bf16_1)
                         T.copy(A[row_start + m_offset, col_start + n_offset], tmp_bf16_2)
                         T.copy(dY[row_start, col_start], tmp_bf16_3)
-                        T.set_flag("mte2", "v", cur)
-                        T.wait_flag("mte2", "v", cur)
                         T.tile.cast(x1_ub[cur, :, :], tmp_bf16_1, "CAST_NONE", elem_num)
                         T.tile.cast(x2_ub[cur, :, :], tmp_bf16_2, "CAST_NONE", elem_num)
                         T.tile.cast(dy_ub[cur, :, :], tmp_bf16_3, "CAST_NONE", elem_num)
@@ -114,11 +106,6 @@ def swi_glu_backward_db(block_M, block_N, split_dim, dtype="float"):
                         T.copy(A[row_start + m_offset, col_start + n_offset], x2_ub[cur, :, :])
                         T.copy(dY[row_start, col_start], dy_ub[cur, :, :])
 
-                    T.pipe_barrier("mte2")
-
-                    T.set_flag("mte2", "v", cur)
-
-                    T.wait_flag("mte2", "v", cur)
                     ## sigmoid(x1)
                     T.tile.sub(temp1[cur, :, :], zero_ub, x1_ub[cur, :, :])
                     T.tile.exp(temp1[cur, :, :], temp1[cur, :, :])
@@ -143,21 +130,11 @@ def swi_glu_backward_db(block_M, block_N, split_dim, dtype="float"):
 
                     ## dx1 = dy * x2 * derivative
                     T.tile.mul(dx1_ub[cur, :, :], dy_ub[cur, :, :], x2_ub[cur, :, :])
-                    T.set_flag("mte3", "v", cur)
-                    T.wait_flag("mte3", "v", cur)
                     T.tile.mul(dx1_ub[cur, :, :], dx1_ub[cur, :, :], temp2[cur, :, :])
-
-                    T.set_flag("v", "mte3", cur)
-                    T.set_flag("v", "mte2", cur)
-
-                    T.wait_flag("v", "mte3", cur)
-                    T.pipe_barrier("mte3")
 
                     ## store
                     if row_start + m_offset < M and col_start + n_offset < N:
                         if need_cast:
-                            T.set_flag("mte3", "v", cur)
-                            T.wait_flag("mte3", "v", cur)
                             T.tile.cast(tmp_bf16_4, dx2_ub[cur, :, :], "CAST_RINT", elem_num)
                             T.tile.cast(tmp_bf16_5, dx1_ub[cur, :, :], "CAST_RINT", elem_num)
                             T.copy(tmp_bf16_4, dA[row_start + m_offset, col_start + n_offset])
@@ -165,9 +142,6 @@ def swi_glu_backward_db(block_M, block_N, split_dim, dtype="float"):
                         else:
                             T.copy(dx2_ub[cur, :, :], dA[row_start + m_offset, col_start + n_offset])
                             T.copy(dx1_ub[cur, :, :], dA[row_start, col_start])
-
-            T.wait_flag("v", "mte2", 0)
-            T.wait_flag("v", "mte2", 1)
 
     return main
 

--- a/examples/activation/swi_glu_v2.py
+++ b/examples/activation/swi_glu_v2.py
@@ -66,9 +66,6 @@ def swi_glu(block_M, block_N, split_dim, dtype="bfloat16"):
             tmp_bf16_2 = T.alloc_ub((rows_per_vec, block_N), dtype)
             tmp_bf16_3 = T.alloc_ub((rows_per_vec, block_N), dtype)
 
-            for s in T.serial(stages):
-                T.set_flag("v", "mte2", s)
-
             for i in T.serial(num_iters):
                 cur = i % stages
 
@@ -81,56 +78,30 @@ def swi_glu(block_M, block_N, split_dim, dtype="bfloat16"):
                     row2 = row + m_offset
                     col2 = col + n_offset
 
-                    T.wait_flag("v", "mte2", cur)
-
-                    T.set_flag("v", "mte2", 3)
-                    T.wait_flag("v", "mte2", 3)
                     if need_cast:
                         T.copy(A[row, col], tmp_bf16_1)
                         T.copy(A[row2, col2], tmp_bf16_2)
-                        T.set_flag("mte2", "v", cur)
-                        T.wait_flag("mte2", "v", cur)
                         T.tile.cast(a0_ub[cur, :, :], tmp_bf16_1, "CAST_NONE", elem_num)
                         T.tile.cast(a1_ub[cur, :, :], tmp_bf16_2, "CAST_NONE", elem_num)
                     else:
                         T.copy(A[row, col], a0_ub[cur, :, :])
                         T.copy(A[row2, col2], a1_ub[cur, :, :])
-                    T.pipe_barrier("mte2")
-
-                    T.set_flag("mte2", "v", cur)
 
                     # compute
-                    T.wait_flag("mte2", "v", cur)
                     T.tile.sub(temp_ub, zero_ub, a0_ub[cur, :, :])
                     T.tile.exp(temp_ub, temp_ub)
                     T.tile.add(temp_ub, temp_ub, 1.0)
                     T.tile.div(temp_ub, a0_ub[cur, :, :], temp_ub)
-                    T.set_flag("mte3", "v", cur)
-                    T.wait_flag("mte3", "v", cur)
                     T.tile.mul(b_ub[cur, :, :], temp_ub, a1_ub[cur, :, :])
-
-                    T.set_flag("v", "mte2", cur)
-
-                    T.set_flag("v", "mte3", cur)
-
-                    T.wait_flag("v", "mte3", cur)
-                    T.pipe_barrier("mte3")
 
                     out_row = bx * block_M + vid * rows_per_vec
                     out_col = by * block_N
 
                     if need_cast:
-                        T.set_flag("mte3", "v", cur)
-                        T.wait_flag("mte3", "v", cur)
                         T.tile.cast(tmp_bf16_3, b_ub[cur, :, :], "CAST_RINT", elem_num)
                         T.copy(tmp_bf16_3, B[out_row, out_col])
                     else:
                         T.copy(b_ub[cur, :, :], B[out_row, out_col])
-
-                    T.pipe_barrier("mte3")
-
-            T.wait_flag("v", "mte2", 0)
-            T.wait_flag("v", "mte2", 1)
 
     return swiglu
 

--- a/examples/activation/swi_glu_v2.py
+++ b/examples/activation/swi_glu_v2.py
@@ -6,7 +6,7 @@ tilelang.cache.clear_cache()
 torch.set_default_device("npu")
 
 pass_configs = {
-    # tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
     # tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
     tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
     # tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
@@ -104,8 +104,7 @@ def swi_glu(block_M, block_N, split_dim, dtype="bfloat16"):
                     T.tile.sub(temp_ub, zero_ub, a0_ub[cur, :, :])
                     T.tile.exp(temp_ub, temp_ub)
                     T.tile.add(temp_ub, temp_ub, 1.0)
-                    T.tile.reciprocal(temp_ub, temp_ub)
-                    T.tile.mul(temp_ub, a0_ub[cur, :, :], temp_ub)
+                    T.tile.div(temp_ub, a0_ub[cur, :, :], temp_ub)
                     T.set_flag("mte3", "v", cur)
                     T.wait_flag("mte3", "v", cur)
                     T.tile.mul(b_ub[cur, :, :], temp_ub, a1_ub[cur, :, :])


### PR DESCRIPTION
**根因：** 

PTO 后端的 TRECIP（reciprocal）指令在与其他向量操作组合使用时产生精度错误。将 reciprocal + mul 替换为 div 后问题消除。

**修改点：**

swi_glu_v2.py:

启用 TL_ASCEND_AUTO_SYNC: True
将 T.tile.reciprocal + T.tile.mul(a0, sigmoid) 替换为 T.tile.div(a0, 1+exp(-a0))，直接计算 SiLU


swi_glu_grad.py:

启用 TL_ASCEND_AUTO_SYNC: True
将 T.tile.reciprocal + T.tile.mul(one, sigmoid) 替换为 T.tile.div(one, 1+exp(-x))，计算 sigmoid
T.tile.div 是单个 PTO ISA 操作（TDIV），避免了 TRECIP 后接 TMUL 的两步组合可能导致的精度问题。同时 TL_ASCEND_AUTO_SYNC 确保向量流水线同步。
