### PR TITLE
[Fix] Fix workspace reduction type_map_ keys and copy-back insertion 🤖

### DIFF
--- a/src/transform/ascend_workspace_reduction.cc
+++ b/src/transform/ascend_workspace_reduction.cc
@@ -616,9 +616,10 @@ private:
 
       // access_args layout: [type_annotation, var, offset, extent, rw_mask]
       // Only consider buffer as a "consumer" if rw_mask has read bit set.
-      // Skip write-only access (rw_mask == 2) since no copy-back needed before a write.
-      ICHECK(access_args.size() >= 5)
-          << "[Error]<WorkspaceReduction>: access ptr args size too small for rw_mask!";
+      // Skip write-only access (rw_mask == 2) since no copy-back needed before
+      // a write.
+      ICHECK(access_args.size() >= 5) << "[Error]<WorkspaceReduction>: access "
+                                         "ptr args size too small for rw_mask!";
       int rw_mask = Downcast<IntImm>(access_args[4])->value;
       if (!(rw_mask & 1)) {
         // write-only access → this buffer is a producer, not a consumer

--- a/src/transform/ascend_workspace_reduction.cc
+++ b/src/transform/ascend_workspace_reduction.cc
@@ -434,15 +434,17 @@ const std::unordered_map<std::string, DataType> CopyInfoCollector::type_map_ = {
     {"float", tvm::runtime::DataType::Float(32)},
     {"float32", tvm::runtime::DataType::Float(32)},
     {"float64", tvm::runtime::DataType::Float(64)},
-    {"int8", tvm::runtime::DataType::Int(8)},
-    {"int16", tvm::runtime::DataType::Int(16)},
+    {"bfloat16_t", tvm::runtime::DataType::BFloat(16)},
+    {"AscendC::int4b_t", tvm::runtime::DataType::Int(4)},
+    {"int8_t", tvm::runtime::DataType::Int(8)},
+    {"int16_t", tvm::runtime::DataType::Int(16)},
     {"int", tvm::runtime::DataType::Int(32)},
     {"int32", tvm::runtime::DataType::Int(32)},
-    {"int64", tvm::runtime::DataType::Int(64)},
-    {"uint8", tvm::runtime::DataType::UInt(8)},
-    {"uint16", tvm::runtime::DataType::UInt(16)},
-    {"uint32", tvm::runtime::DataType::UInt(32)},
-    {"uint64", tvm::runtime::DataType::UInt(64)}};
+    {"int64_t", tvm::runtime::DataType::Int(64)},
+    {"uint8_t", tvm::runtime::DataType::UInt(8)},
+    {"uint16_t", tvm::runtime::DataType::UInt(16)},
+    {"uint32_t", tvm::runtime::DataType::UInt(32)},
+    {"uint64_t", tvm::runtime::DataType::UInt(64)}};
 
 class AscendWorkspaceReductionPass : public arith::IRMutatorWithAnalyzer {
 public:

--- a/src/transform/ascend_workspace_reduction.cc
+++ b/src/transform/ascend_workspace_reduction.cc
@@ -592,18 +592,6 @@ private:
       return EMPTY_BUFFER_LIST;
     }
 
-    const StringImmNode *call_node_name = call_node_args[0].as<StringImmNode>();
-    if (call_node_name != nullptr) {
-      const std::string call_node_name_str = call_node_name->value;
-      for (const auto &copy_stmt : copy_stmt_table_) {
-        // Skip copy statements: only insert copy-back before data consumers,
-        // not producers(copy stmts).
-        if (call_node_name_str.find(copy_stmt) != std::string::npos) {
-          return EMPTY_BUFFER_LIST;
-        }
-      }
-    }
-
     for (int i = 0; i < call_node_args.size(); ++i) {
       const PrimExpr &arg = call_node_args[i];
       const CallNode *access_ptr = arg.as<CallNode>();
@@ -623,6 +611,17 @@ private:
           << "[Error]<WorkspaceReduction>: access ptr args[1] is not VarNode!";
 
       std::string buffer_name = buffer_var->name_hint;
+
+      // access_args layout: [type_annotation, var, offset, extent, rw_mask]
+      // Only consider buffer as a "consumer" if rw_mask has read bit set.
+      // Skip write-only access (rw_mask == 2) since no copy-back needed before a write.
+      ICHECK(access_args.size() >= 5)
+          << "[Error]<WorkspaceReduction>: access ptr args size too small for rw_mask!";
+      int rw_mask = Downcast<IntImm>(access_args[4])->value;
+      if (!(rw_mask & 1)) {
+        // write-only access → this buffer is a producer, not a consumer
+        continue;
+      }
 
       for (const auto &[src_buffer_name, dst_buffer_name] :
            context_.src_to_dst_map_) {


### PR DESCRIPTION
## Summary

Fix two bugs in `AscendWorkspaceReduction` pass that caused conflicts with `CombineCV`, resulting in sync point mismatches.

Fixes the half of https://github.com/tile-ai/tilelang-ascend/issues/1176

## Changes

### 1. Fix `type_map_` keys to match actual Ascend C type names

The `CopyInfoCollector::type_map_` used incorrect key names (e.g. `int8`, `uint32`) that didn't match the actual C++ type strings produced by codegen (e.g. `int8_t`, `uint32_t`). Also added missing entries for `bfloat16_t` and `AscendC::int4b_t`.

### 2. Treat copy calls as possible data consumers to correctly insert copy-backs

The previous logic blanket-skipped all copy-related call statements, assuming they were always producers. This caused the pass to miss cases where a copy call *consumes* a workspace buffer (read access), leading to missing copy-back insertions and downstream sync mismatches in `CombineCV`.

Replaced the coarse copy-statement skip with fine-grained `rw_mask` checking on `access_ptr` arguments: only write-only accesses (`rw_mask == 2`) are treated as producers; read accesses correctly trigger copy-back insertion.

## Testing

Verified with the reproducer kernel from #1176 (matmul_add with `threads=2`, `bfloat16`, all auto-sync/memory-planning passes enabled) — the mentioned issue should be solved.