### PR TITLE
[fix] fix bug for issue #1182

### DIFF
--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -341,8 +341,9 @@ ShapeInfo CodeGenTileLangAscendPto::GetSliceInfo(const CallNode *op) {
       extent, src_addr, offset,    type,      ub_name,         is_slice};
 }
 
-ShapeInfo CodeGenTileLangAscendPto::GetCompareMaskInfo(
-    const CallNode *dst_call, const ShapeInfo &src_info) {
+ShapeInfo
+CodeGenTileLangAscendPto::GetCompareMaskInfo(const CallNode *dst_call,
+                                             const ShapeInfo &src_info) {
   ICHECK(dst_call);
   ICHECK(dst_call->op.same_as(builtin::tvm_access_ptr()));
 
@@ -1914,8 +1915,7 @@ void CodeGenTileLangAscendPto::CompareCodegen(const CallNode *op,
 
   this->PrintIndent();
   this->stream << kAscendPtoScope << "compare(" << dst_name << ", " << src0_name
-               << ", " << src1_name << ", "
-               << "CmpMode::" << mode << ");\n";
+               << ", " << src1_name << ", " << "CmpMode::" << mode << ");\n";
 }
 
 void CodeGenTileLangAscendPto::CompareScalarCodegen(
@@ -1937,8 +1937,8 @@ void CodeGenTileLangAscendPto::CompareScalarCodegen(
 
   this->PrintIndent();
   this->stream << kAscendPtoScope << "compare_scalar(" << dst_name << ", "
-               << src0_name << ", " << src1_name << ", "
-               << "CmpMode::" << mode << ");\n";
+               << src0_name << ", " << src1_name << ", " << "CmpMode::" << mode
+               << ");\n";
 }
 
 void CodeGenTileLangAscendPto::TshCodegen(const CallNode *op,

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -341,6 +341,55 @@ ShapeInfo CodeGenTileLangAscendPto::GetSliceInfo(const CallNode *op) {
       extent, src_addr, offset,    type,      ub_name,         is_slice};
 }
 
+ShapeInfo CodeGenTileLangAscendPto::GetCompareMaskInfo(
+    const CallNode *dst_call, const ShapeInfo &src_info) {
+  ICHECK(dst_call);
+  ICHECK(dst_call->op.same_as(builtin::tvm_access_ptr()));
+
+  Var buffer_var = Downcast<Var>(dst_call->args[1]);
+  ICHECK(buffer_shapess_.count(buffer_var))
+      << "Buffer shape not found: " << buffer_var->name_hint;
+  auto shape = buffer_shapess_.at(buffer_var);
+
+  ICHECK(shape.size() == 4)
+      << "Expected a 4D PTO mask shape [M, N, Valid_M, Valid_N], but got "
+      << shape.size() << "D for " << buffer_var->name_hint;
+  ICHECK(shape[0]->IsInstance<IntImmNode>());
+  ICHECK(shape[1]->IsInstance<IntImmNode>());
+  ICHECK(shape[2]->IsInstance<IntImmNode>());
+  ICHECK(shape[3]->IsInstance<IntImmNode>());
+
+  int32_t row = shape[0].as<IntImmNode>()->value;
+  int32_t col = shape[1].as<IntImmNode>()->value;
+  int32_t valid_col = shape[3].as<IntImmNode>()->value;
+
+  int32_t slice_valid_row = src_info.slice_valid_row;
+  int32_t slice_valid_col =
+      std::min(valid_col, (src_info.slice_valid_col + 7) / 8);
+  int32_t slice_row = slice_valid_row;
+  int32_t slice_col = col;
+
+  ICHECK(buffer_address_map_.count(buffer_var))
+      << "Buffer address not found: " << buffer_var->name_hint;
+  auto src_addr = buffer_address_map_.at(buffer_var);
+  auto offset = PrintExpr(dst_call->args[2]);
+  auto type = getType(dst_call->args[0].dtype());
+  auto ub_name = var_idmap_[dst_call->args[1].as<VarNode>()];
+
+  return ShapeInfo{row,
+                   col,
+                   slice_row,
+                   slice_col,
+                   slice_valid_row,
+                   slice_valid_col,
+                   src_info.extent,
+                   src_addr,
+                   offset,
+                   type,
+                   ub_name,
+                   true};
+}
+
 CodeGenTileLangAscendPto::CodeGenTileLangAscendPto(std::string platform) {
   // restrict_keyword_ = "__gm__ uint8_t *";
   platform_ = platform;
@@ -1855,7 +1904,8 @@ void CodeGenTileLangAscendPto::CompareCodegen(const CallNode *op,
                                               const std::string &op_name) {
   ShapeInfo src0_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
   ShapeInfo src1_shape_info = GetSliceInfo(op->args[2].as<CallNode>());
-  ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
+  ShapeInfo dst_shape_info =
+      GetCompareMaskInfo(op->args[0].as<CallNode>(), src0_shape_info);
   auto mode = Downcast<StringImm>(op->args[3])->value;
 
   std::string src0_name = ResolveUbSliceName(src0_shape_info);
@@ -1871,7 +1921,8 @@ void CodeGenTileLangAscendPto::CompareCodegen(const CallNode *op,
 void CodeGenTileLangAscendPto::CompareScalarCodegen(
     const CallNode *op, const std::string &op_name) {
   ShapeInfo src0_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
-  ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
+  ShapeInfo dst_shape_info =
+      GetCompareMaskInfo(op->args[0].as<CallNode>(), src0_shape_info);
   auto src1_name = PrintExpr(op->args[2]);
   auto mode = Downcast<StringImm>(op->args[3])->value;
 
@@ -3157,8 +3208,10 @@ void CodeGenTileLangAscendPto::AutoFlagOpCodegen(const CallNode *op,
 void CodeGenTileLangAscendPto::SelectCodegen(const CallNode *op) {
   ShapeInfo src0_shape_info = GetSliceInfo(op->args[2].as<CallNode>());
   ShapeInfo dst_shape_info = GetSliceInfo(op->args[0].as<CallNode>());
+  ShapeInfo mask_shape_info =
+      GetCompareMaskInfo(op->args[1].as<CallNode>(), src0_shape_info);
 
-  std::string mask_name = PrintBufferOffset(op->args[1].as<CallNode>());
+  std::string mask_name = ResolveUbSliceName(mask_shape_info);
   std::string temp_name = PrintBufferOffset(op->args[3].as<CallNode>());
   std::string src1_name;
   std::string op_name;

--- a/src/target/codegen_ascend_pto.h
+++ b/src/target/codegen_ascend_pto.h
@@ -184,6 +184,9 @@ private:
 
   void CompareScalarCodegen(const CallNode *op, const std::string &op_name);
 
+  ShapeInfo GetCompareMaskInfo(const CallNode *dst_call,
+                               const ShapeInfo &src_info);
+
   void TshCodegen(const CallNode *op, const std::string &op_name);
 
   void ArithProgressionCodegen(const CallNode *op, const std::string &op_name);

--- a/src/transform/ascend_memory_planning.cc
+++ b/src/transform/ascend_memory_planning.cc
@@ -28,6 +28,7 @@
 #include <tvm/tir/utils.h>
 
 #include "../op/builtin.h"
+#include "./common/attr.h"
 #include "./common/collector.h"
 
 #define ASCEND_SHARED_MEM_SIZE 196352
@@ -67,7 +68,11 @@ public:
     }
 
     Map<Var, Array<PrimExpr>> external_shape_map;
-    if (fn_attr->dict.count("buffer_shapess")) {
+    if (fn_attr->dict.count(kLogicBufferShapes)) {
+      external_shape_map = fn_attr->dict.at(kLogicBufferShapes)
+                               .as<Map<Var, Array<PrimExpr>>>()
+                               .value();
+    } else if (fn_attr->dict.count("buffer_shapess")) {
       external_shape_map = fn_attr->dict.at("buffer_shapess")
                                .as<Map<Var, Array<PrimExpr>>>()
                                .value();
@@ -102,6 +107,7 @@ private:
                                  Map<Var, Array<PrimExpr>> external_shape_map,
                                  bool auto_plan = false) {
       memory_auto_plan = auto_plan;
+      external_shape_map_ = external_shape_map;
       memory_limits_ = {{"shared.dyn", ASCEND_SHARED_DYN_MEM_SIZE},
                         {"wmma.matrix_a", ASCEND_WMMA_MATRIX_A_MEM_SIZE},
                         {"wmma.matrix_b", ASCEND_WMMA_MATRIX_B_MEM_SIZE},
@@ -823,10 +829,20 @@ private:
 
     size_t CalculateBufferSize(const AllocateNode *alloc) {
       size_t size_elements = 1;
-      for (const auto &extent : alloc->extents) {
-        const IntImmNode *int_imm = extent.as<IntImmNode>();
-        ICHECK(int_imm) << "Extent must be an integer constant";
-        size_elements *= int_imm->value;
+      auto shape_it = external_shape_map_.find(alloc->buffer_var);
+      if (shape_it != external_shape_map_.end() &&
+          (*shape_it).second.size() == 4) {
+        const auto &shape = (*shape_it).second;
+        const IntImmNode *row = shape[0].as<IntImmNode>();
+        const IntImmNode *col = shape[1].as<IntImmNode>();
+        ICHECK(row && col) << "PTO physical buffer shape must be constant";
+        size_elements = row->value * col->value;
+      } else {
+        for (const auto &extent : alloc->extents) {
+          const IntImmNode *int_imm = extent.as<IntImmNode>();
+          ICHECK(int_imm) << "Extent must be an integer constant";
+          size_elements *= int_imm->value;
+        }
       }
 
       size_t size_bytes =
@@ -851,6 +867,7 @@ private:
         buffer_scopes_; // buffer scope(UB/L1..)
     std::unordered_map<const VarNode *, size_t>
         buffer_sizes_; // buffer bytes size
+    Map<Var, Array<PrimExpr>> external_shape_map_;
     std::unordered_map<const VarNode *, size_t>
         first_use_; // buffer first use stmt scope
     std::unordered_map<std::string, int>

--- a/src/transform/ascend_memory_planning.cc
+++ b/src/transform/ascend_memory_planning.cc
@@ -107,6 +107,8 @@ private:
                                  Map<Var, Array<PrimExpr>> external_shape_map,
                                  bool auto_plan = false) {
       memory_auto_plan = auto_plan;
+      // Preserve layouts needed by CalculateBufferSize.
+      // PTO 4D shapes are [physical_M, physical_N, valid_M, valid_N].
       external_shape_map_ = external_shape_map;
       memory_limits_ = {{"shared.dyn", ASCEND_SHARED_DYN_MEM_SIZE},
                         {"wmma.matrix_a", ASCEND_WMMA_MATRIX_A_MEM_SIZE},
@@ -867,6 +869,7 @@ private:
         buffer_scopes_; // buffer scope(UB/L1..)
     std::unordered_map<const VarNode *, size_t>
         buffer_sizes_; // buffer bytes size
+    // Layout map used to size PTO 4D tiles by physical footprint.
     Map<Var, Array<PrimExpr>> external_shape_map_;
     std::unordered_map<const VarNode *, size_t>
         first_use_; // buffer first use stmt scope


### PR DESCRIPTION
# 修复  PTO compare mask 布局和物理 buffer 分配大小（issue#1182）

## 概要

这个 PR 修复 `fused_gdn_gating_pto.py` 在 Ascend PTO 后端上的稀疏精度错误。核心改动是让 PTO codegen 把 compare/select 的 predicate mask 当成 PTO mask tile 处理，而不是当成普通 `uint8` tensor。

问题通过临时回退本修改、重新编译安装 `tilelang-ascend` 后复现：

```bash
source /mnt/workspace/gitCode/cann/tilelang-ascend/set_env.sh
cd /mnt/workspace/gitCode/cann/xllm/xllm
python compiler/tilelang/targets/ascend/kernels/fused_gdn_gating_pto.py \
  --output /tmp/fused_gdn_old_nh64_bs4096.cpp \
  --batch-size 48 \
  --num-heads 64 \
  --ref-num-batches 4096 \
  --ref-num-heads-list 64
```

回退后的后端会产生 `1536 / 262144` 个 `g_out` 元素不匹配，约 `0.6%`。恢复修复后的后端可以通过同一测试。

## 修改内容

### 1. 增加 PTO compare mask 专用 shape 处理

新增 `CodeGenTileLangAscendPto::GetCompareMaskInfo`。

该 helper 读取 PTO 的 4D 布局：

```text
[physical_M, physical_N, valid_M, valid_N]
```

并根据源 tensor 的 valid shape 推导 mask slice。对于一个 `32 x 32` 的源 tile，mask 应该表示为：

```cpp
TileUbDataND<uint8_t, 32, 32, 32, 4>
```

而不是普通 slice 语义下的：

```cpp
TileUbDataND<uint8_t, 4, 32, 4, 32>
```

### 2. 让 compare 和 select 使用同一种 mask view

更新了：

```cpp
CompareCodegen
CompareScalarCodegen
SelectCodegen
```

修复前：

```cpp
TileUbDataND<uint8_t, 4, 32, 4, 32> softplus_cmp_mask_ub_temp_0;
compare_scalar(softplus_cmp_mask_ub_temp_0, beta_x_ub, softplus_threshold, CmpMode::GT);
TSEL(beta_x_ub, softplus_cmp_mask_ub, x_ub, beta_x_ub, tmp_ub);
```

修复后：

```cpp
TileUbDataND<uint8_t, 32, 32, 32, 4> softplus_cmp_mask_ub_temp_0;
compare_scalar(softplus_cmp_mask_ub_temp_0, beta_x_ub, softplus_threshold, CmpMode::GT);
TileUbDataND<uint8_t, 32, 32, 32, 4> softplus_cmp_mask_ub_temp_1;
TSEL(beta_x_ub, softplus_cmp_mask_ub_temp_1, x_ub, beta_x_ub, tmp_ub);
```

这样 `compare_scalar` 写入 predicate bytes 和 `TSEL` 读取 predicate bytes 时使用同一种物理/有效布局，不会再发生布局解释不一致。

### 3. memory planning 对 4D PTO buffer 按物理 footprint 分配空间

更新 `AscendMemoryPlanning`，读取 `logic_buffer_shapes`，并在 planner 中保存该 shape map。

对于 4D PTO layout 的 buffer，分配大小改为：

```text
physical_M * physical_N * dtype_size
```

而不是 flattened valid element count。

以代表性的 `num_heads=32` 为例，生成代码从：

```cpp
TASSIGN(softplus_cmp_mask_ub, 32896);
TASSIGN(tmp_ub, 33024);
```

变为：

```cpp
TASSIGN(softplus_cmp_mask_ub, 32896);
TASSIGN(tmp_ub, 33920);
```

也就是为 mask 预留完整的 `32 * 32 = 1024` 字节物理空间，避免后续 `tmp_ub` scratch buffer 与 mask tile 重叠。

## 为什么这个修复是合理的

PTO 的 `TileUbDataND<T, M, N, ValidM, ValidN>` 明确区分物理存储 shape 和有效 payload shape。compare mask 尤其敏感，因为 predicate bytes 是 packed 的，但 tile 本身仍然承载源 tile 的物理行列布局。

如果把 mask 当作普通二维 `uint8` tensor，compare 和 select 就会对同一段 UB 内存使用不同的布局解释，最终导致部分 lane 的 softplus threshold 分支选择错误。

这个修复让 compare 和 select 都使用同一个 PTO tile 抽象，并让 memory planner 按物理 tile footprint 预留空间。因此它修复的是后端 codegen/memory planning 的一致性问题，不改变算子数学公式，也不依赖算子侧 workaround。

## 验证

验证前均执行：

```bash
source /mnt/workspace/gitCode/cann/tilelang-ascend/set_env.sh
bash install_ascend.sh --enable-incremental
```

回退后端时，`ref-num-batches=4096` 的失败情况：

| num_heads | 结果 |
| --- | --- |
| 8 | 256 / 32768 个元素不匹配，0.8% |
| 12 | 512 / 49152 个元素不匹配，1.0% |
| 16 | 256 / 65536 个元素不匹配，0.4% |
| 24 | 768 / 98304 个元素不匹配，0.8% |
| 32 | 256 / 131072 个元素不匹配，0.2% |
| 48 | 1023 / 196608 个元素不匹配，0.5% |
| 64 | 1536 / 262144 个元素不匹配，0.6% |
| 128 | 3072 / 524288 个元素不匹配，0.6% |

修复后端通过以下用例：

```bash
python compiler/tilelang/targets/ascend/kernels/fused_gdn_gating_pto.py \
  --output /tmp/fused_gdn_fixed_nh8_bs4096.cpp \
  --batch-size 48 \
  --num-heads 8 \
  --ref-num-batches 4096 \
  --ref-num-heads-list 8

python compiler/tilelang/targets/ascend/kernels/fused_gdn_gating_pto.py \
  --output /tmp/fused_gdn_fixed_nh64_bs4096.cpp \
  --batch-size 48 \
  --num-heads 64 \
  --ref-num-batches 4096 \
  --ref-num-heads-list 64

python compiler/tilelang/targets/ascend/kernels/fused_gdn_gating_pto.py \
  --output /tmp/fused_gdn_fixed_nh128_bs4096.cpp \
  --batch-size 48 \
  --num-heads 128 \
  --ref-num-batches 4096 \
  --ref-num-heads-list 128
```

三个用例均通过 torch reference check。