### PR TITLE
[bugfix] fix combinCV pass failed when insert T.sync_all()

### DIFF
--- a/src/transform/ascend_combinecv.cc
+++ b/src/transform/ascend_combinecv.cc
@@ -706,8 +706,12 @@ public:
     }
     std::string api_name = "";
     if (call_node_) {
-      if (const auto *str_imm = call_node_->args[0].as<StringImmNode>()) {
-        api_name = str_imm->value;
+      // Guard against zero-arg intrinsics (e.g. tl.ascend_sync_all),
+      // which would otherwise crash on args[0] access. See issue #1244.
+      if (!call_node_->args.empty()) {
+        if (const auto *str_imm = call_node_->args[0].as<StringImmNode>()) {
+          api_name = str_imm->value;
+        }
       }
       if (const auto *op_node = call_node_->op.as<OpNode>();
           op_node && IsRetainedInBothScopes(op_node->name)) {


### PR DESCRIPTION
### 问题背景
CombineCV pass 在做核间 CV 同步插入时，会遍历 `call_extern` 调用节点并取 `args[0]` 解析 API 名字。`T.sync_all()` 是无参 intrinsic，其 `args` 数组为空，直接 `args[0]` 触发 TVM 的 `IndexError`，使整个 pass 崩溃。

### 解决方案
在访问 `args[0]` 前加防御性判空：

```cpp
// Guard against zero-arg intrinsics (e.g. tl.ascend_sync_all),
// which would otherwise crash on args[0] access. See issue #1244.
if (!call_node_->args.empty()) {
  if (const auto *str_imm = call_node_->args[0].as<StringImmNode>()) {
    api_name = str_imm->value;
  }
}
```

零参 intrinsic 跳过 `api_name` 解析，从而不再崩溃。本质上是一个边界条件补丁，而非算法逻辑改动。

### 影响范围
- **影响面小且低风险**: 仅作用于开启 `TL_ASCEND_AUTO_CV_COMBINE` 时的 `CVCombineEmitter` 路径，对其他 pass 无影响；纯防御性判空，不改变正常有参调用的行为。
- **正向收益**: 使带 `T.sync_all()` 的 CV-combine kernel 能顺利通过该 pass。