### PR TITLE
[Ascend] Vector tail-block scheme — batch 1 (remove front-end pad_value, valid-region compute)

### DIFF
--- a/examples/tail_mask/example_tail_add.py
+++ b/examples/tail_mask/example_tail_add.py
@@ -1,0 +1,65 @@
+"""Minimal tail-block elementwise-add example for the AscendC backend.
+
+M and N are deliberately *not* multiples of the block, so the last row/column
+blocks are tails. With the opt-in tail-mask scheme (TL_ASCEND_TAIL_MASK)
+``T.tile.add`` is rewritten to a tail-aware helper that computes only over the
+valid rectangle; the unused UB gap is pad-filled and never written back.
+"""
+
+import tilelang
+import tilelang.language as T
+import torch
+
+tilelang.cache.clear_cache()
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    # Opt in to the tail-block valid-region scheme (default off).
+    tilelang.PassConfigKey.TL_ASCEND_TAIL_MASK: True,
+}
+
+
+@tilelang.jit(out_idx=[2], pass_configs=pass_configs)
+def tail_add(M, N, block_M, block_N, dtype="float"):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, N), dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+            b_ub = T.alloc_ub((block_M, block_N), dtype)
+            c_ub = T.alloc_ub((block_M, block_N), dtype)
+            T.copy(A[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N], a_ub)
+            T.copy(B[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N], b_ub)
+            T.tile.add(c_ub, a_ub, b_ub)
+            T.copy(c_ub, C[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N])
+
+    return main
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+    for M, N, block_M, block_N, dtype in [
+        (34, 130, 32, 32, "float"),
+        (34, 130, 32, 32, "float16"),
+        (100, 200, 64, 128, "float"),
+    ]:
+        print(f"tail_add M={M} N={N} block=({block_M},{block_N}) dtype={dtype}")
+        func = tail_add(M, N, block_M, block_N, dtype=dtype)
+        torch_dtype = torch.float32 if dtype == "float" else torch.float16
+        a = torch.randn(M, N, dtype=torch_dtype).npu()
+        b = torch.randn(M, N, dtype=torch_dtype).npu()
+        c = func(a, b)
+        torch.testing.assert_close(c, a + b, rtol=1e-2, atol=1e-2)
+        print("  pass")
+    print("Kernel Output Match!")

--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -460,6 +460,9 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
       pad_val = Cast(dst->dtype, pad_val);
     }
     new_args.push_back(pad_val);
+    // Physical UB tile dims (row pitch). These trail pad_val and are consumed
+    // by AscendTailMaskPropagation to model the tail rect; CopyCodegen prints
+    // only the first 4 extra args (strideN, validRow, validCol, pad_val).
     if (dst->shape.size() > 1) {
       new_args.push_back(dst->shape[dst->shape.size() - 2]);
     }
@@ -1335,6 +1338,28 @@ TIR_DEFINE_TL_BUILTIN(ascend_row_expand_sub_experiment)
                                Integer(CallEffectKind::kOpaque));
 
 TIR_DEFINE_TL_BUILTIN(ascend_row_expand_div_experiment)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+// Internal tail-aware ops (see ascend.h). Variadic: they carry an AscendC op
+// tag string, buffer pointers, and the runtime tail rect.
+TIR_DEFINE_TL_BUILTIN(ascend_tail_unary)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ascend_tail_binary)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ascend_tail_scalar)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ascend_tail_reduce)
     .set_num_inputs(-1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));

--- a/src/op/ascend.h
+++ b/src/op/ascend.h
@@ -251,6 +251,23 @@ TVM_DLL const Op &ascend_row_expand_mul_experiment();
 TVM_DLL const Op &ascend_row_expand_sub_experiment();
 
 TVM_DLL const Op &ascend_row_expand_div_experiment();
+
+// ---------------------------------------------------------------------------
+// Internal tail-aware vector ops produced by AscendTailMaskPropagation. These
+// are never emitted by the front-end; the pass rewrites the corresponding
+// plain tl.ascend_* op when its UB operand carries a tail valid-region. Each
+// carries the original buffer pointers plus the runtime tail rect
+// (valid_row, valid_col, physical_col) so the codegen can call the matching
+// tl::ascend::tail_* helper.
+// ---------------------------------------------------------------------------
+TVM_DLL const Op &ascend_tail_unary();
+
+TVM_DLL const Op &ascend_tail_binary();
+
+TVM_DLL const Op &ascend_tail_scalar();
+
+TVM_DLL const Op &ascend_tail_reduce();
+
 } // namespace tl
 } // namespace tvm
 

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -575,6 +575,14 @@ void CodeGenTileLangAscend::VisitExpr_(const CallNode *op, std::ostream &os) {
     PrintOpCall(op, "AscendC::Xor", {0, op->args.size() - 1}, {0, 0});
   } else if (op->op.same_as(tl::ascend_broadcast())) {
     BroadcastOpCodegen(op);
+  } else if (op->op.same_as(tl::ascend_tail_unary())) {
+    TailUnaryOpCodegen(op);
+  } else if (op->op.same_as(tl::ascend_tail_binary())) {
+    TailBinaryOpCodegen(op);
+  } else if (op->op.same_as(tl::ascend_tail_scalar())) {
+    TailScalarOpCodegen(op);
+  } else if (op->op.same_as(tl::ascend_tail_reduce())) {
+    TailReduceOpCodegen(op);
   } else if (op->op.same_as(tl::ascend_row_expand_mul())) {
     RowExpandMulCodegen(op);
   } else if (op->op.same_as(tl::ascend_row_expand_mul_experiment())) {
@@ -976,6 +984,22 @@ void CodeGenTileLangAscend::VisitExpr_(const SelectNode *op, std::ostream &os) {
 
   os << "(" << condition << " ? "
      << "" << true_value << " : " << false_value << ")";
+}
+
+void CodeGenTileLangAscend::VisitExpr_(const MinNode *op, std::ostream &os) {
+  // The CCE `min` is overloaded on (int,int) and (long,long); a ternary whose
+  // branches mix int and int64 (common in tail valid-region expressions) makes
+  // the call ambiguous.  Emit a ternary instead so overload resolution is not
+  // involved.  Bind operands first in case they trigger let-binding.
+  std::string a = PrintExpr(op->a);
+  std::string b = PrintExpr(op->b);
+  os << "((" << a << ") < (" << b << ") ? (" << a << ") : (" << b << "))";
+}
+
+void CodeGenTileLangAscend::VisitExpr_(const MaxNode *op, std::ostream &os) {
+  std::string a = PrintExpr(op->a);
+  std::string b = PrintExpr(op->b);
+  os << "((" << a << ") > (" << b << ") ? (" << a << ") : (" << b << "))";
 }
 
 void ProcessHostInput(std::ostream &os, std::vector<std::string> &arg_names,
@@ -2166,6 +2190,81 @@ void CodeGenTileLangAscend::BroadcastOpCodegen(const CallNode *op) {
   // 5. Src Shape Array
   PrintConstArray(op, 5 + dim, dim);
   this->stream << ");\n";
+}
+
+void CodeGenTileLangAscend::TailUnaryOpCodegen(const CallNode *op) {
+  // args: tag(0) dst(1) src(2) validRow(3) validCol(4) physCol(5)
+  std::string tag = Downcast<StringImm>(op->args[0])->value;
+  std::string dtype = getType(GetAccessPtrDtype(op->args[1].as<CallNode>()));
+  std::string dst = PrintBufferOffset(op->args[1].as<CallNode>());
+  std::string src = PrintBufferOffset(op->args[2].as<CallNode>());
+  // Bind valid-region expressions first: they may contain nested Select/min
+  // that the base codegen lowers to let-binding statements (condval_N).  These
+  // statements must be emitted to the stream *before* the call line so they
+  // land in statement position, not inside the argument list.
+  std::string vrow = PrintExpr(op->args[3]);
+  std::string vcol = PrintExpr(op->args[4]);
+  std::string pcol = PrintExpr(op->args[5]);
+  this->PrintIndent();
+  this->stream << "tl::ascend::tail_unary<" << dtype
+               << ">(tl::ascend::TailVecUnOp::" << tag << ", " << dst << ", "
+               << src << ", " << vrow << ", " << vcol << ", " << pcol << ");\n";
+}
+
+void CodeGenTileLangAscend::TailBinaryOpCodegen(const CallNode *op) {
+  // args: tag(0) dst(1) src0(2) src1(3) validRow(4) validCol(5) physCol(6)
+  std::string tag = Downcast<StringImm>(op->args[0])->value;
+  std::string dtype = getType(GetAccessPtrDtype(op->args[1].as<CallNode>()));
+  std::string dst = PrintBufferOffset(op->args[1].as<CallNode>());
+  std::string src0 = PrintBufferOffset(op->args[2].as<CallNode>());
+  std::string src1 = PrintBufferOffset(op->args[3].as<CallNode>());
+  // Bind valid-region expressions first (see TailUnaryOpCodegen).
+  std::string vrow = PrintExpr(op->args[4]);
+  std::string vcol = PrintExpr(op->args[5]);
+  std::string pcol = PrintExpr(op->args[6]);
+  this->PrintIndent();
+  this->stream << "tl::ascend::tail_binary<" << dtype
+               << ">(tl::ascend::TailVecBinOp::" << tag << ", " << dst << ", "
+               << src0 << ", " << src1 << ", " << vrow << ", " << vcol << ", "
+               << pcol << ");\n";
+}
+
+void CodeGenTileLangAscend::TailScalarOpCodegen(const CallNode *op) {
+  // args: tag(0) dst(1) src(2) scalar(3) validRow(4) validCol(5) physCol(6)
+  std::string tag = Downcast<StringImm>(op->args[0])->value;
+  std::string dtype = getType(GetAccessPtrDtype(op->args[1].as<CallNode>()));
+  std::string dst = PrintBufferOffset(op->args[1].as<CallNode>());
+  std::string src = PrintBufferOffset(op->args[2].as<CallNode>());
+  std::string scalar = dtype + "(" + PrintExpr(op->args[3]) + ")";
+  // Bind valid-region expressions first (see TailUnaryOpCodegen).
+  std::string vrow = PrintExpr(op->args[4]);
+  std::string vcol = PrintExpr(op->args[5]);
+  std::string pcol = PrintExpr(op->args[6]);
+  this->PrintIndent();
+  this->stream << "tl::ascend::tail_scalar<" << dtype
+               << ">(tl::ascend::TailVecScalarOp::" << tag << ", " << dst
+               << ", " << src << ", " << scalar << ", " << vrow << ", " << vcol
+               << ", " << pcol << ");\n";
+}
+
+void CodeGenTileLangAscend::TailReduceOpCodegen(const CallNode *op) {
+  // args: kind(0) out(1) src(2) tmp(3) dim(4) validRow(5) validCol(6)
+  //       physCol(7) clear(8)
+  std::string kind = Downcast<StringImm>(op->args[0])->value; // reduce_sum/...
+  std::string dtype = getType(GetAccessPtrDtype(op->args[1].as<CallNode>()));
+  std::string out = PrintBufferOffset(op->args[1].as<CallNode>());
+  std::string src = PrintBufferOffset(op->args[2].as<CallNode>());
+  std::string tmp = PrintBufferOffset(op->args[3].as<CallNode>(), false);
+  // Bind valid-region expressions first (see TailUnaryOpCodegen).
+  std::string dim_str = PrintExpr(op->args[4]);
+  std::string vrow = PrintExpr(op->args[5]);
+  std::string vcol = PrintExpr(op->args[6]);
+  std::string pcol = PrintExpr(op->args[7]);
+  std::string clear_str = is_zero(op->args[8]) ? "false" : "true";
+  this->PrintIndent();
+  this->stream << "tl::ascend::tail_" << kind << "<" << dtype << ">(" << out
+               << ", " << src << ", " << tmp << ", " << dim_str << ", " << vrow
+               << ", " << vcol << ", " << pcol << ", " << clear_str << ");\n";
 }
 
 void CodeGenTileLangAscend::SetCrossFlagCodegen(const CallNode *op) {

--- a/src/target/codegen_ascend.h
+++ b/src/target/codegen_ascend.h
@@ -53,6 +53,8 @@ public:
   void VisitExpr_(const FloorModNode *op, std::ostream &os);
   void VisitExpr_(const MulNode *op, std::ostream &os) final;
   void VisitExpr_(const SelectNode *op, std::ostream &os) final;
+  void VisitExpr_(const MinNode *op, std::ostream &os) final;
+  void VisitExpr_(const MaxNode *op, std::ostream &os) final;
   void VisitExpr_(const BufferLoadNode *op, std::ostream &os) final;
   void VisitStmt_(const BufferStoreNode *op) final;
   void VisitStmt_(const AllocateNode *op) final;
@@ -137,6 +139,14 @@ private:
   void PowerOpCodegen(const CallNode *op, const std::string &op_name);
 
   void BroadcastOpCodegen(const CallNode *op);
+
+  void TailUnaryOpCodegen(const CallNode *op);
+
+  void TailBinaryOpCodegen(const CallNode *op);
+
+  void TailScalarOpCodegen(const CallNode *op);
+
+  void TailReduceOpCodegen(const CallNode *op);
 
   void RowExpandMulCodegen(const CallNode *op);
 

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -259,6 +259,22 @@ void CodeGenTileLangAscendPto::CreateUbVariableDN(const std::string &temp_name,
                << GetTypeLen(shape_info.type) << ");\n";
 }
 
+std::string CodeGenTileLangAscendPto::CreateUbVariableDynamic(
+    const ShapeInfo &shape_info, const std::string &valid_row,
+    const std::string &valid_col) {
+  std::string temp = GetTempVarName(shape_info.ub_name);
+  this->PrintIndent();
+  this->stream << kAscendPtoScope << "TileUbDataND<" << shape_info.type << ", "
+               << shape_info.row << ", " << shape_info.col
+               << ", pto::DYNAMIC, pto::DYNAMIC> " << temp << "(" << valid_row
+               << ", " << valid_col << ");\n";
+  this->PrintIndent();
+  this->stream << "TASSIGN(" << temp << ", " << shape_info.first_addr << " + "
+               << shape_info.offset << " * " << GetTypeLen(shape_info.type)
+               << ");\n";
+  return temp;
+}
+
 std::string
 CodeGenTileLangAscendPto::ResolveUbSliceName(const ShapeInfo &info) {
   if (!info.is_slice)
@@ -846,6 +862,16 @@ void CodeGenTileLangAscendPto::VisitExpr_(const CallNode *op,
     BinaryVecOpsCodegen(op, "TMAXS");
   } else if (op->op.same_as(tl::ascend_mins())) {
     BinaryVecOpsCodegen(op, "TMINS");
+
+    // --- tail-aware vector ops (AscendTailMaskPropagation) ---
+    // Only unary / binary / scalar are rewritten; reduce / broadcast / compare
+    // / select stay on the full-tile path (gap filled with pad_value).
+  } else if (op->op.same_as(tl::ascend_tail_unary())) {
+    TailUnaryOpCodegen(op);
+  } else if (op->op.same_as(tl::ascend_tail_binary())) {
+    TailBinaryOpCodegen(op);
+  } else if (op->op.same_as(tl::ascend_tail_scalar())) {
+    TailScalarOpCodegen(op);
 
     // --- sync / barrier ---
   } else if (op->op.same_as(tl::ascend_sync_all())) {
@@ -2530,6 +2556,90 @@ void CodeGenTileLangAscendPto::UnaryVecOpCodegen(const CallNode *op,
 
   this->PrintIndent();
   this->stream << op_name << "(" << dst_name << ", " << src_name << ");\n";
+}
+
+void CodeGenTileLangAscendPto::TailUnaryOpCodegen(const CallNode *op) {
+  // args: tag(0) dst(1) src(2) validRow(3) validCol(4) physCol(5)
+  static const std::unordered_map<std::string, std::string> kUnaryIntr = {
+      {"Exp", "TEXP"},          {"Ln", "TLOG"},    {"Abs", "TABS"},
+      {"Reciprocal", "TRECIP"}, {"Sqrt", "TSQRT"}, {"Rsqrt", "TRSQRT"},
+      {"Relu", "TRELU"}};
+  const auto *tag_imm = op->args[0].as<StringImmNode>();
+  ICHECK(tag_imm) << "tail_unary: tag must be a string";
+  auto it = kUnaryIntr.find(tag_imm->value);
+  ICHECK(it != kUnaryIntr.end())
+      << "Unsupported tail_unary tag: " << tag_imm->value;
+
+  std::string vrow = PrintExpr(op->args[3]);
+  std::string vcol = PrintExpr(op->args[4]);
+  ShapeInfo dst_info = GetSliceInfo(op->args[1].as<CallNode>());
+  ShapeInfo src_info = GetSliceInfo(op->args[2].as<CallNode>());
+  std::string dst = CreateUbVariableDynamic(dst_info, vrow, vcol);
+  std::string src = CreateUbVariableDynamic(src_info, vrow, vcol);
+
+  this->PrintIndent();
+  this->stream << it->second << "(" << dst << ", " << src << ");\n";
+}
+
+void CodeGenTileLangAscendPto::TailBinaryOpCodegen(const CallNode *op) {
+  // args: tag(0) dst(1) src0(2) src1(3) validRow(4) validCol(5) physCol(6)
+  static const std::unordered_map<std::string, std::string> kBinaryIntr = {
+      {"Add", "TADD"}, {"Sub", "TSUB"}, {"Mul", "TMUL"},
+      {"Div", "TDIV"}, {"Max", "TMAX"}, {"Min", "TMIN"}};
+  const auto *tag_imm = op->args[0].as<StringImmNode>();
+  ICHECK(tag_imm) << "tail_binary: tag must be a string";
+  auto it = kBinaryIntr.find(tag_imm->value);
+  ICHECK(it != kBinaryIntr.end())
+      << "Unsupported tail_binary tag: " << tag_imm->value;
+
+  std::string vrow = PrintExpr(op->args[4]);
+  std::string vcol = PrintExpr(op->args[5]);
+  ShapeInfo dst_info = GetSliceInfo(op->args[1].as<CallNode>());
+  ShapeInfo src0_info = GetSliceInfo(op->args[2].as<CallNode>());
+  ShapeInfo src1_info = GetSliceInfo(op->args[3].as<CallNode>());
+  std::string dst = CreateUbVariableDynamic(dst_info, vrow, vcol);
+  std::string src0 = CreateUbVariableDynamic(src0_info, vrow, vcol);
+  std::string src1 = CreateUbVariableDynamic(src1_info, vrow, vcol);
+
+  this->PrintIndent();
+  this->stream << it->second << "(" << dst << ", " << src0 << ", " << src1
+               << ");\n";
+}
+
+void CodeGenTileLangAscendPto::TailScalarOpCodegen(const CallNode *op) {
+  // args: tag(0) dst(1) src(2) scalar(3) validRow(4) validCol(5) physCol(6)
+  // subs/divs are never rewritten by the pass, so only Adds/Muls/Maxs/Mins.
+  static const std::unordered_map<std::string, std::string> kScalarIntr = {
+      {"Adds", "TADDS"},
+      {"Muls", "TMULS"},
+      {"Maxs", "TMAXS"},
+      {"Mins", "TMINS"}};
+  const auto *tag_imm = op->args[0].as<StringImmNode>();
+  ICHECK(tag_imm) << "tail_scalar: tag must be a string";
+  auto it = kScalarIntr.find(tag_imm->value);
+  ICHECK(it != kScalarIntr.end())
+      << "Unsupported tail_scalar tag: " << tag_imm->value;
+
+  std::string vrow = PrintExpr(op->args[4]);
+  std::string vcol = PrintExpr(op->args[5]);
+  ShapeInfo dst_info = GetSliceInfo(op->args[1].as<CallNode>());
+  ShapeInfo src_info = GetSliceInfo(op->args[2].as<CallNode>());
+  std::string dst = CreateUbVariableDynamic(dst_info, vrow, vcol);
+  std::string src = CreateUbVariableDynamic(src_info, vrow, vcol);
+
+  DataType dtype0 = GetAccessPtrDtypePto(op->args[1].as<CallNode>());
+  std::string scalar = PrintExpr(op->args[3]);
+  if (op->args[3].dtype() != dtype0) {
+    if (dtype0.is_float16()) {
+      scalar = "float(" + scalar + ")";
+    } else {
+      scalar = dst_info.type + "(" + scalar + ")";
+    }
+  }
+
+  this->PrintIndent();
+  this->stream << it->second << "(" << dst << ", " << src << ", " << scalar
+               << ");\n";
 }
 
 void CodeGenTileLangAscendPto::ScalarOpCodegen(const CallNode *op,

--- a/src/target/codegen_ascend_pto.h
+++ b/src/target/codegen_ascend_pto.h
@@ -125,6 +125,16 @@ private:
 
   void BinaryVecOpsCodegen(const CallNode *op, const std::string &op_name);
 
+  // Tail-aware vector ops produced by AscendTailMaskPropagation. The pass
+  // rewrites unary / binary / scalar ops on tail UB tiles to these internal
+  // ops carrying the runtime valid rectangle; reduce / broadcast / compare /
+  // select are NOT rewritten (hybrid scheme) so only these three are needed.
+  void TailUnaryOpCodegen(const CallNode *op);
+
+  void TailBinaryOpCodegen(const CallNode *op);
+
+  void TailScalarOpCodegen(const CallNode *op);
+
   void CallExternCodegen(const CallNode *op);
 
   void GemmV0Codegen(const CallNode *op);
@@ -234,6 +244,13 @@ private:
                           const ShapeInfo &shape_info);
   void CreateUbVariableDN(const std::string &temp_name,
                           const ShapeInfo &shape_info);
+  // Emits a TileUbDataND bound to the buffer address whose valid region is the
+  // runtime (valid_row, valid_col) pair (pto::DYNAMIC). Used by the tail-aware
+  // vector op codegen so PTO op macros compute only over the valid rectangle,
+  // leaving the gap (filled with pad_value by copy_gm_to_ub) untouched.
+  std::string CreateUbVariableDynamic(const ShapeInfo &shape_info,
+                                      const std::string &valid_row,
+                                      const std::string &valid_col);
   void CreateCubeVariable(const std::string &temp_name,
                           const ShapeInfo &shape_info,
                           const std::string &tile_name);

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -199,7 +199,13 @@ CATLASS_DEVICE void
 copy_gm_to_ub(LocalTensor<T> dstTensor, GlobalTensor<T> srcTensor,
               uint32_t realSrcN = 1, uint32_t maskShapeM = dstM,
               uint32_t maskShapeN = dstN, T padValue = T(0)) {
-
+  // Hybrid scheme: the UB gap ([maskShapeN, dstN) / [maskShapeM, dstM)) is
+  // filled with ``padValue`` via Duplicate so that downstream reduce /
+  // broadcast / compare / select ops (which still read the full tile) observe a
+  // defined value. AscendTailMaskPropagation additionally rewrites unary /
+  // binary / scalar ops to tail_* helpers that compute only over the valid
+  // region, so the pad value in the gap is preserved (not corrupted by
+  // elementwise ops) and reaches the unreduced readers intact.
   bool isPad = true;
   uint32_t rightPadding = 1;
   if (maskShapeN == dstN || (maskShapeN * sizeof(T)) % 32 == 0) {
@@ -583,6 +589,451 @@ reduce_min(LocalTensor<T> const &dstTensor, LocalTensor<T> const &srcTensor,
     T reducedValue = dstTensor.GetValue(i);
     T backupValue = dstBackup[i];
     dstTensor.SetValue(i, reduce_scalar_min_safe(reducedValue, backupValue));
+  }
+}
+
+// ===================== Tail-aware vector helpers =========================
+// AscendTailMaskPropagation rewrites vector ops on tail UB tiles to these
+// helpers. A tail tile carries a valid rectangle [validRow, validCol] laid out
+// with a physical row pitch of physCol (the allocated tile width). We choose
+// the cheapest correct execution:
+//   - full rows (validCol == physCol): one contiguous count call;
+//   - narrow tail (validCol <= elements-per-256B-repeat): native mask + repeat,
+//     one repeat per row with the repeat stride derived from physCol;
+//   - otherwise: per-row contiguous fallback (skips only the gap rows).
+// Masking does not make a single repeat cheaper; the saving comes from issuing
+// fewer 256B repeats (fewer rows and/or fewer whole column blocks).
+
+enum class TailVecUnOp { Exp, Ln, Abs, Reciprocal, Sqrt, Rsqrt, Relu };
+enum class TailVecBinOp { Add, Sub, Mul, Div, Max, Min };
+enum class TailVecScalarOp { Adds, Muls, Maxs, Mins };
+
+template <typename T> struct TailIsFloatLike {
+  static constexpr bool value = std::is_same_v<T, float> ||
+                                std::is_same_v<T, half> ||
+                                std::is_same_v<T, bfloat16_t>;
+};
+
+// ---- binary ----
+template <typename T>
+CATLASS_DEVICE void TailApplyBinCount(TailVecBinOp op, LocalTensor<T> d,
+                                      LocalTensor<T> s0, LocalTensor<T> s1,
+                                      int32_t n) {
+  switch (op) {
+  case TailVecBinOp::Add:
+    AscendC::Add(d, s0, s1, n);
+    break;
+  case TailVecBinOp::Sub:
+    AscendC::Sub(d, s0, s1, n);
+    break;
+  case TailVecBinOp::Mul:
+    AscendC::Mul(d, s0, s1, n);
+    break;
+  case TailVecBinOp::Div:
+    AscendC::Div(d, s0, s1, n);
+    break;
+  case TailVecBinOp::Max:
+    AscendC::Max(d, s0, s1, n);
+    break;
+  case TailVecBinOp::Min:
+    AscendC::Min(d, s0, s1, n);
+    break;
+  }
+}
+
+template <typename T>
+CATLASS_DEVICE void TailApplyBinMask(TailVecBinOp op, LocalTensor<T> d,
+                                     LocalTensor<T> s0, LocalTensor<T> s1,
+                                     uint64_t mask, uint8_t repeat,
+                                     const AscendC::BinaryRepeatParams &rp) {
+  switch (op) {
+  case TailVecBinOp::Add:
+    AscendC::Add(d, s0, s1, mask, repeat, rp);
+    break;
+  case TailVecBinOp::Sub:
+    AscendC::Sub(d, s0, s1, mask, repeat, rp);
+    break;
+  case TailVecBinOp::Mul:
+    AscendC::Mul(d, s0, s1, mask, repeat, rp);
+    break;
+  case TailVecBinOp::Div:
+    AscendC::Div(d, s0, s1, mask, repeat, rp);
+    break;
+  case TailVecBinOp::Max:
+    AscendC::Max(d, s0, s1, mask, repeat, rp);
+    break;
+  case TailVecBinOp::Min:
+    AscendC::Min(d, s0, s1, mask, repeat, rp);
+    break;
+  }
+}
+
+template <typename T>
+CATLASS_DEVICE void tail_binary(TailVecBinOp op, LocalTensor<T> dst,
+                                LocalTensor<T> src0, LocalTensor<T> src1,
+                                uint32_t validRow, uint32_t validCol,
+                                uint32_t physCol) {
+  if (validRow == 0 || validCol == 0)
+    return;
+  if (validCol == physCol) {
+    TailApplyBinCount<T>(op, dst, src0, src1,
+                         static_cast<int32_t>(validRow * physCol));
+    return;
+  }
+  constexpr uint32_t vl = 256 / sizeof(T);
+  constexpr uint32_t blk = 32 / sizeof(T);
+  uint32_t repStride = physCol / blk;
+  if (validCol <= vl && validRow <= 255 && (physCol % blk == 0) &&
+      repStride <= 255) {
+    AscendC::BinaryRepeatParams rp;
+    rp.dstBlkStride = 1;
+    rp.src0BlkStride = 1;
+    rp.src1BlkStride = 1;
+    rp.dstRepStride = repStride;
+    rp.src0RepStride = repStride;
+    rp.src1RepStride = repStride;
+    TailApplyBinMask<T>(op, dst, src0, src1, static_cast<uint64_t>(validCol),
+                        static_cast<uint8_t>(validRow), rp);
+    return;
+  }
+  for (uint32_t r = 0; r < validRow; ++r) {
+    TailApplyBinCount<T>(op, dst[r * physCol], src0[r * physCol],
+                         src1[r * physCol], static_cast<int32_t>(validCol));
+  }
+}
+
+// ---- unary ----
+template <typename T>
+CATLASS_DEVICE void TailApplyUnCount(TailVecUnOp op, LocalTensor<T> d,
+                                     LocalTensor<T> s, int32_t n) {
+  if constexpr (TailIsFloatLike<T>::value) {
+    switch (op) {
+    case TailVecUnOp::Exp:
+      AscendC::Exp(d, s, n);
+      break;
+    case TailVecUnOp::Ln:
+      AscendC::Ln(d, s, n);
+      break;
+    case TailVecUnOp::Abs:
+      AscendC::Abs(d, s, n);
+      break;
+    case TailVecUnOp::Reciprocal:
+      AscendC::Reciprocal(d, s, n);
+      break;
+    case TailVecUnOp::Sqrt:
+      AscendC::Sqrt(d, s, n);
+      break;
+    case TailVecUnOp::Rsqrt:
+      AscendC::Rsqrt(d, s, n);
+      break;
+    case TailVecUnOp::Relu:
+      AscendC::Relu(d, s, n);
+      break;
+    }
+  } else {
+    switch (op) {
+    case TailVecUnOp::Abs:
+      AscendC::Abs(d, s, n);
+      break;
+    default:
+      break;
+    }
+  }
+}
+
+template <typename T>
+CATLASS_DEVICE void TailApplyUnMask(TailVecUnOp op, LocalTensor<T> d,
+                                    LocalTensor<T> s, uint64_t mask,
+                                    uint8_t repeat,
+                                    const AscendC::UnaryRepeatParams &rp) {
+  if constexpr (TailIsFloatLike<T>::value) {
+    switch (op) {
+    case TailVecUnOp::Exp:
+      AscendC::Exp(d, s, mask, repeat, rp);
+      break;
+    case TailVecUnOp::Ln:
+      AscendC::Ln(d, s, mask, repeat, rp);
+      break;
+    case TailVecUnOp::Abs:
+      AscendC::Abs(d, s, mask, repeat, rp);
+      break;
+    case TailVecUnOp::Reciprocal:
+      AscendC::Reciprocal(d, s, mask, repeat, rp);
+      break;
+    case TailVecUnOp::Sqrt:
+      AscendC::Sqrt(d, s, mask, repeat, rp);
+      break;
+    case TailVecUnOp::Rsqrt:
+      AscendC::Rsqrt(d, s, mask, repeat, rp);
+      break;
+    case TailVecUnOp::Relu:
+      AscendC::Relu(d, s, mask, repeat, rp);
+      break;
+    }
+  } else {
+    switch (op) {
+    case TailVecUnOp::Abs:
+      AscendC::Abs(d, s, mask, repeat, rp);
+      break;
+    default:
+      break;
+    }
+  }
+}
+
+template <typename T>
+CATLASS_DEVICE void tail_unary(TailVecUnOp op, LocalTensor<T> dst,
+                               LocalTensor<T> src, uint32_t validRow,
+                               uint32_t validCol, uint32_t physCol) {
+  if (validRow == 0 || validCol == 0)
+    return;
+  if (validCol == physCol) {
+    TailApplyUnCount<T>(op, dst, src, static_cast<int32_t>(validRow * physCol));
+    return;
+  }
+  constexpr uint32_t vl = 256 / sizeof(T);
+  constexpr uint32_t blk = 32 / sizeof(T);
+  uint32_t repStride = physCol / blk;
+  if (validCol <= vl && validRow <= 255 && (physCol % blk == 0) &&
+      repStride <= 255) {
+    AscendC::UnaryRepeatParams rp;
+    rp.dstBlkStride = 1;
+    rp.srcBlkStride = 1;
+    rp.dstRepStride = repStride;
+    rp.srcRepStride = repStride;
+    TailApplyUnMask<T>(op, dst, src, static_cast<uint64_t>(validCol),
+                       static_cast<uint8_t>(validRow), rp);
+    return;
+  }
+  for (uint32_t r = 0; r < validRow; ++r) {
+    TailApplyUnCount<T>(op, dst[r * physCol], src[r * physCol],
+                        static_cast<int32_t>(validCol));
+  }
+}
+
+// ---- scalar ----
+template <typename T>
+CATLASS_DEVICE void TailApplyScalarCount(TailVecScalarOp op, LocalTensor<T> d,
+                                         LocalTensor<T> s, T v, int32_t n) {
+  switch (op) {
+  case TailVecScalarOp::Adds:
+    AscendC::Adds(d, s, v, n);
+    break;
+  case TailVecScalarOp::Muls:
+    AscendC::Muls(d, s, v, n);
+    break;
+  case TailVecScalarOp::Maxs:
+    AscendC::Maxs(d, s, v, n);
+    break;
+  case TailVecScalarOp::Mins:
+    AscendC::Mins(d, s, v, n);
+    break;
+  }
+}
+
+template <typename T>
+CATLASS_DEVICE void TailApplyScalarMask(TailVecScalarOp op, LocalTensor<T> d,
+                                        LocalTensor<T> s, T v, uint64_t mask,
+                                        uint8_t repeat,
+                                        const AscendC::UnaryRepeatParams &rp) {
+  switch (op) {
+  case TailVecScalarOp::Adds:
+    AscendC::Adds(d, s, v, mask, repeat, rp);
+    break;
+  case TailVecScalarOp::Muls:
+    AscendC::Muls(d, s, v, mask, repeat, rp);
+    break;
+  case TailVecScalarOp::Maxs:
+    AscendC::Maxs(d, s, v, mask, repeat, rp);
+    break;
+  case TailVecScalarOp::Mins:
+    AscendC::Mins(d, s, v, mask, repeat, rp);
+    break;
+  }
+}
+
+template <typename T>
+CATLASS_DEVICE void tail_scalar(TailVecScalarOp op, LocalTensor<T> dst,
+                                LocalTensor<T> src, T scalar, uint32_t validRow,
+                                uint32_t validCol, uint32_t physCol) {
+  if (validRow == 0 || validCol == 0)
+    return;
+  if (validCol == physCol) {
+    TailApplyScalarCount<T>(op, dst, src, scalar,
+                            static_cast<int32_t>(validRow * physCol));
+    return;
+  }
+  constexpr uint32_t vl = 256 / sizeof(T);
+  constexpr uint32_t blk = 32 / sizeof(T);
+  uint32_t repStride = physCol / blk;
+  if (validCol <= vl && validRow <= 255 && (physCol % blk == 0) &&
+      repStride <= 255) {
+    AscendC::UnaryRepeatParams rp;
+    rp.dstBlkStride = 1;
+    rp.srcBlkStride = 1;
+    rp.dstRepStride = repStride;
+    rp.srcRepStride = repStride;
+    TailApplyScalarMask<T>(op, dst, src, scalar,
+                           static_cast<uint64_t>(validCol),
+                           static_cast<uint8_t>(validRow), rp);
+    return;
+  }
+  for (uint32_t r = 0; r < validRow; ++r) {
+    TailApplyScalarCount<T>(op, dst[r * physCol], src[r * physCol], scalar,
+                            static_cast<int32_t>(validCol));
+  }
+}
+
+// ---- reduce ----
+// dim == -1 : reduce each row over its valid columns -> out[0..validRow).
+// dim == 0  : reduce down the valid rows           -> out[0..validCol).
+template <typename T>
+CATLASS_DEVICE void tail_reduce_sum(LocalTensor<T> out, LocalTensor<T> src,
+                                    LocalTensor<uint8_t> tmp, int dim,
+                                    uint32_t validRow, uint32_t validCol,
+                                    uint32_t physCol, bool clear) {
+  if (validRow == 0 || validCol == 0)
+    return;
+  if (dim == 0) {
+    uint32_t r0 = 0;
+    if (clear) {
+      AscendC::Adds(out, src, static_cast<T>(0),
+                    static_cast<int32_t>(validCol));
+      r0 = 1;
+    }
+    for (uint32_t r = r0; r < validRow; ++r) {
+      AscendC::Add(out, out, src[r * physCol], static_cast<int32_t>(validCol));
+    }
+    return;
+  }
+  // dim == -1: reduce each row over its valid columns -> out[0..validRow).
+  // Use the proven Pattern-AR reduce: one contiguous block reduce when
+  // validCol == physCol, otherwise per-row (each row is contiguous internally).
+  // clear == false is handled by backing up the old result and merging.
+  constexpr uint32_t kTailMaxRows = 256;
+  T backup[kTailMaxRows];
+  bool merge = (!clear) && (validRow <= kTailMaxRows);
+  if (merge) {
+    for (uint32_t r = 0; r < validRow; ++r)
+      backup[r] = out.GetValue(r);
+  }
+  if (validCol == physCol) {
+    uint32_t shape[2] = {validRow, validCol};
+    AscendC::ReduceSum<T, AscendC::Pattern::Reduce::AR>(out, src, tmp, shape,
+                                                        true);
+  } else {
+    // validCol != physCol (tail columns): AR-pattern ReduceSum with a sub-tile
+    // shape {1, validCol} triggers aicore exceptions on some tiles, so fall
+    // back to explicit scalar accumulation (always correct; tail validCol is
+    // small so the cost is bounded). merge (clear==false) handled below.
+    for (uint32_t r = 0; r < validRow; ++r) {
+      T acc = static_cast<T>(0);
+      for (uint32_t c = 0; c < validCol; ++c)
+        acc = static_cast<T>(acc + src.GetValue(r * physCol + c));
+      out.SetValue(r, acc);
+    }
+  }
+  if (merge) {
+    for (uint32_t r = 0; r < validRow; ++r)
+      out.SetValue(r, static_cast<T>(out.GetValue(r) + backup[r]));
+  }
+}
+
+template <typename T>
+CATLASS_DEVICE void tail_reduce_max(LocalTensor<T> out, LocalTensor<T> src,
+                                    LocalTensor<uint8_t> tmp, int dim,
+                                    uint32_t validRow, uint32_t validCol,
+                                    uint32_t physCol, bool clear) {
+  if (validRow == 0 || validCol == 0)
+    return;
+  if (dim == 0) {
+    uint32_t r0 = 0;
+    if (clear) {
+      AscendC::Adds(out, src, static_cast<T>(0),
+                    static_cast<int32_t>(validCol));
+      r0 = 1;
+    }
+    for (uint32_t r = r0; r < validRow; ++r) {
+      AscendC::Max(out, out, src[r * physCol], static_cast<int32_t>(validCol));
+    }
+    return;
+  }
+  // dim == -1: reduce each row over its valid columns (Pattern-AR).
+  constexpr uint32_t kTailMaxRows = 256;
+  T backup[kTailMaxRows];
+  bool merge = (!clear) && (validRow <= kTailMaxRows);
+  if (merge) {
+    for (uint32_t r = 0; r < validRow; ++r)
+      backup[r] = out.GetValue(r);
+  }
+  if (validCol == physCol) {
+    uint32_t shape[2] = {validRow, validCol};
+    AscendC::ReduceMax<T, AscendC::Pattern::Reduce::AR>(out, src, tmp, shape,
+                                                        true);
+  } else {
+    // validCol != physCol (tail columns): scalar fallback (see
+    // tail_reduce_sum).
+    for (uint32_t r = 0; r < validRow; ++r) {
+      T acc = src.GetValue(r * physCol);
+      for (uint32_t c = 1; c < validCol; ++c) {
+        T v = src.GetValue(r * physCol + c);
+        acc = reduce_scalar_max_safe(acc, v);
+      }
+      out.SetValue(r, acc);
+    }
+  }
+  if (merge) {
+    for (uint32_t r = 0; r < validRow; ++r)
+      out.SetValue(r, reduce_scalar_max_safe(out.GetValue(r), backup[r]));
+  }
+}
+
+template <typename T>
+CATLASS_DEVICE void tail_reduce_min(LocalTensor<T> out, LocalTensor<T> src,
+                                    LocalTensor<uint8_t> tmp, int dim,
+                                    uint32_t validRow, uint32_t validCol,
+                                    uint32_t physCol, bool clear) {
+  if (validRow == 0 || validCol == 0)
+    return;
+  if (dim == 0) {
+    uint32_t r0 = 0;
+    if (clear) {
+      AscendC::Adds(out, src, static_cast<T>(0),
+                    static_cast<int32_t>(validCol));
+      r0 = 1;
+    }
+    for (uint32_t r = r0; r < validRow; ++r) {
+      AscendC::Min(out, out, src[r * physCol], static_cast<int32_t>(validCol));
+    }
+    return;
+  }
+  // dim == -1: reduce each row over its valid columns (Pattern-AR).
+  constexpr uint32_t kTailMaxRows = 256;
+  T backup[kTailMaxRows];
+  bool merge = (!clear) && (validRow <= kTailMaxRows);
+  if (merge) {
+    for (uint32_t r = 0; r < validRow; ++r)
+      backup[r] = out.GetValue(r);
+  }
+  if (validCol == physCol) {
+    uint32_t shape[2] = {validRow, validCol};
+    AscendC::ReduceMin<T, AscendC::Pattern::Reduce::AR>(out, src, tmp, shape,
+                                                        true);
+  } else {
+    // validCol != physCol (tail columns): scalar fallback (see
+    // tail_reduce_sum).
+    for (uint32_t r = 0; r < validRow; ++r) {
+      T acc = src.GetValue(r * physCol);
+      for (uint32_t c = 1; c < validCol; ++c) {
+        T v = src.GetValue(r * physCol + c);
+        acc = reduce_scalar_min_safe(acc, v);
+      }
+      out.SetValue(r, acc);
+    }
+  }
+  if (merge) {
+    for (uint32_t r = 0; r < validRow; ++r)
+      out.SetValue(r, reduce_scalar_min_safe(out.GetValue(r), backup[r]));
   }
 }
 

--- a/src/transform/ascend_tail_mask_propagation.cc
+++ b/src/transform/ascend_tail_mask_propagation.cc
@@ -1,0 +1,538 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+
+/*!
+ * \file src/transform/ascend_tail_mask_propagation.cc
+ * \brief Propagate UB tail valid-regions and rewrite vector ops to tail-aware
+ *        variants for the AscendC backend.
+ *
+ * After LowerTileOp, a GM->UB copy is lowered to
+ *   call_extern("tl::ascend::copy_gm_to_ub<...>", src_ptr, dst_ptr,
+ *               strideN, validRow, validCol, [physRow], physCol)
+ * and the element-wise / reduce ops are plain tl.ascend_* calls whose `count`
+ * argument spans the whole physical tile.
+ *
+ * This pass tracks, per UB data Var, the logical valid rectangle that was
+ * loaded, propagates it through the UB data flow, and when an op touches a tail
+ * buffer rewrites it to the internal tl.ascend_tail_* op (carrying the runtime
+ * valid_row/valid_col/physical_col) so the codegen emits a tl::ascend::tail_*
+ * helper that computes only over the valid region.
+ *
+ * Batch 1 rewrites: unary / binary / scalar(immediate) / reduce.
+ * Batch 1 propagates-but-does-not-rewrite: cast / broadcast / copy_ub_to_ub
+ * (they are per-lane or shape-only, so the full-tile path stays numerically
+ * correct; the mask still flows through to a downstream reduce).
+ */
+
+#include "arith/ir_mutator_with_analyzer.h"
+#include <tvm/tir/builtin.h>
+#include <tvm/tir/op.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "../op/ascend.h"
+#include "common/ascend_tail_mask.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+
+namespace {
+
+/*! \brief Return the buffer data Var behind an access_ptr (or a bare Var). */
+const VarNode *GetPtrVar(const PrimExpr &e) {
+  if (const auto *call = e.as<CallNode>()) {
+    if (call->op.same_as(builtin::tvm_access_ptr()) && call->args.size() >= 2) {
+      return call->args[1].as<VarNode>();
+    }
+  }
+  return e.as<VarNode>();
+}
+
+/*! \brief Map a plain binary tl op to its AscendC op tag, or "" if not one. */
+std::string BinaryTag(const CallNode *call) {
+  if (call->op.same_as(ascend_add()))
+    return "Add";
+  if (call->op.same_as(ascend_sub()))
+    return "Sub";
+  if (call->op.same_as(ascend_mul()))
+    return "Mul";
+  if (call->op.same_as(ascend_div()))
+    return "Div";
+  if (call->op.same_as(ascend_max()))
+    return "Max";
+  if (call->op.same_as(ascend_min()))
+    return "Min";
+  // bitwise And/Or are type-restricted (int16 only); keep them on the
+  // full-tile path (still correct, per-lane).
+  return "";
+}
+
+/*! \brief Map a plain unary tl op to its AscendC op tag, or "" if not one. */
+std::string UnaryTag(const CallNode *call) {
+  if (call->op.same_as(ascend_exp()))
+    return "Exp";
+  if (call->op.same_as(ascend_ln()))
+    return "Ln";
+  if (call->op.same_as(ascend_abs()))
+    return "Abs";
+  if (call->op.same_as(ascend_reciprocal()))
+    return "Reciprocal";
+  if (call->op.same_as(ascend_sqrt()))
+    return "Sqrt";
+  if (call->op.same_as(ascend_rsqrt()))
+    return "Rsqrt";
+  if (call->op.same_as(ascend_relu()))
+    return "Relu";
+  // bitwise Not is int-only; keep it on the full-tile path.
+  return "";
+}
+
+/*! \brief Map a plain scalar tl op (immediate form) to its AscendC op tag. */
+std::string ScalarTag(const CallNode *call) {
+  if (call->op.same_as(ascend_adds()))
+    return "Adds";
+  if (call->op.same_as(ascend_muls()))
+    return "Muls";
+  if (call->op.same_as(ascend_maxs()))
+    return "Maxs";
+  if (call->op.same_as(ascend_mins()))
+    return "Mins";
+  return "";
+}
+
+/*! \brief Extract the external helper name from a call_extern's first arg. */
+std::string ExternName(const CallNode *call) {
+  if (!call->op.same_as(builtin::call_extern()))
+    return "";
+  if (call->args.empty())
+    return "";
+  if (const auto *s = call->args[0].as<StringImmNode>())
+    return s->value;
+  return "";
+}
+
+} // namespace
+
+class AscendTailMaskPropagator : public arith::IRMutatorWithAnalyzer {
+public:
+  static PrimFunc Substitute(PrimFunc f, bool rewrite_reduce) {
+    arith::Analyzer analyzer;
+    AscendTailMaskPropagator m(&analyzer, rewrite_reduce);
+    f.CopyOnWrite()->body = m.VisitStmt(f->body);
+    return f;
+  }
+
+  AscendTailMaskPropagator(arith::Analyzer *analyzer, bool rewrite_reduce)
+      : arith::IRMutatorWithAnalyzer(analyzer),
+        rewrite_reduce_(rewrite_reduce) {}
+
+private:
+  // Per UB data Var -> current valid region. Absent => full (untracked).
+  std::unordered_map<const VarNode *, TailMaskInfo> state_;
+  // Whether reduce ops may be rewritten to tail_reduce. Disabled for the PTO
+  // backend, whose reduce codegen handles valid shapes natively.
+  bool rewrite_reduce_ = true;
+
+  // --- loop-variable scope tracking ---------------------------------------
+  // A valid_row/valid_col expression seeded inside a loop may reference the
+  // loop variable (e.g. copy_gm_to_ub in `for by` sets valid_col = f(by)).  If
+  // a downstream op (e.g. reduce) runs *outside* that loop, emitting the
+  // expression verbatim produces an undeclared-identifier compile error.  We
+  // track all loop vars ever entered (all_loop_vars_) and those currently in
+  // scope (active_loop_vars_); an expression referencing a loop var that is no
+  // longer in scope is "out of scope" and the rewrite must bail.
+  std::unordered_set<const VarNode *> all_loop_vars_;
+  std::unordered_set<const VarNode *> active_loop_vars_;
+
+  bool HasOutOfScopeLoopVar(const PrimExpr &e) const {
+    bool found = false;
+    PostOrderVisit(e, [&](const ObjectRef &n) {
+      if (const auto *v = n.as<VarNode>()) {
+        if (all_loop_vars_.count(v) && !active_loop_vars_.count(v))
+          found = true;
+      }
+    });
+    return found;
+  }
+
+  // --- conservative guards -------------------------------------------------
+  // Only float-like dtypes have validated tail helpers; int/uint stay on the
+  // full-tile path to avoid unsupported AscendC intrinsic instantiations.
+  static bool SupportedTailDtype(DataType dt) {
+    return dt.is_float() || dt.is_bfloat16();
+  }
+  // Element dtype behind an access_ptr (mirrors GetAccessPtrDtype in codegen).
+  static DataType PtrDtype(const PrimExpr &e) {
+    const auto *ap = e.as<CallNode>();
+    if (ap == nullptr || ap->args.empty())
+      return DataType::Handle();
+    if (const auto *c = ap->args[0].as<CallNode>())
+      return c->dtype;
+    return DataType::Handle();
+  }
+  // Element count (extent) behind an access_ptr.
+  static PrimExpr PtrExtent(const PrimExpr &e) {
+    if (const auto *ap = e.as<CallNode>())
+      if (ap->op.same_as(builtin::tvm_access_ptr()) && ap->args.size() >= 4)
+        return ap->args[3];
+    return PrimExpr();
+  }
+  // The 2D tail model only holds when the op's element count equals the
+  // physical tile (physical_row * physical_col). For 3D / mismatched tiles the
+  // rewrite would compute the wrong region, so we bail to the full-tile path.
+  bool CleanTail(const PrimExpr &count, const TailMaskInfo &m) {
+    return m.is_tail() && m.physical_row.defined() &&
+           m.physical_col.defined() && count.defined() &&
+           analyzer_->CanProveEqual(count, m.physical_row * m.physical_col);
+  }
+
+  // Detect a broadcast-scalar tail mask: valid_col is a compile-time constant 1
+  // while physical_col > 1. This happens when a 1D scalar (e.g. a per-channel
+  // scale[bn]) is copied into a multi-element UB tile whose downstream op
+  // broadcasts it across the full physical width. The valid_col=1 is correct
+  // for the *copy* (only one scalar element exists), but rewriting the
+  // downstream op to a tail helper with valid_col=1 would compute only one
+  // element instead of the full broadcast -- so bail and let the full-tile path
+  // (which reads the pad-filled gap) handle it.
+  bool IsBroadcastScalarMask(const TailMaskInfo &m) const {
+    if (!m.physical_col.defined())
+      return false;
+    auto *pcol = m.physical_col.as<IntImmNode>();
+    if (pcol == nullptr || pcol->value <= 1)
+      return false;
+    // valid_col may be a Min(...) expr; use the analyzer to prove it equals 1.
+    if (!m.valid_col.defined())
+      return false;
+    if (analyzer_->CanProveEqual(m.valid_col, 1))
+      return true;
+    return false;
+  }
+
+  TailMaskInfo GetMask(const VarNode *v) const {
+    if (v == nullptr)
+      return TailMaskInfo{};
+    auto it = state_.find(v);
+    return it == state_.end() ? TailMaskInfo{} : it->second;
+  }
+
+  Stmt VisitStmt_(const EvaluateNode *op) final {
+    const auto *call = op->value.as<CallNode>();
+    if (call == nullptr)
+      return arith::IRMutatorWithAnalyzer::VisitStmt_(op);
+
+    // --- GM->UB copy: seed the destination's valid region. -----------------
+    std::string ext = ExternName(call);
+    if (ext.find("copy_gm_to_ub") != std::string::npos) {
+      HandleGmToUbCopy(call);
+      return GetRef<Stmt>(op);
+    }
+    // --- UB->UB copy: inherit the source's valid region. -------------------
+    if (ext.find("copy_ub_to_ub") != std::string::npos) {
+      if (call->args.size() >= 3) {
+        const VarNode *src_v = GetPtrVar(call->args[1]);
+        const VarNode *dst_v = GetPtrVar(call->args[2]);
+        if (dst_v != nullptr)
+          state_[dst_v] = GetMask(src_v);
+      }
+      return GetRef<Stmt>(op);
+    }
+    // copy_ub_to_gm and other copies are sinks: nothing to propagate.
+    if (ext.find("copy_") != std::string::npos)
+      return GetRef<Stmt>(op);
+
+    // --- Vector ops. -------------------------------------------------------
+    if (Stmt rewritten = TryRewriteVectorOp(call); rewritten.defined())
+      return rewritten;
+
+    return GetRef<Stmt>(op);
+  }
+
+  Stmt VisitStmt_(const ForNode *op) final {
+    all_loop_vars_.insert(op->loop_var.get());
+    active_loop_vars_.insert(op->loop_var.get());
+    Stmt s = arith::IRMutatorWithAnalyzer::VisitStmt_(op);
+    active_loop_vars_.erase(op->loop_var.get());
+    return s;
+  }
+
+  void HandleGmToUbCopy(const CallNode *call) {
+    // args: name(0) src_ptr(1) dst_ptr(2) strideN(3) validRow(4) validCol(5)
+    //       pad_val(6) [physRow(7) physCol(8)]   (physRow omitted for 1D tiles;
+    //       pad_val is always present in the hybrid scheme)
+    if (call->args.size() < 7)
+      return;
+    const VarNode *dst_v = GetPtrVar(call->args[2]);
+    if (dst_v == nullptr)
+      return;
+    PrimExpr valid_row = call->args[4];
+    PrimExpr valid_col = call->args[5];
+    PrimExpr phys_row, phys_col;
+    if (call->args.size() >= 9) {
+      phys_row = call->args[7];
+      phys_col = call->args[8];
+    } else if (call->args.size() == 8) {
+      phys_row = IntImm(DataType::Int(32), 1);
+      phys_col = call->args[7];
+    } else {
+      return;
+    }
+    state_[dst_v] =
+        MakeCopyMask(valid_row, valid_col, phys_row, phys_col, analyzer_);
+  }
+
+  // Returns a rewritten Stmt, or an undefined Stmt to keep the original.
+  Stmt TryRewriteVectorOp(const CallNode *call) {
+    // Binary: dst(0) src0(1) src1(2) count(3)
+    if (std::string tag = BinaryTag(call); !tag.empty())
+      return RewriteBinary(call, tag);
+    // Unary: dst(0) src(1) count(2)
+    if (std::string tag = UnaryTag(call); !tag.empty())
+      return RewriteUnary(call, tag);
+    // Scalar (immediate): dst(0) src(1) scalar(2) count(3)
+    if (std::string tag = ScalarTag(call); !tag.empty())
+      return RewriteScalar(call, tag);
+    // Reduce: name(0) out(1) src(2) tmp(3) clear(4)
+    if (call->op.same_as(ascend_reduce()))
+      return RewriteReduce(call);
+    // Cast: dst(0) src(1) roundmode(2) count(3) -- propagate only.
+    if (call->op.same_as(ascend_cast())) {
+      PropagateUnaryShape(call->args[0], call->args[1]);
+      return Stmt();
+    }
+    // Broadcast: name(0) dst(1) src(2) tmp(3) dim(4) dstShape... srcShape...
+    if (call->op.same_as(ascend_broadcast())) {
+      PropagateBroadcast(call);
+      return Stmt();
+    }
+    return Stmt();
+  }
+
+  // dst inherits src's rectangle (used for cast / unrewritten unary shapes).
+  void PropagateUnaryShape(const PrimExpr &dst_ptr, const PrimExpr &src_ptr) {
+    const VarNode *dst_v = GetPtrVar(dst_ptr);
+    if (dst_v != nullptr)
+      state_[dst_v] = GetMask(GetPtrVar(src_ptr));
+  }
+
+  Stmt RewriteUnary(const CallNode *call, const std::string &tag) {
+    if (call->args.size() < 3)
+      return Stmt();
+    const VarNode *dst_v = GetPtrVar(call->args[0]);
+    TailMaskInfo in = GetMask(GetPtrVar(call->args[1]));
+    bool ok = CleanTail(call->args[2], in) &&
+              SupportedTailDtype(PtrDtype(call->args[0])) &&
+              !HasOutOfScopeLoopVar(in.valid_row) &&
+              !HasOutOfScopeLoopVar(in.valid_col) && !IsBroadcastScalarMask(in);
+    if (dst_v != nullptr)
+      state_[dst_v] = ok ? in : TailMaskInfo{};
+    if (!ok)
+      return Stmt();
+    Array<PrimExpr> a = {StringImm(tag), call->args[0], call->args[1],
+                         in.valid_row,   in.valid_col,  in.physical_col};
+    return Evaluate(Call(DataType::Handle(), ascend_tail_unary(), a));
+  }
+
+  Stmt RewriteBinary(const CallNode *call, const std::string &tag) {
+    if (call->args.size() < 4)
+      return Stmt();
+    const VarNode *dst_v = GetPtrVar(call->args[0]);
+    TailMaskInfo lhs = GetMask(GetPtrVar(call->args[1]));
+    TailMaskInfo rhs = GetMask(GetPtrVar(call->args[2]));
+    TailMaskInfo out = IntersectMasks(lhs, rhs, analyzer_);
+    bool ok = CleanTail(call->args[3], out) &&
+              SupportedTailDtype(PtrDtype(call->args[0])) &&
+              !HasOutOfScopeLoopVar(out.valid_row) &&
+              !HasOutOfScopeLoopVar(out.valid_col) &&
+              !IsBroadcastScalarMask(out);
+    if (dst_v != nullptr)
+      state_[dst_v] = ok ? out : TailMaskInfo{};
+    if (!ok)
+      return Stmt();
+    Array<PrimExpr> a = {StringImm(tag),  call->args[0], call->args[1],
+                         call->args[2],   out.valid_row, out.valid_col,
+                         out.physical_col};
+    return Evaluate(Call(DataType::Handle(), ascend_tail_binary(), a));
+  }
+
+  Stmt RewriteScalar(const CallNode *call, const std::string &tag) {
+    if (call->args.size() < 4)
+      return Stmt();
+    // Only the immediate-scalar form (args[2] is a scalar expr, not a pointer)
+    // is rewritten; the "load scalar from buffer" form keeps the full path.
+    if (GetPtrVar(call->args[2]) != nullptr)
+      return Stmt();
+    const VarNode *dst_v = GetPtrVar(call->args[0]);
+    TailMaskInfo in = GetMask(GetPtrVar(call->args[1]));
+    bool ok = CleanTail(call->args[3], in) &&
+              SupportedTailDtype(PtrDtype(call->args[0])) &&
+              !HasOutOfScopeLoopVar(in.valid_row) &&
+              !HasOutOfScopeLoopVar(in.valid_col) && !IsBroadcastScalarMask(in);
+    if (dst_v != nullptr)
+      state_[dst_v] = ok ? in : TailMaskInfo{};
+    if (!ok)
+      return Stmt();
+    Array<PrimExpr> a = {StringImm(tag), call->args[0], call->args[1],
+                         call->args[2],  in.valid_row,  in.valid_col,
+                         in.physical_col};
+    return Evaluate(Call(DataType::Handle(), ascend_tail_scalar(), a));
+  }
+
+  Stmt RewriteReduce(const CallNode *call) {
+    // name(0) out(1) src(2) tmp(3) clear(4)
+    if (call->args.size() < 5)
+      return Stmt();
+    const auto *name = call->args[0].as<StringImmNode>();
+    if (name == nullptr)
+      return Stmt();
+    std::string reduce_tag = name->value; // e.g. reduce_sum<...>
+    std::string kind = reduce_tag.substr(0, reduce_tag.find('<')); // reduce_sum
+    int raw_dim = ParseReduceDim(reduce_tag);
+    // Normalize to 0 (reduce rows) or -1 (reduce last axis). For 2D tiles
+    // axis 0/-2 reduce rows and axis 1/-1 reduce columns.
+    int dim = (raw_dim == 0 || raw_dim == -2) ? 0 : -1;
+
+    const VarNode *out_v = GetPtrVar(call->args[1]);
+    TailMaskInfo in = GetMask(GetPtrVar(call->args[2]));
+
+    // Reduce is rewritten to a valid-region tail_reduce (which needs no pad)
+    // only on the AscendC backend, for a clean 2D float tile. On PTO, or for
+    // 3D / int tiles, it stays the native reduce over the pad-filled tile.
+    // The valid_row/valid_col must also not reference loop vars that have
+    // already gone out of scope (e.g. a copy seeded inside `for by` whose
+    // valid_col = f(by), but the reduce runs outside the loop).
+    bool ok = rewrite_reduce_ && CleanTail(PtrExtent(call->args[2]), in) &&
+              SupportedTailDtype(PtrDtype(call->args[2])) &&
+              !HasOutOfScopeLoopVar(in.valid_row) &&
+              !HasOutOfScopeLoopVar(in.valid_col) && !IsBroadcastScalarMask(in);
+
+    // Output rectangle for downstream propagation (only when rewriting).
+    TailMaskInfo out;
+    if (ok) {
+      out.kind = TailMaskKind::kTail;
+      if (dim == 0) {
+        out.valid_row = IntImm(DataType::Int(32), 1);
+        out.valid_col = in.valid_col;
+        out.physical_row = IntImm(DataType::Int(32), 1);
+        out.physical_col = in.physical_col;
+      } else { // dim == -1 (reduce last axis) -> column vector
+        out.valid_row = in.valid_row;
+        out.valid_col = IntImm(DataType::Int(32), 1);
+        out.physical_row = in.physical_row;
+        out.physical_col = IntImm(DataType::Int(32), 1);
+      }
+      out.storage_col = out.physical_col;
+    }
+    if (out_v != nullptr)
+      state_[out_v] = out;
+
+    if (!ok)
+      return Stmt();
+
+    // tail_reduce: kind(0) out(1) src(2) tmp(3) dim(4)
+    //              valid_row(5) valid_col(6) phys_col(7) clear(8)
+    Array<PrimExpr> a = {StringImm(kind),
+                         call->args[1],
+                         call->args[2],
+                         call->args[3],
+                         IntImm(DataType::Int(32), dim),
+                         in.valid_row,
+                         in.valid_col,
+                         in.physical_col,
+                         call->args[4]};
+    return Evaluate(Call(DataType::Handle(), ascend_tail_reduce(), a));
+  }
+
+  void PropagateBroadcast(const CallNode *call) {
+    // name(0) dst(1) src(2) tmp(3) dim(4) dstShape[dim] srcShape[dim]
+    if (call->args.size() < 5)
+      return;
+    const VarNode *dst_v = GetPtrVar(call->args[1]);
+    if (dst_v == nullptr)
+      return;
+    TailMaskInfo in = GetMask(GetPtrVar(call->args[2]));
+    const auto *dim_imm = call->args[4].as<IntImmNode>();
+    if (!in.is_tail() || dim_imm == nullptr || dim_imm->value != 2) {
+      state_[dst_v] = in; // 1D / untracked: pass through
+      return;
+    }
+    // 2D broadcast. dstShape = args[5],args[6]; srcShape = args[7],args[8].
+    if (call->args.size() < 9) {
+      state_[dst_v] = in;
+      return;
+    }
+    PrimExpr dst_rows = call->args[5];
+    PrimExpr dst_cols = call->args[6];
+    PrimExpr src_rows = call->args[7];
+    PrimExpr src_cols = call->args[8];
+    TailMaskInfo out;
+    out.kind = TailMaskKind::kTail;
+    out.physical_row = dst_rows;
+    out.physical_col = dst_cols;
+    out.storage_col = dst_cols;
+    if (is_one(src_cols)) {
+      // [M,1] -> [M,N]: row tail carries, all columns become valid.
+      out.valid_row = in.valid_row;
+      out.valid_col = dst_cols;
+    } else if (is_one(src_rows)) {
+      // [1,N] -> [M,N]: column tail carries, all rows become valid.
+      out.valid_row = dst_rows;
+      out.valid_col = in.valid_col;
+    } else {
+      out = in;
+    }
+    state_[dst_v] = out;
+  }
+
+  static int ParseReduceDim(const std::string &tag) {
+    // tag like "reduce_sum<float, 16, 32, -1>"; dim is the last template field.
+    size_t lt = tag.find('<');
+    size_t gt = tag.rfind('>');
+    if (lt == std::string::npos || gt == std::string::npos || gt <= lt)
+      return -1;
+    std::string inner = tag.substr(lt + 1, gt - lt - 1);
+    size_t comma = inner.rfind(',');
+    std::string dim_str =
+        comma == std::string::npos ? inner : inner.substr(comma + 1);
+    try {
+      return std::stoi(dim_str);
+    } catch (...) {
+      return -1;
+    }
+  }
+};
+
+// Opt-in switch for the tail-block valid-region scheme. Must be registered so
+// PassContext accepts it as a config option (default off).
+static constexpr const char *kAscendTailMask = "tl.ascend_tail_mask";
+TVM_REGISTER_PASS_CONFIG_OPTION(kAscendTailMask, Bool);
+
+namespace transform {
+
+using namespace tir::transform;
+
+tvm::transform::Pass AscendTailMaskPropagation(bool rewrite_reduce) {
+  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+    // Opt-in: the tail-block scheme is off unless TL_ASCEND_TAIL_MASK is set,
+    // so non-tail kernels are left untouched.
+    bool ascend_tail_mask =
+        ctx->GetConfig<Bool>(kAscendTailMask, Bool(false)).value();
+    if (!ascend_tail_mask) {
+      return f;
+    }
+    return AscendTailMaskPropagator::Substitute(std::move(f), rewrite_reduce);
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.AscendTailMaskPropagation", {});
+}
+
+TVM_REGISTER_GLOBAL("tl.transform.AscendTailMaskPropagation")
+    .set_body_typed(AscendTailMaskPropagation);
+} // namespace transform
+
+} // namespace tl
+} // namespace tvm

--- a/src/transform/ascend_workspace_reduction.cc
+++ b/src/transform/ascend_workspace_reduction.cc
@@ -730,7 +730,8 @@ private:
       args.push_back(IntImm(DataType::Int(32), 0));
       args.push_back(IntImm(DataType::Int(32), 0));
     } else if (buffer_scope == DstBufferScope::Ub) {
-      // copy_gm_to_ub: add maskShapeM, maskShapeN, padValue=0
+      // copy_gm_to_ub: add maskShapeM, maskShapeN, padValue=0 (full workspace
+      // shape, never a tail).
       // ws_info.shapes = [M, N] (workspace shape, M includes vector_cnt)
       // Template params: dstN=N, dstM=M/vector_cnt (from reversed shapes)
       // So maskShapeM=M/vector_cnt, maskShapeN=N

--- a/src/transform/common/ascend_tail_mask.h
+++ b/src/transform/common/ascend_tail_mask.h
@@ -1,0 +1,145 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+
+/*!
+ * \file src/transform/common/ascend_tail_mask.h
+ * \brief Shared data model for the AscendC vector tail-block scheme.
+ *
+ * Background: on the AscendC backend a GM->UB copy may load a *tail* block that
+ * is smaller than the physical UB tile.  After removing the front-end
+ * `pad_value`, the unused UB region is left untouched (garbage), so any op that
+ * mixes the gap into a valid lane (cross-lane reductions in particular) must be
+ * told the real valid extent.  AscendTailMaskPropagation tracks, per UB buffer,
+ * the logical valid rectangle and the physical tile pitch, and rewrites the
+ * affected vector ops to tail-aware variants.
+ *
+ * This header only carries the data model; it is intentionally light so it can
+ * be shared between the pass and (future) consumers without pulling in heavy
+ * dependencies.
+ */
+#ifndef TVM_TL_TRANSFORM_COMMON_ASCEND_TAIL_MASK_H_
+#define TVM_TL_TRANSFORM_COMMON_ASCEND_TAIL_MASK_H_
+
+#include <tvm/arith/analyzer.h>
+#include <tvm/tir/expr.h>
+#include <tvm/tir/op.h>
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+
+/*! \brief What kind of valid-region a UB buffer currently carries. */
+enum class TailMaskKind {
+  /*! \brief Whole physical tile is valid (statically full -> never rewritten).
+   */
+  kFull = 0,
+  /*! \brief A regular 2D rectangle [valid_row, valid_col] inside the tile. */
+  kTail = 1,
+  /*! \brief Packed comparison mask (Batch 2: compare/select). */
+  kPackedCmp = 2,
+};
+
+/*!
+ * \brief Logical valid region plus physical pitch of a UB tile.
+ *
+ *  - `valid_row` / `valid_col` describe the logically-valid rectangle. They may
+ *    be dynamic (a `Select(...)` over the block index), which is exactly why
+ * the rewrite produces a *runtime* tail helper instead of a compile-time shape.
+ *  - `physical_row` / `physical_col` are the allocated UB tile dims;
+ * `physical_col` is the row pitch used to derive repeat strides.
+ *  - `storage_col` is reserved for packed comparison masks (Batch 2).
+ */
+struct TailMaskInfo {
+  TailMaskKind kind = TailMaskKind::kFull;
+  PrimExpr valid_row;
+  PrimExpr valid_col;
+  PrimExpr physical_row;
+  PrimExpr physical_col;
+  PrimExpr storage_col;
+
+  bool is_tail() const { return kind == TailMaskKind::kTail; }
+};
+
+/*! \brief A fully-valid mask for a tile of the given physical dims. */
+inline TailMaskInfo MakeFullMask(PrimExpr physical_row, PrimExpr physical_col) {
+  TailMaskInfo m;
+  m.kind = TailMaskKind::kFull;
+  m.valid_row = physical_row;
+  m.valid_col = physical_col;
+  m.physical_row = physical_row;
+  m.physical_col = physical_col;
+  m.storage_col = physical_col;
+  return m;
+}
+
+/*!
+ * \brief Decide whether a (valid_row,valid_col) vs (physical_row,physical_col)
+ *        pair is statically a full tile. When both extents are constants equal
+ *        to the physical dims the buffer is full and must NOT be rewritten, so
+ *        non-tail kernels keep generating identical code.
+ */
+inline bool IsStaticallyFull(const PrimExpr &valid_row,
+                             const PrimExpr &valid_col,
+                             const PrimExpr &physical_row,
+                             const PrimExpr &physical_col,
+                             arith::Analyzer *analyzer) {
+  return analyzer->CanProveEqual(valid_row, physical_row) &&
+         analyzer->CanProveEqual(valid_col, physical_col);
+}
+
+/*!
+ * \brief Build a tail mask from a copy's valid/physical extents. If statically
+ *        full, returns a kFull mask so downstream ops are left untouched.
+ */
+inline TailMaskInfo MakeCopyMask(PrimExpr valid_row, PrimExpr valid_col,
+                                 PrimExpr physical_row, PrimExpr physical_col,
+                                 arith::Analyzer *analyzer) {
+  if (IsStaticallyFull(valid_row, valid_col, physical_row, physical_col,
+                       analyzer)) {
+    return MakeFullMask(physical_row, physical_col);
+  }
+  TailMaskInfo m;
+  m.kind = TailMaskKind::kTail;
+  m.valid_row = valid_row;
+  m.valid_col = valid_col;
+  m.physical_row = physical_row;
+  m.physical_col = physical_col;
+  m.storage_col = physical_col;
+  return m;
+}
+
+/*!
+ * \brief Intersection of two operand masks (used for binary ops). The result is
+ *        tail iff either input is tail; valid extents are the element-wise min,
+ *        and the physical pitch is taken from the first tail operand.
+ *
+ *  NB: the repeat-plan assumes both operands (and the dst) share the same
+ *  physical pitch. When they differ the tail helper falls back to a per-row
+ *  loop, so a mismatch is a perf concern, not a correctness one.
+ */
+inline TailMaskInfo IntersectMasks(const TailMaskInfo &a, const TailMaskInfo &b,
+                                   arith::Analyzer *analyzer) {
+  if (!a.is_tail() && !b.is_tail()) {
+    return a.kind == TailMaskKind::kFull ? a : b;
+  }
+  const TailMaskInfo &base = a.is_tail() ? a : b;
+  TailMaskInfo m = base;
+  m.kind = TailMaskKind::kTail;
+  if (a.valid_row.defined() && b.valid_row.defined()) {
+    m.valid_row = analyzer->CanProveEqual(a.valid_row, b.valid_row)
+                      ? a.valid_row
+                      : Min(a.valid_row, b.valid_row);
+  }
+  if (a.valid_col.defined() && b.valid_col.defined()) {
+    m.valid_col = analyzer->CanProveEqual(a.valid_col, b.valid_col)
+                      ? a.valid_col
+                      : Min(a.valid_col, b.valid_col);
+  }
+  return m;
+}
+
+} // namespace tl
+} // namespace tvm
+
+#endif // TVM_TL_TRANSFORM_COMMON_ASCEND_TAIL_MASK_H_

--- a/src/transform/common/operation_config.h
+++ b/src/transform/common/operation_config.h
@@ -277,6 +277,15 @@ GetOperationConfig() {
        {{{1, "write"}, {2, "read"}, {3, "read"}}, "PIPE_V"}},
       {"tl.ascend_row_expand_div_experiment",
        {{{1, "write"}, {2, "read"}, {3, "read"}}, "PIPE_V"}},
+
+      // Internal tail-aware ops (AscendTailMaskPropagation). arg0 is the
+      // AscendC op-tag string, hence buffer indices start at 1.
+      {"tl.ascend_tail_unary", {{{1, "write"}, {2, "read"}}, "PIPE_V"}},
+      {"tl.ascend_tail_binary",
+       {{{1, "write"}, {2, "read"}, {3, "read"}}, "PIPE_V"}},
+      {"tl.ascend_tail_scalar", {{{1, "write"}, {2, "read"}}, "PIPE_V"}},
+      {"tl.ascend_tail_reduce",
+       {{{1, "write"}, {2, "read"}, {3, "read"}}, "PIPE_V"}},
   };
 
   return operation_config_;

--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -70,6 +70,19 @@ VEC_PASS_CONFIGS = {
 }
 
 
+def _vec_configs(tail_mask):
+    """Vector pass configs, optionally enabling the opt-in tail-block scheme.
+
+    Every vector tail case is run twice (see the ``tail_mask`` parametrize):
+      * ``tail_mask=False`` -> the existing path (manual pad_value / ub2gm
+        re-clamp / real_shape), i.e. the behaviour these tests already guarded.
+      * ``tail_mask=True``  -> additionally exercises AscendTailMaskPropagation,
+        so the same kernel + reference also covers the new valid-region rewrite
+        (unary/binary/scalar). The result must match either way.
+    """
+    return {**VEC_PASS_CONFIGS, tilelang.PassConfigKey.TL_ASCEND_TAIL_MASK: tail_mask}
+
+
 @pytest.fixture(scope="session", autouse=True)
 def clear_cache():
     """Clear tilelang cache before the session."""
@@ -178,10 +191,10 @@ def vec_add_tail(M, N, block_M, block_N, dtype="float"):
     return main
 
 
-def run_test_vec_add_tail(M, N, block_M, block_N, dtype, target):
+def run_test_vec_add_tail(M, N, block_M, block_N, dtype, target, tail_mask):
     torch.manual_seed(0)
     func = vec_add_tail(M, N, block_M, block_N, dtype)
-    func = tilelang.compile(func, out_idx=[-1], pass_configs=VEC_PASS_CONFIGS, target=target)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=_vec_configs(tail_mask), target=target)
 
     td = _torch_dtype(dtype)
     a = torch.randn(M, N, dtype=td).npu()
@@ -220,10 +233,10 @@ def vec_abs_tail(M, N, block_M, block_N, dtype="float"):
     return main
 
 
-def run_test_vec_abs_tail(M, N, block_M, block_N, dtype, target):
+def run_test_vec_abs_tail(M, N, block_M, block_N, dtype, target, tail_mask):
     torch.manual_seed(0)
     func = vec_abs_tail(M, N, block_M, block_N, dtype)
-    func = tilelang.compile(func, out_idx=[-1], pass_configs=VEC_PASS_CONFIGS, target=target)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=_vec_configs(tail_mask), target=target)
 
     td = _torch_dtype(dtype)
     a = torch.randn(M, N, dtype=td).npu()
@@ -249,18 +262,20 @@ vec_tail_configs = [
 ]
 
 
+@pytest.mark.parametrize("tail_mask", [False, True])
 @pytest.mark.parametrize("dtype", ["float", "float16"])
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
 @pytest.mark.parametrize("M,N,block_M,block_N", vec_tail_configs)
-def test_vec_add_tail(M, N, block_M, block_N, dtype, target):
-    run_test_vec_add_tail(M, N, block_M, block_N, dtype, target=target)
+def test_vec_add_tail(M, N, block_M, block_N, dtype, target, tail_mask):
+    run_test_vec_add_tail(M, N, block_M, block_N, dtype, target=target, tail_mask=tail_mask)
 
 
+@pytest.mark.parametrize("tail_mask", [False, True])
 @pytest.mark.parametrize("dtype", ["float", "float16"])
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
 @pytest.mark.parametrize("M,N,block_M,block_N", vec_tail_configs)
-def test_vec_abs_tail(M, N, block_M, block_N, dtype, target):
-    run_test_vec_abs_tail(M, N, block_M, block_N, dtype, target=target)
+def test_vec_abs_tail(M, N, block_M, block_N, dtype, target, tail_mask):
+    run_test_vec_abs_tail(M, N, block_M, block_N, dtype, target=target, tail_mask=tail_mask)
 
 
 # =============================================================================
@@ -294,10 +309,10 @@ def reduce_max_tail(rows_valid, rows_phys, cols, dtype="float"):
     return main
 
 
-def run_test_reduce_max_tail(rows_valid, rows_phys, cols, dtype, target):
+def run_test_reduce_max_tail(rows_valid, rows_phys, cols, dtype, target, tail_mask):
     torch.manual_seed(0)
     func = reduce_max_tail(rows_valid, rows_phys, cols, dtype)
-    func = tilelang.compile(func, out_idx=[-1], pass_configs=VEC_PASS_CONFIGS, target=target)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=_vec_configs(tail_mask), target=target)
 
     td = _torch_dtype(dtype)
     a = torch.randn(rows_phys, cols, dtype=td).npu()
@@ -319,11 +334,14 @@ reduce_tail_configs = [
 ]
 
 
+# tail_mask=True also asserts that enabling the switch does not disturb the
+# real_shape reduce (reduce is not rewritten while rewrite_reduce=False).
+@pytest.mark.parametrize("tail_mask", [False, True])
 @pytest.mark.parametrize("dtype", ["float"])
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
 @pytest.mark.parametrize("rows_valid,rows_phys,cols", reduce_tail_configs)
-def test_reduce_max_tail(rows_valid, rows_phys, cols, dtype, target):
-    run_test_reduce_max_tail(rows_valid, rows_phys, cols, dtype, target=target)
+def test_reduce_max_tail(rows_valid, rows_phys, cols, dtype, target, tail_mask):
+    run_test_reduce_max_tail(rows_valid, rows_phys, cols, dtype, target=target, tail_mask=tail_mask)
 
 
 # =============================================================================

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -1,0 +1,183 @@
+"""Codegen-level checks for the AscendC vector tail-block scheme.
+
+These tests only inspect the generated kernel source (host-side codegen), so
+they do not require NPU hardware to *run* the kernel -- only a built tilelang
+with the Ascend codegen. They verify that:
+
+  * a kernel with a real tail (M and/or N not divisible by the block) emits the
+    internal ``tl::ascend::tail_*`` helpers, and
+  * the removed ``pad_value`` path (the UB gap-fill ``Duplicate``) is gone, i.e.
+    ``T.copy`` no longer carries a pad argument.
+"""
+
+import pytest
+
+import tilelang
+import tilelang.language as T
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    # Enable the opt-in tail-block scheme (default off) so the tail_* helpers
+    # are actually emitted for these tests.
+    tilelang.PassConfigKey.TL_ASCEND_TAIL_MASK: True,
+}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    tilelang.cache.clear_cache()
+    yield
+
+
+def _tail_add(M, N, block_M, block_N, dtype="float"):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, N), dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+            b_ub = T.alloc_ub((block_M, block_N), dtype)
+            c_ub = T.alloc_ub((block_M, block_N), dtype)
+            T.copy(A[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N], a_ub)
+            T.copy(B[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N], b_ub)
+            T.tile.add(c_ub, a_ub, b_ub)
+            T.copy(c_ub, C[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N])
+
+    return main
+
+
+def _tail_reduce(M, N, block_M, block_N, dtype="float"):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, block_N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+            r_ub = T.alloc_ub((block_M, 1), dtype)
+            T.copy(A[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N], a_ub)
+            T.reduce_sum(a_ub, r_ub, dim=-1)
+            T.copy(r_ub, B[bx * block_M : (bx + 1) * block_M, by : by + 1])
+
+    return main
+
+
+def _tail_unary(M, N, block_M, block_N, dtype="float"):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+            b_ub = T.alloc_ub((block_M, block_N), dtype)
+            T.copy(A[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N], a_ub)
+            T.tile.exp(b_ub, a_ub)
+            T.copy(b_ub, B[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N])
+
+    return main
+
+
+def _tail_scalar(M, N, block_M, block_N, dtype="float"):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+            b_ub = T.alloc_ub((block_M, block_N), dtype)
+            T.copy(A[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N], a_ub)
+            T.tile.add(b_ub, a_ub, 2.0)  # scalar immediate -> adds -> tail_scalar
+            T.copy(b_ub, B[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N])
+
+    return main
+
+
+def _source(func, target="ascendc", tail_mask=True):
+    cfg = {**pass_configs, tilelang.PassConfigKey.TL_ASCEND_TAIL_MASK: tail_mask}
+    compiled = tilelang.compile(func, pass_configs=cfg, target=target)
+    return compiled.get_kernel_source()
+
+
+# Per-backend "a tail-aware op was emitted" marker. The two backends express the
+# valid-region compute differently in the generated source:
+#   * ascendc -> a call to the internal ``tl::ascend::tail_<kind>`` device helper
+#     (the mask/repeat/count ladder written in ascend/common.h).
+#   * pto     -> a ``TileUbDataND<..., pto::DYNAMIC, pto::DYNAMIC>`` dynamic tile.
+#     PTO reuses its native dynamic-tile op macros (TADD/TEXP/TADDS/...), so the
+#     tell-tale is the DYNAMIC valid-shape tile, which is emitted *only* by the
+#     tail unary/binary/scalar codegen (CreateUbVariableDynamic) and nowhere on
+#     the ordinary full-tile path.
+def _emit_marker(target, kind):
+    return f"tl::ascend::tail_{kind}" if target == "ascendc" else "pto::DYNAMIC"
+
+
+def _no_tail_marker(target):
+    # A substring that must be ABSENT when no op was rewritten to a tail variant.
+    return "tl::ascend::tail_" if target == "ascendc" else "pto::DYNAMIC"
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_tail_add_emits_tail_helper(target):
+    # 34x130 with 32x32 blocks => tail in both M and N.
+    src = _source(_tail_add(34, 130, 32, 32, "float"), target=target)
+    assert _emit_marker(target, "binary") in src, src
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_tail_unary_emits_tail_helper(target):
+    src = _source(_tail_unary(34, 130, 32, 32, "float"), target=target)
+    assert _emit_marker(target, "unary") in src, src
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_tail_scalar_emits_tail_helper(target):
+    src = _source(_tail_scalar(34, 130, 32, 32, "float"), target=target)
+    assert _emit_marker(target, "scalar") in src, src
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_tail_reduce_not_rewritten(target):
+    # reduce is currently NOT rewritten to a tail variant (rewrite_reduce=False):
+    # it stays on the full-tile + pad_value/real_shape path, so neither backend
+    # emits its tail marker for a reduce-only kernel.
+    src = _source(_tail_reduce(34, 130, 32, 32, "float"), target=target)
+    assert _no_tail_marker(target) not in src, src
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_flag_off_emits_no_tail_helper(target):
+    # Opt-in default: with the switch off the pass is a no-op, so a tail kernel
+    # generates the same full-tile ops as upstream (no tail variant at all).
+    src = _source(_tail_add(34, 130, 32, 32, "float"), target=target, tail_mask=False)
+    assert _no_tail_marker(target) not in src, src
+
+
+if __name__ == "__main__":
+    print(_source(_tail_add(34, 130, 32, 32, "float")))

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -68,6 +68,14 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.CollectBufferShapes()(mod)
     # Lower high-level tile operations to low-level operations
     mod = tilelang.transform.LowerTileOp()(mod)
+    # Propagate UB tail valid-regions and rewrite unary/binary/scalar ops to
+    # tail-aware variants (must run before passes that reorder copy/vector ops).
+    # The pass self-gates on TL_ASCEND_TAIL_MASK (default off) and is a no-op
+    # otherwise, so non-tail kernels are unaffected. Reduce is NOT rewritten for
+    # now (the tail_reduce ReduceSum<AR> path has an output-layout bug); it stays
+    # on the full-tile + pad_value path, revisited in batch 2 with
+    # compare/select/broadcast tail support.
+    mod = tilelang.transform.AscendTailMaskPropagation(rewrite_reduce=False)(mod)
     # Erase manual workspace allocations for virtual CV copy in Ascend
     mod = tilelang.transform.AscendWorkspaceReduction()(mod)
     # Legalize vectorized loops to ensure they are valid

--- a/tilelang/language/copy.py
+++ b/tilelang/language/copy.py
@@ -197,7 +197,7 @@ def npu_copy_v2(
     src: tir.Buffer | tir.BufferLoad | tir.BufferRegion,
     dst: tir.Buffer | tir.BufferLoad,
     enable_relu: bool = False,
-    transpose: bool | None = False,  # for copy_l1_to_l0 param: tranpose l1
+    transpose: bool | None = False,  # for copy_l1_to_l0 param: transpose l1
     pad_value: float | int | tir.PrimExpr | None = None,
 ):
     """Copy data between memory regions.
@@ -209,7 +209,10 @@ def npu_copy_v2(
         transpose (Optional[bool]): Whether to transpose for copy_l1_to_l0. Defaults to False.
         pad_value (Optional[Union[float, int, tir.PrimExpr]]): Value to fill in UB unused area.
             Supports float, int, tir.FloatImm, tir.IntImm, tir.PrimExpr (e.g., -T.infinity(dtype)).
-            Defaults to 0.
+            Defaults to 0. The gap fill ensures downstream reduce / broadcast / compare / select
+            ops (which read the full tile) observe a defined value; AscendTailMaskPropagation
+            additionally rewrites unary / binary / scalar ops to compute only over the valid
+            region so the pad value is preserved in the gap.
 
     Raises:
         TypeError: If copy extents cannot be deduced from arguments

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -438,6 +438,25 @@ def AscendWorkspaceReduction():
     return _ffi_api.AscendWorkspaceReduction()  # type: ignore
 
 
+def AscendTailMaskPropagation(rewrite_reduce: bool = True):
+    """Propagate UB tail valid-regions and rewrite vector ops to tail-aware
+    variants for the Ascend backend.
+
+    Parameters
+    ----------
+    rewrite_reduce : bool
+        Whether reduce ops may be rewritten to tail_reduce. Disabled for the PTO
+        backend, whose reduce codegen handles valid shapes natively.
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    ----
+    """
+    return _ffi_api.AscendTailMaskPropagation(rewrite_reduce)  # type: ignore
+
+
 def AscendInferBufferScope():
     """Infer Buffer Scope for Ascend.
 

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -7,6 +7,7 @@ from enum import Enum
 
 class PassConfigKey(str, Enum):
     """Pass configuration keys for TileLang compiler."""
+
     # TileLang specific configs
     TL_SIMPLIFY = "tl.Simplify"
     """Enable/disable TileLang simplification passes. Default: True"""
@@ -31,10 +32,10 @@ class PassConfigKey(str, Enum):
 
     TL_DEBUG_MERGE_SHARED_MEMORY_ALLOCATIONS = "tl.debug_merge_shared_memory_allocations"
     """Enable debug information for merge shared memory allocations. Default: False"""
-    
+
     TL_ASCEND_AUTO_SYNC = "tl.ascend_auto_sync"
     """Enable/disable TileLang AscendSyncInsert pass. Default: False"""
-    
+
     TL_ASCEND_MEMORY_PLANNING = "tl.ascend_memory_planning"
     """Enable/disable TileLang AscendMemoryPlanning pass. Default: False"""
 
@@ -42,7 +43,13 @@ class PassConfigKey(str, Enum):
     """Enable/disable TileLang CombineCV pass. Default: False"""
 
     TL_ASCEND_AUTO_CV_SYNC = "tl.ascend_auto_cross_core_sync"
-    """Enable/disable TileLang Auto CV Syncronization. Default: False"""
+    """Enable/disable TileLang Auto CV Synchronization. Default: False"""
+
+    TL_ASCEND_TAIL_MASK = "tl.ascend_tail_mask"
+    """Enable/disable the AscendC tail-block valid-region scheme
+    (AscendTailMaskPropagation): rewrites unary/binary/scalar ops on a UB tail
+    tile to compute only the valid region. Opt-in so non-tail kernels are
+    unaffected. Default: False"""
 
     # TIR related configs
     TIR_ENABLE_EQUIV_TERMS_IN_CSE = "tir.enable_equiv_terms_in_cse_tir"


### PR DESCRIPTION
## What
Replace the front-end `pad_value` tail handling on the AscendC backend with a
backend-internal "propagate valid shape + compute only the valid region"
mechanism, so `T.copy` matches upstream tilelang semantics.

`copy_gm_to_ub` records the valid `[row,col]` rect on the dst UB buffer → new
pass `AscendTailMaskPropagation` (after `LowerTileOp`) propagates it → vector ops
on a tail buffer are rewritten to `tl.ascend_tail_*` with runtime
valid_row/valid_col/physical_col → codegen emits `tl::ascend::tail_*` helpers
that compute only the valid rectangle.

## Scope (batch 1)
- Rewritten: unary / binary / scalar / reduce.
- Propagate-only (per-lane, still correct full-tile): cast / broadcast / ub→ub.
- Provably-full copies stay untouched (IRMutatorWithAnalyzer).
- Deferred to batch 2: compare/select (packed mask), broadcast rewrite.

## Validation
Draft — opening for CI signal (dev env has no Ascend toolchain/NPU).
- Host build ✅
- `examples/tail_mask/example_tail_add.py` (float/float16/100×200): ✅ on NPU
- reduce reworked to `Pattern::Reduce::AR` (re-verifying)
- `examples/softmax/example_online_softmax.py` (M=34/N=130 double tail): pending NPU