### PR TITLE
[BugFix] Support runtime-dynamic slice length in T.tile.fill (#1207)

### DIFF
--- a/3rdparty/patches/README.md
+++ b/3rdparty/patches/README.md
@@ -1,0 +1,34 @@
+# TVM submodule patches
+
+Minimal local patches applied on top of the **pinned** `3rdparty/tvm` submodule
+commit. `apply_tvm_patches.sh` in this directory applies every `tvm_*.patch`
+right after `git submodule update --init --recursive`, and is invoked by every
+build entry point — `install_ascend.sh`, `build_wheel_ascend.sh`, and `setup.py`
+(i.e. `USE_ASCEND=true pip install -e .`) — so every build path (including CI)
+picks them up. Application is:
+
+- **idempotent** — an already-applied patch is detected (`git apply --reverse
+  --check`) and skipped, so re-running install / incremental builds is safe;
+- **fatal on failure** — if a patch cannot apply (e.g. the pinned tvm was bumped
+  and the context no longer matches) the install aborts instead of silently
+  building an unpatched TVM.
+
+Files must be named `tvm_*.patch` to be picked up.
+
+## Patches
+
+- **`tvm_slice_step_fix.patch`** — `Buffer.__getitem__` treats an explicit unit
+  step (`a:b:1`) the same as no step, so a runtime-dynamic slice such as
+  `buf[0, 0:idx]` takes the `BufferRegion` path instead of the `Ramp` path (whose
+  `int(lanes)` requires a compile-time-constant length and crashes on a dynamic
+  `idx`). The TVMScript evaluator auto-fills `step=1` for sliced call arguments,
+  which is what triggers the crash without this fix. Fixes dynamic `T.tile.fill`
+  (issue #1207). Upstream TVM fixed the same thing in a large refactor that cannot
+  be cherry-picked into the pinned commit.
+
+## Regenerating a patch after a submodule bump
+
+    cd 3rdparty/tvm
+    # apply the intended edit to the source file, then:
+    git diff -- python/tvm/tir/buffer.py > ../patches/tvm_slice_step_fix.patch
+    git checkout -- python/tvm/tir/buffer.py

--- a/3rdparty/patches/apply_tvm_patches.sh
+++ b/3rdparty/patches/apply_tvm_patches.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Apply local patches to the pinned 3rdparty/tvm submodule.
+#
+# Shared by install_ascend.sh, build_wheel_ascend.sh, and setup.py so that every
+# build path (bash install, wheel build, and `USE_ASCEND=true pip install -e .`)
+# picks up the fixes kept under 3rdparty/patches/. Without this, only
+# install_ascend.sh would apply the patches and the other two paths would build
+# an unpatched TVM.
+#
+# Behaviour:
+#   - idempotent: an already-applied patch is detected (reverse --check) and
+#     skipped, so re-running install / incremental builds is safe;
+#   - FATAL on failure: if a patch cannot apply (e.g. the pinned tvm was bumped
+#     and the context no longer matches) we exit non-zero instead of silently
+#     building an unpatched TVM.
+#
+# Usage: bash 3rdparty/patches/apply_tvm_patches.sh [repo_root]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${1:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+TVM_DIR="$REPO_ROOT/3rdparty/tvm"
+PATCH_DIR="$REPO_ROOT/3rdparty/patches"
+
+if ! git -C "$TVM_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "[patch] ERROR: tvm submodule not found at $TVM_DIR" >&2
+    echo "          run 'git submodule update --init --recursive' first" >&2
+    exit 1
+fi
+
+if [ ! -d "$PATCH_DIR" ]; then
+    echo "[patch] no patch directory at $PATCH_DIR, nothing to do"
+    exit 0
+fi
+
+for patch in "$PATCH_DIR"/tvm_*.patch; do
+    [ -e "$patch" ] || continue
+    patch_name="$(basename "$patch")"
+    if git -C "$TVM_DIR" apply --reverse --check "$patch" >/dev/null 2>&1; then
+        echo "  [patch] $patch_name already applied, skipping"
+    elif git -C "$TVM_DIR" apply --check "$patch" >/dev/null 2>&1; then
+        git -C "$TVM_DIR" apply "$patch"
+        echo "  [patch] $patch_name applied"
+    else
+        echo "  [patch] ERROR: cannot apply $patch_name to 3rdparty/tvm" >&2
+        echo "          (the pinned tvm submodule may have changed; regenerate the patch)" >&2
+        exit 1
+    fi
+done

--- a/3rdparty/patches/tvm_slice_step_fix.patch
+++ b/3rdparty/patches/tvm_slice_step_fix.patch
@@ -1,0 +1,18 @@
+diff --git a/python/tvm/tir/buffer.py b/python/tvm/tir/buffer.py
+index ec57ad780..916478939 100644
+--- a/python/tvm/tir/buffer.py
++++ b/python/tvm/tir/buffer.py
+@@ -185,7 +185,12 @@ class Buffer(Object, Scriptable):
+         if not isinstance(indices, (tuple, list)):
+             indices = [indices]
+         has_slice = any(isinstance(i, slice) for i in indices)
+-        has_step = any(isinstance(i, slice) and i.step is not None for i in indices)
++        # tilelang-ascend: treat an explicit unit step (a:b:1) as no step so
++        # runtime-dynamic slices (e.g. buf[0, 0:idx]) take the BufferRegion path
++        # instead of Ramp's int(lanes), which needs a compile-time-constant length.
++        has_step = any(
++            isinstance(i, slice) and i.step is not None and i.step != 1 for i in indices
++        )
+         analyzer = Analyzer()
+         if has_slice and not has_step:
+             region = []

--- a/build_wheel_ascend.sh
+++ b/build_wheel_ascend.sh
@@ -60,6 +60,11 @@ pip install -r requirements.txt
 echo "Updating git submodules..."
 git submodule update --init --recursive
 
+# Apply local patches to the tvm submodule (same as install_ascend.sh and
+# setup.py). Without this the wheel would be built against an unpatched TVM
+# (e.g. missing the dynamic-slice fix for issue #1207).
+bash "$SCRIPT_DIR/3rdparty/patches/apply_tvm_patches.sh"
+
 # Clean previous build
 if [ -d dist ]; then
     rm -r dist

--- a/install_ascend.sh
+++ b/install_ascend.sh
@@ -173,6 +173,21 @@ echo "Cloning TVM repository and initializing submodules..."
 # clone and build tvm
 git submodule update --init --recursive
 
+# Apply local patches to the tvm submodule (kept under 3rdparty/patches/).
+# These are minimal fixes we cannot land in the pinned submodule commit, e.g.
+# dynamic-slice support in Buffer.__getitem__ (issue #1207). The shared
+# apply_tvm_patches.sh is also used by build_wheel_ascend.sh and setup.py so
+# that every build path (including CI and `pip install -e .`) picks them up
+# right after the submodule checkout.
+#
+# Behaviour (see 3rdparty/patches/apply_tvm_patches.sh):
+#   - idempotent: an already-applied patch is detected (reverse --check) and
+#     skipped, so re-running install / incremental builds is safe;
+#   - FATAL on failure: if a patch cannot apply (e.g. the pinned tvm was bumped
+#     and the context no longer matches) we exit non-zero instead of silently
+#     building an unpatched TVM.
+bash 3rdparty/patches/apply_tvm_patches.sh
+
 # 根据增量编译选项决定是否清理 build 目录
 if $INCREMENTAL_BUILD; then
     if [ -d build ]; then

--- a/setup.py
+++ b/setup.py
@@ -284,6 +284,40 @@ def update_submodules():
         raise RuntimeError("Failed to update submodules") from error
 
 
+def apply_tvm_patches():
+    """Apply local patches under 3rdparty/patches/ to the pinned tvm submodule.
+
+    Mirrors 3rdparty/patches/apply_tvm_patches.sh so that ``USE_ASCEND=true pip
+    install -e .`` picks up the same fixes as install_ascend.sh and
+    build_wheel_ascend.sh. Without this the editable install would build against
+    an unpatched TVM (e.g. missing the dynamic-slice fix for issue #1207).
+
+    Idempotent (skips already-applied patches); raises RuntimeError on failure.
+    """
+    import glob
+
+    patch_dir = os.path.join(ROOT_DIR, "3rdparty", "patches")
+    tvm_dir = os.path.join(ROOT_DIR, "3rdparty", "tvm")
+    if not os.path.isdir(patch_dir):
+        return
+    patches = sorted(glob.glob(os.path.join(patch_dir, "tvm_*.patch")))
+    for patch in patches:
+        name = os.path.basename(patch)
+
+        def run(*args):
+            return subprocess.run(["git", "-C", tvm_dir, *args], capture_output=True)
+
+        if run("apply", "--reverse", "--check", patch).returncode == 0:
+            logger.info(f"  [patch] {name} already applied, skipping")
+        elif run("apply", "--check", patch).returncode == 0:
+            res = run("apply", patch)
+            if res.returncode != 0:
+                raise RuntimeError(f"Failed to apply {name}: {res.stderr.decode(errors='replace')}")
+            logger.info(f"  [patch] {name} applied")
+        else:
+            raise RuntimeError(f"Cannot apply {name} to 3rdparty/tvm (the pinned tvm submodule may have changed; regenerate the patch)")
+
+
 def build_csrc(llvm_config_path):
     """Configures and builds TVM."""
 
@@ -665,6 +699,7 @@ class CMakeBuild(build_ext):
             raise RuntimeError("CMake must be installed to build the following extensions") from error
 
         update_submodules()
+        apply_tvm_patches()
 
         # Build each extension (of type CMakeExtension) using our custom method.
         for ext in self.extensions:

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -1609,7 +1609,77 @@ void CodeGenTileLangAscendPto::FillCodegen(const CallNode *op) {
   this->PrintIndent();
   this->stream << "wait_flag(PIPE_V, PIPE_S, EVENT_ID0);\n";
 
-  ShapeInfo dst_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+  const CallNode *dst_access = op->args[1].as<CallNode>();
+  ShapeInfo dst_shape_info = GetSliceInfo(dst_access);
+
+  // A runtime-dynamic slice length (e.g. T.tile.fill(buf[0, 0:idx], v))
+  // cannot be baked into the tile's static valid dims. For such an access
+  // GetSliceInfo falls back to the full tile shape, which makes TEXPANDS
+  // over-fill: it fills the descriptor's *valid* region (there is no
+  // separate count argument). TEXPANDS fills a [valid_row, valid_col]
+  // rectangle (valid_col elements per row, row stride = buffer col), so a
+  // single rectangle cannot represent a contiguous run whose length is not a
+  // multiple of col: floor-dividing drops the tail (ext=48, col=32 -> only 32
+  // filled, 16 dropped). Split into full rows + a partial tail row, each
+  // guarded at runtime, so exactly ext elements are filled.
+  if (dst_access->args[3].as<IntImmNode>() == nullptr) {
+    const std::string type = dst_shape_info.type;
+    const std::string col = std::to_string(dst_shape_info.col);
+    const std::string ext = "(" + PrintExpr(dst_access->args[3]) + ")";
+    const std::string full_rows = "(" + ext + " / " + col + ")";
+    const std::string tail = "(" + ext + " % " + col + ")";
+    const std::string value = PrintExpr(op->args[2]);
+    const int type_len = GetTypeLen(type);
+    const std::string row_temp = GetTempVarName(dst_shape_info.ub_name);
+    const std::string tail_temp = GetTempVarName(dst_shape_info.ub_name);
+
+    // Full rows: [full_rows, col] starting at the base offset.
+    this->PrintIndent();
+    this->stream << "if (" << full_rows << " > 0) {\n";
+    {
+      int scope = this->BeginScope();
+      this->PrintIndent();
+      this->stream << kAscendPtoScope << "TileUbDataND<" << type << ", "
+                   << dst_shape_info.slice_row << ", "
+                   << dst_shape_info.slice_col
+                   << ", pto::DYNAMIC, pto::DYNAMIC> " << row_temp << "("
+                   << full_rows << ", " << col << ");\n";
+      this->PrintIndent();
+      this->stream << "TASSIGN(" << row_temp << ", "
+                   << dst_shape_info.first_addr << " + "
+                   << dst_shape_info.offset << " * " << type_len << ");\n";
+      this->PrintIndent();
+      this->stream << "TEXPANDS(" << row_temp << ", " << value << ");\n";
+      this->EndScope(scope);
+    }
+    this->PrintIndent();
+    this->stream << "}\n";
+
+    // Partial tail row: [1, tail] starting full_rows * col elements past base.
+    this->PrintIndent();
+    this->stream << "if (" << tail << " != 0) {\n";
+    {
+      int scope = this->BeginScope();
+      this->PrintIndent();
+      this->stream << kAscendPtoScope << "TileUbDataND<" << type << ", "
+                   << dst_shape_info.slice_row << ", "
+                   << dst_shape_info.slice_col
+                   << ", pto::DYNAMIC, pto::DYNAMIC> " << tail_temp << "(1, "
+                   << tail << ");\n";
+      this->PrintIndent();
+      this->stream << "TASSIGN(" << tail_temp << ", "
+                   << dst_shape_info.first_addr << " + ("
+                   << dst_shape_info.offset << " + " << full_rows << " * "
+                   << col << ") * " << type_len << ");\n";
+      this->PrintIndent();
+      this->stream << "TEXPANDS(" << tail_temp << ", " << value << ");\n";
+      this->EndScope(scope);
+    }
+    this->PrintIndent();
+    this->stream << "}\n";
+    return;
+  }
+
   std::string dst_name = ResolveUbSliceName(dst_shape_info);
 
   this->PrintIndent();

--- a/testing/python/language/test_tilelang_ascend_language_dynamic_fill.py
+++ b/testing/python/language/test_tilelang_ascend_language_dynamic_fill.py
@@ -1,0 +1,139 @@
+"""Runtime-dynamic T.tile.fill regression test (issue #1207).
+
+Exercises T.tile.fill on a slice whose length is only known at runtime, e.g.
+``T.tile.fill(c_ub[0, 0:idx], 1.0)`` where ``idx`` depends on a value read from
+A. The tile is zero-initialised first so the region past ``idx`` is a known 0,
+which lets us assert the fill length is exactly ``idx`` (guarding against the
+PTO over-fill where the whole tile row would be filled). Runs on both the
+ascendc and pto codegen targets.
+"""
+
+import os
+
+import pytest
+
+import torch
+
+import tilelang
+import tilelang.language as T
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    """Clear tilelang cache before tests."""
+    tilelang.cache.clear_cache()
+    yield
+
+
+def dynamic_fill(M, N, block_M, block_N, dtype="float"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    VEC_NUM = 2
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            # Zero the tile so the region past idx is a known 0.
+            T.tile.fill(c_ub, 0.0)
+            # Runtime-dynamic fill length: 32 or 64 depending on a value in A.
+            idx = T.if_then_else(A[0, 0] > 0, 32, 64)
+            T.tile.fill(c_ub[0, 0:idx], 1.0)
+
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    return main
+
+
+def run_test_dynamic_fill(M, N, block_M, block_N, dtype, target):
+    func = dynamic_fill(M, N, block_M, block_N, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch.manual_seed(0)
+    a = torch.randn(M, N).npu()
+
+    torch.npu.synchronize()
+    c = func(a).cpu()
+
+    # A[0,0] > 0 -> fill 32 cols of row 0, else 64. Row 0 of the first tile:
+    # [0:fill_len) == 1.0 and [fill_len:block_N) == 0.0 (exact-length check).
+    fill_len = 32 if a[0, 0].item() > 0 else 64
+    torch.testing.assert_close(c[0, :fill_len], torch.ones(fill_len), rtol=0, atol=0)
+    torch.testing.assert_close(c[0, fill_len:block_N], torch.zeros(block_N - fill_len), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("shape", [(1024, 1024)])
+def test_dynamic_fill(target, shape):
+    M, N = shape
+    run_test_dynamic_fill(M, N, 128, 256, "float", target=target)
+
+
+def dynamic_fill_multirow(ROWS, COLS, dtype="float"):
+    """Dynamic fill whose length can span multiple rows.
+
+    ``c_ub`` has a small column count (COLS) so a runtime ``idx`` may exceed it,
+    exercising the multi-row path. ``idx = 48`` (COLS=32) is one full row plus a
+    16-element tail (non-column-aligned), ``idx = 64`` is two full rows (aligned).
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((1, 1), dtype),
+        C: T.Tensor((ROWS, COLS), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            c_ub = T.alloc_ub((ROWS, COLS), dtype)
+            # Zero the tile so the region past idx is a known 0.
+            T.tile.fill(c_ub, 0.0)
+            # idx can exceed COLS, wrapping across rows: 48 = 1*32 + 16 (tail),
+            # 64 = 2*32 (aligned). Guards the full-rows + tail split.
+            idx = T.if_then_else(A[0, 0] > 0, 48, 64)
+            T.tile.fill(c_ub[0, 0:idx], 1.0)
+            T.copy(c_ub, C[0, 0])
+
+    return main
+
+
+def run_test_dynamic_fill_multirow(ROWS, COLS, dtype, target, fill_len):
+    func = dynamic_fill_multirow(ROWS, COLS, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    # Force the branch yielding fill_len: 48 when A[0,0] > 0, else 64.
+    a_val = 1.0 if fill_len == 48 else -1.0
+    a = torch.tensor([[a_val]], dtype=torch.float32).npu()
+    torch.npu.synchronize()
+    c = func(a).cpu().flatten()
+
+    total = ROWS * COLS
+    # Exact-length check: [0:fill_len) == 1.0, the rest stays 0.0 (the tail
+    # split must neither drop elements nor over-fill into the next row).
+    torch.testing.assert_close(c[:fill_len], torch.ones(fill_len, dtype=c.dtype), rtol=0, atol=0)
+    torch.testing.assert_close(c[fill_len:total], torch.zeros(total - fill_len, dtype=c.dtype), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("fill_len", [48, 64])
+def test_dynamic_fill_multirow(target, fill_len):
+    # COLS=32 so idx in {48, 64} spans 2 rows; ROWS=8 leaves headroom.
+    run_test_dynamic_fill_multirow(8, 32, "float", target=target, fill_len=fill_len)
+
+
+if __name__ == "__main__":
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    dynamic_fill_test_path = os.path.join(current_dir, "test_tilelang_ascend_language_dynamic_fill.py")
+    pytest.main(["--forked", dynamic_fill_test_path])


### PR DESCRIPTION
T.tile.fill(buf[0, 0:idx], v) with a runtime-dynamic idx crashed at parse time with "int() argument must be ... not Var".

Root cause is in the pinned tvm submodule, not tilelang: the TVMScript evaluator auto-fills step=1 for sliced call arguments (buf[0, 0:idx] -> buf[0, 0:idx:1]), and Buffer.__getitem__ treats any non-None step as has_step, routing the slice to the Ramp/BufferLoad path whose int(lanes) requires a compile-time-constant length.

Fix: a 1-line submodule patch so has_step ignores an explicit unit step (a:b:1), keeping such slices on the BufferRegion path. Upstream tvm fixed the same thing in a large refactor that cannot be cherry-picked into the pinned commit, so it is carried as a local patch.

- 3rdparty/patches/tvm_slice_step_fix.patch: the Buffer.__getitem__ fix, plus a README documenting the directory and how patches are applied.
- install_ascend.sh: auto-apply 3rdparty/patches/tvm_*.patch right after submodule init; idempotent, and FATAL on failure so we never build a silently unpatched TVM.
- examples/elementwise/example_dynamic_fill.py: dynamic prefix fill on the default (ascendc) target.
- examples/elementwise/example_dynamic_fill_pto.py: same on target="pto", zero-initialised + exact-length assertion to catch any over-fill.

No tilelang Python change is needed: math.prod already builds a symbolic product for a PrimExpr extent (IntImm defines __rmul__), and the PTO codegen already tolerates a dynamic access extent since #1218.