### PR TITLE
[feat] add mask_indices_by_tp from TileKernel

### DIFF
--- a/examples/tile_kernels/moe/moe_mask_indices_by_tp.py
+++ b/examples/tile_kernels/moe/moe_mask_indices_by_tp.py
@@ -1,0 +1,254 @@
+import os
+import sys
+import torch
+import tilelang
+from tilelang import language as T
+import pytest
+
+tilelang.cache.clear_cache()
+
+INT64_DTYPE = "int64"
+INT32_DTYPE = "int32"
+
+pass_configs = {
+    tilelang.PassConfigKey.TIR_MERGE_STATIC_SMEM: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+}
+
+
+@tilelang.jit(pass_configs=pass_configs)
+def get_mask_indices_by_tp_kernel(num_topk: int, num_aligned_topk: int):
+    num_tokens = T.symbolic("num_tokens")
+
+    @T.prim_func
+    def mask_indices_by_tp_kernel(
+        indices: T.Tensor[(num_tokens, num_topk), INT64_DTYPE],
+        masked_indices: T.Tensor[(num_tokens, num_aligned_topk), INT64_DTYPE],
+        per_npu: T.int32,
+        per_dp: T.int32,
+        num_tp_ranks: T.int32,
+        tp_rank: T.int32,
+    ):
+        VEC_NUM = 2
+        num_blocks = 64
+        chunk_size = num_blocks * VEC_NUM
+        num_batches = (num_tokens + chunk_size - 1) // chunk_size
+
+        with T.Kernel(num_blocks, is_npu=True) as (cid, vid):
+            indices_ub_ping = T.alloc_ub((num_aligned_topk,), INT64_DTYPE)
+            indices_ub_pong = T.alloc_ub((num_aligned_topk,), INT64_DTYPE)
+            masked_ub_ping = T.alloc_ub((num_aligned_topk,), INT64_DTYPE)
+            masked_ub_pong = T.alloc_ub((num_aligned_topk,), INT64_DTYPE)
+
+            token_idx_0 = (0 * num_blocks + cid) * VEC_NUM + vid
+            if token_idx_0 < num_tokens:
+                T.copy(
+                    indices[token_idx_0, 0:num_topk],
+                    indices_ub_ping,
+                    pad_value=T.cast(-1, INT64_DTYPE),
+                )
+
+            for batch_idx in T.serial(num_batches):
+                if batch_idx % 2 == 0:
+                    T.barrier_all()
+
+                    token_idx = (batch_idx * num_blocks + cid) * VEC_NUM + vid
+                    if token_idx < num_tokens:
+                        next_batch_idx = batch_idx + 1
+                        if next_batch_idx < num_batches:
+                            next_token_idx = (next_batch_idx * num_blocks + cid) * VEC_NUM + vid
+                            if next_token_idx < num_tokens:
+                                T.copy(
+                                    indices[next_token_idx, 0:num_topk],
+                                    indices_ub_pong,
+                                    pad_value=T.cast(-1, INT64_DTYPE),
+                                )
+
+                        for j in T.serial(num_aligned_topk):
+                            value = indices_ub_ping[j]
+                            value_int32 = T.cast(value, INT32_DTYPE)
+
+                            local_value = value_int32 - tp_rank * per_npu
+                            dp_rank = T.truncdiv(local_value, per_dp)
+                            remapped = local_value - dp_rank * (per_dp - per_npu)
+
+                            ans = T.Select(
+                                remapped < 0,
+                                T.cast(-1, INT64_DTYPE),
+                                T.cast(remapped, INT64_DTYPE),
+                            )
+                            ans = T.Select(
+                                T.truncmod(T.truncdiv(value_int32, per_npu), num_tp_ranks) != tp_rank,
+                                T.cast(-1, INT64_DTYPE),
+                                ans,
+                            )
+                            ans = T.Select(value_int32 < 0, T.cast(-1, INT64_DTYPE), ans)
+
+                            masked_ub_ping[j] = ans
+
+                        T.copy(
+                            masked_ub_ping[0:num_aligned_topk],
+                            masked_indices[token_idx, 0:num_aligned_topk],
+                        )
+                else:
+                    T.barrier_all()
+
+                    token_idx = (batch_idx * num_blocks + cid) * VEC_NUM + vid
+                    if token_idx < num_tokens:
+                        next_batch_idx = batch_idx + 1
+                        if next_batch_idx < num_batches:
+                            next_token_idx = (next_batch_idx * num_blocks + cid) * VEC_NUM + vid
+                            if next_token_idx < num_tokens:
+                                T.copy(
+                                    indices[next_token_idx, 0:num_topk],
+                                    indices_ub_ping,
+                                    pad_value=T.cast(-1, INT64_DTYPE),
+                                )
+
+                        for j in T.serial(num_aligned_topk):
+                            value = indices_ub_pong[j]
+                            value_int32 = T.cast(value, INT32_DTYPE)
+
+                            local_value = value_int32 - tp_rank * per_npu
+                            dp_rank = T.truncdiv(local_value, per_dp)
+                            remapped = local_value - dp_rank * (per_dp - per_npu)
+
+                            ans = T.Select(
+                                remapped < 0,
+                                T.cast(-1, INT64_DTYPE),
+                                T.cast(remapped, INT64_DTYPE),
+                            )
+                            ans = T.Select(
+                                T.truncmod(T.truncdiv(value_int32, per_npu), num_tp_ranks) != tp_rank,
+                                T.cast(-1, INT64_DTYPE),
+                                ans,
+                            )
+                            ans = T.Select(value_int32 < 0, T.cast(-1, INT64_DTYPE), ans)
+
+                            masked_ub_pong[j] = ans
+
+                        T.copy(
+                            masked_ub_pong[0:num_aligned_topk],
+                            masked_indices[token_idx, 0:num_aligned_topk],
+                        )
+
+    return mask_indices_by_tp_kernel
+
+
+def mask_indices_by_tp(indices: torch.Tensor, n: int, num_ep_ranks: int, tp_rank: int, num_tp_ranks: int) -> torch.Tensor:
+    """Mask expert indices to keep only those belonging to the given TP rank."""
+    num_topk = indices.shape[1]
+    per_npu = n // num_ep_ranks
+    per_dp = num_tp_ranks * per_npu
+
+    num_aligned_topk = (num_topk + 7) // 8 * 8
+
+    kernel = get_mask_indices_by_tp_kernel(num_topk, num_aligned_topk)
+
+    if int(os.getenv("TK_PRINT_KERNEL_SOURCE", 0)):
+        print(kernel.get_kernel_source())
+
+    if indices.shape[0] > 0:
+        masked_indices_padded = torch.empty((indices.shape[0], num_aligned_topk), dtype=torch.int64, device=indices.device)
+        kernel(indices, masked_indices_padded, per_npu, per_dp, num_tp_ranks, tp_rank)
+        return masked_indices_padded[:, :num_topk].contiguous()
+    else:
+        return torch.empty_like(indices)
+
+
+def mask_indices_by_tp_ref(
+    indices: torch.Tensor,
+    n: int,
+    num_ep_ranks: int,
+    tp_rank: int,
+    num_tp_ranks: int,
+) -> torch.Tensor:
+    """Reference implementation of expert index masking for TP ranks."""
+    per_gpu = n // num_ep_ranks
+    per_dp = num_tp_ranks * per_gpu
+
+    value = indices.clone()
+    invalid = (value < 0) | ((value // per_gpu) % num_tp_ranks != tp_rank)
+
+    value = value - tp_rank * per_gpu
+    dp_rank = value // per_dp
+    value = value - dp_rank * (per_dp - per_gpu)
+
+    value[invalid | (value < 0)] = -1
+    return value
+
+
+def get_device() -> str:
+    if hasattr(torch, "npu") and torch.npu.is_available():
+        return "npu"
+    elif torch.cuda.is_available():
+        return "cuda"
+    return "cpu"
+
+
+def generate_moe_params():
+    """Generate coverage combinations for MoE parameters."""
+    for ep, experts_list in [(8, [9, 32]), (64, [4])]:
+        for experts in experts_list:
+            for topk in [2, 6, 8, 9]:
+                yield {
+                    "num_experts": experts,
+                    "num_ep_ranks": ep,
+                    "num_topk": topk,
+                }
+
+
+def generate_test_params() -> list[dict]:
+    """Augment base configs with different tensor-parallel sizes."""
+    params = []
+    for moe in generate_moe_params():
+        for tp in [2, 4, 8]:
+            params.append({**moe, "num_tp_ranks": tp})
+    return params
+
+
+def generate_test_data(params: dict):
+    """Create random test data: indices, token count, tp_rank, total experts."""
+    num_experts = params["num_experts"]
+    num_ep_ranks = params["num_ep_ranks"]
+    num_topk = params["num_topk"]
+    num_tp_ranks = params["num_tp_ranks"]
+    total_experts = num_experts * num_ep_ranks
+
+    num_tokens = torch.randint(1000, 40000, (1,)).item()
+
+    indices = torch.randint(0, total_experts, (num_tokens, num_topk), dtype=torch.int64)
+    mask = torch.rand(indices.shape) < 0.1
+    indices[mask] = -1
+
+    tp_rank = torch.randint(0, num_tp_ranks, (1,)).item()
+    n = total_experts
+
+    return indices, num_tokens, tp_rank, n
+
+
+def make_param_id(params: dict) -> str:
+    return f"ep={params['num_ep_ranks']}_experts={params['num_experts']}_topk={params['num_topk']}_tp={params['num_tp_ranks']}"
+
+
+@pytest.mark.parametrize("params", generate_test_params(), ids=make_param_id)
+def test_mask_indices_by_tp(params):
+    device = get_device()
+    torch.manual_seed(42)
+
+    indices, num_tokens, tp_rank, n = generate_test_data(params)
+    indices = indices.to(device)
+
+    out_ref = mask_indices_by_tp_ref(indices.cpu(), n, params["num_ep_ranks"], tp_rank, params["num_tp_ranks"]).to(device)
+    out_tl = mask_indices_by_tp(indices, n, params["num_ep_ranks"], tp_rank, params["num_tp_ranks"])
+
+    assert out_tl.shape == out_ref.shape, f"Shape mismatch: {out_tl.shape} vs {out_ref.shape}"
+    assert torch.equal(out_tl, out_ref), f"Result mismatch for {make_param_id(params)}"
+    print(f"Forward Test passed for params: {make_param_id(params)}")
+
+
+if __name__ == "__main__":
+    exit_code = pytest.main([__file__, "-v"])
+    if exit_code == pytest.ExitCode.OK:
+        print("All mask_indices_by_tp tests passed! Kernel Output Match!")
+    sys.exit(exit_code)

--- a/examples/topk_selector/example_mask_indices_by_tp.py
+++ b/examples/topk_selector/example_mask_indices_by_tp.py
@@ -1,0 +1,184 @@
+import argparse
+import os
+import torch
+import tilelang
+import tilelang.language as T
+
+# Constants for data types
+INT32_DTYPE = "int32"
+INT64_DTYPE = "int64"
+
+# Clear cache to force recompilation or load latest kernel
+tilelang.cache.clear_cache()
+
+# Compilation optimization configs for Ascend NPU
+pass_configs = {
+    tilelang.PassConfigKey.TIR_MERGE_STATIC_SMEM: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+}
+
+
+@tilelang.jit(pass_configs=pass_configs)
+def get_mask_indices_by_tp_kernel(num_tokens: int, top_k: int):
+    """Generate Ascend operator kernel for given shape."""
+    # Align top_k to 32 for better Vector instruction handling
+    num_aligned_top_k = (top_k + 31) // 32 * 32
+
+    @T.prim_func
+    def mask_indices_by_tp_kernel(
+        indices: T.Tensor[(num_tokens, top_k), INT64_DTYPE],
+        masked_indices: T.Tensor[(num_tokens, top_k), INT64_DTYPE],
+        per_npu: T.int32,
+        per_dp: T.int32,
+        num_tp_ranks: T.int32,
+        tp_rank: T.int32,
+    ):
+        # is_npu=True indicates this kernel runs on Ascend NPU
+        with T.Kernel(num_tokens, is_npu=True) as (cid, _):
+            # Allocate Unified Buffer (UB)
+            indices_ub = T.alloc_ub((num_aligned_top_k,), INT64_DTYPE)
+            masked_ub = T.alloc_ub((num_aligned_top_k,), INT64_DTYPE)
+
+            # Copy data from global memory to UB
+            T.copy(indices[cid, 0:top_k], indices_ub[0:top_k])
+
+            for j in T.serial(top_k):
+                value = indices_ub[j]
+                value_int32 = T.cast(value, INT32_DTYPE)
+
+                # Mask experts not belonging to current TP rank
+                if value_int32 < 0:
+                    masked_ub[j] = T.cast(-1, INT64_DTYPE)
+                else:
+                    tp_group = T.truncdiv(value_int32, per_npu)
+                    rank_in_tp = T.truncmod(tp_group, num_tp_ranks)
+                    if rank_in_tp != tp_rank:
+                        masked_ub[j] = T.cast(-1, INT64_DTYPE)
+                    else:
+                        local_value = value_int32 - tp_rank * per_npu
+                        dp_rank = T.truncdiv(local_value, per_dp)
+                        remapped = local_value - dp_rank * (per_dp - per_npu)
+                        # Use T.Select to avoid nested if
+                        masked_ub[j] = T.Select(
+                            remapped < 0,
+                            T.cast(-1, INT64_DTYPE),
+                            T.cast(remapped, INT64_DTYPE),
+                        )
+
+            # Write back results from UB to global memory
+            T.copy(masked_ub[0:top_k], masked_indices[cid, 0:top_k])
+
+    return mask_indices_by_tp_kernel
+
+
+def mask_indices_by_tp(
+    indices: torch.Tensor,
+    n: int,
+    num_ep_ranks: int,
+    num_tp_ranks: int,
+    tp_rank: int,
+) -> torch.Tensor:
+    """Forward wrapper to invoke TileLang kernel."""
+    num_tokens, top_k = indices.shape
+    per_npu = n // num_ep_ranks
+    per_dp = num_tp_ranks * per_npu
+
+    if not indices.is_contiguous():
+        indices = indices.contiguous()
+
+    kernel = get_mask_indices_by_tp_kernel(num_tokens=num_tokens, top_k=top_k)
+
+    if int(os.getenv("TK_PRINT_KERNEL_SOURCE", 0)):
+        print(kernel.get_kernel_source())
+
+    masked_indices = torch.empty((num_tokens, top_k), dtype=indices.dtype, device=indices.device)
+    if num_tokens > 0:
+        kernel(indices, masked_indices, per_npu, per_dp, num_tp_ranks, tp_rank)
+
+    return masked_indices
+
+
+def ref_mask_indices_by_tp(
+    indices: torch.Tensor,
+    n: int,
+    num_ep_ranks: int,
+    tp_rank: int,
+    num_tp_ranks: int,
+) -> torch.Tensor:
+    """CPU reference implementation to avoid NPU internal format warnings."""
+    orig_device = indices.device
+    value_cpu = indices.cpu()
+
+    per_npu = n // num_ep_ranks
+    per_dp = num_tp_ranks * per_npu
+
+    invalid = (value_cpu < 0) | ((value_cpu // per_npu) % num_tp_ranks != tp_rank)
+
+    value_cpu = value_cpu - tp_rank * per_npu
+    dp_rank = value_cpu // per_dp
+    value_cpu = value_cpu - dp_rank * (per_dp - per_npu)
+
+    value_cpu[invalid | (value_cpu < 0)] = -1
+
+    return value_cpu.to(orig_device)
+
+
+def check_case(
+    num_tokens: int,
+    top_k: int,
+    n: int,
+    num_ep_ranks: int,
+    num_tp_ranks: int,
+    tp_rank: int,
+):
+    """Test and compare custom kernel against PyTorch reference."""
+    print(f"\n Testing Case: tokens={num_tokens}, top_k={top_k}, n={n}, ep={num_ep_ranks}, tp={num_tp_ranks}, tp_rank={tp_rank} ")
+
+    indices = torch.randint(-1, n, (num_tokens, top_k), dtype=torch.int64).npu()
+
+    out_indices = mask_indices_by_tp(indices, n, num_ep_ranks, num_tp_ranks, tp_rank)
+    ref_indices = ref_mask_indices_by_tp(indices, n, num_ep_ranks, tp_rank, num_tp_ranks)
+
+    out_indices_cpu = out_indices.cpu()
+    ref_indices_cpu = ref_indices.cpu()
+
+    total = num_tokens * top_k
+    matches = (out_indices_cpu == ref_indices_cpu).sum().item()
+    accuracy = matches / total
+
+    print(f"[Forward] Total matches: {matches} / {total}")
+    print(f"[Forward] Accuracy: {accuracy}")
+
+    assert matches == total, "TileLang kernel output does not match PyTorch reference!"
+    print("Kernel Check Passed!")
+
+
+def main(custom_args=None):
+    parser = argparse.ArgumentParser(description="mask_indices_by_tp Test Example")
+    parser.add_argument("--tokens", type=int, default=1024, help="Number of tokens")
+    parser.add_argument("--topk", type=int, default=8, help="Top-K experts")
+    parser.add_argument("--n", type=int, default=16, help="Total number of experts")
+    parser.add_argument("--ep", type=int, default=2, help="Expert Parallel size")
+    parser.add_argument("--tp", type=int, default=4, help="Tensor Parallel size")
+    parser.add_argument("--rank", type=int, default=1, help="Current TP rank")
+
+    args, remains = parser.parse_known_args(custom_args)
+    if remains:
+        print(f"[{parser.description}] Unknown args:", remains)
+
+    torch.manual_seed(0)
+
+    check_case(args.tokens, args.topk, args.n, args.ep, args.tp, args.rank)
+
+    check_case(4096, 4, 32, 4, 4, 0)
+    check_case(8192, 2, 8, 1, 8, 3)
+    check_case(128, 16, 64, 8, 2, 1)
+
+    print("\nmask_indices_by_tp example passed!")
+    print("Kernel Output Match!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
基于开源TileKernel，实现面向NPU的mask_indices_by_tp算子。
验证迁移后基于tilelang-ascend架构NPU运行TileKernel用例全部通过。