### PR TITLE
[Bug]solve example dequant gemm w4a8 bug

### DIFF
--- a/examples/dequantize_gemm/example_dequant_gemm_w4a8.py
+++ b/examples/dequantize_gemm/example_dequant_gemm_w4a8.py
@@ -167,7 +167,6 @@ def generate_quantized_weight(N, K):
 
 def test(M, N, K):
     kernel = w4a8_gemm_cv(M, N, K)
-    # print(kernel.get_kernel_source())
 
     A_int8 = torch.randint(-8, 8, (M, K), dtype=torch.int8).npu()
     qB, B_int8_ref = generate_quantized_weight(N, K)

--- a/examples/dequantize_gemm/example_dequant_gemm_w4a8.py
+++ b/examples/dequantize_gemm/example_dequant_gemm_w4a8.py
@@ -22,7 +22,7 @@ BLOCK_K_HALF = 128
 VEC_NUM = 2
 
 
-@tilelang.jit(out_idx=[-1], pass_configs=PASS_CONFIGS)
+@tilelang.jit(out_idx=[-1], target="pto", pass_configs=PASS_CONFIGS)
 def w4a8_gemm_cv(M, N, K):
     """W4A8 GEMM CV Fusion - Developer mode with dual V-core parallelization
 
@@ -58,7 +58,7 @@ def w4a8_gemm_cv(M, N, K):
             high_ub = T.alloc_shared((BLOCK_K_HALF,), "int16")
             low_half_ub = T.alloc_shared((BLOCK_K_HALF,), "float16")
             high_half_ub = T.alloc_shared((BLOCK_K_HALF,), "float16")
-            cmp_ub = T.alloc_shared((BLOCK_K_HALF,), "float16")
+            cmp_ub = T.alloc_shared((BLOCK_K_HALF,), "uint8")
             neg16_ub = T.alloc_shared((BLOCK_K_HALF,), "float16")
             zero_ub = T.alloc_shared((BLOCK_K_HALF,), "float16")
             adj_ub = T.alloc_shared((BLOCK_K_HALF,), "float16")
@@ -167,6 +167,7 @@ def generate_quantized_weight(N, K):
 
 def test(M, N, K):
     kernel = w4a8_gemm_cv(M, N, K)
+    print(kernel.get_kernel_source())
 
     A_int8 = torch.randint(-8, 8, (M, K), dtype=torch.int8).npu()
     qB, B_int8_ref = generate_quantized_weight(N, K)
@@ -202,10 +203,10 @@ def main():
         test(64, 64, 256)
 
         # Level 1: K=512
-        test(128, 128, 512)
+        # test(128, 128, 512)
 
         # Level 2: K=1024
-        test(256, 256, 1024)
+        # test(256, 256, 1024)
 
     print("Test Passed!")
 

--- a/examples/dequantize_gemm/example_dequant_gemm_w4a8.py
+++ b/examples/dequantize_gemm/example_dequant_gemm_w4a8.py
@@ -22,7 +22,7 @@ BLOCK_K_HALF = 128
 VEC_NUM = 2
 
 
-@tilelang.jit(out_idx=[-1], target="pto", pass_configs=PASS_CONFIGS)
+@tilelang.jit(out_idx=[-1], pass_configs=PASS_CONFIGS)
 def w4a8_gemm_cv(M, N, K):
     """W4A8 GEMM CV Fusion - Developer mode with dual V-core parallelization
 
@@ -167,7 +167,7 @@ def generate_quantized_weight(N, K):
 
 def test(M, N, K):
     kernel = w4a8_gemm_cv(M, N, K)
-    print(kernel.get_kernel_source())
+    # print(kernel.get_kernel_source())
 
     A_int8 = torch.randint(-8, 8, (M, K), dtype=torch.int8).npu()
     qB, B_int8_ref = generate_quantized_weight(N, K)
@@ -203,10 +203,10 @@ def main():
         test(64, 64, 256)
 
         # Level 1: K=512
-        # test(128, 128, 512)
+        test(128, 128, 512)
 
         # Level 2: K=1024
-        # test(256, 256, 1024)
+        test(256, 256, 1024)
 
     print("Test Passed!")
 

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -35,6 +35,7 @@ using BufferInfo = CodeGenTileLangAscendPto::BufferInfo;
 // Hardware / platform constants
 // ---------------------------------------------------------------------------
 constexpr int kUbAlignmentBytes = 32;
+constexpr int kUbAlignment16Bytes = 16;
 constexpr int kUbAlignmentMask = kUbAlignmentBytes - 1;
 constexpr int kVectorRepeatBytes = 256;
 constexpr int kEleNumPerC0 = 16;
@@ -172,6 +173,14 @@ int GetValidShape(int shape, const std::string &dtype) {
     return shape;
   }
   return shape + (kUbAlignmentBytes - shape_mod) / dtype_len;
+}
+
+int GetValid16BytesShape(int shape) {
+  int shape_mod = shape % kUbAlignment16Bytes;
+  if (shape_mod == 0) {
+    return shape;
+  }
+  return shape + (kUbAlignment16Bytes - shape_mod);
 }
 
 int GetRowReduceTmpCol(int valid_col, const std::string &dtype) {
@@ -1271,9 +1280,9 @@ void CodeGenTileLangAscendPto::GemmV0Codegen(const CallNode *op) {
   this->stream << kAscendPtoScope << "gemm_v0" << "<"
                << params["data_type_input"] << ", "
                << params["data_type_output"] << ", "
-               << params["M"] << ", "
-               << params["N"] << ", "
-               << params["K"] << ", "
+               << GetValid16BytesShape(std::stoi(params["M"])) << ", "
+               << GetValid16BytesShape(std::stoi(params["N"])) << ", "
+               << GetValidShape(std::stoi(params["K"]), data_type_input) << ", "
                << params["M"] << ", " << params["N"] << ", " << params["K"]
                << ", " << kL0Tail << ", " << params["transpose_A"] << ", "
                << params["transpose_B"] << ">" << "(";

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -1271,9 +1271,9 @@ void CodeGenTileLangAscendPto::GemmV0Codegen(const CallNode *op) {
   this->stream << kAscendPtoScope << "gemm_v0" << "<"
                << params["data_type_input"] << ", "
                << params["data_type_output"] << ", "
-               << GetValidShape(std::stoi(params["M"]), data_type_input) << ", "
-               << GetValidShape(std::stoi(params["N"]), data_type_input) << ", "
-               << GetValidShape(std::stoi(params["K"]), data_type_input) << ", "
+               << params["M"] << ", "
+               << params["N"] << ", "
+               << params["K"] << ", "
                << params["M"] << ", " << params["N"] << ", " << params["K"]
                << ", " << kL0Tail << ", " << params["transpose_A"] << ", "
                << params["transpose_B"] << ">" << "(";
@@ -2733,7 +2733,7 @@ inline void PrintConst(const FloatImmNode *op, std::ostream &os,
     break;
   }
   case 16: {
-    os << "half_t" << '(';
+    os << "half" << '(';
     FloatImm const_f32 = FloatImm(DataType::Float(32), op->value);
     PrintConst(const_f32.get(), os, p);
     os << ')';

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -35,7 +35,7 @@ using BufferInfo = CodeGenTileLangAscendPto::BufferInfo;
 // Hardware / platform constants
 // ---------------------------------------------------------------------------
 constexpr int kUbAlignmentBytes = 32;
-constexpr int kUbAlignment16Bytes = 16;
+constexpr int kAlignment16Bytes = 16;
 constexpr int kUbAlignmentMask = kUbAlignmentBytes - 1;
 constexpr int kVectorRepeatBytes = 256;
 constexpr int kEleNumPerC0 = 16;
@@ -176,11 +176,11 @@ int GetValidShape(int shape, const std::string &dtype) {
 }
 
 int GetValid16BytesShape(int shape) {
-  int shape_mod = shape % kUbAlignment16Bytes;
+  int shape_mod = shape % kAlignment16Bytes;
   if (shape_mod == 0) {
     return shape;
   }
-  return shape + (kUbAlignment16Bytes - shape_mod);
+  return shape + (kAlignment16Bytes - shape_mod);
 }
 
 int GetRowReduceTmpCol(int valid_col, const std::string &dtype) {


### PR DESCRIPTION
/dequantize_gemm/example_dequant_gemm_w4a8.py pto报错
报错一：
1）报错信息：
no matching function for call to 'gemm_v0'

参数类型不匹配：TileMatL1<int8_t, 16, 256, 16, 256> 无法转换为 TileMatL1<signed char, 32, 256, 16, 256>
2）报错原因：
 tl::ascend_pto::TileMatL1<int8_t, 16, 256, 16, 256> B_L1; --B_L1本身信息N=16
tl::ascend_pto::gemm_v0<int8_t, int, 64, 32, 256, 64, 16, 256, 128, false, true>(A_L1, B_L1, C_L0, (k_chunk == 0)); 模板参数N为32不匹配
代码处理位置：
GemmV0Codegen：this->stream << kAscendPtoScope << "gemm_v0" << "<"
               << params["data_type_input"] << ", "
               << params["data_type_output"] << ", "
               << GetValidShape(std::stoi(params["M"]), data_type_input) << ", "
               << GetValidShape(std::stoi(params["N"]), data_type_input) << ", "
               << GetValidShape(std::stoi(params["K"]), data_type_input) << ", "做了getvalidshape操作，16->32
3)修改方案：对照矩阵排布，M/N修改为16元素对齐，K保持32字节对齐
报错二：
1）报错信息：
use of undeclared identifier 'half_t'; did you mean 'half'?
      tl::ascend_pto::compare_scalar(cmp_ub, low_half_ub, half_t(8.000000e+00f), CmpMode::GE);
2）报错原因：
PrintConst（）方法中，若op->dtype.bits()则转化为half_t
3）修改方案：
PrintConst（）方法中，若op->dtype.bits()则转化为half

报错三：
1）报错信息
no matching function for call to 'vcmp_dispatch'
no known conversion from '__ubuf__ half *' to '__ubuf__ uint8_t *'
2）报错原因
compare_scalar 期望 dst 是 uint8_t*，但实际传入的是 half*
3）修改前端定义

cmp_ub = T.alloc_shared((BLOCK_K_HALF,), "float16")


应该改成：
cmp_ub = T.alloc_shared((BLOCK_K_HALF,), "uint8")