### PR TITLE
A5 camodel support

### DIFF
--- a/.agents/skills/tilelang-a5-sim-convert/SKILL.md
+++ b/.agents/skills/tilelang-a5-sim-convert/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: tilelang-a5-sim-convert
+description: "将 tilelang example 脚本转换为可在 A5 camodel 仿真器上直接运行的版本。输入脚本路径，输出一个新的 *_sim.py 文件，不覆盖原始文件。触发：仿真运行、camodel、A5 仿真、sim 模式、转换脚本为仿真、不需要 NPU 跑 kernel、simulate A5。"
+---
+
+# TileLang A5 Camodel 仿真脚本转换
+
+将任意 tilelang DSL 脚本转换为 A5 camodel 仿真可运行的独立脚本。
+
+## 模板结构（260 行，只改两处）
+
+模板文件：`.agents/skills/tilelang-a5-sim-convert/scripts/run_a5_sim_template.py`
+
+```
+行 1-24    import 语句            ← 不动
+行 25-96   环境自动设置            ← 不动（_find_ascend_home, _source_cann, _find_sim_lib, setup）
+行 99-133  加载 camodel 运行时    ← 不动（load_runtime, dev_malloc）
+行 136-166 kernel 定义            ← ★ 第 1 处要改
+行 169-260 main() 编译+运行+验证   ← 部分要改（详见下方）
+```
+
+## 工作流程
+
+收到脚本路径后，按以下步骤执行：
+
+### Step 1: 运行解析脚本获取 kernel 信息
+
+```bash
+cd <tilelang-ascend-root>
+python .agents/skills/tilelang-a5-sim-convert/scripts/parse_example.py <target_script>
+```
+
+输出 JSON，包含 `kernel_name`、`buffers`（shape/dtype 列表）。
+
+### Step 2: 读取模板 + 原始脚本
+
+- 读取 `.agents/skills/tilelang-a5-sim-convert/scripts/run_a5_sim_template.py`
+- Read 目标脚本，找到 kernel 定义部分（`@T.prim_func` 或 `@tilelang.jit` 装饰的函数体）
+
+### Step 3: 生成 *_sim.py
+
+输出路径：`<原路径>/<原名>_sim.py`（**绝不覆盖原始文件**）。
+
+---
+
+## 改动清单
+
+### 改动 1：kernel 定义（模板 136-166 行）
+
+| 原始脚本 | 仿真脚本 |
+|---------|---------|
+| `@tilelang.jit(out_idx=[-1])` | 删掉 |
+| `def matmul(M, N, K, ...):` | `def make_kernel():` |
+| `T.Tensor((M, K), dtype)` | `T.Tensor((1024, 256), "float16")` ← 用 Step1 解析出的具体数值 |
+| `T.alloc_L0C(..., "float16")` | `T.alloc_L0C(..., "float")` ← A5 pto-isa 要求 float32 |
+| `func = matmul(...)` 触发编译 | 删掉，编译在 main() 里统一处理 |
+
+**生成的代码结构**：
+
+```python
+def make_kernel():
+    import tilelang.language as T
+    @T.prim_func
+    def main(
+        A: T.Tensor((1024, 256), "float16"),   # ← 具体数值
+        B: T.Tensor((256, 1024), "float16"),
+        C: T.Tensor((1024, 1024), "float16"),
+    ):
+        # ... kernel 逻辑（和原始脚本一模一样）...
+    return main
+```
+
+### 改动 2：数据准备（模板 214-233 行）
+
+**a) 维度变量**（第 215 行）
+
+根据 Step1 的 `buffers` 设置：
+
+```python
+# 原始模板（gemm 专用）
+M, N, K = 1024, 512, 256
+
+# 通用写法：从 buffers 提取
+# buffers[0].shape = [M, K]  →  M = shape[0], K = shape[1]
+# buffers[1].shape = [K, N]  →  N = shape[1]
+# buffers[2].shape = [M, N]
+```
+
+如果不是矩阵（比如 1D/3D tensor），按实际 shape 处理。
+
+**b) 数据 dtype（第 216-218 行）**
+
+```python
+# float16 → np.float16
+# float32 → np.float32
+# int32   → np.int32
+```
+
+**c) 数据填充（第 219-224 行）**
+
+float16 必须用小值防止溢出（>65504 就变成 inf）：
+
+```python
+# 模式：np.float16((i % 100 + 1) * (j % 100 + 1) * 0.0001)
+# 根据实际 tensor 维度调整循环层数
+```
+
+**d) 设备内存分配（第 227-229 行）**
+
+```python
+# float16：每个元素 2 字节 → size * 2
+# float32：每个元素 4 字节 → size * 4
+itemsize = 2 if dtype == "float16" else 4
+d_A = dev_malloc(rt, total_elements * itemsize)
+```
+
+**e) 参考计算（第 225 行）**
+
+```python
+# gemm：       h_Ref = h_A.astype(np.float32) @ h_B.astype(np.float32)
+# elementwise：h_Ref = (h_A.astype(np.float32) + h_B.astype(np.float32))
+# 其他：根据原始脚本的逻辑写对等的 numpy 计算
+```
+
+### 改动 3：`call` 函数签名（模板 210 行）
+
+```python
+# 原始模板（3 输入 + stream = 4 个参数）
+kl.call.argtypes = [ctypes.c_void_p] * 4
+
+# 实际参数数量 = kernel 的 buffer 数量 + 1（stream）
+# buffers 有 3 个 → argtypes = [ctypes.c_void_p] * 4
+# buffers 有 2 个 → argtypes = [ctypes.c_void_p] * 3
+# buffers 有 4 个 → argtypes = [ctypes.c_void_p] * 5
+```
+
+`call()` 的调用（第 237 行）也要对应：
+
+```python
+# 3 个 buffer：kl.call(d_A, d_B, d_C, stream)
+# 2 个 buffer：kl.call(d_in, d_out, stream)
+# 4 个 buffer：kl.call(d_A, d_B, d_C, d_D, stream)
+```
+
+### 改动 4：H2D 和 D2H 拷贝
+
+```python
+# H2D（CPU → 设备），第 230-231 行
+rt.rtMemcpy(d_A, size, h_A.ctypes.data, size, 1)  # 最后一个参数 1 = host→device
+                                                    # 每个输入 buffer 都要拷一次
+
+# D2H（设备 → CPU），第 239 行
+rt.rtMemcpy(h_C.ctypes.data, size, d_C, size, 2)  # 最后一个参数 2 = device→host
+                                                    # 只有输出 buffer 需要拷
+```
+
+### 不需要改的部分
+
+**以下代码在任何转换中都保持原样：**
+- `import` 语句（12-18 行）
+- `_find_ascend_home()`、`_source_cann()`、`_find_sim_lib()`、`setup()`（25-96 行）
+- `load_runtime()`、`dev_malloc()`（99-133 行）
+- `tilelang.lower()` + `LibraryGenerator` 编译流程（189-211 行）
+- `rtStreamCreate` / `rtStreamSynchronize` / `rtStreamDestroy`（232-233、238、254 行）
+- 验证逻辑框架（242-251 行）
+- 清理代码（253-256 行）
+
+## 测试数据生成规则
+
+- float16：`np.float16((i % 100 + 1) * (j % 100 + 1) * 0.0001)`，防溢出（max ≈ 65504）
+- float32：直接用 `np.float32(...)`，范围宽不溢出
+- 参考输出：统一用 float32 计算，保证精度

--- a/.agents/skills/tilelang-a5-sim-convert/scripts/parse_example.py
+++ b/.agents/skills/tilelang-a5-sim-convert/scripts/parse_example.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Parse a tilelang example script to extract kernel info for A5 sim conversion.
+
+Usage: python parse_example.py <script_path>
+Output: JSON with kernel shapes, dtypes, and the kernel function name.
+"""
+
+import sys
+import os
+import json
+import importlib.util
+
+def parse(script_path):
+    script_path = os.path.abspath(script_path)
+    script_dir = os.path.dirname(script_path)
+    sys.path.insert(0, script_dir)
+
+    # --- Mock torch.npu before import ---
+    import torch as _torch
+    _orig_tensor_npu = getattr(_torch.Tensor, "npu", None)
+    _torch.Tensor.npu = lambda self, *a, **kw: self
+    try:
+        _torch.nn.Module.npu = lambda self, *a, **kw: self
+    except Exception:
+        pass
+
+    # --- Protect sys.argv ---
+    _saved_argv = sys.argv
+    sys.argv = [script_path]
+
+    spec = importlib.util.spec_from_file_location("_target", script_path)
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as e:
+        # Non-fatal: script's torch.npu calls failed but kernel was defined
+        pass
+    finally:
+        sys.argv = _saved_argv
+        if _orig_tensor_npu is not None:
+            _torch.Tensor.npu = _orig_tensor_npu
+
+    # --- Find kernel ---
+    prim_func = None
+    kernel_name = None
+    wrapped_args = None
+
+    # Try make_kernel()
+    if hasattr(mod, "make_kernel"):
+        prim_func = mod.make_kernel()
+        kernel_name = "make_kernel"
+    # Try common names
+    for name in ["matmul", "kernel", "main"]:
+        if hasattr(mod, name):
+            obj = getattr(mod, name)
+            if hasattr(obj, "__wrapped__"):
+                kernel_name = name
+                # Try calling with minimal args
+                import inspect
+                sig = inspect.signature(obj.__wrapped__)
+                params = list(sig.parameters.keys())
+                # Provide sensible defaults based on param count
+                n_params = len(params)
+                if n_params >= 6:
+                    prim_func = obj.__wrapped__(1024, 512, 256, 128, 256, 64)
+                elif n_params >= 3:
+                    prim_func = obj.__wrapped__(1024, 512, 256)
+                else:
+                    prim_func = obj.__wrapped__()
+                break
+            elif isinstance(obj, __import__('tilelang').tvm.tir.PrimFunc):
+                prim_func = obj
+                kernel_name = name
+                break
+
+    # Fallback: search all module attributes
+    if prim_func is None:
+        import tilelang
+        for name in dir(mod):
+            obj = getattr(mod, name)
+            if hasattr(obj, "__wrapped__"):
+                try:
+                    prim_func = obj.__wrapped__(1024, 512, 256, 128, 256, 64)
+                    kernel_name = name
+                    break
+                except Exception:
+                    pass
+            if isinstance(obj, tilelang.tvm.tir.PrimFunc):
+                prim_func = obj
+                kernel_name = name
+                break
+
+    if prim_func is None:
+        raise RuntimeError(f"No kernel found in {script_path}")
+
+    # --- Extract shapes & dtypes ---
+    buffers = []
+    for p in prim_func.params:
+        buf = prim_func.buffer_map.get(p)
+        if buf is not None:
+            buffers.append({
+                "shape": [int(s) for s in buf.shape],
+                "dtype": str(buf.dtype),
+            })
+
+    result = {
+        "script_path": script_path,
+        "kernel_name": kernel_name,
+        "buffers": buffers,
+        "num_buffers": len(buffers),
+    }
+
+    # Read original source code to extract the kernel definition text
+    with open(script_path) as f:
+        original_source = f.read()
+
+    result["original_lines"] = len(original_source.splitlines())
+
+    return result
+
+if __name__ == "__main__":
+    result = parse(sys.argv[1])
+    print(json.dumps(result, indent=2))

--- a/.agents/skills/tilelang-a5-sim-convert/scripts/parse_example.py
+++ b/.agents/skills/tilelang-a5-sim-convert/scripts/parse_example.py
@@ -5,10 +5,12 @@ Usage: python parse_example.py <script_path>
 Output: JSON with kernel shapes, dtypes, and the kernel function name.
 """
 
+import contextlib
 import sys
 import os
 import json
 import importlib.util
+
 
 def parse(script_path):
     script_path = os.path.abspath(script_path)
@@ -17,12 +19,11 @@ def parse(script_path):
 
     # --- Mock torch.npu before import ---
     import torch as _torch
+
     _orig_tensor_npu = getattr(_torch.Tensor, "npu", None)
     _torch.Tensor.npu = lambda self, *a, **kw: self
-    try:
+    with contextlib.suppress(Exception):
         _torch.nn.Module.npu = lambda self, *a, **kw: self
-    except Exception:
-        pass
 
     # --- Protect sys.argv ---
     _saved_argv = sys.argv
@@ -32,7 +33,7 @@ def parse(script_path):
     mod = importlib.util.module_from_spec(spec)
     try:
         spec.loader.exec_module(mod)
-    except Exception as e:
+    except Exception:
         # Non-fatal: script's torch.npu calls failed but kernel was defined
         pass
     finally:
@@ -43,7 +44,6 @@ def parse(script_path):
     # --- Find kernel ---
     prim_func = None
     kernel_name = None
-    wrapped_args = None
 
     # Try make_kernel()
     if hasattr(mod, "make_kernel"):
@@ -57,6 +57,7 @@ def parse(script_path):
                 kernel_name = name
                 # Try calling with minimal args
                 import inspect
+
                 sig = inspect.signature(obj.__wrapped__)
                 params = list(sig.parameters.keys())
                 # Provide sensible defaults based on param count
@@ -68,7 +69,7 @@ def parse(script_path):
                 else:
                     prim_func = obj.__wrapped__()
                 break
-            elif isinstance(obj, __import__('tilelang').tvm.tir.PrimFunc):
+            elif isinstance(obj, __import__("tilelang").tvm.tir.PrimFunc):
                 prim_func = obj
                 kernel_name = name
                 break
@@ -76,6 +77,7 @@ def parse(script_path):
     # Fallback: search all module attributes
     if prim_func is None:
         import tilelang
+
         for name in dir(mod):
             obj = getattr(mod, name)
             if hasattr(obj, "__wrapped__"):
@@ -98,10 +100,12 @@ def parse(script_path):
     for p in prim_func.params:
         buf = prim_func.buffer_map.get(p)
         if buf is not None:
-            buffers.append({
-                "shape": [int(s) for s in buf.shape],
-                "dtype": str(buf.dtype),
-            })
+            buffers.append(
+                {
+                    "shape": [int(s) for s in buf.shape],
+                    "dtype": str(buf.dtype),
+                }
+            )
 
     result = {
         "script_path": script_path,
@@ -117,6 +121,7 @@ def parse(script_path):
     result["original_lines"] = len(original_source.splitlines())
 
     return result
+
 
 if __name__ == "__main__":
     result = parse(sys.argv[1])

--- a/.agents/skills/tilelang-a5-sim-convert/scripts/run_a5_sim_template.py
+++ b/.agents/skills/tilelang-a5-sim-convert/scripts/run_a5_sim_template.py
@@ -22,10 +22,9 @@ import numpy as np
 # Phase 0 — Environment auto-setup (runs BEFORE import tilelang / torch)
 # =============================================================================
 
+
 def _find_ascend_home():
-    for d in [os.environ.get("ASCEND_HOME_PATH", ""),
-              os.environ.get("ASCEND_HOME", ""),
-              "/usr/local/Ascend/ascend-toolkit/latest"]:
+    for d in [os.environ.get("ASCEND_HOME_PATH", ""), os.environ.get("ASCEND_HOME", ""), "/usr/local/Ascend/ascend-toolkit/latest"]:
         if d and os.path.isdir(d):
             return d
     for base in ["/usr/local/CANN", "/usr/local/Ascend"]:
@@ -45,8 +44,10 @@ def _source_cann(ascend_home):
         return
     r = subprocess.run(
         f"source {setenv} && env",
-        shell=True, executable=shutil.which("bash") or "bash",
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        shell=True,
+        executable=shutil.which("bash") or "bash",
+        capture_output=True,
+        text=True,
     )
     for line in r.stdout.splitlines():
         if "=" in line:
@@ -100,6 +101,7 @@ def setup(log_dir=None):
 # Phase 1 — Load camodel runtime (rt APIs)
 # =============================================================================
 
+
 def load_runtime(sim_lib):
     sys.setdlopenflags(os.RTLD_LAZY | os.RTLD_GLOBAL)
     # Load by full path — LD_LIBRARY_PATH changes from within Python
@@ -137,8 +139,10 @@ def dev_malloc(rt, size):
 # Phase 2 — Kernel definition (add your own here)
 # =============================================================================
 
+
 def make_gemm(M=1024, N=512, K=256, block_M=128, block_N=256, K_L1=64):
     import tilelang.language as T
+
     m_num, n_num = M // block_M, N // block_N
 
     @T.prim_func
@@ -160,6 +164,7 @@ def make_gemm(M=1024, N=512, K=256, block_M=128, block_N=256, K_L1=64):
                     T.gemm_v0(A_L1, B_L1, C_L0, init=(k == 0))
                     T.barrier_all()
                 T.copy(C_L0, C[bx * block_M, by * block_N])
+
     return main
 
 
@@ -170,12 +175,11 @@ KERNELS = {"gemm": make_gemm}
 # main
 # =============================================================================
 
+
 def main():
     parser = argparse.ArgumentParser(description="A5 camodel simulator — one-command runner")
-    parser.add_argument("-t", "--kernel", default="gemm", choices=list(KERNELS.keys()),
-                        help="Built-in kernel name")
-    parser.add_argument("--log-dir", default=None,
-                        help="Camodel log output directory (default: ./camodel_log)")
+    parser.add_argument("-t", "--kernel", default="gemm", choices=list(KERNELS.keys()), help="Built-in kernel name")
+    parser.add_argument("--log-dir", default=None, help="Camodel log output directory (default: ./camodel_log)")
     args = parser.parse_args()
 
     # ---- 0. auto env setup ----
@@ -188,6 +192,7 @@ def main():
     # ---- 2. import tilelang (now env is ready) ----
     import tilelang
     from tilelang.jit.adapter.libgen import LibraryGenerator
+
     tilelang.cache.clear_cache()
 
     # ---- 3. generate kernel source ----
@@ -250,8 +255,11 @@ def main():
         print("FAILED")
         sys.exit(1)
 
-    rt.rtFree(d_A); rt.rtFree(d_B); rt.rtFree(d_C)
-    rt.rtStreamDestroy(stream); rt.rtDeviceReset(0)
+    rt.rtFree(d_A)
+    rt.rtFree(d_B)
+    rt.rtFree(d_C)
+    rt.rtStreamDestroy(stream)
+    rt.rtDeviceReset(0)
     libgen.remove_lib()
     print("Done!")
 

--- a/.agents/skills/tilelang-a5-sim-convert/scripts/run_a5_sim_template.py
+++ b/.agents/skills/tilelang-a5-sim-convert/scripts/run_a5_sim_template.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Run tilelang DSL kernel on A5 camodel simulator — one command, no manual env setup.
+
+Usage:
+    python testing/camodel/run_a5_sim.py                  # default: gemm
+    python testing/camodel/run_a5_sim.py -t gemm           # explicit
+
+All environment (CANN paths, camodel lib, torch_npu disable) is set up
+internally, before any import.
+"""
+
+import argparse
+import ctypes
+import os
+import shutil
+import subprocess
+import sys
+import numpy as np
+
+
+# =============================================================================
+# Phase 0 — Environment auto-setup (runs BEFORE import tilelang / torch)
+# =============================================================================
+
+def _find_ascend_home():
+    for d in [os.environ.get("ASCEND_HOME_PATH", ""),
+              os.environ.get("ASCEND_HOME", ""),
+              "/usr/local/Ascend/ascend-toolkit/latest"]:
+        if d and os.path.isdir(d):
+            return d
+    for base in ["/usr/local/CANN", "/usr/local/Ascend"]:
+        if not os.path.isdir(base):
+            continue
+        for e in sorted(os.listdir(base), reverse=True):
+            p = os.path.join(base, e)
+            if os.path.isdir(p) and os.path.exists(os.path.join(p, "bin", "setenv.bash")):
+                return p
+    raise RuntimeError("CANN not found. Set ASCEND_HOME_PATH.")
+
+
+def _source_cann(ascend_home):
+    """Source CANN setenv.bash and capture resulting environment."""
+    setenv = os.path.join(ascend_home, "bin", "setenv.bash")
+    if not os.path.exists(setenv):
+        return
+    r = subprocess.run(
+        f"source {setenv} && env",
+        shell=True, executable=shutil.which("bash") or "bash",
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+    for line in r.stdout.splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            os.environ[k] = v
+
+
+def _find_sim_lib(ascend_home):
+    """Find Ascend950PR_9599 simulator lib/ directory."""
+    sim_base = os.path.join(ascend_home, "tools", "simulator")
+    for soc in ["Ascend950PR_9599", "Ascend910_9599"]:
+        lib_dir = os.path.join(sim_base, soc, "lib")
+        if os.path.isdir(lib_dir):
+            return lib_dir
+    raise RuntimeError(f"Simulator not found under {sim_base}")
+
+
+def setup(log_dir=None):
+    ascend_home = _find_ascend_home()
+    os.environ["ASCEND_HOME_PATH"] = ascend_home
+    _source_cann(ascend_home)
+
+    sim_lib = _find_sim_lib(ascend_home)
+    lib64 = os.path.join(ascend_home, "x86_64-linux", "lib64")
+    ld = os.environ.get("LD_LIBRARY_PATH", "")
+    paths = [sim_lib, lib64] + [p for p in ld.split(":") if p and p not in (sim_lib, lib64)]
+    os.environ["LD_LIBRARY_PATH"] = ":".join(paths)
+
+    os.environ["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"
+    os.environ["TL_RUN_MODE"] = "sim"
+    os.environ["TL_PLATFORM"] = "A5"
+
+    # Camodel log output directory (default: ./camodel_log)
+    if log_dir is None:
+        log_dir = os.path.join(os.getcwd(), "camodel_log")
+    os.makedirs(log_dir, exist_ok=True)
+    os.environ["CAMODEL_LOG_PATH"] = log_dir
+
+    # Re-exec self if LD_LIBRARY_PATH wasn't set at shell level before launch.
+    if "_A5_SIM_REEXEC" not in os.environ:
+        os.environ["_A5_SIM_REEXEC"] = "1"
+        os.execve(sys.executable, [sys.executable] + sys.argv, os.environ)
+
+    print(f"[INFO] ascend:  {ascend_home}")
+    print(f"[INFO] sim lib: {sim_lib}")
+    print(f"[INFO] log dir: {log_dir}")
+    return sim_lib
+
+
+# =============================================================================
+# Phase 1 — Load camodel runtime (rt APIs)
+# =============================================================================
+
+def load_runtime(sim_lib):
+    sys.setdlopenflags(os.RTLD_LAZY | os.RTLD_GLOBAL)
+    # Load by full path — LD_LIBRARY_PATH changes from within Python
+    # don't reliably propagate to dlopen.
+    rt_path = os.path.join(sim_lib, "libruntime_camodel.so")
+    rt = ctypes.CDLL(rt_path)
+    rt.rtSetDevice.argtypes = [ctypes.c_int32]
+    rt.rtSetDevice.restype = ctypes.c_int
+    rt.rtMalloc.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_uint64, ctypes.c_int, ctypes.c_uint16]
+    rt.rtMalloc.restype = ctypes.c_int
+    rt.rtFree.argtypes = [ctypes.c_void_p]
+    rt.rtFree.restype = ctypes.c_int
+    rt.rtMemcpy.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_uint64, ctypes.c_int]
+    rt.rtMemcpy.restype = ctypes.c_int
+    rt.rtStreamCreate.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_int32]
+    rt.rtStreamCreate.restype = ctypes.c_int
+    rt.rtStreamSynchronize.argtypes = [ctypes.c_void_p]
+    rt.rtStreamSynchronize.restype = ctypes.c_int
+    rt.rtStreamDestroy.argtypes = [ctypes.c_void_p]
+    rt.rtStreamDestroy.restype = ctypes.c_int
+    rt.rtDeviceReset.argtypes = [ctypes.c_int32]
+    rt.rtDeviceReset.restype = ctypes.c_int
+    if rt.rtSetDevice(0) != 0:
+        raise RuntimeError("rtSetDevice(0) failed")
+    return rt
+
+
+def dev_malloc(rt, size):
+    p = ctypes.c_void_p()
+    assert rt.rtMalloc(ctypes.byref(p), size, 2, 0) == 0
+    return p
+
+
+# =============================================================================
+# Phase 2 — Kernel definition (add your own here)
+# =============================================================================
+
+def make_gemm(M=1024, N=512, K=256, block_M=128, block_N=256, K_L1=64):
+    import tilelang.language as T
+    m_num, n_num = M // block_M, N // block_N
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), "float16"),
+        B: T.Tensor((K, N), "float16"),
+        C: T.Tensor((M, N), "float16"),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx, by = cid // n_num, cid % n_num
+            A_L1 = T.alloc_L1((block_M, K_L1), "float16")
+            B_L1 = T.alloc_L1((K_L1, block_N), "float16")
+            C_L0 = T.alloc_L0C((block_M, block_N), "float")
+            with T.Scope("C"):
+                for k in T.serial(T.ceildiv(K, K_L1)):
+                    T.copy(A[bx * block_M, k * K_L1], A_L1)
+                    T.copy(B[k * K_L1, by * block_N], B_L1)
+                    T.barrier_all()
+                    T.gemm_v0(A_L1, B_L1, C_L0, init=(k == 0))
+                    T.barrier_all()
+                T.copy(C_L0, C[bx * block_M, by * block_N])
+    return main
+
+
+KERNELS = {"gemm": make_gemm}
+
+
+# =============================================================================
+# main
+# =============================================================================
+
+def main():
+    parser = argparse.ArgumentParser(description="A5 camodel simulator — one-command runner")
+    parser.add_argument("-t", "--kernel", default="gemm", choices=list(KERNELS.keys()),
+                        help="Built-in kernel name")
+    parser.add_argument("--log-dir", default=None,
+                        help="Camodel log output directory (default: ./camodel_log)")
+    args = parser.parse_args()
+
+    # ---- 0. auto env setup ----
+    sim_lib = setup(log_dir=args.log_dir)
+
+    # ---- 1. load camodel runtime ----
+    print("=== Load camodel runtime ===")
+    rt = load_runtime(sim_lib)
+
+    # ---- 2. import tilelang (now env is ready) ----
+    import tilelang
+    from tilelang.jit.adapter.libgen import LibraryGenerator
+    tilelang.cache.clear_cache()
+
+    # ---- 3. generate kernel source ----
+    print(f"=== Generate kernel: {args.kernel} ===")
+    prim_func = KERNELS[args.kernel]()
+    artifact = tilelang.lower(prim_func, target="pto", platform="A5")
+    print(f"  Source: {len(artifact.kernel_source.splitlines())} lines")
+
+    # ---- 4. compile .so ----
+    print("=== Compile kernel ===")
+    libgen = LibraryGenerator(target="pto", platform="A5")
+    libgen.update_lib_code(artifact.kernel_source)
+    libgen.compile_lib()
+    so = libgen.get_lib_path()
+    print(f"  {so}")
+
+    # ---- 5. load kernel .so ----
+    print("=== Load kernel ===")
+    kl = ctypes.CDLL(so)
+    kl.call.argtypes = [ctypes.c_void_p] * 4
+    kl.call.restype = None
+
+    # ---- 6. prepare data ----
+    print("=== Prepare data ===")
+    M, N, K = 1024, 512, 256
+    h_A = np.zeros((M, K), dtype=np.float16)
+    h_B = np.zeros((K, N), dtype=np.float16)
+    h_C = np.zeros((M, N), dtype=np.float16)
+    for i in range(M):
+        for kk in range(K):
+            h_A[i, kk] = np.float16((i % 100 + 1) * (kk % 100 + 1) * 0.0001)
+    for kk in range(K):
+        for j in range(N):
+            h_B[kk, j] = np.float16((kk % 100 + 1) * (j % 100 + 1) * 0.0001)
+    h_Ref = h_A.astype(np.float32) @ h_B.astype(np.float32)
+
+    d_A = dev_malloc(rt, M * K * 2)
+    d_B = dev_malloc(rt, K * N * 2)
+    d_C = dev_malloc(rt, M * N * 2)
+    rt.rtMemcpy(d_A, M * K * 2, h_A.ctypes.data, M * K * 2, 1)
+    rt.rtMemcpy(d_B, K * N * 2, h_B.ctypes.data, K * N * 2, 1)
+    stream = ctypes.c_void_p()
+    rt.rtStreamCreate(ctypes.byref(stream), 0)
+
+    # ---- 7. launch ----
+    print("=== Launch kernel ===")
+    kl.call(d_A, d_B, d_C, stream)
+    rt.rtStreamSynchronize(stream)
+    rt.rtMemcpy(h_C.ctypes.data, M * N * 2, d_C, M * N * 2, 2)
+
+    # ---- 8. verify ----
+    print("=== Verify ===")
+    diff = np.abs(h_C.astype(np.float32) - h_Ref)
+    rel = diff / np.maximum(np.abs(h_Ref), 1e-6)
+    print(f"  Max abs error: {diff.max():.6f}")
+    print(f"  Max rel error: {rel.max():.6f}")
+    if rel.max() < 0.1:
+        print("KERNEL OUTPUT MATCH!")
+    else:
+        print("FAILED")
+        sys.exit(1)
+
+    rt.rtFree(d_A); rt.rtFree(d_B); rt.rtFree(d_C)
+    rt.rtStreamDestroy(stream); rt.rtDeviceReset(0)
+    libgen.remove_lib()
+    print("Done!")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/TileLang-Ascend Programming Guide.md
+++ b/docs/TileLang-Ascend Programming Guide.md
@@ -191,6 +191,89 @@ TileLang还支持JIT（Just-in-time，即时编译）。JIT是一种动态编译
 
 在TileLang kernel开发中，通过 **@jit** 装饰器来触发调用时的即时编译。
 
+### 2.4 A5 Camodel 仿真运行
+
+如果需要在 **无真实 A5 NPU 硬件** 的环境下开发和验证 A5 kernel，可以使用 CANN 提供的 **camodel（Cycle-Accurate Model，节拍精确模型）** 进行软件仿真。只要安装了包含 A5 simulator 镜像（`Ascend950PR_9599`）的 CANN 包，即可在任意 x86/Linux 机器上模拟 A5 平台运行 TileLang kernel，完成正确性验证和指令级分析。
+
+#### 2.4.1 为什么需要 camodel 仿真
+
+- **无 NPU 硬件时开发和验证**：在只有 CPU 的服务器或开发机上运行和调试 kernel
+- **指令级 trace 分析**：camodel 可以输出每个 AIC core 的指令日志（`core*.instr_log.dump`）、UB 读写 dump（`core*.ub.rd_log.dump`/`core*.ub.wr_log.dump`），用于分析 kernel 执行细节
+- **快速迭代**：不需要排队等待 NPU 资源，本地即可验证 kernel 逻辑正确性
+
+#### 2.4.2 原理
+
+原始 kernel 运行流程：`DSL 定义 → JIT 编译 → torch.npu 分配 NPU 内存 → 真实 NPU 执行`
+
+camodel 仿真流程：`DSL 定义 → 链接 libruntime_camodel.so 编译 → rtMalloc 分配模拟内存 → CPU 模拟 NPU 执行`
+
+核心区别在于编译时**用 `libruntime_camodel.so` 替代 `libruntime.so`**——前者是一个用软件模拟 NPU 行为的库，对外接口与真实运行时库完全一致。
+
+#### 2.4.3 一条命令运行内置示例
+
+TileLang-Ascend 提供了开箱即用的仿真运行脚本，位于 `.agents/skills/tilelang-a5-sim-convert/` 目录下。运行前需要确保基础环境已就绪（CANN 已安装、`bisheng` 编译器可用、`tilelang` 可 import）。脚本会自动完成 camodel 相关的环境设置（库路径、设备初始化、`os.execve` 重启等），无需手动配置 `TL_RUN_MODE`、`LD_LIBRARY_PATH` 等仿真专用变量：
+
+```bash
+python .agents/skills/tilelang-a5-sim-convert/scripts/run_a5_sim_template.py
+```
+
+成功输出：
+```
+KERNEL OUTPUT MATCH!
+Done!
+```
+
+脚本会自动完成：查找 CANN 安装路径 → 设置 camodel 库路径 → 加载软件模拟 NPU → 编译 kernel → 分配模拟内存 → 启动 kernel → 验证结果。
+
+可通过 `--log-dir` 指定 camodel 日志输出目录：
+
+```bash
+python .agents/skills/tilelang-a5-sim-convert/scripts/run_a5_sim_template.py --log-dir ./my_sim_logs
+```
+
+#### 2.4.4 将已有脚本转换为仿真版本
+
+使用 `/tilelang-a5-sim-convert` skill（位于 `.agents/skills/tilelang-a5-sim-convert/`），输入一个 tilelang DSL 脚本路径，自动生成对应的 `*_sim.py` 仿真脚本（不覆盖原始文件）：
+
+```
+/tilelang-a5-sim-convert examples/gemm/example_gemm.py
+```
+
+转换的核心改动（人工转换时也遵循相同规则）：
+
+| 原始脚本 | 仿真脚本 |
+|---------|---------|
+| `import torch` | 删除（用 `numpy` 替代） |
+| `torch.randn(...).half().npu()` | `np.zeros(...)` + `rtMalloc` + `rtMemcpy` |
+| `@tilelang.jit(out_idx=[-1])` | `def make_kernel(): return main`（DSL 逻辑不变） |
+| `T.Tensor((M, K), dtype)` | `T.Tensor((1024, 256), "float16")`（替换为具体数值） |
+| `T.alloc_L0C(..., "float16")` | `T.alloc_L0C(..., "float")`（A5 pto-isa 要求 float32 累积器） |
+| `c = func(a, b)` | `kl.call(d_A, d_B, d_C, stream)`（RT API 调用） |
+| `torch.testing.assert_close` | `np.abs(got - ref).max()` |
+
+详细模板和逐行说明见 `.agents/skills/tilelang-a5-sim-convert/`。
+
+#### 2.4.5 环境变量说明
+
+仿真运行依赖以下环境变量（由 `run_a5_sim.py` 自动设置，手动运行时需自行配置）：
+
+| 变量 | 值 | 作用 |
+|------|------|------|
+| `TL_RUN_MODE` | `sim` | 触发 camodel 编译路径（替换 `-lruntime` → `-lruntime_camodel`） |
+| `TL_PLATFORM` | `A5` | 指定目标平台（仅在 `TL_RUN_MODE=sim` 时生效，不影响真实 NPU 硬件检测） |
+| `LD_LIBRARY_PATH` | 需在最前面包含 `<CANN>/tools/simulator/Ascend950PR_9599/lib` | 让动态链接器优先找到 camodel 库 |
+| `TORCH_DEVICE_BACKEND_AUTOLOAD` | `0` | 阻止 `torch_npu` 自动初始化（camodel 环境下会失败） |
+| `CAMODEL_LOG_PATH` | 任意目录路径 | camodel 日志输出目录（包含 instruction trace、UB dump 等） |
+
+#### 2.4.6 局限性
+
+- 仅支持 PTO 后端（`target="pto"`）的 A5 平台仿真
+- camodel 模拟器的执行速度远慢于真实 NPU（约 1000 倍以上），仅适用于功能验证，不适用于性能测试
+- 不支持 `torch.npu` 接口，数据管理需通过 `rtMalloc`/`rtMemcpy` 等 RT API
+- 需要 CANN 9.0.0 及以上版本（包含 `Ascend950PR_9599` simulator 镜像）
+
+---
+
 ## 3. TileLang语法基础
 
 本节介绍TileLang（tile-lang）领域特定语言（DSL）的核心语法基础，你将使用这种语言编写高性能的内核。重点介绍如何定义内核、表达迭代操作、在内存域之间移动数据，以及如何通过即时编译（JIT）运行内核。
@@ -2327,3 +2410,4 @@ g.replay()
 | 2026.1.22 | Initial release | Chaoyang Ji |
 | 2026.2.03 | MsProf update   | Yuhan Zhang |
 | 2026.3.12 | aclgraph        |   Di He     |
+| 2026.6.04 | A5 Camodel      | Jiajun Wu   |

--- a/src/tl_templates/pto/common.h
+++ b/src/tl_templates/pto/common.h
@@ -1,20 +1,3 @@
-// Forward declarations of TCVT_IMPL so the pto::TCVT template body
-// compiles even when TCVT full headers are not included.  The actual
-// implementations are in npu/a5/TCvt.hpp (included via pto_instr_impl.hpp
-// when __DAV_VEC__ is defined).
-namespace pto {
-enum class RoundMode : uint8_t;
-enum class SaturationMode : uint8_t;
-template <typename D, typename S>
-void TCVT_IMPL(D &dst, S &src, RoundMode mode);
-template <typename D, typename S>
-void TCVT_IMPL(D &dst, S &src, RoundMode mode, SaturationMode sat);
-template <typename D, typename S, typename T>
-void TCVT_IMPL(D &dst, S &src, T &tmp, RoundMode mode);
-template <typename D, typename S, typename T>
-void TCVT_IMPL(D &dst, S &src, T &tmp, RoundMode mode, SaturationMode sat);
-} // namespace pto
-
 #include <pto/pto-inst.hpp>
 #include <type_traits>
 

--- a/src/tl_templates/pto/common.h
+++ b/src/tl_templates/pto/common.h
@@ -1,3 +1,20 @@
+// Forward declarations of TCVT_IMPL so the pto::TCVT template body
+// compiles even when TCVT full headers are not included.  The actual
+// implementations are in npu/a5/TCvt.hpp (included via pto_instr_impl.hpp
+// when __DAV_VEC__ is defined).
+namespace pto {
+enum class RoundMode : uint8_t;
+enum class SaturationMode : uint8_t;
+template <typename D, typename S>
+void TCVT_IMPL(D &dst, S &src, RoundMode mode);
+template <typename D, typename S>
+void TCVT_IMPL(D &dst, S &src, RoundMode mode, SaturationMode sat);
+template <typename D, typename S, typename T>
+void TCVT_IMPL(D &dst, S &src, T &tmp, RoundMode mode);
+template <typename D, typename S, typename T>
+void TCVT_IMPL(D &dst, S &src, T &tmp, RoundMode mode, SaturationMode sat);
+} // namespace pto
+
 #include <pto/pto-inst.hpp>
 #include <type_traits>
 

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -49,6 +49,36 @@ def _get_ascend_home_path() -> str:
     return ascend_home
 
 
+def _get_simulator_lib_path(ascend_home: str, platform: str) -> str:
+    """Get the camodel simulator library path for the given platform.
+
+    Returns the directory containing libruntime_camodel.so.
+    """
+    sim_base = os.path.join(ascend_home, "tools", "simulator")
+    if not os.path.isdir(sim_base):
+        sim_base = os.path.join(ascend_home, "simulator")
+
+    if platform == "A5":
+        soc_candidates = ["Ascend950PR_9599", "Ascend910_9599"]
+    else:
+        soc_candidates = ["Ascend910B1", "Ascend910_9599"]
+
+    for soc in soc_candidates:
+        soc_dir = os.path.join(sim_base, soc)
+        if not os.path.isdir(soc_dir):
+            continue
+        # The lib/ directory contains required config.json + *.toml files.
+        # The camodel/ directory lacks these configs, causing TMultiRing crash.
+        candidate = os.path.join(soc_dir, "lib")
+        if os.path.isdir(candidate):
+            return candidate
+
+    raise FileNotFoundError(
+        f"Simulator library not found for platform {platform}. "
+        f"Searched: {sim_base}/<soc>/lib and {sim_base}/<soc>/camodel"
+    )
+
+
 class LibraryGenerator:
     srcpath: str | None = None
     libpath: str | None = None
@@ -65,6 +95,13 @@ class LibraryGenerator:
     def load_lib(self, lib_path: str | None = None):
         if lib_path is None:
             lib_path = self.libpath
+        run_mode = os.environ.get("TL_RUN_MODE", "npu")
+        if run_mode == "sim":
+            ascend_home = _get_ascend_home_path()
+            sim_lib_path = _get_simulator_lib_path(ascend_home, self.platform)
+            ld_path = os.environ.get("LD_LIBRARY_PATH", "")
+            if sim_lib_path not in ld_path.split(":"):
+                os.environ["LD_LIBRARY_PATH"] = f"{sim_lib_path}:{ld_path}"
         return ctypes.CDLL(lib_path)
 
     def compile_lib(self, timeout: float = None):
@@ -153,6 +190,33 @@ class LibraryGenerator:
             ]
             if os.environ.get("TL_PTO_DEBUG") == "1":
                 command += ["-D_DEBUG", "--cce-enable-print"]
+
+        # --- camodel (simulator) support ---
+        run_mode = os.environ.get("TL_RUN_MODE", "npu")
+        if run_mode == "sim":
+            sim_lib_path = _get_simulator_lib_path(ASCEND_HOME_PATH, self.platform)
+            # Insert simulator library path before ASCEND_HOME_PATH/lib64 so
+            # libruntime_camodel.so takes precedence over libruntime.so.
+            # --disable-new-dtags makes -rpath set DT_RPATH (transitive) instead
+            # of DT_RUNPATH (non-transitive), so that libruntime_camodel.so's
+            # own dependencies (e.g. libnpu_drv_camodel.so) are also resolved.
+            try:
+                ascend_lib_idx = command.index(f"-L{ASCEND_HOME_PATH}/lib64")
+                command.insert(ascend_lib_idx, f"-L{sim_lib_path}")
+                command.insert(ascend_lib_idx + 1, f"-Wl,-rpath,{sim_lib_path}")
+                command.insert(ascend_lib_idx + 2, "-Wl,--disable-new-dtags")
+            except ValueError:
+                command.insert(1, f"-L{sim_lib_path}")
+                command.insert(2, f"-Wl,-rpath,{sim_lib_path}")
+                command.insert(3, "-Wl,--disable-new-dtags")
+            # Replace '-lruntime' with '-lruntime_camodel'
+            try:
+                rt_idx = command.index("-lruntime")
+                command[rt_idx] = "-lruntime_camodel"
+            except ValueError:
+                pass
+            logger.info("camodel sim mode: using %s", sim_lib_path)
+
         command += ["-o", libpath]
 
         src.write(self.lib_code)

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -74,8 +74,7 @@ def _get_simulator_lib_path(ascend_home: str, platform: str) -> str:
             return candidate
 
     raise FileNotFoundError(
-        f"Simulator library not found for platform {platform}. "
-        f"Searched: {sim_base}/<soc>/lib and {sim_base}/<soc>/camodel"
+        f"Simulator library not found for platform {platform}. Searched: {sim_base}/<soc>/lib and {sim_base}/<soc>/camodel"
     )
 
 

--- a/tilelang/utils/target.py
+++ b/tilelang/utils/target.py
@@ -1,8 +1,10 @@
 # Copyright (c) Tile-AI Corporation.
 # Licensed under the MIT License.
 
+from __future__ import annotations
+
 import os
-from typing import Literal, Union
+from typing import Literal
 from tilelang import tvm as tvm
 from tvm.target import Target
 from tvm.contrib import rocm
@@ -52,13 +54,13 @@ def check_npu_availability() -> bool:
     """
     try:
         import torch
-        return hasattr(torch, 'npu') and torch.npu.is_available()
+
+        return hasattr(torch, "npu") and torch.npu.is_available()
     except Exception:
         return False
 
 
-def determine_target(target: Union[str, Target, Literal["auto"]] = "auto",
-                     return_object: bool = False) -> Union[str, Target]:
+def determine_target(target: str | Target | Literal["auto"] = "auto", return_object: bool = False) -> str | Target:
     """
     Determine the appropriate target for compilation (CUDA, HIP, or manual selection).
 
@@ -75,7 +77,7 @@ def determine_target(target: Union[str, Target, Literal["auto"]] = "auto",
         AssertionError: If the target is invalid.
     """
 
-    return_var: Union[str, Target] = target
+    return_var: str | Target = target
 
     if target == "auto":
         # Check for CUDA and HIP availability
@@ -98,13 +100,13 @@ def determine_target(target: Union[str, Target, Literal["auto"]] = "auto",
         return_var = "llvm --keys=ascend"
     else:
         # Validate the target if it's not "auto"
-        assert isinstance(
-            target, Target) or target in AVALIABLE_TARGETS, f"Target {target} is not supported"
+        assert isinstance(target, Target) or target in AVALIABLE_TARGETS, f"Target {target} is not supported"
         return_var = target
 
     if return_object:
         return Target(return_var)
     return return_var
+
 
 def determine_platform(platform: str = "auto") -> str:
     """
@@ -137,13 +139,9 @@ def determine_platform(platform: str = "auto") -> str:
 
             if "910B" in name:
                 return "A2"
-            elif "910_93" in name:
+            elif "910_93" in name or "910C" in name:
                 return "A3"
-            elif "910C" in name:
-                return "A3"
-            elif "950" in name:
-                return "A5"
-            elif "910_95" in name:
+            elif "950" in name or "910_95" in name:
                 return "A5"
             elif "910" in name:  # Covers 910A
                 return "A2"

--- a/tilelang/utils/target.py
+++ b/tilelang/utils/target.py
@@ -1,6 +1,7 @@
 # Copyright (c) Tile-AI Corporation.
 # Licensed under the MIT License.
 
+import os
 from typing import Literal, Union
 from tilelang import tvm as tvm
 from tvm.target import Target
@@ -111,7 +112,8 @@ def determine_platform(platform: str = "auto") -> str:
 
     Args:
         platform (str): User-specified platform.
-            - If "auto", the system will automatically detect the platform based on the device properties.
+            - If "auto", the system will first check TL_PLATFORM env var,
+              then automatically detect the platform based on the device properties.
             - If a string, it is directly validated.
 
     Returns:
@@ -119,6 +121,11 @@ def determine_platform(platform: str = "auto") -> str:
     """
     if platform != "auto":
         return platform
+
+    # Allow explicit platform override via environment variable (useful for sim mode)
+    env_platform = os.environ.get("TL_PLATFORM")
+    if env_platform:
+        return env_platform
 
     # Detect platform based on NPU device properties
     try:


### PR DESCRIPTION
### A5 Camodel Support Commit
Added runtime support for A5 Camodel simulation. Core modified files include `src/tl_templates/pto/common.h` and `tilelang/jit/adapter/libgen.py`. The changes mainly involve configuring environment variables and adjusting generated compilation commands to target Camodel.
Implemented a new skill to auto-generate A5 Camodel simulation launch scripts; relevant code resides under `.agents/skills/tilelang-a5-sim-convert/`.
Validation passed with `examples/gemm/example_gemm.py`. However, incompatible legacy code elsewhere in the repository causes runtime errors when converting other test scripts into simulation scripts. A typical error is shown below:
```
/home/wujiajun/llvm-workspace/tilelang-ascend/tilelang/../src/tl_templates/pto/common.h:153:23: error: the ranges of 2nd parameter must be [0, 1], [4, 5]
  set_flag(PIPE_MTE2, PIPE_MTE1, war_event_id);
                      ^
/home/wujiajun/llvm-workspace/tilelang-ascend/tilelang/../src/tl_templates/pto/common.h:154:24: error: the ranges of 2nd parameter must be [0, 1], [4, 5]
  wait_flag(PIPE_MTE2, PIPE_MTE1, war_event_id);
                       ^
```
Agent-proposed fix: wrap problematic synchronization logic in `src/tl_templates/pto/common.h` with platform guard macros to skip execution on A5 hardware:
```c
#ifndef PTO_PLATFORM_A5
    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
#endif
    pto::TASSIGN(dst_tile, ub_shape_addr + ub_offset * len);
    pto::TFILLPAD_INPLACE(dst_tile, src_tile);
#ifndef PTO_PLATFORM_A5
    set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
    wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
#endif
```
With this patch, the problematic logic is omitted during A5 execution.

### PTO_TCVT Commit
Fixes tracked issue: https://github.com/tile-ai/tilelang-ascend/issues/1072
Added A5 PTO-ISA support for TCVT instructions to deliver accurate `float32 → float16` conversion aligned with AscendC’s DeInterleave + EVEN/ODD CastTrait specification.
```python
T.tile.cast(c_t_ub, a_ub, "CAST_TRUNC", N)
T.tile.cast(c_rd_ub, a_ub, "CAST_ROUND", N)
T.tile.cast(c_ri_ub, a_ub, "CAST_RINT", N)
```
- `CAST_TRUNC`: Truncation conversion mode
- `CAST_ROUND`: Matches AscendC rounding rule (round to nearest, ties away from zero)
- `CAST_RINT`: Complies with IEEE 754 standard consistent with NumPy reference (round to nearest, ties to even)

Test runtime log as below, matching design expectations:
```
Full dataset (256 elements) vs numpy IEEE 754 fp16 reference:
Method                             Mismatches    Max err   Max ULPs
────────────────────────────────── ────────── ────────── ──────────
PTO CAST_TRUNC (truncation)               133    16.0000       1.00
PTO CAST_ROUND (tie away from 0)            2     4.0000       1.00
PTO CAST_RINT  (tie to even)                0          ─          ─

Pairwise comparison:
CAST_TRUNC ≠ CAST_RINT:   133 values  (TRUNC drops round bits)
CAST_ROUND ≠ CAST_RINT:     2 values  (tie-breaking differs)
CAST_RINT  ≠ IEEE ref:      0 values  ← PERFECT MATCH!
[info] [MCU_LOG] [INFO] [0000004439] stop (645):: mcu_wrapper is stopping...
[info] [MCU_LOG] [INFO] [0000004439] main_loop (624):: mcu_wrapper loop is stopping...
[info] [MCU_LOG] [INFO] [0000004439] stop (654):: mcu_wrapper loop joined successfully.
[INFO] Model Stop Time: 2026-06-02 20:12:46
Model RUN TIME: 60362.9 ms
[INFO] Total tick: 4438
[INFO] Model stopped successfully.
```