### PR TITLE
Fix AscendC GetWithOffset allocation size alignment

### DIFF
--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -766,9 +766,24 @@ void CodeGenTileLangAscend::VisitStmt_(const AllocateNode *op) {
             << target_var_name
             << ". All buffers must be pre-allocated via address_map_.";
 
+        size_t allocation_size = op->ConstantAllocationSize();
+        size_t elem_bytes = op->dtype.bytes();
+        if (elem_bytes != 0) {
+          size_t a = elem_bytes;
+          size_t b = 32;
+          while (b != 0) {
+            size_t t = b;
+            b = a % b;
+            a = t;
+          }
+          size_t align_elems = 32 / a;
+          allocation_size =
+              ((allocation_size + align_elems - 1) / align_elems) * align_elems;
+        }
+
         stream << "auto " << vid << " = " << pos << ".GetWithOffset<" << type
-               << ">(" << op->ConstantAllocationSize() << ", "
-               << PrintExpr(target_expr) << ");\n";
+               << ">(" << allocation_size << ", " << PrintExpr(target_expr)
+               << ");\n";
       };
 
   if (scope == "wmma.matrix_a") {

--- a/testing/python/language/test_tilelang_ascend_language_alloc_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_alloc_codegen.py
@@ -132,6 +132,25 @@ def dev_ub_explicit_splice(dim, block_N=128, block_size=128, live_max=64):
     return main
 
 
+def dev_unaligned_ub_alloc():
+    dtype = "float32"
+
+    @T.prim_func
+    def main(
+        Output: T.Tensor([126], dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            row_ub = T.alloc_ub([126], dtype)
+
+            with T.Scope("V"):
+                for i in T.serial(126):
+                    row_ub[i] = T.cast(i, dtype)
+                for i in T.serial(126):
+                    Output[i] = row_ub[i]
+
+    return main
+
+
 def _compile_and_get_source(target):
     prim_func = dev_L1_explicit_splice(dim=64)
     with (
@@ -166,6 +185,25 @@ def _compile_ub_and_get_source(target):
             out_idx=[2],
             pass_configs=DEV_CONFIGS,
             target=target,
+        )
+    return compiled.get_kernel_source()
+
+
+def _compile_unaligned_ub_and_get_source():
+    prim_func = dev_unaligned_ub_alloc()
+    with (
+        patch("tilelang.jit.adapter.libgen.LibraryGenerator.compile_lib") as mock_compile,
+        patch(
+            "tilelang.jit.adapter.libgen.LibraryGenerator.load_lib",
+            return_value=None,
+        ),
+    ):
+        mock_compile.return_value = None
+        compiled = tilelang.compile(
+            prim_func,
+            out_idx=[0],
+            pass_configs=DEV_CONFIGS,
+            target="ascendc",
         )
     return compiled.get_kernel_source()
 
@@ -218,6 +256,14 @@ def test_ub_splice_codegen(target):
         assert "TileMatL1" not in k_ub_alloc_line[0], (
             f"k_ub was incorrectly allocated as TileMatL1 instead of TileUbDataND:\n{k_ub_alloc_line[0]}"
         )
+
+
+def test_ub_getwithoffset_size_is_32byte_aligned_for_unaligned_shape():
+    code = _compile_unaligned_ub_and_get_source()
+
+    assert "row_ub = ascend_ub.GetWithOffset<float>(128, 0)" in code, (
+        "A 126-float UB allocation should request a 32-byte aligned LocalTensor capacity from AscendC GetWithOffset:\n" + code
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- round AscendC `TBuf::GetWithOffset` allocation sizes up to a 32-byte boundary when emitting local tensor allocations
- add a codegen regression for `T.alloc_ub([126], "float32")`, which should request `GetWithOffset<float>(128, 0)` instead of a 504-byte LocalTensor capacity

## Reproducer
Without this change, a 126-float UB allocation emits:

```cpp
auto row_ub = ascend_ub.GetWithOffset<float>(126, 0);
```

That gives AscendC a non-32-byte LocalTensor data length. In the reported UB roundtrip / UB-to-GM copy case, values after the last 32-byte-aligned boundary can be read back as zero on hardware. After the change, the same TileLang source emits:

```cpp
auto row_ub = ascend_ub.GetWithOffset<float>(128, 0);
```

The logical TileLang shape and loop bounds remain unchanged; only the AscendC LocalTensor capacity is rounded up to match the existing byte-aligned memory planning.

Related to #1304. This PR intentionally keeps the change scoped to GetWithOffset allocation-size codegen; row-slice GM stride handling is tracked separately in #1298.

## Tests
- `USE_ASCEND=true bash install_ascend.sh --enable-incremental`
- `python3 -m pytest testing/python/language/test_tilelang_ascend_language_alloc_codegen.py -q`
