### PR TITLE
[fix] fix T.Parallel UB copy lowering

### DIFF
--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -1172,13 +1172,20 @@ void CodeGenTileLangAscendPto::CopyUBToUBCodegen(const CallNode *call) {
     auto dst_tile_cols = Downcast<IntImm>(call->args[7])->value;
     auto dst_buf_cols = Downcast<IntImm>(call->args[8])->value;
 
+    ICHECK_EQ(src_tile_rows, dst_tile_rows)
+        << "UB-to-UB copy requires matching source and destination row counts";
+    ICHECK_EQ(src_tile_cols, dst_tile_cols)
+        << "UB-to-UB copy requires matching source and destination column counts";
+
+    ShapeInfo src_shape_info = GetSliceInfo(src_info.access_ptr);
+    ShapeInfo dst_shape_info = GetSliceInfo(dst_info.access_ptr);
+    src_buf_cols = src_shape_info.col;
+    dst_buf_cols = dst_shape_info.col;
+
     bool src_strided = (src_tile_cols != src_buf_cols);
     bool dst_strided = (dst_tile_cols != dst_buf_cols);
 
     if (!src_strided && !dst_strided) {
-      ShapeInfo src_shape_info = GetSliceInfo(src_info.access_ptr);
-      ShapeInfo dst_shape_info = GetSliceInfo(dst_info.access_ptr);
-
       src_shape_info.slice_valid_row = src_tile_rows;
       src_shape_info.slice_valid_col = src_tile_cols;
       src_shape_info.slice_row = src_tile_rows;

--- a/src/transform/ascend_lower_parallel_to_vector.cc
+++ b/src/transform/ascend_lower_parallel_to_vector.cc
@@ -1753,8 +1753,12 @@ private:
         PrimExpr col = truncmod(src_offset, src_ub->shape[1]);
         actual_src_indices.push_back(row);
         actual_src_indices.push_back(col);
-        src_extents.push_back(dst_gm->shape[0]); // outer_extent
-        src_extents.push_back(dst_gm->shape[1]); // inner_vec_len
+        PrimExpr copy_cols = vector_dim_extent_ > 0
+                                 ? Integer(vector_dim_extent_)
+                                 : src_ub->shape[1];
+        PrimExpr rows = floordiv(Integer(element_count), copy_cols);
+        src_extents.push_back(analyzer_->Simplify(rows));
+        src_extents.push_back(copy_cols);
       }
     }
 
@@ -1781,13 +1785,15 @@ private:
       }
     } else {
       if (dst_gm->shape.size() == 1) {
-        dst_indices.push_back(IntImm(DataType::Int(32), 0));
+        dst_indices.push_back(dst_offset);
         dst_extents.push_back(IntImm(DataType::Int(32), element_count));
       } else if (dst_gm->shape.size() == 2) {
-        dst_indices.push_back(IntImm(DataType::Int(32), 0));
-        dst_indices.push_back(IntImm(DataType::Int(32), 0));
-        dst_extents.push_back(dst_gm->shape[0]);
-        dst_extents.push_back(dst_gm->shape[1]);
+        PrimExpr row = floordiv(dst_offset, dst_gm->shape[1]);
+        PrimExpr col = truncmod(dst_offset, dst_gm->shape[1]);
+        dst_indices.push_back(row);
+        dst_indices.push_back(col);
+        dst_extents.push_back(src_extents[0]);
+        dst_extents.push_back(src_extents[1]);
       }
     }
 

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -439,7 +439,10 @@ private:
         tile_op->Lower(LowerArgs{target_, thread_bounds, thread_var_->var,
                                  callback, layout_map_, buffer_remap_,
                                  disable_tma_lower, resource_scope_},
-                       analyzer_);
+                        analyzer_);
+    if (thread_block_size_ == 0) {
+      lowered = tir::Substitute(lowered, {{thread_var_->var, Integer(0)}});
+    }
     return IRMutatorWithAnalyzer::VisitStmt(lowered);
   }
 

--- a/testing/python/language/parallel/test_tilelang_ascend_language_parallel_issue_1194.py
+++ b/testing/python/language/parallel/test_tilelang_ascend_language_parallel_issue_1194.py
@@ -1,0 +1,173 @@
+import os
+import pathlib
+import pytest
+import shutil
+import subprocess
+import tempfile
+import tilelang
+import tilelang.language as T
+import torch
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+def lower_pto_source(func):
+    with tilelang.tvm.transform.PassContext(opt_level=3, config=PASS_CONFIGS):
+        artifact = tilelang.lower(func, target="pto")
+    return artifact.kernel_source
+
+
+def pto_runtime_jit_available():
+    bisheng = shutil.which("bisheng")
+    if bisheng is None:
+        return False
+
+    tl_root = pathlib.Path(__file__).resolve().parents[4]
+    pto_include = tl_root / "3rdparty" / "pto-isa" / "include"
+    if not (pto_include / "pto" / "pto-inst.hpp").is_file():
+        return False
+
+    ascend_home = os.environ.get("ASCEND_HOME_PATH") or os.environ.get(
+        "ASCEND_HOME", "/usr/local/Ascend/ascend-toolkit/latest"
+    )
+    ascend_include = pathlib.Path(ascend_home) / "include"
+    if not ascend_include.is_dir():
+        return False
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = pathlib.Path(temp_dir) / "probe.cpp"
+        object_path = pathlib.Path(temp_dir) / "probe.o"
+        source_path.write_text(
+            '#include <pto/pto-inst.hpp>\nextern "C" __global__ __aicore__ void probe() {}\n',
+            encoding="utf-8",
+        )
+        result = subprocess.run(
+            [
+                bisheng,
+                "--cce-aicore-arch=dav-c220",
+                "-DMEMORY_BASE",
+                "-O2",
+                "-std=gnu++17",
+                "-xcce",
+                f"-I{pto_include}",
+                f"-I{ascend_include}",
+                "-c",
+                str(source_path),
+                "-o",
+                str(object_path),
+            ],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+        )
+        return result.returncode == 0
+
+
+requires_pto_runtime_jit = pytest.mark.skipif(
+    not pto_runtime_jit_available(),
+    reason="PTO runtime JIT compiler cannot compile pto-isa probe in this environment",
+)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    tilelang.cache.clear_cache()
+    yield
+
+
+@pytest.fixture
+def setup_random_seed():
+    torch.manual_seed(0)
+    yield
+
+
+def make_compact_to_aligned_kernel(groups=8, compact_cols=4, aligned_cols=8, dtype="float"):
+    @T.prim_func
+    def main(A: T.Tensor((groups, compact_cols), dtype), C: T.Tensor((groups, aligned_cols), dtype)):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            src = T.alloc_ub((groups, compact_cols), dtype)
+            dst = T.alloc_ub((groups, aligned_cols), dtype)
+            with T.Scope("V"):
+                T.copy(A, src)
+                T.tile.fill(dst, 0.0)
+                for i, j in T.Parallel(groups, compact_cols):
+                    dst[i, j] = src[i, j]
+                T.copy(dst, C)
+
+    return main
+
+
+def compile_compact_to_aligned(target="pto"):
+    return tilelang.compile(
+        make_compact_to_aligned_kernel(),
+        out_idx=[-1],
+        pass_configs=PASS_CONFIGS,
+        target=target,
+    )
+
+
+def test_parallel_compact_to_aligned_ub_copy_emits_strided_pto_copy():
+    source = lower_pto_source(make_compact_to_aligned_kernel())
+
+    assert "copy_ub_to_ub_strided" in source
+    assert ", 8, 4," in source
+
+
+@requires_pto_runtime_jit
+def test_parallel_compact_to_aligned_ub_copy_preserves_padding(setup_random_seed):
+    kernel = compile_compact_to_aligned(target="pto")
+
+    a = torch.arange(32, dtype=torch.float32, device="npu").reshape(8, 4)
+    expected = torch.zeros((8, 8), dtype=torch.float32, device="npu")
+    expected[:, :4] = a
+
+    torch.npu.synchronize()
+    out = kernel(a)
+
+    torch.testing.assert_close(out, expected, rtol=1e-2, atol=1e-2)
+
+
+def make_parallel_1d_multi_store_kernel(length=128, dtype="float"):
+    @T.prim_func
+    def main(A: T.Tensor((length,), dtype), C: T.Tensor((length,), dtype)):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            src = T.alloc_ub((length,), dtype)
+            dst = T.alloc_ub((length,), dtype)
+            with T.Scope("V"):
+                T.copy(A, src)
+                for i in T.Parallel(length):
+                    dst[i] = src[i]
+                    dst[i] = dst[i] + 1.0
+                T.copy(dst, C)
+
+    return main
+
+
+def test_parallel_1d_multi_store_codegen_does_not_reference_v_thread():
+    source = lower_pto_source(make_parallel_1d_multi_store_kernel())
+
+    assert "v_thread" not in source
+
+
+@requires_pto_runtime_jit
+def test_parallel_1d_multi_store_runs_correctly(setup_random_seed):
+    kernel = tilelang.compile(
+        make_parallel_1d_multi_store_kernel(),
+        out_idx=[-1],
+        pass_configs=PASS_CONFIGS,
+        target="pto",
+    )
+    a = torch.randn(128, device="npu")
+
+    torch.npu.synchronize()
+    out = kernel(a)
+
+    torch.testing.assert_close(out, a + 1.0, rtol=1e-2, atol=1e-2)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
This PR fixes issue #1194, where `T.Parallel` could lower a compact-to-aligned UB store into an incorrect flat UB-to-UB copy.

The problematic case is copying compact logical data like `[G, 4]` into the first columns of an aligned UB buffer like `[G, 8]`. That copy must preserve the destination row stride, otherwise data from later rows can be written into padding or adjacent groups.

Changes:
- Preserve compact logical copy extents for source-indexed 2D UB copies.
- Preserve the destination offset instead of resetting destination indices to zero.
- Emit PTO `copy_ub_to_ub_strided` when physical row stride differs from logical copy width.
- Derive physical UB row stride from slice metadata in PTO codegen.
- Add shape checks for UB-to-UB source/destination tile compatibility.
- Replace fallback `v_thread` with constant `0` when no real thread axis exists.
- Add regression tests for compact-to-aligned UB copy and `v_thread` codegen.

## Validation
Local validation:
- `ruff check` passed for the new regression test.
- Python compile check passed for the new regression test.
- `git diff --check` passed.
- C++ syntax checks passed for the three changed C++ files.

Remote Ascend validation:
- Rebuilt TileLang on the Ascend server.
- Verified `tilelang` and `tvm` import from the rebuilt tree.
- Ran targeted issue #1194 pytest.
- Result: `2 passed, 2 skipped`.

Notes:
- The two passing tests verify source/codegen behavior:
  - compact-to-aligned UB copy emits strided PTO copy
  - generated source no longer references `v_thread`
- The two skipped tests are runtime/NPU behavior checks.
- They were skipped because the remote PTO JIT compiler cannot compile a minimal `pto-isa` probe in the current environment.
- The skip is environment-related; skipped runtime tests are not counted as passed.