### PR TITLE
[fix] run elememtwise_print.py failed

### DIFF
--- a/docs/tutorials/print.md
+++ b/docs/tutorials/print.md
@@ -4,6 +4,26 @@ TileLang-ascend introduces new debugging API interfaces: `T.printf` and `T.dump_
 
 *Note: `T.printf` and `T.dump_tensor` are device-side debugging tools; for the host side, use Python's built-in print directly.*
 
+## Prerequisites
+
+To enable `T.printf` and `T.dump_tensor` output at runtime, the environment
+variable `TL_PTO_DEBUG` must be set to `"1"` **before** kernel compilation:
+
+```python
+import os
+os.environ["TL_PTO_DEBUG"] = "1"
+```
+
+This appends the compiler flags `-D_DEBUG` and `--cce-enable-print`,
+which activate the device-side printf infrastructure that is otherwise compiled
+out for performance reasons.
+
+> **Warning**: `TL_PTO_DEBUG` is intended for **debugging only**. Leaving it
+> enabled degrades kernel performance and each tile's printf/dump buffer is
+> capped at 1 MB.
+
+See the *TileLang-Ascend Programming Guide* for full details.
+
 ## Printf
 ### Interface Prototype
     ```python

--- a/examples/print/elementwise_print.py
+++ b/examples/print/elementwise_print.py
@@ -1,5 +1,6 @@
 import argparse
 
+import os
 import tilelang
 import tilelang.language as T
 import torch
@@ -17,6 +18,8 @@ N = 16
 block_M = 2
 block_N = 16
 
+os.environ["TL_PTO_DEBUG"] = "1"
+
 
 @tilelang.jit(out_idx=[-1])
 def bitwise_and(M, N, block_M, block_N, dtype="int16"):
@@ -27,9 +30,9 @@ def bitwise_and(M, N, block_M, block_N, dtype="int16"):
 
     @T.prim_func
     def main(
-            A: T.Tensor((M, N), dtype),
-            B: T.Tensor((M, N), dtype),
-            C: T.Tensor((M, N), dtype),
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, N), dtype),
+        C: T.Tensor((M, N), dtype),
     ):
         T.printf("===========A:\n")
         T.dump_tensor(A, 111, M * N, (M, N))
@@ -65,6 +68,7 @@ def bitwise_and(M, N, block_M, block_N, dtype="int16"):
 
         T.printf("===========C:\n")
         T.dump_tensor(C, 111, M * N, (M, N))
+
     return main
 
 
@@ -77,7 +81,7 @@ torch.npu.synchronize()
 print("init successful!")
 
 c = func(a, b)
-print(f"*******c:")
+print("*******c:")
 print(c)
 ref_c = a & b
 

--- a/examples/print/elementwise_print.py
+++ b/examples/print/elementwise_print.py
@@ -18,6 +18,10 @@ N = 16
 block_M = 2
 block_N = 16
 
+# TL_PTO_DEBUG=1 enables device-side printf/dump_tensor output.
+# This adds -D_DEBUG and --cce-enable-print compiler flags.
+# It degrades performance; intended for debugging only.
+# See: docs/TileLang-Ascend Programming Guide.md for details.
 os.environ["TL_PTO_DEBUG"] = "1"
 
 

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -349,6 +349,11 @@ std::string CodeGenTileLangAscendPto::Finish() {
   decl_stream << "#include <pto/pto-inst.hpp>\n";
   decl_stream << "#include \"acl/acl.h\"\n";
   decl_stream << "#include <runtime/rt_ffts.h>\n";
+
+  if (has_dump_tensor_) {
+    decl_stream << "#include \"tl_templates/pto/printf.h\"\n";
+  }
+
   decl_stream << "using namespace pto;\n";
   decl_stream << "\n";
   std::ostringstream code;
@@ -1857,9 +1862,43 @@ void CodeGenTileLangAscendPto::PrintfOpCodegen(const CallNode *op,
 
 void CodeGenTileLangAscendPto::DumpTensorCodegen(const CallNode *op,
                                                  const std::string &op_name) {
+  has_dump_tensor_ = true;
   this->PrintIndent();
-  this->stream << "TPRINT" << "(";
-  this->stream << PrintBufferOffset(op->args[0].as<CallNode>());
+  this->stream << "tl::ascend_pto::DumpTensor(";
+
+  // arg 0: buffer pointer or tile reference
+  // For GM buffers: var_idmap_ returns e.g. "A" but C++ param is "A_handle".
+  // copy_base_addr_map_ maps buf_name → handle_name for GM buffers.
+  auto call = op->args[0].as<CallNode>();
+  std::string buf_name = PrintBufferOffset(call);
+  auto it = copy_base_addr_map_.find(String(buf_name));
+  if (it != copy_base_addr_map_.end()) {
+    buf_name = static_cast<std::string>((*it).second);
+  }
+  this->stream << buf_name << ", ";
+
+  // arg 1: desc
+  this->stream << PrintExpr(op->args[1]) << ", ";
+
+  // arg 2: dumpSize
+  this->stream << PrintExpr(op->args[2]) << ", ";
+
+  // arg 3: dim (number of shape dimensions)
+  this->stream << PrintExpr(op->args[3]) << ", ";
+
+  // arg 4: shapeInfo[] array
+  if (op->args.size() > 4) {
+    this->stream << "(uint32_t[]){";
+    for (size_t i = 4; i < op->args.size(); ++i) {
+      if (i > 4)
+        this->stream << ", ";
+      this->stream << PrintExpr(op->args[i]);
+    }
+    this->stream << "}";
+  } else {
+    this->stream << "nullptr";
+  }
+
   this->stream << ");\n";
 }
 

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -1867,9 +1867,10 @@ void CodeGenTileLangAscendPto::DumpTensorCodegen(const CallNode *op,
   this->stream << "tl::ascend_pto::DumpTensor(";
 
   // arg 0: buffer pointer or tile reference
-  // For GM buffers: var_idmap_ returns e.g. "A" but C++ param is "A_handle".
-  // copy_base_addr_map_ maps buf_name → handle_name for GM buffers.
+  // For GM buffers: var_idmap_ returns e.g. "A_handle" but C++ param is "A".
+  // copy_base_addr_map_ maps handle_name → buf_name for GM buffers.
   auto call = op->args[0].as<CallNode>();
+  ICHECK(call) << "Expected CallNode for DumpTensor argument 0";
   std::string buf_name = PrintBufferOffset(call);
   auto it = copy_base_addr_map_.find(String(buf_name));
   if (it != copy_base_addr_map_.end()) {

--- a/src/target/codegen_ascend_pto.h
+++ b/src/target/codegen_ascend_pto.h
@@ -306,6 +306,10 @@ private:
 
   std::string platform_;
 
+  // Whether dump_tensor has been used (controls conditional include of
+  // printf.h)
+  bool has_dump_tensor_{false};
+
   std::string current_resource_scope_ =
       ""; // Identifies whether it's CUBE or VEC
 };

--- a/src/tl_templates/pto/printf.h
+++ b/src/tl_templates/pto/printf.h
@@ -1,9 +1,22 @@
 #ifndef TL_TEMPLATES_PTO_PRINTF_H_
 #define TL_TEMPLATES_PTO_PRINTF_H_
 
+#include <cstdint>
 #include <type_traits>
 
 namespace tl::ascend_pto {
+
+// Common data-type list: each entry is X(CppType, NameString).
+// Add or remove types here — all consumers update automatically.
+#define TL_PTO_DTYPE_LIST(X)                                                   \
+  X(float, "float32")                                                          \
+  X(half, "float16")                                                           \
+  X(int32_t, "int32")                                                          \
+  X(uint32_t, "uint32")                                                        \
+  X(int16_t, "int16")                                                          \
+  X(uint16_t, "uint16")                                                        \
+  X(int8_t, "int8")                                                            \
+  X(uint8_t, "uint8")
 
 #if defined(_DEBUG) || defined(__CPU_SIM)
 
@@ -28,30 +41,12 @@ template <typename T> __aicore__ inline void PrintScalar(T val, uint32_t col) {
 template <typename T> __aicore__ inline const __gm__ char *TypeName() {
   return "unknown";
 }
-template <> __aicore__ inline const __gm__ char *TypeName<float>() {
-  return "float32";
-}
-template <> __aicore__ inline const __gm__ char *TypeName<half>() {
-  return "float16";
-}
-template <> __aicore__ inline const __gm__ char *TypeName<int32_t>() {
-  return "int32";
-}
-template <> __aicore__ inline const __gm__ char *TypeName<uint32_t>() {
-  return "uint32";
-}
-template <> __aicore__ inline const __gm__ char *TypeName<int16_t>() {
-  return "int16";
-}
-template <> __aicore__ inline const __gm__ char *TypeName<uint16_t>() {
-  return "uint16";
-}
-template <> __aicore__ inline const __gm__ char *TypeName<int8_t>() {
-  return "int8";
-}
-template <> __aicore__ inline const __gm__ char *TypeName<uint8_t>() {
-  return "uint8";
-}
+#define TL_PTO_TYPENAME_SPECIALIZE(CppType, NameStr)                           \
+  template <> __aicore__ inline const __gm__ char *TypeName<CppType>() {       \
+    return NameStr;                                                            \
+  }
+TL_PTO_DTYPE_LIST(TL_PTO_TYPENAME_SPECIALIZE)
+#undef TL_PTO_TYPENAME_SPECIALIZE
 
 } // namespace detail
 
@@ -68,6 +63,8 @@ template <typename T>
 __aicore__ inline void DumpTensor(__gm__ T *src, uint32_t desc,
                                   uint32_t dumpSize, uint8_t dim,
                                   const uint32_t shapeInfo[]) {
+  if (dumpSize == 0)
+    return;
   pipe_barrier(PIPE_ALL);
   cce::printf("=== DumpTensor [desc=%u] GM tensor, dtype=%s, dumpSize=%u, "
               "dim=%u ===\n",
@@ -77,14 +74,15 @@ __aicore__ inline void DumpTensor(__gm__ T *src, uint32_t desc,
     uint32_t cols = shapeInfo[dim - 1];
     if (cols == 0)
       cols = dumpSize;
-    uint32_t rows = dumpSize / cols;
-    if (rows == 0)
-      rows = 1;
+    uint32_t rows = (dumpSize + cols - 1) / cols;
 
     for (uint32_t r = 0; r < rows; ++r) {
       for (uint32_t c = 0; c < cols; ++c) {
-        T val = src[r * cols + c];
-        detail::PrintScalar<T>(val, c);
+        uint32_t idx = r * cols + c;
+        if (idx < dumpSize) {
+          T val = src[idx];
+          detail::PrintScalar<T>(val, c);
+        }
       }
       cce::printf("\n");
     }
@@ -110,6 +108,8 @@ __aicore__ inline void DumpTensor(__gm__ T *, uint32_t, uint32_t, uint8_t,
                                   const uint32_t[]) {}
 
 #endif // defined(_DEBUG) || defined(__CPU_SIM)
+
+#undef TL_PTO_DTYPE_LIST
 
 } // namespace tl::ascend_pto
 

--- a/src/tl_templates/pto/printf.h
+++ b/src/tl_templates/pto/printf.h
@@ -1,0 +1,116 @@
+#ifndef TL_TEMPLATES_PTO_PRINTF_H_
+#define TL_TEMPLATES_PTO_PRINTF_H_
+
+#include <type_traits>
+
+namespace tl::ascend_pto {
+
+#if defined(_DEBUG) || defined(__CPU_SIM)
+
+namespace detail {
+
+template <typename T> __aicore__ inline void PrintScalar(T val, uint32_t col) {
+  if (col > 0)
+    cce::printf(" ");
+  if constexpr (std::is_same_v<T, float>) {
+    cce::printf("%8.4f", val);
+  } else if constexpr (std::is_same_v<T, half>) {
+    cce::printf("%8.4f", static_cast<float>(val));
+  } else if constexpr (std::is_signed_v<T> && std::is_integral_v<T>) {
+    cce::printf("%8ld", static_cast<long>(val));
+  } else if constexpr (std::is_unsigned_v<T> && std::is_integral_v<T>) {
+    cce::printf("%8lu", static_cast<unsigned long>(val));
+  } else {
+    cce::printf("%8d", static_cast<int>(val));
+  }
+}
+
+template <typename T> __aicore__ inline const __gm__ char *TypeName() {
+  return "unknown";
+}
+template <> __aicore__ inline const __gm__ char *TypeName<float>() {
+  return "float32";
+}
+template <> __aicore__ inline const __gm__ char *TypeName<half>() {
+  return "float16";
+}
+template <> __aicore__ inline const __gm__ char *TypeName<int32_t>() {
+  return "int32";
+}
+template <> __aicore__ inline const __gm__ char *TypeName<uint32_t>() {
+  return "uint32";
+}
+template <> __aicore__ inline const __gm__ char *TypeName<int16_t>() {
+  return "int16";
+}
+template <> __aicore__ inline const __gm__ char *TypeName<uint16_t>() {
+  return "uint16";
+}
+template <> __aicore__ inline const __gm__ char *TypeName<int8_t>() {
+  return "int8";
+}
+template <> __aicore__ inline const __gm__ char *TypeName<uint8_t>() {
+  return "uint8";
+}
+
+} // namespace detail
+
+template <typename Tile>
+__aicore__ inline void DumpTensor(Tile &src, uint32_t desc, uint32_t dumpSize,
+                                  uint8_t dim, const uint32_t shapeInfo[]) {
+  pipe_barrier(PIPE_ALL);
+  cce::printf("=== DumpTensor [desc=%u] UB tile, dumpSize=%u ===\n", desc,
+              dumpSize);
+  TPRINT(src);
+}
+
+template <typename T>
+__aicore__ inline void DumpTensor(__gm__ T *src, uint32_t desc,
+                                  uint32_t dumpSize, uint8_t dim,
+                                  const uint32_t shapeInfo[]) {
+  pipe_barrier(PIPE_ALL);
+  cce::printf("=== DumpTensor [desc=%u] GM tensor, dtype=%s, dumpSize=%u, "
+              "dim=%u ===\n",
+              desc, detail::TypeName<T>(), dumpSize, dim);
+
+  if (dim > 0 && shapeInfo != nullptr) {
+    uint32_t cols = shapeInfo[dim - 1];
+    if (cols == 0)
+      cols = dumpSize;
+    uint32_t rows = dumpSize / cols;
+    if (rows == 0)
+      rows = 1;
+
+    for (uint32_t r = 0; r < rows; ++r) {
+      for (uint32_t c = 0; c < cols; ++c) {
+        T val = src[r * cols + c];
+        detail::PrintScalar<T>(val, c);
+      }
+      cce::printf("\n");
+    }
+  } else {
+    for (uint32_t i = 0; i < dumpSize; ++i) {
+      T val = src[i];
+      detail::PrintScalar<T>(val, i % 8);
+      if ((i + 1) % 8 == 0 || i == dumpSize - 1) {
+        cce::printf("\n");
+      }
+    }
+  }
+}
+
+#else // !(_DEBUG || __CPU_SIM)
+
+template <typename Tile>
+__aicore__ inline void DumpTensor(Tile &, uint32_t, uint32_t, uint8_t,
+                                  const uint32_t[]) {}
+
+template <typename T>
+__aicore__ inline void DumpTensor(__gm__ T *, uint32_t, uint32_t, uint8_t,
+                                  const uint32_t[]) {}
+
+#endif // defined(_DEBUG) || defined(__CPU_SIM)
+
+} // namespace tl::ascend_pto
+
+#endif // TL_TEMPLATES_PTO_PRINTF_H_


### PR DESCRIPTION
## 原始报错

`examples/print/elementwise_print.py` 在 pto 后端编译时失败：

```
error: no member named 'printf' in namespace 'cce'
error: use of undeclared identifier 'A'
error: use of undeclared identifier 'TPRINT'
error: use of undeclared identifier 'B'
error: use of undeclared identifier 'C'
...
```

### 错误分类

| 错误 | 示例 | 原因 |
|------|------|------|
| `cce::printf` 不存在 | `no member named 'printf' in namespace 'cce'` | PTO 后端下 `cce::printf` 仅在 `_DEBUG` \|\| `__CPU_SIM` 时可用，非 debug 编译时该 API 不存在 |
| `TPRINT(buf)` 变量名错误 | `use of undeclared identifier 'A'` | codegen 直接写出 buffer 名如 `A`，但生成的 C++ 中该变量不存在（应是句柄名） |
| `TPRINT` 本身不存在 | `use of undeclared identifier 'TPRINT'` | 同上，`TPRINT` 也是 debug-only API，非 debug 模式无定义 |

## 修复思路（b9daebc + 5f80dbe）

核心方案：**用自定义 `DumpTensor` 替代直接生成 `TPRINT` / `cce::printf`**：

1. **`printf.h`** 中所有 `cce::printf` 调用都保护在 `#if defined(_DEBUG) || defined(__CPU_SIM)` 内，非 debug 模式提供空实现 → 解决第一类报错
2. **codegen** 改为生成 `tl::ascend_pto::DumpTensor(buf, desc, size, dim, shape[])` → 解决 `TPRINT(A)` 变量名直接暴露问题
3. 通过 `copy_base_addr_map_` 将句柄名映射回 buffer 名 → 解决 UB 变量解析问题
4. GM buffer 场景用 `cce::printf` 逐元素打印（debug-only），UB tile 场景仍 fallback 到 `TPRINT`
