### PR TITLE
[Fix] xattention Fix the accuracy issue of target="pto

### DIFF
--- a/examples/xattention/xattention.py
+++ b/examples/xattention/xattention.py
@@ -667,7 +667,6 @@ def xattention():
 
                                     T.copy(m_i, m_i_prev)
                                     T.copy(m_i, m_i_prev_chunk)
-                                    T.pipe_barrier("v")
                                     T.wait_cross_flag(SHARED_QK_READY_BASE)
 
                                     for row_pipe in T.serial(SHARED_S_ROW_TILES + 1):
@@ -696,6 +695,7 @@ def xattention():
                                                 acc_s_ub[compute_side, :, :],
                                                 sm_scale,
                                             )
+                                            T.pipe_barrier("v")
                                             if (task_k + 1) * EFFECTIVE_BLOCK_N > shared_kv_lens[task_request_idx]:
                                                 for mask_row in T.serial(SHARED_S_ROWS):
                                                     for mask_col in T.serial(EFFECTIVE_BLOCK_N):
@@ -729,6 +729,7 @@ def xattention():
                                                     m_i_prev_chunk_tiles[row_tile, :, :],
                                                     m_i_tiles[row_tile, :, :],
                                                 )
+                                                T.pipe_barrier("v")
                                                 T.tile.exp(
                                                     m_i_prev_chunk_tiles[row_tile, :, :],
                                                     m_i_prev_chunk_tiles[row_tile, :, :],
@@ -739,7 +740,6 @@ def xattention():
                                                     sumexp_tiles[row_tile, :, :],
                                                     m_i_prev_chunk_tiles[row_tile, :, :],
                                                 )
-                                                T.pipe_barrier("v")
                                             T.tile.brcb_experiment(
                                                 shared_s_brcb_buf,
                                                 m_i_next,
@@ -763,6 +763,7 @@ def xattention():
                                                     ],
                                                     shared_s_brcb_buf,
                                                 )
+                                            T.pipe_barrier("v")
                                             T.tile.exp(
                                                 acc_s_ub[compute_side, :, :],
                                                 acc_s_ub[compute_side, :, :],
@@ -779,7 +780,6 @@ def xattention():
                                                 sumexp_tiles[row_tile, :, :],
                                                 sumexp_i[0, :, :],
                                             )
-                                            T.pipe_barrier("v")
 
                                             T.wait_flag("mte3", "v", compute_side)
                                             T.copy(
@@ -801,10 +801,10 @@ def xattention():
                                             T.set_flag("mte3", "v", compute_side)
 
                                     T.tile.sub(m_i_prev, m_i_prev, m_i)
+                                    T.pipe_barrier("v")
                                     T.tile.exp(m_i_prev, m_i_prev)
                                     T.pipe_barrier("v")
                                     T.copy(m_i_prev, shared_o_scale_slots[o_slot, :, :])
-                                    T.pipe_barrier("v")
                                     if task_k == SHARED_KV_TILES - 1:
                                         T.tile.brcb_experiment(
                                             shared_gm_store_buf,
@@ -931,7 +931,6 @@ def xattention():
                                             ],
                                         )
                                         T.set_flag("mte3", "v", 2)
-                                    T.pipe_barrier("v")
 
                         for final_mte3_event in T.serial(4):
                             T.wait_flag("mte3", "v", final_mte3_event)
@@ -1121,7 +1120,9 @@ def xattention():
                             unshared_s,
                             unshared_mask,
                         )
+                        T.pipe_barrier("v")
                         T.tile.mul(unshared_s, unshared_s, sm_scale)
+                        T.pipe_barrier("v")
                         T.reduce_max(unshared_s, unshared_m, dim=-1)
                         T.pipe_barrier("v")
                         T.tile.brcb_experiment(
@@ -1145,10 +1146,10 @@ def xattention():
                                 ],
                                 unshared_m_broadcast,
                             )
+                        T.pipe_barrier("v")
                         T.tile.exp(unshared_s, unshared_s)
                         T.pipe_barrier("v")
                         T.reduce_sum(unshared_s, unshared_sum, dim=-1)
-                        T.pipe_barrier("v")
                         T.copy(unshared_s, unshared_s_half)
                         if i + 1 < TASKS_PER_CORE:
                             T.set_flag("v", "mte2", 0)
@@ -1286,7 +1287,6 @@ def xattention():
                             merge_s_gm,
                             dim=-1,
                         )
-                        T.pipe_barrier("v")
                         T.reduce_max(
                             merge_s_gl_load_lane[merge_buf, :, :],
                             merge_s_gl,
@@ -1310,7 +1310,6 @@ def xattention():
                         )
                         T.pipe_barrier("v")
                         T.tile.add(merge_gl, merge_s_gl, merge_u_gl[merge_buf, :, :])
-                        T.pipe_barrier("v")
                         T.tile.brcb_experiment(
                             merge_s_gm_lane,
                             merge_cor_s,
@@ -1334,7 +1333,6 @@ def xattention():
                                 ],
                                 merge_s_gm_lane,
                             )
-                        T.pipe_barrier("v")
                         T.tile.brcb_experiment(
                             merge_s_gl_lane,
                             merge_cor_u,
@@ -1364,7 +1362,6 @@ def xattention():
                             merge_s_O[merge_buf, :, :],
                             merge_u_O[merge_buf, :, :],
                         )
-                        T.pipe_barrier("v")
                         T.tile.brcb_experiment(
                             merge_s_gm_lane,
                             merge_gl,
@@ -1395,7 +1392,6 @@ def xattention():
                             merge_s_O[merge_buf, :, :],
                             merge_out[merge_buf, :, :],
                         )
-                        T.pipe_barrier("v")
                         T.set_flag("v", "mte2", merge_buf)
 
                         T.set_flag("v", "mte3", 2 + merge_buf)

--- a/examples/xattention/xattention_paged.py
+++ b/examples/xattention/xattention_paged.py
@@ -670,7 +670,6 @@ def xattention_paged():
 
                                     T.copy(m_i, m_i_prev)
                                     T.copy(m_i, m_i_prev_chunk)
-                                    T.pipe_barrier("v")
                                     T.wait_cross_flag(SHARED_QK_READY_BASE)
 
                                     for row_pipe in T.serial(SHARED_S_ROW_TILES + 1):
@@ -699,6 +698,7 @@ def xattention_paged():
                                                 acc_s_ub[compute_side, :, :],
                                                 sm_scale,
                                             )
+                                            T.pipe_barrier("v")
                                             if (task_k + 1) * EFFECTIVE_BLOCK_N > shared_kv_lens[task_request_idx]:
                                                 for mask_row in T.serial(SHARED_S_ROWS):
                                                     for mask_col in T.serial(EFFECTIVE_BLOCK_N):
@@ -732,6 +732,7 @@ def xattention_paged():
                                                     m_i_prev_chunk_tiles[row_tile, :, :],
                                                     m_i_tiles[row_tile, :, :],
                                                 )
+                                                T.pipe_barrier("v")
                                                 T.tile.exp(
                                                     m_i_prev_chunk_tiles[row_tile, :, :],
                                                     m_i_prev_chunk_tiles[row_tile, :, :],
@@ -742,7 +743,6 @@ def xattention_paged():
                                                     sumexp_tiles[row_tile, :, :],
                                                     m_i_prev_chunk_tiles[row_tile, :, :],
                                                 )
-                                                T.pipe_barrier("v")
                                             T.tile.brcb_experiment(
                                                 shared_s_brcb_buf,
                                                 m_i_next,
@@ -766,6 +766,7 @@ def xattention_paged():
                                                     ],
                                                     shared_s_brcb_buf,
                                                 )
+                                            T.pipe_barrier("v")
                                             T.tile.exp(
                                                 acc_s_ub[compute_side, :, :],
                                                 acc_s_ub[compute_side, :, :],
@@ -782,7 +783,6 @@ def xattention_paged():
                                                 sumexp_tiles[row_tile, :, :],
                                                 sumexp_i[0, :, :],
                                             )
-                                            T.pipe_barrier("v")
 
                                             T.wait_flag("mte3", "v", compute_side)
                                             T.copy(
@@ -804,10 +804,10 @@ def xattention_paged():
                                             T.set_flag("mte3", "v", compute_side)
 
                                     T.tile.sub(m_i_prev, m_i_prev, m_i)
+                                    T.pipe_barrier("v")
                                     T.tile.exp(m_i_prev, m_i_prev)
                                     T.pipe_barrier("v")
                                     T.copy(m_i_prev, shared_o_scale_slots[o_slot, :, :])
-                                    T.pipe_barrier("v")
                                     if task_k == SHARED_KV_TILES - 1:
                                         T.tile.brcb_experiment(
                                             shared_gm_store_buf,
@@ -934,7 +934,6 @@ def xattention_paged():
                                             ],
                                         )
                                         T.set_flag("mte3", "v", 2)
-                                    T.pipe_barrier("v")
 
                         for final_mte3_event in T.serial(4):
                             T.wait_flag("mte3", "v", final_mte3_event)
@@ -1124,7 +1123,9 @@ def xattention_paged():
                             unshared_s,
                             unshared_mask,
                         )
+                        T.pipe_barrier("v")
                         T.tile.mul(unshared_s, unshared_s, sm_scale)
+                        T.pipe_barrier("v")
                         T.reduce_max(unshared_s, unshared_m, dim=-1)
                         T.pipe_barrier("v")
                         T.tile.brcb_experiment(
@@ -1148,10 +1149,10 @@ def xattention_paged():
                                 ],
                                 unshared_m_broadcast,
                             )
+                        T.pipe_barrier("v")
                         T.tile.exp(unshared_s, unshared_s)
                         T.pipe_barrier("v")
                         T.reduce_sum(unshared_s, unshared_sum, dim=-1)
-                        T.pipe_barrier("v")
                         T.copy(unshared_s, unshared_s_half)
                         if i + 1 < TASKS_PER_CORE:
                             T.set_flag("v", "mte2", 0)
@@ -1289,7 +1290,6 @@ def xattention_paged():
                             merge_s_gm,
                             dim=-1,
                         )
-                        T.pipe_barrier("v")
                         T.reduce_max(
                             merge_s_gl_load_lane[merge_buf, :, :],
                             merge_s_gl,
@@ -1313,7 +1313,6 @@ def xattention_paged():
                         )
                         T.pipe_barrier("v")
                         T.tile.add(merge_gl, merge_s_gl, merge_u_gl[merge_buf, :, :])
-                        T.pipe_barrier("v")
                         T.tile.brcb_experiment(
                             merge_s_gm_lane,
                             merge_cor_s,
@@ -1337,7 +1336,6 @@ def xattention_paged():
                                 ],
                                 merge_s_gm_lane,
                             )
-                        T.pipe_barrier("v")
                         T.tile.brcb_experiment(
                             merge_s_gl_lane,
                             merge_cor_u,
@@ -1367,7 +1365,6 @@ def xattention_paged():
                             merge_s_O[merge_buf, :, :],
                             merge_u_O[merge_buf, :, :],
                         )
-                        T.pipe_barrier("v")
                         T.tile.brcb_experiment(
                             merge_s_gm_lane,
                             merge_gl,
@@ -1398,7 +1395,6 @@ def xattention_paged():
                             merge_s_O[merge_buf, :, :],
                             merge_out[merge_buf, :, :],
                         )
-                        T.pipe_barrier("v")
                         T.set_flag("v", "mte2", merge_buf)
 
                         T.set_flag("v", "mte3", 2 + merge_buf)

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -1265,8 +1265,8 @@ void CodeGenTileLangAscendPto::GMCopyCall(const CallNode *call,
   // gm addr
   stream << copy_base_addr_map_.at(gm_info.id) << " + " << gm_offset_string;
 
-  stream << ", pto::Shape<" << shape_tmpl << ">()" << ", pto::Stride<"
-         << stride_tmpl << ">(" << stride_param << ")";
+  stream << ", pto::Shape<" << shape_tmpl << ">()"
+         << ", pto::Stride<" << stride_tmpl << ">(" << stride_param << ")";
 
   stream << ", " << local_addr_str << ", " << local_offset_str << ", "
          << valid_rows_str << ", " << valid_cols_str << ");\n";
@@ -1515,13 +1515,14 @@ void CodeGenTileLangAscendPto::GemmV0Codegen(const CallNode *op) {
 
   this->PrintIndent();
   std::string data_type_input = params["data_type_input"];
-  this->stream << kAscendPtoScope << "gemm_v0" << "<"
-               << params["data_type_input"] << ", "
+  this->stream << kAscendPtoScope << "gemm_v0"
+               << "<" << params["data_type_input"] << ", "
                << params["data_type_output"] << ", " << GetValid16BytesShape(M)
                << ", " << GetValid16BytesShape(N) << ", "
                << GetValidShape(K, data_type_input) << ", " << M << ", " << N
                << ", " << K << ", " << kL0Tail << ", " << params["transpose_A"]
-               << ", " << params["transpose_B"] << ">" << "(";
+               << ", " << params["transpose_B"] << ">"
+               << "(";
   this->stream << a_name << ", " << b_name << ", " << c_name << ", "
                << PrintExpr(op->args[4]) << ");\n";
 }
@@ -1560,13 +1561,16 @@ void CodeGenTileLangAscendPto::HandleA5Flag(const std::string &op,
                                             const std::string &pipe, int flag) {
   if (this->current_resource_scope_ == "CUBE") {
     this->PrintIndent();
-    this->stream << op << "(" << "PIPE_" << pipe << ", " << flag << ");\n";
+    this->stream << op << "("
+                 << "PIPE_" << pipe << ", " << flag << ");\n";
     this->PrintIndent();
-    this->stream << op << "(" << "PIPE_" << pipe << ", "
-                 << flag + kA5CubeFlagOffset << ");\n";
+    this->stream << op << "("
+                 << "PIPE_" << pipe << ", " << flag + kA5CubeFlagOffset
+                 << ");\n";
   } else if (this->current_resource_scope_ == "VEC") {
     this->PrintIndent();
-    this->stream << op << "(" << "PIPE_" << pipe << ", " << flag << ");\n";
+    this->stream << op << "("
+                 << "PIPE_" << pipe << ", " << flag << ");\n";
   } else {
     LOG(WARNING) << op << " called outside of known scope (CUBE/VEC)!";
   }
@@ -1607,8 +1611,9 @@ void CodeGenTileLangAscendPto::AutoSetCrossFlagCodegen(const CallNode *op) {
     int config =
         kFftsBaseConfig | (mode << kFftsModeShift) | (flag << kFftsFlagShift);
     this->PrintIndent();
-    this->stream << "ffts_cross_core_sync" << "(" << "PIPE_" << pipe << ", "
-                 << config << ");\n";
+    this->stream << "ffts_cross_core_sync"
+                 << "("
+                 << "PIPE_" << pipe << ", " << config << ");\n";
   }
 }
 
@@ -1728,8 +1733,8 @@ void CodeGenTileLangAscendPto::FillCodegen(const CallNode *op) {
   std::string dst_name = ResolveUbSliceName(dst_shape_info);
 
   this->PrintIndent();
-  this->stream << "TEXPANDS" << "(" << dst_name << ", "
-               << PrintExpr(op->args[2]) << ");\n";
+  this->stream << "TEXPANDS"
+               << "(" << dst_name << ", " << PrintExpr(op->args[2]) << ");\n";
 }
 
 void CodeGenTileLangAscendPto::CreateVecIndexCodegen(
@@ -1743,9 +1748,10 @@ void CodeGenTileLangAscendPto::CreateVecIndexCodegen(
   auto total_elems = M * N;
 
   this->PrintIndent();
-  this->stream << kAscendPtoScope << "tci" << "<" << getType(dst_info.dtype)
-               << ", 1, " << PrintExpr(total_elems) << ">" << "("
-               << PrintExpr(dst_slice_info.first_addr) << ", "
+  this->stream << kAscendPtoScope << "tci"
+               << "<" << getType(dst_info.dtype) << ", 1, "
+               << PrintExpr(total_elems) << ">"
+               << "(" << PrintExpr(dst_slice_info.first_addr) << ", "
                << dst_slice_info.offset << ", "
                << GetTypeLen(dst_slice_info.type) << ", " << first_value
                << ");\n";
@@ -2184,7 +2190,8 @@ void CodeGenTileLangAscendPto::CompareCodegen(const CallNode *op,
 
   this->PrintIndent();
   this->stream << kAscendPtoScope << "compare(" << dst_name << ", " << src0_name
-               << ", " << src1_name << ", " << "CmpMode::" << mode << ");\n";
+               << ", " << src1_name << ", "
+               << "CmpMode::" << mode << ");\n";
 }
 
 void CodeGenTileLangAscendPto::CompareScalarCodegen(
@@ -2206,8 +2213,8 @@ void CodeGenTileLangAscendPto::CompareScalarCodegen(
 
   this->PrintIndent();
   this->stream << kAscendPtoScope << "compare_scalar(" << dst_name << ", "
-               << src0_name << ", " << src1_name << ", " << "CmpMode::" << mode
-               << ");\n";
+               << src0_name << ", " << src1_name << ", "
+               << "CmpMode::" << mode << ");\n";
 }
 
 void CodeGenTileLangAscendPto::TshCodegen(const CallNode *op,
@@ -2369,7 +2376,8 @@ void CodeGenTileLangAscendPto::CodegenRowBroadcast(const ShapeInfo &dst,
   }
 
   this->PrintIndent();
-  this->stream << "TROWEXPAND" << "(" << dst_name << ", " << src_name << ");\n";
+  this->stream << "TROWEXPAND"
+               << "(" << dst_name << ", " << src_name << ");\n";
 }
 
 void CodeGenTileLangAscendPto::CodegenColBroadcast(const ShapeInfo &dst,
@@ -2388,7 +2396,8 @@ void CodeGenTileLangAscendPto::CodegenColBroadcast(const ShapeInfo &dst,
   }
 
   this->PrintIndent();
-  this->stream << "TCOLEXPAND" << "(" << dst_name << ", " << src_name << ");\n";
+  this->stream << "TCOLEXPAND"
+               << "(" << dst_name << ", " << src_name << ");\n";
 }
 
 void CodeGenTileLangAscendPto::RowExpandMulCodegen(const CallNode *op) {
@@ -2413,11 +2422,16 @@ void CodeGenTileLangAscendPto::RowExpandBinOpExperimentCodegenPto(
     Var buf_var = Downcast<Var>(access_ptr->args[1]);
     auto shape = buffer_shapess_.at(buf_var);
     if (shape.size() >= 3) {
-      int32_t last_dim = shape.back().as<IntImmNode>()->value;
-      info.slice_col = GetValidShape(last_dim, info.type);
-      info.slice_row = info.extent / last_dim;
-      info.slice_valid_col = last_dim;
-      info.slice_valid_row = info.slice_row;
+      int32_t phys_col = shape.back().as<IntImmNode>()->value;
+      int dtype_bits = info.type == "float" ? 32 : 16;
+      int elems_per_block = 32 / (dtype_bits / 8);
+      int elems_per_repeat = 8 * elems_per_block;
+      int32_t valid_row = info.extent / elems_per_repeat;
+      int32_t valid_col = elems_per_repeat;
+      info.slice_valid_col = valid_col;
+      info.slice_valid_row = valid_row;
+      info.slice_col = GetValidShape(phys_col, info.type);
+      info.slice_row = valid_row;
     }
   };
   fix_nd_2d(dst, op->args[1].as<CallNode>());
@@ -2454,14 +2468,9 @@ void CodeGenTileLangAscendPto::RowExpandBinOpExperimentCodegenPto(
     CreateUbVariableND(src0_name, src0);
   }
 
-  int32_t src1_len = src1.slice_col;
-  int32_t dst_rows = dst.is_slice ? dst.slice_valid_row : dst.row;
-  int32_t dst_cols = dst.is_slice ? dst.slice_valid_col : dst.col;
-
   this->PrintIndent();
-  this->stream << kAscendPtoScope << pto_op_name << "<" << src1.type << ", "
-               << dst_rows << ", " << dst_cols << ", " << src1_len << ">("
-               << dst_name << ", " << src0_name << ", " << src1_name << ", "
+  this->stream << kAscendPtoScope << pto_op_name << "(" << dst_name << ", "
+               << src0_name << ", " << src1_name << ", "
                << PrintExpr(src1.first_addr) << ", " << src1.offset;
   if (has_tmp) {
     this->stream << ", " << tmp.ub_name;
@@ -3364,8 +3373,8 @@ void CodeGenTileLangAscendPto::VisitExpr_(const SelectNode *op,
   auto true_value = PrintExpr(op->true_value);
   auto false_value = PrintExpr(op->false_value);
 
-  os << "(" << condition << " ? " << "" << true_value << " : " << false_value
-     << ")";
+  os << "(" << condition << " ? "
+     << "" << true_value << " : " << false_value << ")";
 }
 
 static void ProcessHostInput(std::ostream &os,
@@ -3373,7 +3382,8 @@ static void ProcessHostInput(std::ostream &os,
                              std::vector<const tir::VarNode *> &shape_vars,
                              bool add_args = true) {
   for (auto shape_var : shape_vars) {
-    os << ", " << "int64_t " << shape_var->name_hint;
+    os << ", "
+       << "int64_t " << shape_var->name_hint;
     if (add_args) {
       arg_names.push_back(shape_var->name_hint);
     }
@@ -3535,7 +3545,8 @@ void CodeGenTileLangAscendPto::AddFunction(const GlobalVar &gvar,
     stream << ", ";
   }
   for (auto shape_var : shape_vars) {
-    stream << "int64_t" << " " << GetVarID(shape_var);
+    stream << "int64_t"
+           << " " << GetVarID(shape_var);
     if (index != shape_vars.size() - 1) {
       stream << ", ";
     }
@@ -3595,7 +3606,8 @@ void CodeGenTileLangAscendPto::AutoFlagOpCodegen(const CallNode *op,
   std::string dst = event_type.substr(pos + 1);
 
   auto event_id = PrintExpr(op->args[1]);
-  this->stream << op_name << "(PIPE_" << src << ", " << "PIPE_" << dst << ", "
+  this->stream << op_name << "(PIPE_" << src << ", "
+               << "PIPE_" << dst << ", "
                << "EVENT_ID" << event_id << ");\n";
 }
 

--- a/src/tl_templates/pto/common.h
+++ b/src/tl_templates/pto/common.h
@@ -596,101 +596,129 @@ AICORE PTO_INLINE void TROWEXPAND_with_slice_buffer(
 }
 
 // Row-wise broadcast multiply helper.
-// Reinterprets src1 (RowMajor row vector [1, vecLen]) as a ColMajor column
-// vector [vecLen, 1] (same memory layout), then calls TROWEXPANDMUL.
-template <typename T, int32_t dstRows, int32_t dstCols, int32_t vecLen>
+// src1_vec can be either:
+// - A multi-row ND RowMajor tile (brcb result [N, 8]): pass directly to
+//   TROWEXPANDMUL which reads src1[i, 0] per row.
+// - A 1-row row vector [1, N] (flattened from [N, 1] by Flatten2D): reinterpret
+//   as ColMajor column vector [N, 1] via src1_addr/src1_offset so TROWEXPANDMUL
+//   broadcasts scalar i to row i.
+template <typename DstTile, typename Src0Tile, typename Src1Tile>
 AICORE PTO_INLINE void
-TROWEXPANDMUL_row_vec(TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &dst,
-                      TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &src0,
-                      TileUbDataND<T, 1, vecLen, 1, vecLen> &src1_vec,
+TROWEXPANDMUL_row_vec(DstTile &dst, Src0Tile &src0, Src1Tile &src1_vec,
                       int32_t src1_addr, int32_t src1_offset) {
-  constexpr int32_t alignedRows =
-      ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
-  constexpr int32_t typeLen = sizeof(T);
-  (void)src1_vec;
-  TileUbDataDN<T, alignedRows, 1, vecLen, 1> src1_dn;
-  pto::TASSIGN(src1_dn, src1_addr + src1_offset * typeLen);
-  TROWEXPANDMUL(dst, src0, src1_dn);
+  if constexpr (Src1Tile::ValidRow == 1) {
+    using T = typename Src1Tile::DType;
+    constexpr int32_t vecLen = Src1Tile::ValidCol;
+    constexpr int32_t alignedRows =
+        ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
+    TileUbDataDN<T, alignedRows, 1, vecLen, 1> src1_dn;
+    pto::TASSIGN(src1_dn, src1_addr + src1_offset * sizeof(T));
+    TROWEXPANDMUL(dst, src0, src1_dn);
+  } else {
+    (void)src1_addr;
+    (void)src1_offset;
+    TROWEXPANDMUL(dst, src0, src1_vec);
+  }
 }
 
-template <typename T, int32_t dstRows, int32_t dstCols, int32_t vecLen,
+template <typename DstTile, typename Src0Tile, typename Src1Tile,
           typename TmpTile>
 AICORE PTO_INLINE void
-TROWEXPANDMUL_row_vec(TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &dst,
-                      TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &src0,
-                      TileUbDataND<T, 1, vecLen, 1, vecLen> &src1_vec,
+TROWEXPANDMUL_row_vec(DstTile &dst, Src0Tile &src0, Src1Tile &src1_vec,
                       int32_t src1_addr, int32_t src1_offset, TmpTile &tmp) {
-  constexpr int32_t alignedRows =
-      ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
-  constexpr int32_t typeLen = sizeof(T);
-  (void)src1_vec;
-  TileUbDataDN<T, alignedRows, 1, vecLen, 1> src1_dn;
-  pto::TASSIGN(src1_dn, src1_addr + src1_offset * typeLen);
-  TROWEXPANDMUL(dst, src0, src1_dn, tmp);
+  if constexpr (Src1Tile::ValidRow == 1) {
+    using T = typename Src1Tile::DType;
+    constexpr int32_t vecLen = Src1Tile::ValidCol;
+    constexpr int32_t alignedRows =
+        ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
+    TileUbDataDN<T, alignedRows, 1, vecLen, 1> src1_dn;
+    pto::TASSIGN(src1_dn, src1_addr + src1_offset * sizeof(T));
+    TROWEXPANDMUL(dst, src0, src1_dn, tmp);
+  } else {
+    (void)src1_addr;
+    (void)src1_offset;
+    TROWEXPANDMUL(dst, src0, src1_vec, tmp);
+  }
 }
 
 // Row-wise broadcast subtract helper.
-template <typename T, int32_t dstRows, int32_t dstCols, int32_t vecLen>
+template <typename DstTile, typename Src0Tile, typename Src1Tile>
 AICORE PTO_INLINE void
-TROWEXPANDSUB_row_vec(TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &dst,
-                      TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &src0,
-                      TileUbDataND<T, 1, vecLen, 1, vecLen> &src1_vec,
+TROWEXPANDSUB_row_vec(DstTile &dst, Src0Tile &src0, Src1Tile &src1_vec,
                       int32_t src1_addr, int32_t src1_offset) {
-  constexpr int32_t alignedRows =
-      ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
-  constexpr int32_t typeLen = sizeof(T);
-  (void)src1_vec;
-  TileUbDataDN<T, alignedRows, 1, vecLen, 1> src1_dn;
-  pto::TASSIGN(src1_dn, src1_addr + src1_offset * typeLen);
-  TROWEXPANDSUB(dst, src0, src1_dn);
+  if constexpr (Src1Tile::ValidRow == 1) {
+    using T = typename Src1Tile::DType;
+    constexpr int32_t vecLen = Src1Tile::ValidCol;
+    constexpr int32_t alignedRows =
+        ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
+    TileUbDataDN<T, alignedRows, 1, vecLen, 1> src1_dn;
+    pto::TASSIGN(src1_dn, src1_addr + src1_offset * sizeof(T));
+    TROWEXPANDSUB(dst, src0, src1_dn);
+  } else {
+    (void)src1_addr;
+    (void)src1_offset;
+    TROWEXPANDSUB(dst, src0, src1_vec);
+  }
 }
 
-template <typename T, int32_t dstRows, int32_t dstCols, int32_t vecLen,
+template <typename DstTile, typename Src0Tile, typename Src1Tile,
           typename TmpTile>
 AICORE PTO_INLINE void
-TROWEXPANDSUB_row_vec(TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &dst,
-                      TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &src0,
-                      TileUbDataND<T, 1, vecLen, 1, vecLen> &src1_vec,
+TROWEXPANDSUB_row_vec(DstTile &dst, Src0Tile &src0, Src1Tile &src1_vec,
                       int32_t src1_addr, int32_t src1_offset, TmpTile &tmp) {
-  constexpr int32_t alignedRows =
-      ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
-  constexpr int32_t typeLen = sizeof(T);
-  (void)src1_vec;
-  TileUbDataDN<T, alignedRows, 1, vecLen, 1> src1_dn;
-  pto::TASSIGN(src1_dn, src1_addr + src1_offset * typeLen);
-  TROWEXPANDSUB(dst, src0, src1_dn, tmp);
+  if constexpr (Src1Tile::ValidRow == 1) {
+    using T = typename Src1Tile::DType;
+    constexpr int32_t vecLen = Src1Tile::ValidCol;
+    constexpr int32_t alignedRows =
+        ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
+    TileUbDataDN<T, alignedRows, 1, vecLen, 1> src1_dn;
+    pto::TASSIGN(src1_dn, src1_addr + src1_offset * sizeof(T));
+    TROWEXPANDSUB(dst, src0, src1_dn, tmp);
+  } else {
+    (void)src1_addr;
+    (void)src1_offset;
+    TROWEXPANDSUB(dst, src0, src1_vec, tmp);
+  }
 }
 
 // Row-wise broadcast divide helper.
-template <typename T, int32_t dstRows, int32_t dstCols, int32_t vecLen>
+template <typename DstTile, typename Src0Tile, typename Src1Tile>
 AICORE PTO_INLINE void
-TROWEXPANDDIV_row_vec(TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &dst,
-                      TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &src0,
-                      TileUbDataND<T, 1, vecLen, 1, vecLen> &src1_vec,
+TROWEXPANDDIV_row_vec(DstTile &dst, Src0Tile &src0, Src1Tile &src1_vec,
                       int32_t src1_addr, int32_t src1_offset) {
-  constexpr int32_t alignedRows =
-      ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
-  constexpr int32_t typeLen = sizeof(T);
-  (void)src1_vec;
-  TileUbDataDN<T, alignedRows, 1, vecLen, 1> src1_dn;
-  pto::TASSIGN(src1_dn, src1_addr + src1_offset * typeLen);
-  TROWEXPANDDIV(dst, src0, src1_dn);
+  if constexpr (Src1Tile::ValidRow == 1) {
+    using T = typename Src1Tile::DType;
+    constexpr int32_t vecLen = Src1Tile::ValidCol;
+    constexpr int32_t alignedRows =
+        ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
+    TileUbDataDN<T, alignedRows, 1, vecLen, 1> src1_dn;
+    pto::TASSIGN(src1_dn, src1_addr + src1_offset * sizeof(T));
+    TROWEXPANDDIV(dst, src0, src1_dn);
+  } else {
+    (void)src1_addr;
+    (void)src1_offset;
+    TROWEXPANDDIV(dst, src0, src1_vec);
+  }
 }
 
-template <typename T, int32_t dstRows, int32_t dstCols, int32_t vecLen,
+template <typename DstTile, typename Src0Tile, typename Src1Tile,
           typename TmpTile>
 AICORE PTO_INLINE void
-TROWEXPANDDIV_row_vec(TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &dst,
-                      TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &src0,
-                      TileUbDataND<T, 1, vecLen, 1, vecLen> &src1_vec,
+TROWEXPANDDIV_row_vec(DstTile &dst, Src0Tile &src0, Src1Tile &src1_vec,
                       int32_t src1_addr, int32_t src1_offset, TmpTile &tmp) {
-  constexpr int32_t alignedRows =
-      ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
-  constexpr int32_t typeLen = sizeof(T);
-  (void)src1_vec;
-  TileUbDataDN<T, alignedRows, 1, vecLen, 1> src1_dn;
-  pto::TASSIGN(src1_dn, src1_addr + src1_offset * typeLen);
-  TROWEXPANDDIV(dst, src0, src1_dn, tmp);
+  if constexpr (Src1Tile::ValidRow == 1) {
+    using T = typename Src1Tile::DType;
+    constexpr int32_t vecLen = Src1Tile::ValidCol;
+    constexpr int32_t alignedRows =
+        ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
+    TileUbDataDN<T, alignedRows, 1, vecLen, 1> src1_dn;
+    pto::TASSIGN(src1_dn, src1_addr + src1_offset * sizeof(T));
+    TROWEXPANDDIV(dst, src0, src1_dn, tmp);
+  } else {
+    (void)src1_addr;
+    (void)src1_offset;
+    TROWEXPANDDIV(dst, src0, src1_vec, tmp);
+  }
 }
 
 template <pipe_t pipe>


### PR DESCRIPTION
Fix the compilation errors in the row_expand_*_experiment API of PTO codegen:
1. Template type deduction: TROWEXPAND{MUL,SUB,DIV}_row_vec is changed from hard-coded TileUbDataND<T,1,vecLen,...> to deduced typename DstTile/Src0Tile/Src1Tile, with the function body directly passing src1_vec to TROWEXPAND
2. Shape derivation: Calculate valid rows/columns based on the ascendc repeat semantics (8 * elems_per_block) for fix_nd_2d, and modify src1_len to dst_rows
3. XAttention: Pipe Barrier Position Adjustment, Correcting V Pipe Data Dependencies