### PR TITLE
[Fix] Add missing RowValid/ColValid template params to compare() in common.h 🤖

### DIFF
--- a/src/tl_templates/pto/common.h
+++ b/src/tl_templates/pto/common.h
@@ -1215,24 +1215,26 @@ transpose(TileUbDataND<T, DstRows, DstCols, DstRowValid, DstColValid> &dst,
 }
 
 template <typename DstT, typename SrcT, int32_t DstRows, int32_t DstCols,
-          int32_t SrcRows, int32_t SrcCols>
+          int32_t DstRowValid, int32_t DstColValid, int32_t SrcRows,
+          int32_t SrcCols, int32_t SrcRowValid, int32_t SrcColValid>
 AICORE PTO_INLINE void
-compare(TileUbDataND<DstT, DstRows, DstCols, DstRows, DstCols> &dst,
-        TileUbDataND<SrcT, SrcRows, SrcCols, SrcRows, SrcCols> &src0,
-        TileUbDataND<SrcT, SrcRows, SrcCols, SrcRows, SrcCols> &src1,
+compare(TileUbDataND<DstT, DstRows, DstCols, DstRowValid, DstColValid> &dst,
+        TileUbDataND<SrcT, SrcRows, SrcCols, SrcRowValid, SrcColValid> &src0,
+        TileUbDataND<SrcT, SrcRows, SrcCols, SrcRowValid, SrcColValid> &src1,
         pto::CmpMode mode) {
   pto::TCMP(dst, src0, src1, mode);
 }
 
-template <typename SrcT, int32_t DstRows, int32_t DstCols, int32_t SrcRows,
-          int32_t SrcCols>
+template <typename SrcT, int32_t DstRows, int32_t DstCols, int32_t DstRowValid,
+          int32_t DstColValid, int32_t SrcRows, int32_t SrcCols,
+          int32_t SrcRowValid, int32_t SrcColValid>
 AICORE PTO_INLINE void
-compare(TileUbDataND<int8_t, DstRows, DstCols, DstRows, DstCols> &dst,
-        TileUbDataND<SrcT, SrcRows, SrcCols, SrcRows, SrcCols> &src0,
-        TileUbDataND<SrcT, SrcRows, SrcCols, SrcRows, SrcCols> &src1,
+compare(TileUbDataND<int8_t, DstRows, DstCols, DstRowValid, DstColValid> &dst,
+        TileUbDataND<SrcT, SrcRows, SrcCols, SrcRowValid, SrcColValid> &src0,
+        TileUbDataND<SrcT, SrcRows, SrcCols, SrcRowValid, SrcColValid> &src1,
         pto::CmpMode mode) {
   auto &dst_uint8 = reinterpret_cast<
-      TileUbDataND<uint8_t, DstRows, DstCols, DstRows, DstCols> &>(dst);
+      TileUbDataND<uint8_t, DstRows, DstCols, DstRowValid, DstColValid> &>(dst);
   pto::TCMP(dst_uint8, src0, src1, mode);
 }
 


### PR DESCRIPTION
## Summary

Fix compilation error when running `examples/activation/gelu_grad.py` on the PTO backend. The `compare()` template functions in `src/tl_templates/pto/common.h` were hardcoding `RowValid=Rows` and `ColValid=Cols`, which fails for tiles where valid dimensions differ from allocated dimensions (e.g. tail blocks).

## Changes

- Add `DstRowValid`, `DstColValid`, `SrcRowValid`, `SrcColValid` as independent template parameters to both `compare()` overloads
- Previously these were hardcoded to `DstRows`/`DstCols`/`SrcRows`/`SrcCols`, preventing use with tiles that have different valid vs. allocated dimensions

## Testing

```bash
cd examples/activation
python gelu_grad.py
```