### PR TITLE
[Fix] Update default seq_len to 1024 in block_sparse_mqa_attn_expert_test

### DIFF
--- a/examples/HISA/block_sparse_mqa_attn_expert.py
+++ b/examples/HISA/block_sparse_mqa_attn_expert.py
@@ -570,7 +570,7 @@ def ref_block_sparse_mqa_attn(
     return logits
 
 
-def test_block_sparse_mqa_attn(
+def run_block_sparse_mqa_attn(
     seq_len: int,
     seq_len_kv: int,
     heads: int,
@@ -669,7 +669,7 @@ if __name__ == "__main__":
     print(f"  dtype: {args.dtype}")
     print()
 
-    test_block_sparse_mqa_attn(
+    run_block_sparse_mqa_attn(
         seq_len=args.seq_len,
         seq_len_kv=args.seq_len_kv,
         heads=args.heads,

--- a/examples/HISA/block_sparse_mqa_attn_expert_test.py
+++ b/examples/HISA/block_sparse_mqa_attn_expert_test.py
@@ -637,7 +637,7 @@ def test_block_sparse_mqa_attn(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Block Sparse MQA Attention Kernel Test")
-    parser.add_argument("--seq_len", type=int, default=32, help="Query sequence length")
+    parser.add_argument("--seq_len", type=int, default=1024, help="Query sequence length")
     parser.add_argument("--seq_len_kv", type=int, default=128 * 1024, help="KV sequence length")
     parser.add_argument("--heads", type=int, default=32, help="Number of attention heads")
     parser.add_argument("--index_dim", type=int, default=128, help="Index dimension")

--- a/examples/HISA/paged_block_sparse_mqa_attn_expert.py
+++ b/examples/HISA/paged_block_sparse_mqa_attn_expert.py
@@ -468,7 +468,7 @@ def ref_paged_block_sparse_mqa_attn(
     return logits_out.view(batch, seq_len, topk * kv_block_size)
 
 
-def test_paged_block_sparse_mqa_attn(
+def run_paged_block_sparse_mqa_attn(
     batch: int,
     seq_len: int,
     num_phys_blocks: int,
@@ -584,7 +584,7 @@ if __name__ == "__main__":
     print("  V UB: s_ub_e + s_ub_l per AIV (DMA ∥ compute)")
     print()
 
-    test_paged_block_sparse_mqa_attn(
+    run_paged_block_sparse_mqa_attn(
         batch=args.batch,
         seq_len=args.seq_len,
         num_phys_blocks=args.num_phys_blocks,


### PR DESCRIPTION
Update default seq_len to 1024 in block_sparse_mqa_attn_expert_test