### PR TITLE
[BugFix] Fix the PTO backend generating unnecessary TFILLPAD_INPLACE when alig…

### DIFF
--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -1118,6 +1118,20 @@ FormatStrides(CodeGenTileLangAscendPto *codegen, const Array<PrimExpr> &shape,
 }
 
 std::string CodeGenTileLangAscendPto::GetPadEnum(const PrimExpr value) {
+  if (!value.defined()) {
+    return "pto::PadValue::Null";
+  }
+  if (const auto *int_value = value.as<IntImmNode>()) {
+    if (int_value->value == 0) {
+      return "pto::PadValue::Zero";
+    }
+  }
+  if (const auto *float_value = value.as<FloatImmNode>()) {
+    if (float_value->value == 0.0) {
+      return "pto::PadValue::Zero";
+    }
+  }
+
   std::string value_str = PrintExpr(value);
 
   std::string pad_value_enum = "pto::PadValue::Null";
@@ -1131,9 +1145,7 @@ std::string CodeGenTileLangAscendPto::GetPadEnum(const PrimExpr value) {
              value_str.find("INFINITY") != std::string::npos ||
              value_str == "std::numeric_limits<float>::infinity()") {
     pad_value_enum = "pto::PadValue::Max";
-  } else if (value_str == "0" || value_str == "0.0" || value_str == "0.0f" ||
-             value_str.find("0.000000e+00") != std::string::npos ||
-             value_str.find("0e+00") != std::string::npos) {
+  } else if (value_str == "0" || value_str == "0.0" || value_str == "0.0f") {
     pad_value_enum = "pto::PadValue::Zero";
   }
 
@@ -1196,14 +1208,15 @@ void CodeGenTileLangAscendPto::GMCopyCall(const CallNode *call,
   if (op_name.rfind("copy_gm_to_ub", 0) == 0) {
     // Use buffer's full shape (row/col) for UB tile physical dimensions
     // to ensure correct physical row stride for column slices.
-    stream << slice_info.row << ", " << slice_info.col << ", ";
-    // For sliced accesses, disable padding: TFILLPAD_INPLACE would write
-    // zeros to the full tile's non-valid region (cols beyond the slice),
-    // corrupting adjacent column data or crossing buffer boundaries.
+    stream << slice_info.row << "," << slice_info.col << ",";
+
+    // For sliced accesses, disable padding. TFILLPAD_INPLACE would write
+    // zeros to the full tile's non-valid region, corrupting adjacent column
+    // data or crossing buffer boundaries.
     if (slice_info.is_slice) {
       stream << "pto::PadValue::Null";
     } else {
-      stream << GetPadEnum(call->args[6]);
+      stream << GetPadEnum(call->args.size() > 6 ? call->args[6] : PrimExpr());
     }
   } else if (op_name.rfind("copy_ub_to_gm", 0) == 0 ||
              op_name.find("atomic_add_ub_to_gm") != std::string::npos) {

--- a/testing/python/language/test_tilelang_ascend_language_copy_pad_value.py
+++ b/testing/python/language/test_tilelang_ascend_language_copy_pad_value.py
@@ -1,0 +1,66 @@
+import pytest
+
+import tilelang
+import tilelang.language as T
+
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+}
+
+
+def copy_pad_value_kernel(valid_cols=63, gm_cols=64, ub_cols=64, pad_value=None, explicit_pad_value=False):
+    @T.prim_func
+    def main(
+        A: T.Tensor((1, gm_cols), "float16"),
+        B: T.Tensor((1, gm_cols), "float16"),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((1, ub_cols), "float16")
+
+            with T.Scope("V"):
+                if explicit_pad_value:
+                    T.copy(A[0, 0:valid_cols], a_ub[0, 0:valid_cols], pad_value=pad_value)
+                else:
+                    T.copy(A[0, 0:valid_cols], a_ub[0, 0:valid_cols])
+                T.copy(a_ub[0, 0:valid_cols], B[0, 0:valid_cols])
+
+    return main
+
+
+def compile_pto_source(program):
+    func = tilelang.compile(
+        program,
+        out_idx=[-1],
+        pass_configs=pass_configs,
+        target="pto",
+    )
+    return func.get_kernel_source()
+
+
+def gm_to_ub_copy_lines(code):
+    return [line.strip() for line in code.splitlines() if "copy_gm_to_ub_dynamic<" in line or "copy_gm_to_ub_dynamic(" in line]
+
+
+def test_sliced_default_copy_pad_value_generates_null_for_pto():
+    code = compile_pto_source(copy_pad_value_kernel())
+    copy_lines = gm_to_ub_copy_lines(code)
+
+    assert copy_lines
+    assert any("pto::PadValue::Null" in line for line in copy_lines)
+    assert not any("pto::PadValue::Zero" in line for line in copy_lines)
+
+
+def test_explicit_zero_copy_pad_value_generates_zero_for_pto():
+    code = compile_pto_source(copy_pad_value_kernel(valid_cols=64, gm_cols=64, ub_cols=64, pad_value=0, explicit_pad_value=True))
+    copy_lines = gm_to_ub_copy_lines(code)
+
+    assert copy_lines
+    assert any("pto::PadValue::Zero" in line for line in copy_lines)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/testing/python/language/test_tilelang_ascend_language_copy_pad_value.py
+++ b/testing/python/language/test_tilelang_ascend_language_copy_pad_value.py
@@ -21,12 +21,11 @@ def copy_pad_value_kernel(valid_cols=63, gm_cols=64, ub_cols=64, pad_value=None,
         with T.Kernel(1, is_npu=True) as (cid, vid):
             a_ub = T.alloc_ub((1, ub_cols), "float16")
 
-            with T.Scope("V"):
-                if explicit_pad_value:
-                    T.copy(A[0, 0:valid_cols], a_ub[0, 0:valid_cols], pad_value=pad_value)
-                else:
-                    T.copy(A[0, 0:valid_cols], a_ub[0, 0:valid_cols])
-                T.copy(a_ub[0, 0:valid_cols], B[0, 0:valid_cols])
+            if explicit_pad_value:
+                T.copy(A[0, 0:valid_cols], a_ub[0, 0:valid_cols], pad_value=pad_value)
+            else:
+                T.copy(A[0, 0:valid_cols], a_ub[0, 0:valid_cols])
+            T.copy(a_ub[0, 0:valid_cols], B[0, 0:valid_cols])
 
     return main
 


### PR DESCRIPTION
解决的是“PTO 对 sliced UB/local copy 误触发 TFILLPAD_INPLACE”这个问题，但不是“把所有默认 T.copy(..., pad_value=None) 都改成 PadValue::Null”