### PR TITLE
[Feat] Support KERNEL_TYPE_AIV_ONLY for pure vector kernels in Ascend C backend 🤖

### DIFF
--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -692,10 +692,6 @@ void CodeGenTileLangAscend::VisitStmt_(const AttrStmtNode *op) {
       }
       this->stream << "auto " << current_block_id
                    << " = AscendC::GetBlockIdx();\n";
-      if (!has_cube_op_ && cv_ratio_ != cv_1_1) {
-        this->PrintIndent();
-        this->stream << "auto __raw_cid__ = " << current_block_id << ";\n";
-      }
       this->PrintIndent();
       this->stream << "if ASCEND_IS_AIV {\n";
       this->PrintIndent();
@@ -714,7 +710,7 @@ void CodeGenTileLangAscend::VisitStmt_(const AttrStmtNode *op) {
       auto vec_id_ = AllocVarID(iv->var.get());
       this->PrintIndent();
       if (!has_cube_op_ && cv_ratio_ != cv_1_1) {
-        this->stream << "auto " << vec_id_ << " = __raw_cid__ % 2;\n";
+        this->stream << "auto " << vec_id_ << " = AscendC::GetBlockIdx() % 2;\n";
       } else {
         this->stream << "auto " << vec_id_ << " = AscendC::GetSubBlockIdx();\n";
       }

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -710,7 +710,8 @@ void CodeGenTileLangAscend::VisitStmt_(const AttrStmtNode *op) {
       auto vec_id_ = AllocVarID(iv->var.get());
       this->PrintIndent();
       if (!has_cube_op_ && cv_ratio_ != cv_1_1) {
-        this->stream << "auto " << vec_id_ << " = AscendC::GetBlockIdx() % 2;\n";
+        this->stream << "auto " << vec_id_
+                     << " = AscendC::GetBlockIdx() % 2;\n";
       } else {
         this->stream << "auto " << vec_id_ << " = AscendC::GetSubBlockIdx();\n";
       }

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -26,6 +26,28 @@
 namespace tvm {
 namespace codegen {
 
+class CubeOpDetector : public StmtExprVisitor {
+public:
+  bool Detect(const Stmt &stmt) {
+    has_cube_op_ = false;
+    VisitStmt(stmt);
+    return has_cube_op_;
+  }
+
+private:
+  void VisitExpr_(const CallNode *op) final {
+    if (op->op.same_as(tl::ascend_gemm_v0()) ||
+        op->op.same_as(tl::ascend_gemm_v1()) ||
+        op->op.same_as(tl::ascend_mma())) {
+      has_cube_op_ = true;
+      return;
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+  bool has_cube_op_{false};
+};
+
 #define ASCEND_A2A3_L0A_SIZE (65536)
 #define ASCEND_A2A3_L0B_SIZE (65536)
 #define ASCEND_A2A3_L1_SIZE (524032)
@@ -573,7 +595,9 @@ void CodeGenTileLangAscend::VisitExpr_(const CallNode *op, std::ostream &os) {
   } else if (op->op.same_as(tl::ascend_pipe_barrier())) {
     PipeBarrierCodegen(op);
   } else if (op->op.same_as(tl::ascend_sync_all())) {
-    PrintOpCall(op, "AscendC::SyncAll<false>", {0, 0}, {0, 0});
+    std::string sync_call =
+        !has_cube_op_ ? "AscendC::SyncAll<true>" : "AscendC::SyncAll<false>";
+    PrintOpCall(op, sync_call, {0, 0}, {0, 0});
   } else if (op->op.same_as(tl::ascend_gemm_v0())) {
     GemmOpCodegen(op);
   } else if (op->op.same_as(tl::ascend_printf())) {
@@ -660,6 +684,10 @@ void CodeGenTileLangAscend::VisitStmt_(const AttrStmtNode *op) {
       }
       this->stream << "auto " << current_block_id
                    << " = AscendC::GetBlockIdx();\n";
+      if (!has_cube_op_ && cv_ratio_ != cv_1_1) {
+        this->PrintIndent();
+        this->stream << "auto __raw_cid__ = " << current_block_id << ";\n";
+      }
       this->PrintIndent();
       this->stream << "if ASCEND_IS_AIV {\n";
       this->PrintIndent();
@@ -672,14 +700,17 @@ void CodeGenTileLangAscend::VisitStmt_(const AttrStmtNode *op) {
       this->stream << "}\n";
 
       this->core_num_ = PrintExpr(op->value);
-    } else if (iv->thread_tag == "blockIdx.y" && iv->var->name_hint != "_") {
+    } else if ((iv->thread_tag == "blockIdx.y" ||
+                iv->thread_tag == "threadIdx.x") &&
+               iv->var->name_hint != "_") {
       auto vec_id_ = AllocVarID(iv->var.get());
       this->PrintIndent();
-      this->stream << "auto " << vec_id_ << " = AscendC::GetSubBlockIdx();\n";
-    } else if (iv->thread_tag == "threadIdx.x") {
-      auto vec_id_ = AllocVarID(iv->var.get());
-      this->PrintIndent();
-      this->stream << "auto " << vec_id_ << " = AscendC::GetSubBlockIdx();\n";
+      if (!has_cube_op_ && cv_ratio_ != cv_1_1) {
+        this->stream << "auto " << vec_id_ << " = __raw_cid__ % 2;\n";
+      } else {
+        this->stream << "auto " << vec_id_
+                     << " = AscendC::GetSubBlockIdx();\n";
+      }
     }
     this->VisitStmt(op->body);
     return;
@@ -881,7 +912,9 @@ void CodeGenTileLangAscend::VisitExpr_(const MulNode *op,
 void CodeGenTileLangAscend::PreFunctionBody(const PrimFunc &f) {
   int func_scope = this->BeginScope();
   this->PrintIndent();
-  if (cv_ratio_ == cv_1_1) {
+  if (!has_cube_op_) {
+    stream << "KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_AIV_ONLY);\n";
+  } else if (cv_ratio_ == cv_1_1) {
     stream << "KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_1);\n";
   } else {
     stream << "KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);\n";
@@ -1066,7 +1099,12 @@ void CodeGenTileLangAscend::PrintHostFunc(
   CallTilingInput(os, tiling_func_name, tiling_args, shape_vars);
   this->PrintIndent();
 
-  os << name << "<<<" << core << ", nullptr, stream>>>(";
+  if (!has_cube_op_ && cv_ratio_ != cv_1_1) {
+    os << name << "<<<" << core << " * 2"
+       << ", nullptr, stream>>>(";
+  } else {
+    os << name << "<<<" << core << ", nullptr, stream>>>(";
+  }
   for (auto &arg_name : arg_names) {
     os << arg_name;
     if (arg_name != arg_names.back()) {
@@ -1095,6 +1133,9 @@ void CodeGenTileLangAscend::AddFunction(const GlobalVar &gvar,
   CodeGenC::DeclareFunction(gvar, f);
   // clear previous generated state.
   this->InitFuncState(f);
+
+  CubeOpDetector detector;
+  has_cube_op_ = detector.Detect(f->body);
 
   auto global_symbol = f->GetAttr<String>(tvm::attr::kGlobalSymbol);
 

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -35,7 +35,15 @@ public:
   }
 
 private:
+  void VisitStmt(const Stmt &stmt) final {
+    if (has_cube_op_)
+      return;
+    StmtExprVisitor::VisitStmt(stmt);
+  }
+
   void VisitExpr_(const CallNode *op) final {
+    if (has_cube_op_)
+      return;
     if (op->op.same_as(tl::ascend_gemm_v0()) ||
         op->op.same_as(tl::ascend_gemm_v1()) ||
         op->op.same_as(tl::ascend_mma())) {
@@ -708,8 +716,7 @@ void CodeGenTileLangAscend::VisitStmt_(const AttrStmtNode *op) {
       if (!has_cube_op_ && cv_ratio_ != cv_1_1) {
         this->stream << "auto " << vec_id_ << " = __raw_cid__ % 2;\n";
       } else {
-        this->stream << "auto " << vec_id_
-                     << " = AscendC::GetSubBlockIdx();\n";
+        this->stream << "auto " << vec_id_ << " = AscendC::GetSubBlockIdx();\n";
       }
     }
     this->VisitStmt(op->body);
@@ -1100,7 +1107,7 @@ void CodeGenTileLangAscend::PrintHostFunc(
   this->PrintIndent();
 
   if (!has_cube_op_ && cv_ratio_ != cv_1_1) {
-    os << name << "<<<" << core << " * 2"
+    os << name << "<<<(" << core << ") * 2"
        << ", nullptr, stream>>>(";
   } else {
     os << name << "<<<" << core << ", nullptr, stream>>>(";

--- a/src/target/codegen_ascend.h
+++ b/src/target/codegen_ascend.h
@@ -247,6 +247,8 @@ private:
   bool use_swizzle_{false};
 
   std::string platform_;
+
+  bool has_cube_op_{false};
 };
 
 } // namespace codegen


### PR DESCRIPTION
## Summary

Support automatic kernel type selection for Ascend C backend: pure vector kernels use `KERNEL_TYPE_AIV_ONLY` to reduce launch overhead, while kernels with cube operations continue using `KERNEL_TYPE_MIX_AIC_1_1/1_2`.

## Changes

- Add `CubeOpDetector` visitor to detect gemm/mma operations in kernel body
- Generate `KERNEL_TYPE_AIV_ONLY` for pure vector kernels (no cube ops detected)
- Generate `KERNEL_TYPE_MIX_AIC_1_1/1_2` for kernels with cube operations (unchanged behavior)
- Handle vid derivation from block ID (`__raw_cid__ % 2`) for pure vector + cv_1_2 mode
- Multiply grid size by 2 for pure vector + cv_1_2 to replace sub-block mechanism
- Use `SyncAll<true>` for pure vector kernels to avoid cross-core sync overhead

## Background

Previously, the Ascend C backend always generated `KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_1/1_2)`, causing unnecessary AIC core allocation for pure vector operators. This resulted in higher kernel launch overhead and wasted hardware resources.

The PTO backend already supports automatic kernel type inference by the compiler, so no changes are needed there.

## Testing

Verified with msprof profiling:
- Pure vector kernel (elementwise_add): `main_kernel` now shows `AI_VECTOR_CORE` (was `MIX_AIC`)
- GEMM kernel: `main_kernel` still shows `MIX_AIC` (correct, has cube ops)
- All existing examples pass: elementwise_add, gemm, activation, normalization, reduce, etc.

## Files Changed

- `src/target/codegen_ascend.h`: Add `has_cube_op_` member variable
- `src/target/codegen_ascend.cc`: Add `CubeOpDetector` and kernel type selection logic