### PR TITLE
[Fix] Fix PTO printf template compilation error in elementwise_print example 🤖

### DIFF
--- a/src/tl_templates/pto/printf.h
+++ b/src/tl_templates/pto/printf.h
@@ -42,7 +42,7 @@ template <typename T> AICORE inline const __gm__ char *TypeName() {
   return "unknown";
 }
 #define TL_PTO_TYPENAME_SPECIALIZE(CppType, NameStr)                           \
-  template <> AICORE inline const __gm__ char *TypeName<CppType>() {       \
+  template <> AICORE inline const __gm__ char *TypeName<CppType>() {           \
     return NameStr;                                                            \
   }
 TL_PTO_DTYPE_LIST(TL_PTO_TYPENAME_SPECIALIZE)
@@ -52,7 +52,7 @@ TL_PTO_DTYPE_LIST(TL_PTO_TYPENAME_SPECIALIZE)
 
 template <typename Tile>
 AICORE inline void DumpTensor(Tile &src, uint32_t desc, uint32_t dumpSize,
-                                  uint8_t dim, const uint32_t shapeInfo[]) {
+                              uint8_t dim, const uint32_t shapeInfo[]) {
   pipe_barrier(PIPE_ALL);
   cce::printf("=== DumpTensor [desc=%u] UB tile, dumpSize=%u ===\n", desc,
               dumpSize);
@@ -60,9 +60,8 @@ AICORE inline void DumpTensor(Tile &src, uint32_t desc, uint32_t dumpSize,
 }
 
 template <typename T>
-AICORE inline void DumpTensor(__gm__ T *src, uint32_t desc,
-                                  uint32_t dumpSize, uint8_t dim,
-                                  const uint32_t shapeInfo[]) {
+AICORE inline void DumpTensor(__gm__ T *src, uint32_t desc, uint32_t dumpSize,
+                              uint8_t dim, const uint32_t shapeInfo[]) {
   if (dumpSize == 0)
     return;
   pipe_barrier(PIPE_ALL);
@@ -101,11 +100,11 @@ AICORE inline void DumpTensor(__gm__ T *src, uint32_t desc,
 
 template <typename Tile>
 AICORE inline void DumpTensor(Tile &, uint32_t, uint32_t, uint8_t,
-                                  const uint32_t[]) {}
+                              const uint32_t[]) {}
 
 template <typename T>
 AICORE inline void DumpTensor(__gm__ T *, uint32_t, uint32_t, uint8_t,
-                                  const uint32_t[]) {}
+                              const uint32_t[]) {}
 
 #endif // defined(_DEBUG) || defined(__CPU_SIM)
 

--- a/src/tl_templates/pto/printf.h
+++ b/src/tl_templates/pto/printf.h
@@ -22,7 +22,7 @@ namespace tl::ascend_pto {
 
 namespace detail {
 
-template <typename T> __aicore__ inline void PrintScalar(T val, uint32_t col) {
+template <typename T> AICORE inline void PrintScalar(T val, uint32_t col) {
   if (col > 0)
     cce::printf(" ");
   if constexpr (std::is_same_v<T, float>) {
@@ -38,11 +38,11 @@ template <typename T> __aicore__ inline void PrintScalar(T val, uint32_t col) {
   }
 }
 
-template <typename T> __aicore__ inline const __gm__ char *TypeName() {
+template <typename T> AICORE inline const __gm__ char *TypeName() {
   return "unknown";
 }
 #define TL_PTO_TYPENAME_SPECIALIZE(CppType, NameStr)                           \
-  template <> __aicore__ inline const __gm__ char *TypeName<CppType>() {       \
+  template <> AICORE inline const __gm__ char *TypeName<CppType>() {       \
     return NameStr;                                                            \
   }
 TL_PTO_DTYPE_LIST(TL_PTO_TYPENAME_SPECIALIZE)
@@ -51,7 +51,7 @@ TL_PTO_DTYPE_LIST(TL_PTO_TYPENAME_SPECIALIZE)
 } // namespace detail
 
 template <typename Tile>
-__aicore__ inline void DumpTensor(Tile &src, uint32_t desc, uint32_t dumpSize,
+AICORE inline void DumpTensor(Tile &src, uint32_t desc, uint32_t dumpSize,
                                   uint8_t dim, const uint32_t shapeInfo[]) {
   pipe_barrier(PIPE_ALL);
   cce::printf("=== DumpTensor [desc=%u] UB tile, dumpSize=%u ===\n", desc,
@@ -60,7 +60,7 @@ __aicore__ inline void DumpTensor(Tile &src, uint32_t desc, uint32_t dumpSize,
 }
 
 template <typename T>
-__aicore__ inline void DumpTensor(__gm__ T *src, uint32_t desc,
+AICORE inline void DumpTensor(__gm__ T *src, uint32_t desc,
                                   uint32_t dumpSize, uint8_t dim,
                                   const uint32_t shapeInfo[]) {
   if (dumpSize == 0)
@@ -100,11 +100,11 @@ __aicore__ inline void DumpTensor(__gm__ T *src, uint32_t desc,
 #else // !(_DEBUG || __CPU_SIM)
 
 template <typename Tile>
-__aicore__ inline void DumpTensor(Tile &, uint32_t, uint32_t, uint8_t,
+AICORE inline void DumpTensor(Tile &, uint32_t, uint32_t, uint8_t,
                                   const uint32_t[]) {}
 
 template <typename T>
-__aicore__ inline void DumpTensor(__gm__ T *, uint32_t, uint32_t, uint8_t,
+AICORE inline void DumpTensor(__gm__ T *, uint32_t, uint32_t, uint8_t,
                                   const uint32_t[]) {}
 
 #endif // defined(_DEBUG) || defined(__CPU_SIM)


### PR DESCRIPTION
## Summary

Fix compilation error when running `examples/print/elementwise_print.py` on the PTO backend by replacing `__aicore__` with the `AICORE` macro in the printf template header.

## Changes

- Replace all `__aicore__` annotations with `AICORE` macro in `src/tl_templates/pto/printf.h`
- Affects `PrintScalar`, `TypeName`, and `DumpTensor` template functions

## Testing

```bash
cd examples/print
python elementwise_print.py
```