### PR TITLE
[Doc] Add arith, cast, fill docs (v0) 🤖

### DIFF
--- a/docs/language/tile_abs.md
+++ b/docs/language/tile_abs.md
@@ -1,0 +1,62 @@
+# T.tile.abs
+
+## 1. 功能说明
+
+对源操作数逐元素执行绝对值运算：`dst[i] = |src[i]|`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def abs(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放绝对值运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 源操作数 | 张量（tensor） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 |
+|------|:---:|:----:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 |
+| Ascend A5 | uint8, int8, int16, float16, int32, float32, int64 | uint8, int8, int16, float16, int32, float32, int64 |
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src0 的元素总数必须相同
+2. 操作数地址需 32 字节对齐（硬件约束）
+
+## 3. 示例代码
+
+**示例 1：逐元素绝对值运算（float16）**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.abs(dst, src0)  # dst[i] = |src0[i]|
+```
+
+**示例 2：逐元素绝对值运算（int32，仅 A5）**
+
+```python
+src0 = T.alloc_ub((256,), "int32")
+dst = T.alloc_ub((256,), "int32")
+T.tile.abs(dst, src0)  # dst[i] = |src0[i]|，A5 平台支持 int32
+```

--- a/docs/language/tile_add.md
+++ b/docs/language/tile_add.md
@@ -1,0 +1,70 @@
+# T.tile.add
+
+## 1. 功能说明
+
+对两个操作数逐元素执行加法运算：`dst[i] = src0[i] + src1[i]`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def add(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion | BufferLoad | PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放加法运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二个源操作数，支持 tensor 或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 buffer 元素访问（BufferLoad）或 Python 标量/表达式（PrimExpr）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | int16, float16, int32, float32 | int16, float16, int32, float32 | int16, float16, int32, float32 |
+| Ascend A5 | int8, uint8, int16, uint16, float16, bfloat16, int32, uint32, float32, int64, uint64 | int8, uint8, int16, uint16, float16, bfloat16, int32, uint32, float32, int64, uint64 | int8, uint8, int16, uint16, float16, bfloat16, int32, uint32, float32, int64, uint64 |
+
+> **后端差异说明**：A5 平台上 int64/uint64 仅 Ascend C 后端支持，PTO 后端不支持。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src0 的 shape 必须相同
+2. src1 为 tensor 时，shape 也必须与 dst 相同
+3. src0 和 src1 的 dtype 必须与 dst 一致
+4. 操作数地址需 32 字节对齐（硬件约束）
+
+## 3. 示例代码
+
+**示例 1：tensor-tensor 加法**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+src1 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.add(dst, src0, src1)
+```
+
+**示例 2：tensor-scalar 加法**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.add(dst, src0, 1.0)  # src1 = 1.0，每个元素加 1.0
+```

--- a/docs/language/tile_axpy.md
+++ b/docs/language/tile_axpy.md
@@ -1,0 +1,75 @@
+# T.tile.axpy
+
+## 1. 功能说明
+
+将源 buffer 与标量相乘后逐元素加到目标 buffer 上：`dst[i] = scalar * src[i] + dst[i]`
+
+dst 同时作为输入和输出，原地更新 dst 的内容。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def axpy(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    scalar_value: PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输入/输出 | 目标 buffer，同时作为累加器输入 Y 和输出 | 张量（tensor） | 必填 |
+| src0 | 输入 | 源 buffer X | 张量（tensor） | 必填 |
+| scalar_value | 输入 | 标量系数 alpha | 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 Python 标量或表达式（PrimExpr）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | scalar_value |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 | float16, float32 |
+| Ascend A5 | float16, float32, bfloat16, int64, uint64 | float16, float32, bfloat16, int64, uint64 | float16, float32, bfloat16, int64, uint64 |
+
+> **混合精度说明**：PTO 后端支持 dst=float32 + src0=float16 的混合精度组合；Ascend C 后端强制要求 dst 与 src0 的 dtype 必须相同。
+
+> **后端差异说明**：A5 平台上 int64/uint64 仅 Ascend C 后端支持。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- dst 与 src0 的元素总数必须相同
+
+### 2.4 约束条件
+
+1. dst 为 read-write 语义：调用后 dst 内容被原地修改
+2. dst 与 src0 的 shape 必须兼容（元素总数一致）
+3. Ascend C 后端要求 dst 与 src0 的 dtype 相同
+4. src=float16 + dst=float32 时，Ascend C 不支持地址重叠
+5. 操作数地址需 32 字节对齐（硬件约束）
+
+## 3. 示例代码
+
+**示例 1：标量乘加**
+
+```python
+dst = T.alloc_ub((128,), "float16")
+src = T.alloc_ub((128,), "float16")
+T.tile.axpy(dst, src, 2.0)  # dst = 2.0 * src + dst
+```
+
+**示例 2：累加缩放**
+
+```python
+acc = T.alloc_ub((64, 128), "float16")
+grad = T.alloc_ub((64, 128), "float16")
+T.tile.axpy(acc, grad, 0.1)  # acc = 0.1 * grad + acc（梯度累加）
+```

--- a/docs/language/tile_bitwise_and.md
+++ b/docs/language/tile_bitwise_and.md
@@ -1,0 +1,71 @@
+# T.tile.bitwise_and
+
+## 1. 功能说明
+
+对两个操作数逐元素执行按位与运算：`dst[i] = src0[i] & src1[i]`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def bitwise_and(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion | BufferLoad | PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放按位与运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二个源操作数，支持 tensor 或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 buffer 元素访问（BufferLoad）或 Python 标量/表达式（PrimExpr）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | int16, uint16 | int16, uint16 | int16, uint16 |
+| Ascend A5 | int8, uint8, int16, uint16, int32, uint32, int64, uint64 | int8, uint8, int16, uint16, int32, uint32, int64, uint64 | int8, uint8, int16, uint16, int32, uint32, int64, uint64 |
+
+> **说明**：A2/A3 上 int32/uint32 需通过 ReinterpretCast 转为 int16/uint16 后调用。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src0 的 shape 必须相同
+2. src1 为 tensor 时，shape 也必须与 dst 相同
+3. src0 和 src1 的 dtype 必须与 dst 一致
+4. 仅支持整数类型，不支持浮点类型
+5. 操作数地址需 32 字节对齐（硬件约束）
+
+## 3. 示例代码
+
+**示例 1：tensor-tensor 按位与**
+
+```python
+src0 = T.alloc_ub((256,), "int16")
+src1 = T.alloc_ub((256,), "int16")
+dst = T.alloc_ub((256,), "int16")
+T.tile.bitwise_and(dst, src0, src1)
+```
+
+**示例 2：tensor-scalar 按位与**
+
+```python
+src0 = T.alloc_ub((256,), "int16")
+dst = T.alloc_ub((256,), "int16")
+T.tile.bitwise_and(dst, src0, 0xFF)  # src1 = 0xFF，每个元素与 0xFF 做按位与
+```

--- a/docs/language/tile_bitwise_lshift.md
+++ b/docs/language/tile_bitwise_lshift.md
@@ -1,0 +1,65 @@
+# T.tile.bitwise_lshift
+
+## 1. 功能说明
+
+对 buffer 中每个元素执行标量左移运算：`dst[i] = src[i] << shift_amount`
+
+无符号类型执行逻辑左移（高位丢弃，低位补 0），有符号类型执行算术左移（次高位丢弃，低位补 0）。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def bitwise_lshift(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    scalarValue: PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放左移运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 源操作数 | 张量（tensor） | 必填 |
+| scalarValue | 输入 | 位移位数（标量） | 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：Python 标量或表达式（PrimExpr），表示位移位数，不支持 tensor-tensor 位移
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | scalarValue |
+|------|:---:|:----:|:-----------:|
+| Ascend A2 / A3 | int16, uint16, int32, uint32 | int16, uint16, int32, uint32 | 与 dst dtype 一致 |
+| Ascend A5 | int8, uint8, int16, uint16, int32, uint32, int64, uint64 | int8, uint8, int16, uint16, int32, uint32, int64, uint64 | 与 dst dtype 一致 |
+
+> **说明**：scalarValue 的数据类型需与 dst 元素类型一致（Ascend C 约束）。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src0 的元素总数必须相同
+2. src0 的 dtype 必须与 dst 一致
+3. 仅支持整数类型，不支持浮点类型
+4. scalarValue 必须为标量（PrimExpr），不支持 tensor-tensor 位移
+5. scalarValue 的数据类型需与 dst 元素类型一致
+6. 操作数地址需 32 字节对齐（硬件约束）
+
+## 3. 示例代码
+
+**示例 1：标量左移**
+
+```python
+src0 = T.alloc_ub((256,), "int16")
+dst = T.alloc_ub((256,), "int16")
+T.tile.bitwise_lshift(dst, src0, 2)  # dst[i] = src0[i] << 2
+```

--- a/docs/language/tile_bitwise_not.md
+++ b/docs/language/tile_bitwise_not.md
@@ -1,0 +1,58 @@
+# T.tile.bitwise_not
+
+## 1. 功能说明
+
+对操作数逐元素执行按位取反运算：`dst[i] = ~src[i]`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def bitwise_not(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放按位取反运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 源操作数 | 张量（tensor） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 |
+|------|:---:|:----:|
+| Ascend A2 / A3 | int16, uint16 | int16, uint16 |
+| Ascend A5 | int8, uint8, int16, uint16, int32, uint32 | int8, uint8, int16, uint16, int32, uint32 |
+
+> **说明**：A2/A3 上 int32/uint32 需通过 ReinterpretCast 转为 int16/uint16 后调用。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src0 的 shape 必须相同
+2. src0 的 dtype 必须与 dst 一致
+3. 仅支持整数类型，不支持浮点类型
+4. 操作数地址需 32 字节对齐（硬件约束）
+
+## 3. 示例代码
+
+**示例 1：按位取反**
+
+```python
+src0 = T.alloc_ub((256,), "int16")
+dst = T.alloc_ub((256,), "int16")
+T.tile.bitwise_not(dst, src0)  # dst[i] = ~src0[i]
+```

--- a/docs/language/tile_bitwise_or.md
+++ b/docs/language/tile_bitwise_or.md
@@ -1,0 +1,71 @@
+# T.tile.bitwise_or
+
+## 1. 功能说明
+
+对两个操作数逐元素执行按位或运算：`dst[i] = src0[i] | src1[i]`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def bitwise_or(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion | BufferLoad | PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放按位或运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二个源操作数，支持 tensor 或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 buffer 元素访问（BufferLoad）或 Python 标量/表达式（PrimExpr）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | int16, uint16 | int16, uint16 | int16, uint16 |
+| Ascend A5 | int8, uint8, int16, uint16, int32, uint32, int64, uint64 | int8, uint8, int16, uint16, int32, uint32, int64, uint64 | int8, uint8, int16, uint16, int32, uint32, int64, uint64 |
+
+> **说明**：A2/A3 上 int32/uint32 需通过 ReinterpretCast 转为 int16/uint16 后调用。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src0 的 shape 必须相同
+2. src1 为 tensor 时，shape 也必须与 dst 相同
+3. src0 和 src1 的 dtype 必须与 dst 一致
+4. 仅支持整数类型，不支持浮点类型
+5. 操作数地址需 32 字节对齐（硬件约束）
+
+## 3. 示例代码
+
+**示例 1：tensor-tensor 按位或**
+
+```python
+src0 = T.alloc_ub((256,), "int16")
+src1 = T.alloc_ub((256,), "int16")
+dst = T.alloc_ub((256,), "int16")
+T.tile.bitwise_or(dst, src0, src1)
+```
+
+**示例 2：tensor-scalar 按位或**
+
+```python
+src0 = T.alloc_ub((256,), "int16")
+dst = T.alloc_ub((256,), "int16")
+T.tile.bitwise_or(dst, src0, 0x0F)  # src1 = 0x0F，每个元素与 0x0F 做按位或
+```

--- a/docs/language/tile_bitwise_rshift.md
+++ b/docs/language/tile_bitwise_rshift.md
@@ -1,0 +1,66 @@
+# T.tile.bitwise_rshift
+
+## 1. 功能说明
+
+对 buffer 中每个元素执行标量右移运算：`dst[i] = src[i] >> shift_amount`
+
+无符号类型执行逻辑右移（低位丢弃，高位补 0），有符号类型执行算术右移（低位丢弃，高位复制符号位）。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def bitwise_rshift(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    scalarValue: PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放右移运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 源操作数 | 张量（tensor） | 必填 |
+| scalarValue | 输入 | 位移位数（标量） | 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：Python 标量或表达式（PrimExpr），表示位移位数，不支持 tensor-tensor 位移
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | scalarValue |
+|------|:---:|:----:|:-----------:|
+| Ascend A2 / A3 | int16, uint16, int32, uint32 | int16, uint16, int32, uint32 | 与 dst dtype 一致 |
+| Ascend A5 | int8, uint8, int16, uint16, int32, uint32, int64, uint64 | int8, uint8, int16, uint16, int32, uint32, int64, uint64 | 与 dst dtype 一致 |
+
+> **说明**：scalarValue 的数据类型需与 dst 元素类型一致（Ascend C 约束）。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src0 的元素总数必须相同
+2. src0 的 dtype 必须与 dst 一致
+3. 仅支持整数类型，不支持浮点类型
+4. scalarValue 必须为标量（PrimExpr），不支持 tensor-tensor 位移
+5. scalarValue 的数据类型需与 dst 元素类型一致
+6. 不支持 roundEn 舍入参数（Ascend C ShiftRight 原生支持，TileLang-Ascend 未暴露）
+7. 操作数地址需 32 字节对齐（硬件约束）
+
+## 3. 示例代码
+
+**示例 1：标量右移**
+
+```python
+src0 = T.alloc_ub((256,), "int16")
+dst = T.alloc_ub((256,), "int16")
+T.tile.bitwise_rshift(dst, src0, 3)  # dst[i] = src0[i] >> 3
+```

--- a/docs/language/tile_bitwise_xor.md
+++ b/docs/language/tile_bitwise_xor.md
@@ -1,0 +1,66 @@
+# T.tile.bitwise_xor
+
+## 1. 功能说明
+
+对两个操作数逐元素执行按位异或运算：`dst[i] = src0[i] ^ src1[i]`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def bitwise_xor(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放按位异或运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二个源操作数（仅支持 tensor，不支持 scalar） | 张量（tensor） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - bitwise_xor 的 src1 仅支持 Buffer/BufferRegion，不支持 BufferLoad 或 PrimExpr 标量
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | int16, uint16 | int16, uint16 | int16, uint16 |
+| Ascend A5 | int8, uint8, int16, uint16, int32, uint32 | int8, uint8, int16, uint16, int32, uint32 | int8, uint8, int16, uint16, int32, uint32 |
+
+> **说明**：A2/A3 上 bitwise_xor 为复合实现（TOR → TAND → TNOT → TAND），需要临时缓冲区；A5 上有原生 vxor 指令支持。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src0 的 shape 必须相同
+2. src1 的 shape 也必须与 dst 相同
+3. src0 和 src1 的 dtype 必须与 dst 一致
+4. 仅支持整数类型，不支持浮点类型
+5. src1 不支持标量（scalar），仅支持 tensor
+6. 接口内部使用框架自动申请的临时缓冲区（大小与 src 相同），无需用户手动分配
+7. A2/A3 上为复合实现，dst/src0/src1/tmp 四个操作数地址不得重叠
+8. 操作数地址需 32 字节对齐（硬件约束）
+
+## 3. 示例代码
+
+**示例 1：tensor-tensor 按位异或**
+
+```python
+src0 = T.alloc_ub((256,), "int16")
+src1 = T.alloc_ub((256,), "int16")
+dst = T.alloc_ub((256,), "int16")
+T.tile.bitwise_xor(dst, src0, src1)  # dst[i] = src0[i] ^ src1[i]
+```

--- a/docs/language/tile_cast.md
+++ b/docs/language/tile_cast.md
@@ -1,0 +1,107 @@
+# T.tile.cast
+
+## 1. 功能说明
+
+将 buffer 中的元素从源数据类型转换为目标数据类型：`dst[i] = (target_dtype)src[i]`
+
+支持 7 种舍入模式控制精度损失行为。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def cast(
+    dst: Buffer | BufferRegion,
+    src: Buffer | BufferRegion,
+    mode: str,
+    count: PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放类型转换结果，dtype 为目标类型 | 张量（tensor） | 必填 |
+| src | 输入 | 源操作数，dtype 为源类型 | 张量（tensor） | 必填 |
+| mode | 输入 | 舍入模式 | 字符串（string） | 必填 |
+| count | 输入 | 参与计算的元素个数 | 整数（integer） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **string**：7 种合法舍入模式字符串之一
+> - **integer**：正整数表达式（PrimExpr），指定参与计算的元素个数
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+dst 和 src 可以具有不同的数据类型，形成转换对。以下列出各平台支持的转换对（src → dst）：
+
+| 平台 | 支持的转换对 |
+|------|-------------|
+| Ascend A2 / A3 | float32 ↔ float16, float32 ↔ bfloat16, float32 ↔ int16/int32/int64, float16 ↔ int8/int16/int32, int8/uint8 → float16, bfloat16 → int32/float32, int32 → int16/int64, int64 → int32/float32, int4b_t ↔ float16 |
+| Ascend A5 | float32 ↔ float16/bfloat16/int16/int32/int64/float8/hifloat8, float16 ↔ int4b_t/int8/int16/int32/hifloat8, bfloat16 ↔ float32/int32/float16/float4, int8 → int16/int32, uint8 → uint16/float16/uint32, int16 → uint8/uint32/int32/float16/float32, uint16 → uint8/uint32, uint32 → uint8/uint16/int16, int4b_t → int16/float16/bfloat16, float8_e4m3/e5m2 → float32, hifloat8 ↔ float16/float32, float4 → bfloat16, double ↔ bfloat16/int32/int64/float32 |
+
+> **平台说明**：A5 的转换对远多于 A2/A3，包含 float8、hifloat8、float4、double 等新增类型。具体转换对取决于使用的后端（Ascend C 或 PTO），详见 AscendC:Cast.md 和 pto-isa:TCVT.md。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- dst 与 src 的元素总数必须相同，count 不超过 dst 和 src 的元素总数
+
+#### 2.3.3 mode 参数说明
+
+mode 参数控制类型转换时的舍入行为，必须为以下 7 种合法值之一：
+
+| mode 值 | 舍入行为 | 适用场景 |
+|---------|---------|---------|
+| `CAST_NONE` | 无特定舍入，由硬件默认行为决定 | 无精度损失的转换（如 float16 → float32） |
+| `CAST_RINT` | 向最近整数舍入 | 通用舍入，最常用 |
+| `CAST_FLOOR` | 向负无穷方向舍入（向下取整） | 需要保证结果不大于原值 |
+| `CAST_CEIL` | 向正无穷方向舍入（向上取整） | 需要保证结果不小于原值 |
+| `CAST_ROUND` | 向最近整数舍入，0.5 远离零舍入 | 与 CAST_RINT 的区别在于 0.5 的处理 |
+| `CAST_TRUNC` | 向零方向截断 | 直接丢弃小数部分 |
+| `CAST_ODD` | 向最近奇数舍入 | 特定量化场景 |
+
+> **特殊说明**：
+> - 当转换无精度损失时（如 float16 → float32 向上转换），mode 参数不生效，可使用 `CAST_NONE`
+> - int32 → float16 转换时 roundMode 不生效，需配合 SetDeqScale 使用
+> - TileLang-Ascend 不支持 Ascend C 的 CAST_HYBRID 模式（仅 hifloat8 专用随机舍入）
+
+### 2.4 约束条件
+
+1. mode 必须为 7 种合法舍入模式之一，否则 assert 失败
+2. count 为必填参数，需显式指定参与计算的元素个数（不同于多数 tile API 自动推断 size）
+3. dst 与 src 的 shape 必须兼容（count 不超过 dst 和 src 的元素总数）
+4. dst 与 src 的 dtype 转换对必须在硬件支持的范围内
+5. 操作数地址需 32 字节对齐（硬件约束）
+6. 当 src 和 dst 位宽不同时，stride 参数以较大位宽为准
+7. int32 → float16 转换时 roundMode 不生效，需配合 SetDeqScale 使用
+
+## 3. 示例代码
+
+**示例 1：float16 → float32 上转换**
+
+```python
+src = T.alloc_ub((1024,), "float16")
+dst = T.alloc_ub((1024,), "float32")
+T.tile.cast(dst, src, "CAST_NONE", 1024)  # fp16 → fp32，无精度损失，mode 不生效
+```
+
+**示例 2：float32 → float16 下转换（带舍入）**
+
+```python
+src = T.alloc_ub((512,), "float32")
+dst = T.alloc_ub((512,), "float16")
+T.tile.cast(dst, src, "CAST_RINT", 512)  # fp32 → fp16，向最近整数舍入
+```
+
+**示例 3：float32 → int32 截断**
+
+```python
+src = T.alloc_ub((256,), "float32")
+dst = T.alloc_ub((256,), "int32")
+T.tile.cast(dst, src, "CAST_TRUNC", 256)  # fp32 → int32，截断小数部分
+```

--- a/docs/language/tile_clamp.md
+++ b/docs/language/tile_clamp.md
@@ -1,0 +1,91 @@
+# T.tile.clamp
+
+## 1. 功能说明
+
+将 buffer 中的元素钳位到指定范围：`dst[i] = max(min_val, min(src[i], max_val))`
+
+超出边界的值替换为边界值，边界内的值保持不变。
+
+> **注意区分**：`T.clamp`（标量级运算，用于 `T.Parallel` 循环内的逐元素表达式）与 `T.tile.clamp`（buffer 级 intrinsic，操作整个 buffer 区域）名称相似但层级不同。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def clamp(
+    dst: Buffer | BufferRegion,
+    src: Buffer | BufferRegion,
+    min_val: PrimExpr,
+    max_val: PrimExpr,
+    count: PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放钳位运算结果 | 张量（tensor） | 必填 |
+| src | 输入 | 源操作数 | 张量（tensor） | 必填 |
+| min_val | 输入 | 下界标量值 | 标量（scalar） | 必填 |
+| max_val | 输入 | 上界标量值 | 标量（scalar） | 必填 |
+| count | 输入 | 参与计算的元素个数 | 整数（integer） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 Python 标量或表达式（PrimExpr）
+> - **integer**：正整数表达式（PrimExpr），指定参与计算的元素个数
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src | min_val / max_val |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | float16, float32, int16, int32 | float16, float32, int16, int32 | float16, float32, int16, int32 |
+| Ascend A5 | float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32, int64, uint64 | float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32, int64, uint64 | float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32, int64, uint64 |
+
+> **平台说明**：A5 的 int8/uint8/int16/uint16/int32/uint32/bfloat16 dtype 仅在 Ascend C 后端下支持；PTO 后端仅支持 float16 和 float32。A2/A3 的 int16/int32 由 PTO 后端的 TMINS/TMAXS 指令组合支持。
+
+> **后端差异说明**：A5 平台上 int64/uint64 仅 Ascend C 后端支持。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- dst 与 src 的元素总数必须相同，count 不超过 dst 和 src 的元素总数
+
+#### 2.3.3 min_val / max_val 说明
+
+- min_val 和 max_val 为标量值，不支持 Tensor 级边界（无法逐元素指定不同的边界值）
+- min_val 必须小于或等于 max_val，否则钳位结果无意义
+- 当需要逐元素钳位（如 attention 中的 mask）时，需改用 `T.Parallel` + `T.max/T.min` 标量运算实现
+
+### 2.4 约束条件
+
+1. count 为必填参数，需显式指定参与计算的元素个数（不同于多数 tile API 自动推断 size）
+2. dst 与 src 的 dtype 必须一致
+3. dst 与 src 的 shape 必须兼容（count 不超过 dst 和 src 的元素总数）
+4. min_val / max_val 为标量值，不支持 Tensor 级边界
+5. 操作数地址需 32 字节对齐（硬件约束）
+6. Ascend C 后端不支持源操作数与目的操作数地址重叠
+7. Ascend C 的 Clamp 为高阶 API，仅 A5（950PR/950DT）支持；A2/A3 使用 PTO 后端的 TMINS/TMAXS 指令组合实现
+8. 接口内部使用框架自动申请的临时缓冲区（大小与 src 相同），无需用户手动分配
+
+## 3. 示例代码
+
+**示例 1：ReLU6 钳位**
+
+```python
+src = T.alloc_ub((1024,), "float16")
+dst = T.alloc_ub((1024,), "float16")
+T.tile.clamp(dst, src, 0.0, 6.0, 1024)  # 钳位到 [0, 6]，即 ReLU6
+```
+
+**示例 2：梯度裁剪**
+
+```python
+grad = T.alloc_ub((64, 128), "float32")
+clipped = T.alloc_ub((64, 128), "float32")
+T.tile.clamp(clipped, grad, -1.0, 1.0, 64 * 128)  # 梯度裁剪到 [-1, 1]
+```

--- a/docs/language/tile_clamp_max.md
+++ b/docs/language/tile_clamp_max.md
@@ -1,0 +1,88 @@
+# T.tile.clamp_max
+
+## 1. 功能说明
+
+将 buffer 中的元素钳位到上界：`dst[i] = min(src[i], max_val)`
+
+超过上界的值替换为上界值，小于或等于上界的值保持不变。
+
+> **注意区分**：`T.min`（标量级运算，用于 `T.Parallel` 循环内的逐元素表达式）与 `T.tile.clamp_max`（buffer 级 intrinsic，操作整个 buffer 区域）名称相似但层级不同。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def clamp_max(
+    out: Buffer | BufferRegion,
+    buffer: Buffer | BufferRegion,
+    max_val: PrimExpr,
+    count: PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| out | 输出 | 存放钳位运算结果 | 张量（tensor） | 必填 |
+| buffer | 输入 | 源操作数 | 张量（tensor） | 必填 |
+| max_val | 输入 | 上界标量值 | 标量（scalar） | 必填 |
+| count | 输入 | 参与计算的元素个数 | 整数（integer） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 Python 标量或表达式（PrimExpr）
+> - **integer**：正整数表达式（PrimExpr），指定参与计算的元素个数
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | out | buffer | max_val |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | float16, float32, int16, int32 | float16, float32, int16, int32 | float16, float32, int16, int32 |
+| Ascend A5 | float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32, int64, uint64 | float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32, int64, uint64 | float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32, int64, uint64 |
+
+> **平台说明**：A5 的 int8/uint8/int16/uint16/int32/uint32/bfloat16 dtype 仅在 Ascend C 后端下支持；PTO 后端仅支持 float16 和 float32。A2/A3 的 int16/int32 由 PTO 后端的 TMAXS 指令支持。
+
+> **后端差异说明**：A5 平台上 int64/uint64 仅 Ascend C 后端支持。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- out 与 buffer 的元素总数必须相同，count 不超过 out 和 buffer 的元素总数
+
+#### 2.3.3 max_val 说明
+
+- max_val 为标量值，不支持 Tensor 级边界（无法逐元素指定不同的上界值）
+- 当需要逐元素上界钳位时，需改用 `T.Parallel` + `T.min` 标量运算实现
+
+### 2.4 约束条件
+
+1. count 为必填参数，需显式指定参与计算的元素个数（不同于多数 tile API 自动推断 size）
+2. out 与 buffer 的 dtype 必须一致
+3. out 与 buffer 的 shape 必须兼容（count 不超过 out 和 buffer 的元素总数）
+4. max_val 为标量值，不支持 Tensor 级边界
+5. 操作数地址需 32 字节对齐（硬件约束）
+6. Ascend C 后端不支持源操作数与目的操作数地址重叠
+7. Ascend C 的 ClampMax 为高阶 API，仅 A5（950PR/950DT）支持；A2/A3 使用 PTO 后端的 TMAXS 指令实现
+8. 接口内部使用框架自动申请的临时缓冲区（大小与 src 相同），无需用户手动分配
+
+## 3. 示例代码
+
+**示例 1：上界裁剪**
+
+```python
+src = T.alloc_ub((1024,), "float16")
+dst = T.alloc_ub((1024,), "float16")
+T.tile.clamp_max(dst, src, 1.0, 1024)  # 将所有值限制在不超过 1.0
+```
+
+**示例 2：梯度上限裁剪**
+
+```python
+grad = T.alloc_ub((64, 128), "float32")
+clipped = T.alloc_ub((64, 128), "float32")
+T.tile.clamp_max(clipped, grad, 1.0, 64 * 128)  # 梯度上限裁剪到 1.0
+```

--- a/docs/language/tile_clamp_min.md
+++ b/docs/language/tile_clamp_min.md
@@ -1,0 +1,83 @@
+# T.tile.clamp_min
+
+## 1. 功能说明
+
+将 buffer 中的元素钳位到下界：`dst[i] = max(src[i], min_val)`
+
+低于下界的值替换为下界值，大于或等于下界的值保持不变。
+
+> **注意区分**：`T.max`（标量级运算，用于 `T.Parallel` 循环内的逐元素表达式）与 `T.tile.clamp_min`（buffer 级 intrinsic，操作整个 buffer 区域）名称相似但层级不同。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def clamp_min(
+    out: Buffer | BufferRegion,
+    buffer: Buffer | BufferRegion,
+    min_val: PrimExpr,
+    count: PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| out | 输出 | 存放钳位运算结果 | 张量（tensor） | 必填 |
+| buffer | 输入 | 源操作数 | 张量（tensor） | 必填 |
+| min_val | 输入 | 下界标量值 | 标量（scalar） | 必填 |
+| count | 输入 | 参与计算的元素个数 | 整数（integer） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 Python 标量或表达式（PrimExpr）
+> - **integer**：正整数表达式（PrimExpr），指定参与计算的元素个数
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | out | buffer | min_val |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | float16, float32, int16, int32 | float16, float32, int16, int32 | float16, float32, int16, int32 |
+| Ascend A5 | float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32, int64, uint64 | float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32, int64, uint64 | float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32, int64, uint64 |
+
+> **平台说明**：A5 的 int8/uint8/int16/uint16/int32/uint32/bfloat16 dtype 仅在 Ascend C 后端下支持；PTO 后端仅支持 float16 和 float32。A2/A3 的 int16/int32 由 PTO 后端的 TMINS 指令支持。
+
+> **后端差异说明**：A5 平台上 int64/uint64 仅 Ascend C 后端支持。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- out 与 buffer 的元素总数必须相同，count 不超过 out 和 buffer 的元素总数
+
+### 2.4 约束条件
+
+1. count 为必填参数，需显式指定参与计算的元素个数（不同于多数 tile API 自动推断 size）
+2. out 与 buffer 的 dtype 必须一致
+3. out 与 buffer 的 shape 必须兼容（count 不超过 out 和 buffer 的元素总数）
+4. min_val 为标量值，不支持 Tensor 级边界
+5. 操作数地址需 32 字节对齐（硬件约束）
+6. Ascend C 后端不支持源操作数与目的操作数地址重叠
+7. Ascend C 的 ClampMin 为高阶 API，仅 A5（950PR/950DT）支持；A2/A3 使用 PTO 后端的 TMINS 指令实现
+8. 接口内部使用框架自动申请的临时缓冲区（大小与 src 相同），无需用户手动分配
+
+## 3. 示例代码
+
+**示例 1：ReLU 激活（下界为 0）**
+
+```python
+src = T.alloc_ub((1024,), "float16")
+dst = T.alloc_ub((1024,), "float16")
+T.tile.clamp_min(dst, src, 0.0, 1024)  # 将所有值限制在不低于 0.0，即 ReLU
+```
+
+**示例 2：数值稳定性（防止除零）**
+
+```python
+denom = T.alloc_ub((512,), "float32")
+safe_denom = T.alloc_ub((512,), "float32")
+T.tile.clamp_min(safe_denom, denom, 1e-6, 512)  # 防止除零，将分母下限设为 1e-6
+```

--- a/docs/language/tile_clear.md
+++ b/docs/language/tile_clear.md
@@ -1,0 +1,68 @@
+# T.tile.clear
+
+## 1. 功能说明
+
+将 buffer 中的所有元素清零：`buffer[i] = 0`
+
+内部委托给 `fill(buffer, 0)` 实现，不生成独立的底层指令。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def clear(
+    buffer: Buffer | BufferRegion | tir.Var,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| buffer | 输入/输出 | 待清零的 buffer | 张量（tensor） / 变量（var） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **var**：tir.Var 变量，当传入 tir.Var 时，clear 会通过 `T.has_let_value` / `T.get_let_value` 解析为 BufferRegion 再调用 fill
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | buffer |
+|------|:------:|
+| Ascend A2 / A3 | 所有已支持的 dtype（float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32） |
+| Ascend A5 | 所有已支持的 dtype（float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32, int64, uint64） |
+
+> **说明**：clear 委托给 fill 实现，dtype 支持范围与 fill 相同。fill 的底层指令（Duplicate / TEXPANDS）支持所有常见 dtype。
+
+> **后端差异说明**：A2/A3 平台上 bfloat16 仅 Ascend C 后端支持；int8/uint8 仅 PTO 后端支持。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- size 由 buffer shape 自动推断（BufferRegion 时取 region extent 的乘积，Buffer 时取 shape 的乘积）
+
+### 2.4 约束条件
+
+1. clear 委托给 fill(buffer, 0) 实现，不生成独立的底层指令
+2. buffer 地址需 32 字节对齐（硬件约束）
+3. size 由 buffer shape 自动推断，无需显式传入 count 参数
+4. 当传入 tir.Var 时，需确保该变量已通过 `T.has_let_value` 绑定到有效的 BufferRegion
+
+## 3. 示例代码
+
+**示例 1：清零累加器**
+
+```python
+acc_s_ub = T.alloc_ub((block_M, block_N), "float16")
+T.tile.clear(acc_s_ub)  # 将 acc_s_ub 所有元素清零
+```
+
+**示例 2：清零 L0C 累加器**
+
+```python
+C_L0 = T.alloc_L0C((block_M, block_N), "float32")
+T.tile.clear(C_L0)  # 清零 L0C 累加器
+```

--- a/docs/language/tile_cos.md
+++ b/docs/language/tile_cos.md
@@ -1,0 +1,69 @@
+# T.tile.cos
+
+## 1. 功能说明
+
+对操作数逐元素执行余弦运算：`dst[i] = cos(src[i])`
+
+> cos 为独立实现，直接映射到 `tl.ascend_cos` intrinsic。Ascend C 后端使用高阶 API，内部需要临时空间（tmpBuffer）存储中间变量。PTO 后端不支持 sin/cos（无原生 PTO-ISA 指令）。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def cos(
+    dst: Buffer | BufferRegion,
+    src: Buffer | BufferRegion,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放余弦运算结果 | 张量（tensor） | 必填 |
+| src | 输入 | 源操作数 | 张量（tensor） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src |
+|------|:---:|:---:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 |
+| Ascend A5 | float16, float32 | float16, float32 |
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src 的元素总数必须相同，否则 assert 失败
+2. dst 与 src 的 dtype 必须一致（Ascend C 约束）
+3. 不支持源操作数与目的操作数地址重叠（Ascend C 约束）
+4. 操作数地址需 32 字节对齐（硬件约束）
+5. A2/A3 平台输入值域必须在 [-65504.0, 65504.0] 范围内（POLYNOMIAL_APPROXIMATION 算法限制），超出此范围结果不可预测
+6. PTO 后端不支持 sin/cos，使用 PTO 后端编译含 cos 的 kernel 会产生无效代码
+7. 接口内部使用框架自动申请的临时缓冲区（大小为 `2 × N × sizeof(dtype)` 字节，N 为元素个数），无需用户手动分配
+
+## 3. 示例代码
+
+**示例 1：1D 余弦运算**
+
+```python
+src = T.alloc_ub((1024,), "float16")
+dst = T.alloc_ub((1024,), "float16")
+T.tile.cos(dst, src)
+```
+
+**示例 2：2D 余弦运算**
+
+```python
+src = T.alloc_ub((128, 64), "float16")
+dst = T.alloc_ub((128, 64), "float16")
+T.tile.cos(dst, src)
+```

--- a/docs/language/tile_div.md
+++ b/docs/language/tile_div.md
@@ -1,0 +1,74 @@
+# T.tile.div
+
+## 1. 功能说明
+
+对两个操作数逐元素执行除法运算：`dst[i] = src0[i] / src1[i]`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def div(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion | BufferLoad,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放除法运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一个源操作数（被除数） | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二个源操作数（除数），支持 tensor 或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 buffer 元素访问（BufferLoad）或 Python 标量/表达式（PrimExpr）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 | float16, float32 |
+| Ascend A5 | int16, uint16, float16, int32, uint32, float32, int64, uint64 | int16, uint16, float16, int32, uint32, float32, int64, uint64 | int16, uint16, float16, int32, uint32, float32, int64, uint64 |
+
+> **注意**：
+> - A2 / A3 平台仅支持浮点类型（float16, float32），不支持整数除法
+> - A5 平台不支持 bfloat16 的除法运算
+> **后端差异说明**：A5 平台上 int64/uint64 仅 Ascend C 后端支持，PTO 后端不支持。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src0 的 shape 必须相同
+2. src1 为 tensor 时，shape 也必须与 dst 相同
+3. src0 和 src1 的 dtype 必须与 dst 一致
+4. 操作数地址需 32 字节对齐（硬件约束）
+5. A2 / A3 平台仅支持浮点除法，不支持整数除法
+
+## 3. 示例代码
+
+**示例 1：tensor-tensor 除法**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+src1 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.div(dst, src0, src1)
+```
+
+**示例 2：tensor-scalar 除法**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.div(dst, src0, 2.0)  # src1 = 2.0，每个元素除以 2.0
+```

--- a/docs/language/tile_exp.md
+++ b/docs/language/tile_exp.md
@@ -1,0 +1,54 @@
+# T.tile.exp
+
+## 1. 功能说明
+
+对源操作数逐元素执行指数运算：`dst[i] = e^src[i]`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def exp(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放指数运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 源操作数 | 张量（tensor） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 |
+|------|:---:|:----:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 |
+| Ascend A5 | float16, float32 | float16, float32 |
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src0 的元素总数必须相同
+2. 操作数地址需 32 字节对齐（硬件约束）
+
+## 3. 示例代码
+
+**示例 1：逐元素指数运算**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.exp(dst, src0)  # dst[i] = e^src0[i]
+```

--- a/docs/language/tile_fill.md
+++ b/docs/language/tile_fill.md
@@ -1,0 +1,77 @@
+# T.tile.fill
+
+## 1. 功能说明
+
+将 buffer 中的所有元素填充为指定标量值：`buffer[i] = value`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def fill(
+    buffer: Buffer | BufferRegion,
+    value: PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| buffer | 输入/输出 | 待填充的 buffer | 张量（tensor） | 必填 |
+| value | 输入 | 填充的标量值 | 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 Python 标量或表达式（PrimExpr），dtype 需与 buffer 一致
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | buffer | value |
+|------|:------:|:-----:|
+| Ascend A2 / A3 | float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32 | float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32 |
+| Ascend A5 | float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32, int64, uint64 | float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32, int64, uint64 |
+
+> **说明**：fill 的底层指令（Ascend C 后端使用 Duplicate / Fill，PTO 后端使用 TEXPANDS）支持所有常见 dtype。value 的 dtype 需与 buffer 的 dtype 一致。
+
+> **后端差异说明**：A2/A3 平台上 bfloat16 仅 Ascend C 后端支持；int8/uint8 仅 PTO 后端支持。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- size 由 buffer shape 自动推断（BufferRegion 时取 region extent 的乘积，Buffer 时取 shape 的乘积）
+
+### 2.4 约束条件
+
+1. value 的 dtype 需与 buffer 的 dtype 一致（Ascend C Duplicate 约束）
+2. buffer 地址需 32 字节对齐（硬件约束）
+3. size 由 buffer shape 自动推断，无需显式传入 count 参数
+4. fill 不区分 UB 级别和 L1/L0 级别，统一使用 `tl.ascend_fill` intrinsic
+5. 仅支持片上 buffer fill，GM 级别 fill 需用 T.copy
+
+## 3. 示例代码
+
+**示例 1：填充零值**
+
+```python
+acc_s_ub = T.alloc_ub((block_M, block_N), "float16")
+T.tile.fill(acc_s_ub, 0.0)  # 将 acc_s_ub 所有元素填充为 0.0
+```
+
+**示例 2：填充常量值**
+
+```python
+scale_ub = T.alloc_ub((128,), "float32")
+T.tile.fill(scale_ub, 0.125)  # 将 scale_ub 所有元素填充为 0.125
+```
+
+**示例 3：与 clear 的等价关系**
+
+```python
+buf = T.alloc_ub((256,), "float16")
+T.tile.fill(buf, 0.0)   # 填充为 0.0
+T.tile.clear(buf)        # 等价写法：清零（内部调用 fill(buf, 0)）
+```

--- a/docs/language/tile_leaky_relu.md
+++ b/docs/language/tile_leaky_relu.md
@@ -1,0 +1,76 @@
+# T.tile.leaky_relu
+
+## 1. 功能说明
+
+对操作数逐元素执行 Leaky ReLU 激活运算：`dst[i] = src[i] if src[i] >= 0 else alpha * src[i]`，其中 alpha 为负斜率系数，控制负值区域的斜率。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def leaky_relu(
+    dst: Buffer | BufferRegion,
+    src: Buffer | BufferRegion,
+    alpha: PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放 Leaky ReLU 运算结果 | 张量（tensor） | 必填 |
+| src | 输入 | 源操作数 | 张量（tensor） | 必填 |
+| alpha | 输入 | 负斜率系数（negative slope） | 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 Python 标量或表达式（PrimExpr）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src | alpha |
+|------|:---:|:---:|:---:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 | float16, float32 |
+| Ascend A5 | float16, float32 | float16, float32 | float16, float32 |
+
+> **注意**：alpha 的 dtype 若与 dst 不同，codegen 会自动插入类型转换（如 `half(0.01)`）。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+#### 2.3.3 alpha 参数
+
+- alpha 为必填参数，无默认值，需显式指定负斜率系数
+- 常用取值范围：0.01 ~ 0.1 的小正数
+- alpha 的数据类型需与 dst 元素类型一致，若不一致 codegen 会自动转换
+
+### 2.4 约束条件
+
+1. dst 与 src 的元素总数必须相同
+2. dst 与 src 的 dtype 必须一致（Ascend C 硬件约束）
+3. alpha 的数据类型需与 dst 元素类型一致（Ascend C 约束）
+4. 操作数地址需 32 字节对齐（硬件约束）
+5. 不支持 BF16 数据类型
+
+## 3. 示例代码
+
+**示例 1：1D Leaky ReLU**
+
+```python
+src = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.leaky_relu(dst, src, 0.01)  # negative slope = 0.01
+```
+
+**示例 2：2D Leaky ReLU**
+
+```python
+src = T.alloc_ub((128, 64), "float16")
+dst = T.alloc_ub((128, 64), "float16")
+T.tile.leaky_relu(dst, src, 0.01)  # negative slope = 0.01
+```

--- a/docs/language/tile_ln.md
+++ b/docs/language/tile_ln.md
@@ -1,0 +1,55 @@
+# T.tile.ln
+
+## 1. 功能说明
+
+对源操作数逐元素执行自然对数运算：`dst[i] = ln(src[i])`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def ln(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放自然对数运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 源操作数 | 张量（tensor） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 |
+|------|:---:|:----:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 |
+| Ascend A5 | float16, float32 | float16, float32 |
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src0 的元素总数必须相同
+2. 操作数地址需 32 字节对齐（硬件约束）
+3. src0 输入应为正数，否则结果未定义
+
+## 3. 示例代码
+
+**示例 1：逐元素自然对数运算**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.ln(dst, src0)  # dst[i] = ln(src0[i])
+```

--- a/docs/language/tile_max.md
+++ b/docs/language/tile_max.md
@@ -1,0 +1,74 @@
+# T.tile.max
+
+## 1. 功能说明
+
+对两个操作数逐元素取最大值：`dst[i] = max(src0[i], src1[i])`
+
+> **注意**：本 API 是逐元素极值运算，与归约类 API（`T.reduce_max`）不同。归约类沿指定维度压缩，本组逐元素比较两个同 shape 输入。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def max(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion | BufferLoad | PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放逐元素取最大值的结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二个源操作数，支持 tensor 或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 buffer 元素访问（BufferLoad）或 Python 标量/表达式（PrimExpr）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | int16, float16, int32, float32 | int16, float16, int32, float32 | int16, float16, int32, float32 |
+| Ascend A5 | int8, uint8, int16, uint16, float16, bfloat16, int32, uint32, float32, int64, uint64 | int8, uint8, int16, uint16, float16, bfloat16, int32, uint32, float32, int64, uint64 | int8, uint8, int16, uint16, float16, bfloat16, int32, uint32, float32, int64, uint64 |
+
+> **注意**：A5 平台上 int8 / uint8 / int64 / uint64 仅支持前 n 个数据接口。
+
+> **后端差异说明**：A5 平台上 bfloat16、int64、uint64 仅 Ascend C 后端支持，PTO 后端不支持。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. src0 和 src1 的 dtype 必须与 dst 一致
+2. dst 与 src0 的 shape 必须相同
+3. src1 为 tensor 时，shape 也必须与 dst 相同
+4. 操作数地址需 32 字节对齐（硬件约束）
+
+## 3. 示例代码
+
+**示例 1：tensor-tensor 逐元素取最大值**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+src1 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.max(dst, src0, src1)
+```
+
+**示例 2：tensor-scalar 逐元素取最大值**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.max(dst, src0, 0.0)  # src1 = 0.0，每个元素与 0.0 取最大值
+```

--- a/docs/language/tile_min.md
+++ b/docs/language/tile_min.md
@@ -1,0 +1,74 @@
+# T.tile.min
+
+## 1. 功能说明
+
+对两个操作数逐元素取最小值：`dst[i] = min(src0[i], src1[i])`
+
+> **注意**：本 API 是逐元素极值运算，与归约类 API（`T.reduce_min`）不同。归约类沿指定维度压缩，本组逐元素比较两个同 shape 输入。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def min(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion | BufferLoad | PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放逐元素取最小值的结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二个源操作数，支持 tensor 或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 buffer 元素访问（BufferLoad）或 Python 标量/表达式（PrimExpr）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | int16, float16, int32, float32 | int16, float16, int32, float32 | int16, float16, int32, float32 |
+| Ascend A5 | int8, uint8, int16, uint16, float16, bfloat16, int32, uint32, float32, int64, uint64 | int8, uint8, int16, uint16, float16, bfloat16, int32, uint32, float32, int64, uint64 | int8, uint8, int16, uint16, float16, bfloat16, int32, uint32, float32, int64, uint64 |
+
+> **注意**：A5 平台上 int8 / uint8 / int64 / uint64 仅支持前 n 个数据接口。
+
+> **后端差异说明**：A5 平台上 bfloat16、int64、uint64 仅 Ascend C 后端支持，PTO 后端不支持。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. src0 和 src1 的 dtype 必须与 dst 一致
+2. dst 与 src0 的 shape 必须相同
+3. src1 为 tensor 时，shape 也必须与 dst 相同
+4. 操作数地址需 32 字节对齐（硬件约束）
+
+## 3. 示例代码
+
+**示例 1：tensor-tensor 逐元素取最小值**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+src1 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.min(dst, src0, src1)
+```
+
+**示例 2：tensor-scalar 逐元素取最小值**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.min(dst, src0, 0.0)  # src1 = 0.0，每个元素与 0.0 取最小值
+```

--- a/docs/language/tile_mul.md
+++ b/docs/language/tile_mul.md
@@ -1,0 +1,71 @@
+# T.tile.mul
+
+## 1. 功能说明
+
+对两个操作数逐元素执行乘法运算：`dst[i] = src0[i] * src1[i]`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def mul(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion | BufferLoad | PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放乘法运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二个源操作数，支持 tensor 或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 buffer 元素访问（BufferLoad）或 Python 标量/表达式（PrimExpr）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | int16, float16, int32, float32 | int16, float16, int32, float32 | int16, float16, int32, float32 |
+| Ascend A5 | int16, uint16, float16, bfloat16, int32, uint32, float32, int64, uint64 | int16, uint16, float16, bfloat16, int32, uint32, float32, int64, uint64 | int16, uint16, float16, bfloat16, int32, uint32, float32, int64, uint64 |
+
+> **注意**：A5 平台不支持 int8 / uint8 的乘法运算。
+> **后端差异说明**：A5 平台上 int64/uint64 仅 Ascend C 后端支持，PTO 后端不支持。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src0 的 shape 必须相同
+2. src1 为 tensor 时，shape 也必须与 dst 相同
+3. src0 和 src1 的 dtype 必须与 dst 一致
+4. 操作数地址需 32 字节对齐（硬件约束）
+
+## 3. 示例代码
+
+**示例 1：tensor-tensor 乘法**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+src1 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.mul(dst, src0, src1)
+```
+
+**示例 2：tensor-scalar 乘法**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.mul(dst, src0, 0.5)  # src1 = 0.5，每个元素乘 0.5
+```

--- a/docs/language/tile_mul_add_dst.md
+++ b/docs/language/tile_mul_add_dst.md
@@ -1,0 +1,78 @@
+# T.tile.mul_add_dst
+
+## 1. 功能说明
+
+将 src0 与 src1 逐元素相乘，再与 dst 中的现有值相加，结果写回 dst：`dst[i] = src0[i] * src1[i] + dst[i]`
+
+dst 同时作为输入（累加器）和输出，这是该 API 与普通 `mul` + `add` 组合的关键区别。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def mul_add_dst(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输入/输出 | 目标 buffer，同时作为累加器输入和输出，必须位于 UB scope | 张量（tensor） | 必填 |
+| src0 | 输入 | 乘法第一个源操作数 | 张量（tensor） | 必填 |
+| src1 | 输入 | 乘法第二个源操作数 | 张量（tensor） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 | float16, float32 |
+| Ascend A5 | float16, float32, int64, uint64 | float16, float32, int64, uint64 | float16, float32, int64, uint64 |
+
+> **混合精度说明**：支持 dst=float32 + src0/src1=float16 的组合（half 乘法结果累加到 float 累加器）。
+
+> **后端差异说明**：A5 平台上 int64/uint64 仅 Ascend C 后端支持。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- dst、src0、src1 的元素总数必须相同
+
+### 2.4 约束条件
+
+1. dst 为 read-write 语义：调用前 dst 必须包含有效数据，调用后 dst 内容被原地修改
+2. dst、src0、src1 的元素总数必须相同，否则 assert 失败
+3. dst 必须位于 UB（Unified Buffer）scope
+4. 当 src dtype 为 float16、dst dtype 为 float32 时，不支持地址重叠
+5. MulAddDst 受 bank 冲突影响：地址不重叠时只能达到一半理论并行度
+6. 操作数地址需 32 字节对齐（硬件约束）
+7. 接口内部使用框架自动申请的临时缓冲区（大小与 dst 相同），无需用户手动分配
+
+## 3. 示例代码
+
+**示例 1：融合乘加累加**
+
+```python
+a_ub = T.alloc_ub((64, 128), "float16")
+b_ub = T.alloc_ub((64, 128), "float16")
+c_ub = T.alloc_ub((64, 128), "float32")  # dst 必须预先包含有效数据
+T.tile.mul_add_dst(c_ub, a_ub, b_ub)  # c_ub = a_ub * b_ub + c_ub
+```
+
+**示例 2：Softmax 中的乘加**
+
+```python
+acc_s_ub = T.alloc_ub((block_M, block_N), "float16")
+acc_s_ub_ = T.alloc_ub((block_M, block_N), "float16")
+acc_o_ub = T.alloc_ub((block_M, block_N), "float16")
+T.tile.mul_add_dst(acc_o_ub, acc_s_ub, acc_s_ub_)  # acc_o = acc_s * acc_s_ + acc_o
+```

--- a/docs/language/tile_pow.md
+++ b/docs/language/tile_pow.md
@@ -1,0 +1,76 @@
+# T.tile.pow
+
+## 1. 功能说明
+
+对两个 buffer 逐元素做幂运算：`dst[i] = src0[i] ^ src1[i]`
+
+以 src0 为底、src1 为指数的逐元素 power 计算。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def pow(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放幂运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 底数 buffer | 张量（tensor） | 必填 |
+| src1 | 输入 | 指数 buffer | 张量（tensor） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | float16, float32, int8, uint8, int16, uint16, int32, uint32 | float16, float32, int8, uint8, int16, uint16, int32, uint32 | float16, float32, int8, uint8, int16, uint16, int32, uint32 |
+| Ascend A5 | float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32 | float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32 | float16, float32, bfloat16, int8, uint8, int16, uint16, int32, uint32 |
+
+> **平台说明**：A5 的 int8/uint8/int16/uint16/int32/uint32 dtype 仅在 Ascend C 后端下支持；PTO 后端在 A5 上额外支持 bfloat16。A2/A3 的 int8/uint8/int16/uint16/int32/uint32 由 PTO-ISA TPOW 指令支持，Ascend C Power 也支持 int32。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- dst、src0、src1 的元素总数必须相同
+
+### 2.4 约束条件
+
+1. dst、src0、src1 的 dtype 必须一致（Ascend C 硬件约束）
+2. dst、src0、src1 的 shape 必须兼容（元素总数一致）
+3. 不支持源操作数与目的操作数地址重叠
+4. 操作数地址需 32 字节对齐（硬件约束）
+5. 接口内部使用框架自动申请的临时缓冲区（大小为 `2 × N × sizeof(dtype)` 字节，N 为元素个数），无需用户手动分配
+6. 不支持 Scalar 指数参数（src1 必须为 buffer），若需固定指数幂运算，需先分配 buffer 并 fill 为常量值
+
+## 3. 示例代码
+
+**示例 1：逐元素幂运算**
+
+```python
+base_ub = T.alloc_ub((128,), "float16")
+exp_ub = T.alloc_ub((128,), "float16")
+dst_ub = T.alloc_ub((128,), "float16")
+T.tile.pow(dst_ub, base_ub, exp_ub)  # dst = base ^ exp
+```
+
+**示例 2：平方运算（需先 fill 指数 buffer）**
+
+```python
+values = T.alloc_ub((256,), "float32")
+squared = T.alloc_ub((256,), "float32")
+exp_two = T.alloc_ub((256,), "float32")
+T.tile.fill(exp_two, 2.0)  # 指数 buffer 填充为 2.0
+T.tile.pow(squared, values, exp_two)  # dst = values ^ 2
+```

--- a/docs/language/tile_reciprocal.md
+++ b/docs/language/tile_reciprocal.md
@@ -1,0 +1,58 @@
+# T.tile.reciprocal
+
+## 1. 功能说明
+
+对源操作数逐元素执行求倒数运算：`dst[i] = 1/src[i]`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def reciprocal(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放求倒数运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 源操作数 | 张量（tensor） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 |
+|------|:---:|:----:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 |
+| Ascend A5 | float16, float32, int64, uint64 | float16, float32, int64, uint64 |
+
+> **后端差异说明**：A5 平台上 int64/uint64 仅 Ascend C 后端支持。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src0 的元素总数必须相同
+2. 操作数地址需 32 字节对齐（硬件约束）
+3. src0 输入不应为 0，否则结果未定义
+4. INTRINSIC 模式精度有限：float16 不满足双千分之一，float32 不满足双万分之一；需要高精度时应考虑用 `T.tile.div` 替代
+
+## 3. 示例代码
+
+**示例 1：逐元素求倒数运算**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.reciprocal(dst, src0)  # dst[i] = 1 / src0[i]
+```

--- a/docs/language/tile_relu.md
+++ b/docs/language/tile_relu.md
@@ -1,0 +1,65 @@
+# T.tile.relu
+
+## 1. 功能说明
+
+对操作数逐元素执行 ReLU（Rectified Linear Unit）激活运算：`dst[i] = max(0, src[i])`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def relu(
+    dst: Buffer | BufferRegion,
+    src: Buffer | BufferRegion,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放 ReLU 运算结果 | 张量（tensor） | 必填 |
+| src | 输入 | 源操作数 | 张量（tensor） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src |
+|------|:---:|:---:|
+| Ascend A2 / A3 | float16, int32, float32 | float16, int32, float32 |
+| Ascend A5 | float16, int32, float32, int64 | float16, int32, float32, int64 |
+
+> **注意**：A5 平台 int64 仅支持前 n 个数据接口。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src 的元素总数必须相同
+2. dst 与 src 的 dtype 必须一致（Ascend C 硬件约束）
+3. 操作数地址需 32 字节对齐（硬件约束）
+
+## 3. 示例代码
+
+**示例 1：1D ReLU**
+
+```python
+src = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.relu(dst, src)
+```
+
+**示例 2：2D ReLU**
+
+```python
+src = T.alloc_ub((128, 256), "float16")
+dst = T.alloc_ub((128, 256), "float16")
+T.tile.relu(dst, src)
+```

--- a/docs/language/tile_round.md
+++ b/docs/language/tile_round.md
@@ -1,0 +1,74 @@
+# T.tile.round
+
+## 1. 功能说明
+
+将 buffer 中的元素四舍五入到最接近的整数：`dst[i] = round(src[i])`
+
+当小数部分恰好为 0.5 时，采用"向偶数舍入"（banker's rounding）策略。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def round(
+    dst: Buffer | BufferRegion,
+    src: Buffer | BufferRegion,
+    count: PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放舍入运算结果 | 张量（tensor） | 必填 |
+| src | 输入 | 源操作数 | 张量（tensor） | 必填 |
+| count | 输入 | 参与计算的元素个数 | 整数（integer） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **integer**：正整数表达式（PrimExpr），指定参与计算的元素个数
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src |
+|------|:---:|:----:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 |
+| Ascend A5 | float16, float32 | float16, float32 |
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- dst 与 src 的元素总数必须相同，count 不超过 dst 和 src 的元素总数
+
+### 2.4 约束条件
+
+1. count 为必填参数，需显式指定参与计算的元素个数（不同于多数 tile API 自动推断 size）
+2. dst 与 src 的 dtype 必须相同
+3. 仅支持 float16 和 float32 两种 dtype
+4. 只支持四舍五入到整数，不支持四舍五入到小数位
+5. 小数部分为 0.5 时向偶数舍入（banker's rounding）：3.5 舍入到 4，2.5 舍入到 2
+6. 操作数地址需 32 字节对齐（硬件约束）
+7. Ascend C 后端的 Round 为高阶 API，需要临时空间（tmpBuffer），TileLang 未暴露 sharedTmpBuffer 参数
+8. 接口内部使用框架自动申请的临时缓冲区（大小为 `max(256, N × sizeof(dtype))` 字节，N 为元素个数），无需用户手动分配
+
+## 3. 示例代码
+
+**示例 1：四舍五入**
+
+```python
+src = T.alloc_ub((1024,), "float16")
+dst = T.alloc_ub((1024,), "float16")
+T.tile.round(dst, src, 1024)  # banker's rounding: 3.5→4, 2.5→2
+```
+
+**示例 2：量化前的舍入**
+
+```python
+values = T.alloc_ub((256,), "float32")
+rounded = T.alloc_ub((256,), "float32")
+T.tile.round(rounded, values, 256)  # 舍入到整数后再 cast 到 int32
+```

--- a/docs/language/tile_rsqrt.md
+++ b/docs/language/tile_rsqrt.md
@@ -1,0 +1,56 @@
+# T.tile.rsqrt
+
+## 1. 功能说明
+
+对源操作数逐元素执行平方根倒数运算：`dst[i] = 1/√src[i]`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def rsqrt(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放平方根倒数运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 源操作数 | 张量（tensor） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 |
+|------|:---:|:----:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 |
+| Ascend A5 | float16, float32 | float16, float32 |
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src0 的元素总数必须相同
+2. 操作数地址需 32 字节对齐（硬件约束）
+3. src0 输入应为正数，否则结果未定义
+4. INTRINSIC 模式精度有限：float16 不满足双千分之一，float32 不满足双万分之一；需要高精度时应考虑用 `T.tile.div` + `T.tile.sqrt` 替代
+
+## 3. 示例代码
+
+**示例 1：逐元素平方根倒数运算**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.rsqrt(dst, src0)  # dst[i] = 1 / √src0[i]
+```

--- a/docs/language/tile_sigmoid.md
+++ b/docs/language/tile_sigmoid.md
@@ -1,0 +1,67 @@
+# T.tile.sigmoid
+
+## 1. 功能说明
+
+对操作数逐元素执行 Sigmoid 激活运算：`dst[i] = 1 / (1 + e^(-src[i]))`
+
+> sigmoid 为独立实现，直接映射到 `tl.ascend_sigmoid` intrinsic，非 `unary_op` 通用分发器路径。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def sigmoid(
+    dst: Buffer | BufferRegion,
+    src: Buffer | BufferRegion,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放 Sigmoid 运算结果 | 张量（tensor） | 必填 |
+| src | 输入 | 源操作数 | 张量（tensor） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src |
+|------|:---:|:---:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 |
+| Ascend A5 | float16, float32 | float16, float32 |
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src 的元素总数必须相同
+2. dst 与 src 的 dtype 必须一致（Ascend C 硬件约束）
+3. src 与 dst 的地址不能重叠
+4. 操作数地址需 32 字节对齐（硬件约束）
+5. 接口内部使用框架自动申请的临时缓冲区（大小为 `N × sizeof(dtype)` 字节，N 为元素个数），无需用户手动分配
+
+## 3. 示例代码
+
+**示例 1：1D Sigmoid**
+
+```python
+src = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.sigmoid(dst, src)
+```
+
+**示例 2：2D Sigmoid**
+
+```python
+src = T.alloc_ub((128, 256), "float16")
+dst = T.alloc_ub((128, 256), "float16")
+T.tile.sigmoid(dst, src)
+```

--- a/docs/language/tile_silu.md
+++ b/docs/language/tile_silu.md
@@ -1,0 +1,68 @@
+# T.tile.silu
+
+## 1. 功能说明
+
+对操作数逐元素执行 SiLU（Sigmoid Linear Unit，也称 Swish）激活运算：`dst[i] = src[i] * sigmoid(src[i])`，即 `dst[i] = src[i] / (1 + e^(-src[i]))`
+
+> silu 为独立实现，直接映射到 `tl.ascend_silu` intrinsic，非 `unary_op` 通用分发器路径。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def silu(
+    dst: Buffer | BufferRegion,
+    src: Buffer | BufferRegion,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放 SiLU 运算结果 | 张量（tensor） | 必填 |
+| src | 输入 | 源操作数 | 张量（tensor） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src |
+|------|:---:|:---:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 |
+| Ascend A5 | float16, float32 | float16, float32 |
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src 的元素总数必须相同
+2. dst 与 src 的 dtype 必须一致（Ascend C 硬件约束）
+3. src 与 dst 的地址不能重叠
+4. 操作数地址需 32 字节对齐（硬件约束）
+5. 仅支持 ND 格式输入，不支持其他格式（Ascend C 约束）
+6. 接口内部使用框架自动申请的临时缓冲区（大小与 dst 相同），无需用户手动分配
+
+## 3. 示例代码
+
+**示例 1：1D SiLU**
+
+```python
+src = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.silu(dst, src)
+```
+
+**示例 2：2D SiLU**
+
+```python
+src = T.alloc_ub((128, 256), "float16")
+dst = T.alloc_ub((128, 256), "float16")
+T.tile.silu(dst, src)
+```

--- a/docs/language/tile_sin.md
+++ b/docs/language/tile_sin.md
@@ -1,0 +1,69 @@
+# T.tile.sin
+
+## 1. 功能说明
+
+对操作数逐元素执行正弦运算：`dst[i] = sin(src[i])`
+
+> sin 为独立实现，直接映射到 `tl.ascend_sin` intrinsic。Ascend C 后端使用高阶 API，内部需要临时空间（tmpBuffer）存储中间变量。PTO 后端不支持 sin/cos（无原生 PTO-ISA 指令）。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def sin(
+    dst: Buffer | BufferRegion,
+    src: Buffer | BufferRegion,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放正弦运算结果 | 张量（tensor） | 必填 |
+| src | 输入 | 源操作数 | 张量（tensor） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src |
+|------|:---:|:---:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 |
+| Ascend A5 | float16, float32 | float16, float32 |
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src 的元素总数必须相同，否则 assert 失败
+2. dst 与 src 的 dtype 必须一致（Ascend C 约束）
+3. 不支持源操作数与目的操作数地址重叠（Ascend C 约束）
+4. 操作数地址需 32 字节对齐（硬件约束）
+5. A2/A3 平台输入值域必须在 [-65504.0, 65504.0] 范围内（POLYNOMIAL_APPROXIMATION 算法限制），超出此范围结果不可预测
+6. PTO 后端不支持 sin/cos，使用 PTO 后端编译含 sin 的 kernel 会产生无效代码
+7. 接口内部使用框架自动申请的临时缓冲区（大小为 `2 × N × sizeof(dtype)` 字节，N 为元素个数），无需用户手动分配
+
+## 3. 示例代码
+
+**示例 1：1D 正弦运算**
+
+```python
+src = T.alloc_ub((1024,), "float16")
+dst = T.alloc_ub((1024,), "float16")
+T.tile.sin(dst, src)
+```
+
+**示例 2：2D 正弦运算**
+
+```python
+src = T.alloc_ub((128, 64), "float16")
+dst = T.alloc_ub((128, 64), "float16")
+T.tile.sin(dst, src)
+```

--- a/docs/language/tile_sqrt.md
+++ b/docs/language/tile_sqrt.md
@@ -1,0 +1,55 @@
+# T.tile.sqrt
+
+## 1. 功能说明
+
+对源操作数逐元素执行平方根运算：`dst[i] = √src[i]`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def sqrt(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放平方根运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 源操作数 | 张量（tensor） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 |
+|------|:---:|:----:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 |
+| Ascend A5 | float16, float32 | float16, float32 |
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src0 的元素总数必须相同
+2. 操作数地址需 32 字节对齐（硬件约束）
+3. src0 输入应为正数，否则结果未定义
+
+## 3. 示例代码
+
+**示例 1：逐元素平方根运算**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.sqrt(dst, src0)  # dst[i] = √src0[i]
+```

--- a/docs/language/tile_sub.md
+++ b/docs/language/tile_sub.md
@@ -1,0 +1,70 @@
+# T.tile.sub
+
+## 1. 功能说明
+
+对两个操作数逐元素执行减法运算：`dst[i] = src0[i] - src1[i]`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def sub(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion | BufferLoad,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放减法运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二个源操作数，支持 tensor 或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 buffer 元素访问（BufferLoad）或 Python 标量/表达式（PrimExpr）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | int16, float16, int32, float32 | int16, float16, int32, float32 | int16, float16, int32, float32 |
+| Ascend A5 | int8, uint8, int16, uint16, float16, bfloat16, int32, uint32, float32, int64, uint64 | int8, uint8, int16, uint16, float16, bfloat16, int32, uint32, float32, int64, uint64 | int8, uint8, int16, uint16, float16, bfloat16, int32, uint32, float32, int64, uint64 |
+
+> **后端差异说明**：A5 平台上 int64/uint64 仅 Ascend C 后端支持，PTO 后端不支持。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 与 src0 的 shape 必须相同
+2. src1 为 tensor 时，shape 也必须与 dst 相同
+3. src0 和 src1 的 dtype 必须与 dst 一致
+4. 操作数地址需 32 字节对齐（硬件约束）
+
+## 3. 示例代码
+
+**示例 1：tensor-tensor 减法**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+src1 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.sub(dst, src0, src1)
+```
+
+**示例 2：tensor-scalar 减法**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.sub(dst, src0, 1.0)  # src1 = 1.0，每个元素减 1.0
+```


### PR DESCRIPTION
## Summary

Add the first batch (`v0`) of `T.tile.*` API reference documents under `docs/language/`, covering arithmetic, bitwise, cast, math-unary, fill/clear, clamp and activation tile primitives (32 files, +2230 lines).

## Changes

- **Arithmetic (10)**: `tile_abs`, `tile_add`, `tile_sub`, `tile_mul`, `tile_div`, `tile_max`, `tile_min`, `tile_pow`, `tile_axpy`, `tile_mul_add_dst`
- **Bitwise (6)**: `tile_bitwise_and`, `tile_bitwise_or`, `tile_bitwise_xor`, `tile_bitwise_not`, `tile_bitwise_lshift`, `tile_bitwise_rshift`
- **Cast (1)**: `tile_cast`
- **Math unary (8)**: `tile_exp`, `tile_sqrt`, `tile_rsqrt`, `tile_sin`, `tile_cos`, `tile_ln`, `tile_reciprocal`, `tile_round`
- **Fill / Clear (2)**: `tile_fill`, `tile_clear`
- **Clamp (1)**: `tile_clamp`
- **Activation (4)**: `tile_relu`, `tile_leaky_relu`, `tile_sigmoid`, `tile_silu`

Each doc follows the existing `docs/language/` template (description, signature, parameters, example, notes).

## Testing

Documentation-only change; no code/behavior impact. Verified all 32 files render under `docs/language/`.