### PR TITLE
[Fix] fix MUL/SUB/DIV _experiment    vaildcol != col

### DIFF
--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -2332,14 +2332,17 @@ void CodeGenTileLangAscendPto::RowExpandBinOpExperimentCodegenPto(
     CreateUbVariableND(src0_name, src0);
   }
 
-  int32_t src1_len = src1.slice_col;
   int32_t dst_rows = dst.is_slice ? dst.slice_valid_row : dst.row;
   int32_t dst_cols = dst.is_slice ? dst.slice_valid_col : dst.col;
+  int32_t src1_len = dst_rows;
+  int32_t dst_row_valid = dst.is_slice ? dst.slice_valid_row : dst.row;
+  int32_t dst_col_valid = dst.is_slice ? dst.slice_valid_col : dst.col;
 
   this->PrintIndent();
   this->stream << kAscendPtoScope << pto_op_name << "<" << src1.type << ", "
-               << dst_rows << ", " << dst_cols << ", " << src1_len << ">("
-               << dst_name << ", " << src0_name << ", " << src1_name << ", "
+               << dst_rows << ", " << dst_cols << ", " << dst_row_valid << ", "
+               << dst_col_valid << ", " << src1_len << ">(" << dst_name << ", "
+               << src0_name << ", " << src1_name << ", "
                << PrintExpr(src1.first_addr) << ", " << src1.offset;
   if (has_tmp) {
     this->stream << ", " << tmp.ub_name;
@@ -3100,15 +3103,17 @@ void CodeGenTileLangAscendPto::VisitStmt_(const AllocateNode *op) {
   ICHECK(shape.size() == 4)
       << "Expected a 4D shape [M, N, Valid_M, Valid_N] for PTO, but got "
       << shape.size() << "D for " << op->buffer_var->name_hint;
-  const auto &M = shape[0];
-  const auto &N = shape[1];
-  const auto &valid_M = shape[2];
-  const auto &valid_N = shape[3];
+  int32_t M_int = shape[0].as<IntImmNode>()->value;
+  int32_t N_int = shape[1].as<IntImmNode>()->value;
+  int32_t valid_M_int = shape[2].as<IntImmNode>()->value;
+  int32_t valid_N_int = shape[3].as<IntImmNode>()->value;
+  int32_t N_aligned = GetValidShape(N_int, type);
 
-  // Print the Tile object declaration
+  // Print the Tile object declaration. Cols (N) must be 32B-aligned for PTO
+  // tile static assertions; valid_N keeps the logical (unpadded) column count.
   this->PrintIndent();
-  stream << op_name << "<" << type << ", " << M << ", " << N << ", " << valid_M
-         << ", " << valid_N << "> " << vid << ";\n";
+  stream << op_name << "<" << type << ", " << M_int << ", " << N_aligned
+         << ", " << valid_M_int << ", " << valid_N_int << "> " << vid << ";\n";
 
   // address_map, use name_hint as key
   Map<String, PrimExpr> address_map_name_hint;

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -2315,9 +2315,7 @@ void CodeGenTileLangAscendPto::RowExpandBinOpExperimentCodegenPto(
   std::string src1_name = src1.ub_name;
   if (src1.is_slice) {
     src1_name = GetTempVarName(src1.ub_name);
-    ShapeInfo src1_aligned = src1;
-    src1_aligned.slice_valid_col = src1.slice_col;
-    CreateUbVariableND(src1_name, src1_aligned);
+    CreateUbVariableND(src1_name, src1);
   }
 
   std::string dst_name = dst.ub_name;

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -2332,11 +2332,11 @@ void CodeGenTileLangAscendPto::RowExpandBinOpExperimentCodegenPto(
     CreateUbVariableND(src0_name, src0);
   }
 
-  int32_t dst_rows = dst.is_slice ? dst.slice_valid_row : dst.row;
-  int32_t dst_cols = dst.is_slice ? dst.slice_valid_col : dst.col;
-  int32_t src1_len = dst_rows;
+  int32_t dst_rows = dst.is_slice ? dst.slice_row : dst.row;
+  int32_t dst_cols = dst.is_slice ? dst.slice_col : dst.col;
   int32_t dst_row_valid = dst.is_slice ? dst.slice_valid_row : dst.row;
   int32_t dst_col_valid = dst.is_slice ? dst.slice_valid_col : dst.col;
+  int32_t src1_len = dst_row_valid;
 
   this->PrintIndent();
   this->stream << kAscendPtoScope << pto_op_name << "<" << src1.type << ", "

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -3103,17 +3103,15 @@ void CodeGenTileLangAscendPto::VisitStmt_(const AllocateNode *op) {
   ICHECK(shape.size() == 4)
       << "Expected a 4D shape [M, N, Valid_M, Valid_N] for PTO, but got "
       << shape.size() << "D for " << op->buffer_var->name_hint;
-  int32_t M_int = shape[0].as<IntImmNode>()->value;
-  int32_t N_int = shape[1].as<IntImmNode>()->value;
-  int32_t valid_M_int = shape[2].as<IntImmNode>()->value;
-  int32_t valid_N_int = shape[3].as<IntImmNode>()->value;
-  int32_t N_aligned = GetValidShape(N_int, type);
+  const auto &M = shape[0];
+  const auto &N = shape[1];
+  const auto &valid_M = shape[2];
+  const auto &valid_N = shape[3];
 
-  // Print the Tile object declaration. Cols (N) must be 32B-aligned for PTO
-  // tile static assertions; valid_N keeps the logical (unpadded) column count.
+  // Print the Tile object declaration
   this->PrintIndent();
-  stream << op_name << "<" << type << ", " << M_int << ", " << N_aligned
-         << ", " << valid_M_int << ", " << valid_N_int << "> " << vid << ";\n";
+  stream << op_name << "<" << type << ", " << M << ", " << N << ", " << valid_M
+         << ", " << valid_N << "> " << vid << ";\n";
 
   // address_map, use name_hint as key
   Map<String, PrimExpr> address_map_name_hint;

--- a/src/tl_templates/pto/common.h
+++ b/src/tl_templates/pto/common.h
@@ -598,12 +598,14 @@ AICORE PTO_INLINE void TROWEXPAND_with_slice_buffer(
 // Row-wise broadcast multiply helper.
 // Reinterprets src1 (RowMajor row vector [1, vecLen]) as a ColMajor column
 // vector [vecLen, 1] (same memory layout), then calls TROWEXPANDMUL.
-template <typename T, int32_t dstRows, int32_t dstCols, int32_t vecLen>
+template <typename T, int32_t dstRows, int32_t dstCols, int32_t dstRowValid,
+          int32_t dstColValid, int32_t vecLen, int32_t Src1Col>
 AICORE PTO_INLINE void
-TROWEXPANDMUL_row_vec(TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &dst,
-                      TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &src0,
-                      TileUbDataND<T, 1, vecLen, 1, vecLen> &src1_vec,
-                      int32_t src1_addr, int32_t src1_offset) {
+TROWEXPANDMUL_row_vec(
+    TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &dst,
+    TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &src0,
+    TileUbDataND<T, 1, Src1Col, 1, vecLen> &src1_vec, int32_t src1_addr,
+    int32_t src1_offset) {
   constexpr int32_t alignedRows =
       ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
   constexpr int32_t typeLen = sizeof(T);
@@ -613,13 +615,14 @@ TROWEXPANDMUL_row_vec(TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &dst,
   TROWEXPANDMUL(dst, src0, src1_dn);
 }
 
-template <typename T, int32_t dstRows, int32_t dstCols, int32_t vecLen,
-          typename TmpTile>
+template <typename T, int32_t dstRows, int32_t dstCols, int32_t dstRowValid,
+          int32_t dstColValid, int32_t vecLen, int32_t Src1Col, typename TmpTile>
 AICORE PTO_INLINE void
-TROWEXPANDMUL_row_vec(TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &dst,
-                      TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &src0,
-                      TileUbDataND<T, 1, vecLen, 1, vecLen> &src1_vec,
-                      int32_t src1_addr, int32_t src1_offset, TmpTile &tmp) {
+TROWEXPANDMUL_row_vec(
+    TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &dst,
+    TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &src0,
+    TileUbDataND<T, 1, Src1Col, 1, vecLen> &src1_vec, int32_t src1_addr,
+    int32_t src1_offset, TmpTile &tmp) {
   constexpr int32_t alignedRows =
       ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
   constexpr int32_t typeLen = sizeof(T);
@@ -630,12 +633,14 @@ TROWEXPANDMUL_row_vec(TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &dst,
 }
 
 // Row-wise broadcast subtract helper.
-template <typename T, int32_t dstRows, int32_t dstCols, int32_t vecLen>
+template <typename T, int32_t dstRows, int32_t dstCols, int32_t dstRowValid,
+          int32_t dstColValid, int32_t vecLen, int32_t Src1Col>
 AICORE PTO_INLINE void
-TROWEXPANDSUB_row_vec(TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &dst,
-                      TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &src0,
-                      TileUbDataND<T, 1, vecLen, 1, vecLen> &src1_vec,
-                      int32_t src1_addr, int32_t src1_offset) {
+TROWEXPANDSUB_row_vec(
+    TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &dst,
+    TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &src0,
+    TileUbDataND<T, 1, Src1Col, 1, vecLen> &src1_vec, int32_t src1_addr,
+    int32_t src1_offset) {
   constexpr int32_t alignedRows =
       ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
   constexpr int32_t typeLen = sizeof(T);
@@ -645,13 +650,14 @@ TROWEXPANDSUB_row_vec(TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &dst,
   TROWEXPANDSUB(dst, src0, src1_dn);
 }
 
-template <typename T, int32_t dstRows, int32_t dstCols, int32_t vecLen,
-          typename TmpTile>
+template <typename T, int32_t dstRows, int32_t dstCols, int32_t dstRowValid,
+          int32_t dstColValid, int32_t vecLen, int32_t Src1Col, typename TmpTile>
 AICORE PTO_INLINE void
-TROWEXPANDSUB_row_vec(TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &dst,
-                      TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &src0,
-                      TileUbDataND<T, 1, vecLen, 1, vecLen> &src1_vec,
-                      int32_t src1_addr, int32_t src1_offset, TmpTile &tmp) {
+TROWEXPANDSUB_row_vec(
+    TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &dst,
+    TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &src0,
+    TileUbDataND<T, 1, Src1Col, 1, vecLen> &src1_vec, int32_t src1_addr,
+    int32_t src1_offset, TmpTile &tmp) {
   constexpr int32_t alignedRows =
       ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
   constexpr int32_t typeLen = sizeof(T);
@@ -662,12 +668,14 @@ TROWEXPANDSUB_row_vec(TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &dst,
 }
 
 // Row-wise broadcast divide helper.
-template <typename T, int32_t dstRows, int32_t dstCols, int32_t vecLen>
+template <typename T, int32_t dstRows, int32_t dstCols, int32_t dstRowValid,
+          int32_t dstColValid, int32_t vecLen, int32_t Src1Col>
 AICORE PTO_INLINE void
-TROWEXPANDDIV_row_vec(TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &dst,
-                      TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &src0,
-                      TileUbDataND<T, 1, vecLen, 1, vecLen> &src1_vec,
-                      int32_t src1_addr, int32_t src1_offset) {
+TROWEXPANDDIV_row_vec(
+    TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &dst,
+    TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &src0,
+    TileUbDataND<T, 1, Src1Col, 1, vecLen> &src1_vec, int32_t src1_addr,
+    int32_t src1_offset) {
   constexpr int32_t alignedRows =
       ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
   constexpr int32_t typeLen = sizeof(T);
@@ -677,13 +685,14 @@ TROWEXPANDDIV_row_vec(TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &dst,
   TROWEXPANDDIV(dst, src0, src1_dn);
 }
 
-template <typename T, int32_t dstRows, int32_t dstCols, int32_t vecLen,
-          typename TmpTile>
+template <typename T, int32_t dstRows, int32_t dstCols, int32_t dstRowValid,
+          int32_t dstColValid, int32_t vecLen, int32_t Src1Col, typename TmpTile>
 AICORE PTO_INLINE void
-TROWEXPANDDIV_row_vec(TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &dst,
-                      TileUbDataND<T, dstRows, dstCols, dstRows, dstCols> &src0,
-                      TileUbDataND<T, 1, vecLen, 1, vecLen> &src1_vec,
-                      int32_t src1_addr, int32_t src1_offset, TmpTile &tmp) {
+TROWEXPANDDIV_row_vec(
+    TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &dst,
+    TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &src0,
+    TileUbDataND<T, 1, Src1Col, 1, vecLen> &src1_vec, int32_t src1_addr,
+    int32_t src1_offset, TmpTile &tmp) {
   constexpr int32_t alignedRows =
       ((vecLen * sizeof(T) + 31) / 32) * (32 / sizeof(T));
   constexpr int32_t typeLen = sizeof(T);

--- a/src/tl_templates/pto/common.h
+++ b/src/tl_templates/pto/common.h
@@ -600,8 +600,7 @@ AICORE PTO_INLINE void TROWEXPAND_with_slice_buffer(
 // vector [vecLen, 1] (same memory layout), then calls TROWEXPANDMUL.
 template <typename T, int32_t dstRows, int32_t dstCols, int32_t dstRowValid,
           int32_t dstColValid, int32_t vecLen, int32_t Src1Col>
-AICORE PTO_INLINE void
-TROWEXPANDMUL_row_vec(
+AICORE PTO_INLINE void TROWEXPANDMUL_row_vec(
     TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &dst,
     TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &src0,
     TileUbDataND<T, 1, Src1Col, 1, vecLen> &src1_vec, int32_t src1_addr,
@@ -616,9 +615,9 @@ TROWEXPANDMUL_row_vec(
 }
 
 template <typename T, int32_t dstRows, int32_t dstCols, int32_t dstRowValid,
-          int32_t dstColValid, int32_t vecLen, int32_t Src1Col, typename TmpTile>
-AICORE PTO_INLINE void
-TROWEXPANDMUL_row_vec(
+          int32_t dstColValid, int32_t vecLen, int32_t Src1Col,
+          typename TmpTile>
+AICORE PTO_INLINE void TROWEXPANDMUL_row_vec(
     TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &dst,
     TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &src0,
     TileUbDataND<T, 1, Src1Col, 1, vecLen> &src1_vec, int32_t src1_addr,
@@ -635,8 +634,7 @@ TROWEXPANDMUL_row_vec(
 // Row-wise broadcast subtract helper.
 template <typename T, int32_t dstRows, int32_t dstCols, int32_t dstRowValid,
           int32_t dstColValid, int32_t vecLen, int32_t Src1Col>
-AICORE PTO_INLINE void
-TROWEXPANDSUB_row_vec(
+AICORE PTO_INLINE void TROWEXPANDSUB_row_vec(
     TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &dst,
     TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &src0,
     TileUbDataND<T, 1, Src1Col, 1, vecLen> &src1_vec, int32_t src1_addr,
@@ -651,9 +649,9 @@ TROWEXPANDSUB_row_vec(
 }
 
 template <typename T, int32_t dstRows, int32_t dstCols, int32_t dstRowValid,
-          int32_t dstColValid, int32_t vecLen, int32_t Src1Col, typename TmpTile>
-AICORE PTO_INLINE void
-TROWEXPANDSUB_row_vec(
+          int32_t dstColValid, int32_t vecLen, int32_t Src1Col,
+          typename TmpTile>
+AICORE PTO_INLINE void TROWEXPANDSUB_row_vec(
     TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &dst,
     TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &src0,
     TileUbDataND<T, 1, Src1Col, 1, vecLen> &src1_vec, int32_t src1_addr,
@@ -670,8 +668,7 @@ TROWEXPANDSUB_row_vec(
 // Row-wise broadcast divide helper.
 template <typename T, int32_t dstRows, int32_t dstCols, int32_t dstRowValid,
           int32_t dstColValid, int32_t vecLen, int32_t Src1Col>
-AICORE PTO_INLINE void
-TROWEXPANDDIV_row_vec(
+AICORE PTO_INLINE void TROWEXPANDDIV_row_vec(
     TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &dst,
     TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &src0,
     TileUbDataND<T, 1, Src1Col, 1, vecLen> &src1_vec, int32_t src1_addr,
@@ -686,9 +683,9 @@ TROWEXPANDDIV_row_vec(
 }
 
 template <typename T, int32_t dstRows, int32_t dstCols, int32_t dstRowValid,
-          int32_t dstColValid, int32_t vecLen, int32_t Src1Col, typename TmpTile>
-AICORE PTO_INLINE void
-TROWEXPANDDIV_row_vec(
+          int32_t dstColValid, int32_t vecLen, int32_t Src1Col,
+          typename TmpTile>
+AICORE PTO_INLINE void TROWEXPANDDIV_row_vec(
     TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &dst,
     TileUbDataND<T, dstRows, dstCols, dstRowValid, dstColValid> &src0,
     TileUbDataND<T, 1, Src1Col, 1, vecLen> &src1_vec, int32_t src1_addr,


### PR DESCRIPTION
- row_vec helpers (MUL/SUB/DIV x with/without tmp): decouple dst/src0 physical dims (dstRows/dstCols) from valid dims (dstRowValid/dstColValid), and src1 physical col (Src1Col, deduced) from logical vecLen. Fixes template deduction failure when is_slice buffers have col != validCol.
