### PR TITLE
[Fix] Fixed the faulty slicing logic of pto codegen.

### DIFF
--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -2035,12 +2035,26 @@ void CodeGenTileLangAscendPto::BinaryVecOpsCodegen(const CallNode *op,
 
   if (!buffer) {
     std::string scalar = apply_scalar_for_half(index);
-    this->PrintIndent();
-    this->stream << operation << "(";
-    for (const auto &name : var_names) {
-      this->stream << name << ", ";
+
+    ShapeInfo src_info = GetSliceInfo(op->args[1].as<CallNode>());
+    ShapeInfo dst_info = GetSliceInfo(op->args[0].as<CallNode>());
+
+    if (src_info.is_slice || dst_info.is_slice) {
+      std::string src_name = GetTempVarName(src_info.ub_name);
+      std::string dst_name = GetTempVarName(dst_info.ub_name);
+      CreateUbVariableND(src_name, src_info);
+      CreateUbVariableND(dst_name, dst_info);
+      this->PrintIndent();
+      this->stream << operation << "(" << dst_name << ", " << src_name << ", "
+                   << scalar << ");\n";
+    } else {
+      this->PrintIndent();
+      this->stream << operation << "(";
+      for (const auto &name : var_names) {
+        this->stream << name << ", ";
+      }
+      this->stream << scalar << ");\n";
     }
-    this->stream << scalar << ");\n";
     return;
   }
 
@@ -2495,16 +2509,8 @@ void CodeGenTileLangAscendPto::ReduceOpCodegen(const CallNode *op) {
     ShapeInfo tmp_dst_raw = GetSliceInfo(op->args[4].as<CallNode>());
     ShapeInfo tmp_dst = build_reduce_tmp_dst(tmp_dst_raw);
     if (op_info.direction == ReduceDirection::ROW) {
-      if (is_slice) {
-        dst.slice_valid_col = op_info.buffer_slice_row;
-        tmp_dst.slice_valid_col = op_info.buffer_slice_row;
-      }
       CodegenRowReduce(op_info, tmp_dst, src, tmp);
     } else {
-      if (is_slice) {
-        dst.slice_valid_col = op_info.buffer_slice_col;
-        tmp_dst.slice_valid_col = op_info.buffer_slice_col;
-      }
       CodegenColReduce(op_info, tmp_dst, src, tmp);
     }
     emit_merge(tmp_dst);

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -2036,25 +2036,26 @@ void CodeGenTileLangAscendPto::BinaryVecOpsCodegen(const CallNode *op,
   if (!buffer) {
     std::string scalar = apply_scalar_for_half(index);
 
-    ShapeInfo src_info = GetSliceInfo(op->args[1].as<CallNode>());
-    ShapeInfo dst_info = GetSliceInfo(op->args[0].as<CallNode>());
-
-    if (src_info.is_slice || dst_info.is_slice) {
-      std::string src_name = GetTempVarName(src_info.ub_name);
-      std::string dst_name = GetTempVarName(dst_info.ub_name);
-      CreateUbVariableND(src_name, src_info);
-      CreateUbVariableND(dst_name, dst_info);
-      this->PrintIndent();
-      this->stream << operation << "(" << dst_name << ", " << src_name << ", "
-                   << scalar << ");\n";
-    } else {
-      this->PrintIndent();
-      this->stream << operation << "(";
-      for (const auto &name : var_names) {
-        this->stream << name << ", ";
+    auto src_call = op->args[1].as<CallNode>();
+    auto dst_call = op->args[0].as<CallNode>();
+    if (src_call && dst_call) {
+      ShapeInfo src_info = GetSliceInfo(src_call);
+      ShapeInfo dst_info = GetSliceInfo(dst_call);
+      if (src_info.is_slice || dst_info.is_slice) {
+        std::string src_name = ResolveUbSliceName(src_info);
+        std::string dst_name = ResolveUbSliceName(dst_info);
+        this->PrintIndent();
+        this->stream << operation << "(" << dst_name << ", " << src_name << ", "
+                     << scalar << ");\n";
+        return;
       }
-      this->stream << scalar << ");\n";
     }
+    this->PrintIndent();
+    this->stream << operation << "(";
+    for (const auto &name : var_names) {
+      this->stream << name << ", ";
+    }
+    this->stream << scalar << ");\n";
     return;
   }
 


### PR DESCRIPTION
Fixed the faulty slicing logic; Now flash_attn_bhsd_auto_pipeline_h16_d128 can pass correctly.

**Issue 1: Error in handling sliced ​​UB buffers for binary vector scalar operations**
When the operands of binary vector scalar operations such as TADDS, TMULS, TSUBS, and TDIVS are sub-regions (slices) of the UB buffer, the original code directly uses the full buffer name when generating the PTO, without resolving the slice semantics, causing the computation to operate in the wrong memory region. Solution: Detect slice operands and generate a TileUbDataND temporary variable with the correct dimensions.

**Issue 2: Incorrect Overriding of `slice_valid_col` in the `clear=True` Path for `reduce`**
In the `clear=True` branch of row/column reduce, the original code incorrectly overridden `dst.slice_valid_col`: during row reduce, `buffer_slice_row` (number of rows) was used to cover the effective column width, and during column reduce, redundant assignments were made. This caused the reduce calculation area to be completely incorrect. Solution: Delete the two incorrect `if` blocks and use the correctly initialized slice information at the beginning of the function.