### PR TITLE
[Fix] Fix gemm_aot AOT example build on CANN 9.1.0 / 9.1.0-beta.1 🤖

### DIFF
--- a/examples/gemm_aot/build.sh
+++ b/examples/gemm_aot/build.sh
@@ -13,6 +13,8 @@ bisheng --cce-aicore-arch=dav-c220 \
     -I${ASCEND_HOME_PATH}/compiler/tikcpp/tikcfw/interface \
     -I${ASCEND_HOME_PATH}/include \
     -I${ASCEND_HOME_PATH}/include/experiment/msprof \
+    -I${ASCEND_HOME_PATH}/include/experiment/msprof/toolchain \
+    -I${ASCEND_HOME_PATH}/pkg_inc \
     -I../../3rdparty/catlass/include \
     -I../../3rdparty/shmem/include \
     -I../../3rdparty/shmem/src/device \


### PR DESCRIPTION
## Summary

`examples/gemm_aot` builds on older CANN releases but **fails to compile on CANN 9.1.0 and 9.1.0-beta.1**: the profiling headers the Ascend runtime pulls in transitively are not on `build.sh`'s include path. This adds the include roots each version needs.

## Root Cause

`runtime/rt_ffts.h` → `runtime/base.h` does `#include "profiling/prof_api.h"`, which in turn includes `prof_common.h`. Newer CANN relocated these headers to directories the current `build.sh` doesn't search:

- **9.1.0-beta.1** — `profiling/prof_api.h` is under `${ASCEND_HOME_PATH}/pkg_inc/` → `fatal error: 'profiling/prof_api.h' file not found`
- **9.1.0** — `prof_common.h` is under `${ASCEND_HOME_PATH}/include/experiment/msprof/toolchain/` → `fatal error: 'prof_common.h' file not found`

## Changes

`examples/gemm_aot/build.sh` — add both include roots so a single script covers both releases (extra non-matching `-I` paths are harmless):

```
-I${ASCEND_HOME_PATH}/include/experiment/msprof/toolchain   # 9.1.0
-I${ASCEND_HOME_PATH}/pkg_inc                               # 9.1.0-beta.1
```

## Testing

```bash
source set_env.sh
cd examples/gemm_aot
bash run_example_gemm_aot.sh   # builds kernel_lib.so, prints "Kernel Output Match!"
```

Verified on CANN 9.1.0 and 9.1.0-beta.1.
