### PR TITLE
[optimize] support change jit target by env: TILELANG_JIT_TARGET

### DIFF
--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -111,6 +111,9 @@ TL_TEMPLATE_NOT_FOUND_MESSAGE = "TileLang is not installed or found in the expec
 ", which may lead to compilation bugs when utilize tilelang backend."
 TVM_LIBRARY_NOT_FOUND_MESSAGE = "TVM is not installed or found in the expected path"
 
+# Override jit target when it is "auto"
+TILELANG_JIT_TARGET = os.environ.get("TILELANG_JIT_TARGET", None)
+
 SKIP_LOADING_TILELANG_SO = os.environ.get("SKIP_LOADING_TILELANG_SO", "0")
 
 # Handle TVM_IMPORT_PYTHON_PATH to import tvm from the specified path
@@ -224,6 +227,7 @@ __all__ = [
     "ROCM_HOME",
     "ASCEND_HOME",
     "TILELANG_CACHE_DIR",
+    "TILELANG_JIT_TARGET",
     "TILELANG_AUTO_TUNING_CPU_UTILITIES",
     "TILELANG_AUTO_TUNING_CPU_COUNTS",
     "TILELANG_AUTO_TUNING_MAX_CPU_COUNT",

--- a/tilelang/jit/__init__.py
+++ b/tilelang/jit/__init__.py
@@ -17,6 +17,7 @@ from typing import (
     Dict,  # For type hinting dicts
     Optional,
 )
+from tilelang import env
 from tilelang import tvm as tvm
 from tvm.tir import PrimFunc
 from tvm.target import Target
@@ -275,6 +276,7 @@ def jit(  # This is the new public interface
         Index(es) of the auto-allocated workspace tensors.
     target : Union[str, Target], optional
         Compilation target for TVM (e.g., "cuda", "llvm"). Defaults to "auto".
+        Can be overridden by TILELANG_JIT_TARGET env var when target is "auto".
     target_host : Union[str, Target], optional
         Target host for cross-compilation. Defaults to None.
     platform : Literal
@@ -294,6 +296,9 @@ def jit(  # This is the new public interface
         Either a JIT-compiled wrapper around the input function, or a configured decorator
         instance that can then be applied to a function.
     """
+    env_target = env.TILELANG_JIT_TARGET
+    if env_target and (target == "auto"):
+        target = env_target
     if callable(func):
         # Case 1: Used as @jit (func_or_out_idx is the function, others are defaults)
         # Create a default _JitImplementation instance and apply it to the function.


### PR DESCRIPTION
**改动内容**
[tilelang/env.py] — 新增 TILELANG_JIT_TARGET 环境变量读取，并将其加入环境变量注册列表
[tilelang/jit/__init__.py]— 在 jit() 函数中，当` target="auto" `时，优先使用环境变量 TILELANG_JIT_TARGET 的值覆盖

**这个 PR 的必要性**

目前 `tilelang.jit `的 `target `参数默认值为` "auto"`，会在运行时自动检测硬件平台来决定编译目标。但在以下场景中，自动检测可能不满足需求：
- 调试/实验：想临时切换 `target `进行对比测试，但不想改代码里的` @jit(target=...)`

这个 PR 通过环境变量提供了一种不改代码、不改默认行为的方式来覆盖 `target`，仅在显式设置环境变量且原始 `target `为 `"auto"` 时生效。如果用户已经明确指定了 `target`（如 `@jit(target="cuda")`），环境变量不会覆盖。

