### PR TITLE
[Bugfix] Ascend gemm_v0: N-tiling to fit L0B for large N

### DIFF
--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -602,6 +602,67 @@ gemm_v0(LocalTensor<T1> const &A, LocalTensor<T1> const &B,
   uint32_t kL0Tail = K - (kL0split - 1) * kL0Size;
   bool initflag = false;
 
+  // ---- N tiling -----------------------------------------------------------
+  // The B operand tile loaded into L0B is (kL0Size x nTile); L0B holds 64KB,
+  // and with the kL0 ping-pong the per-slot budget is 32KB. So a single mma
+  // over the whole N (l0b slot = N*kL0Size) overflows L0B once N is large
+  // (e.g. the PV matmul's N = headDim = 512 -> 512*128*2 = 128KB). Tile N into
+  // nTile columns just like the Ascend C reference (N_SPLIT_SIZE = 128): each
+  // tile loads its own (kL0Size x nTile) B sub-block and writes its own column
+  // band of the L0C accumulator. Only the non-transpose-B path is tiled; the
+  // transpose-B callers (e.g. QK with N = block_I <= 128) already fit, so they
+  // keep nTile == N (a single pass, byte-for-byte the original behaviour) and
+  // need no L1 column-offset formula. Compatibility: any existing caller with
+  // N <= nMaxByL0B (transpose or not) sees nL0split == 1 and identical codegen.
+  //
+  // Sub-tile offsets come straight from the catlass tla fractal layouts:
+  //   L0C column n0  ->  n0 * roundUp16(M)   (tla::MakeLayoutL0C N1 stride)
+  //   L1 zN B col n0 ->  n0 * roundUp16(K)   (tla::MakeLayout<zN>  C1 stride)
+  // both of which are consistent with the original K-offset
+  // B[kL0Idx*16*kL0Size] (zN K-row stride) already used below.
+  constexpr uint32_t nMaxByL0B = (32u * 1024u) / (kL0Size * sizeof(T1));
+  constexpr uint32_t nTile = (transpose_B || N <= nMaxByL0B) ? N : nMaxByL0B;
+  static_assert(transpose_B || (N % nTile == 0),
+                "gemm_v0 N-tiling requires N divisible by the N tile size");
+  constexpr uint32_t nL0split = N / nTile;
+  // L0A and L0B are each 64KB. The kL0/N ping-pong uses two slots only when
+  // there is more than one (N-tile, K-tile) step; a single step uses one slot
+  // and may occupy the whole 64KB -- which is why a transpose-B caller with a
+  // single K-tile and N up to 64KB/(kL0Size*sizeof(T)) fits (e.g. fp32 N=128 =
+  // 64KB). So the per-slot budget is 64KB for a single step, 32KB once the
+  // ping-pong actually alternates.
+  constexpr uint32_t kNumSteps = ((K + kL0Size - 1) / kL0Size) * nL0split;
+  constexpr uint32_t kL0Budget = (64u * 1024u) / (kNumSteps > 1 ? 2u : 1u);
+  // The B tile in L0B is (kL0Size x nTile) -- only the transpose-B path keeps
+  // nTile == N, so a large-N transpose-B caller could overflow its L0B slot.
+  static_assert(nTile * kL0Size * sizeof(T1) <= kL0Budget,
+                "gemm_v0: the (kL0Size x nTile) B tile does not fit its L0B "
+                "ping-pong slot");
+  // M is not tiled, so a large M would overflow its L0A slot.
+  static_assert(M * kL0Size * sizeof(T1) <= kL0Budget,
+                "gemm_v0: the (M x kL0Size) A tile does not fit its L0A "
+                "ping-pong slot");
+  // L0C is caller-allocated (the `C` operand) and holds the full (M x N)
+  // accumulator: roundUp16(M) * N * sizeof(T2). It must fit the target's L0C
+  // (A2/A3 128KB, A5 256KB) -- e.g. M=128, N=512, fp32 needs 256KB and only
+  // fits A5. Unlike the L0A/L0B guards above this can't be a static_assert
+  // here: L0C capacity is device-dependent, whereas L0A/L0B are 64KB on both
+  // archs (which is why those two use a literal budget). This device-side
+  // template has no arch macro or L0C-size constant to branch on
+  // (ASCEND_*_L0C_SIZE live in the host codegen), so a literal guard would
+  // reject a valid A5 caller or silently pass on A2/A3. The constraint is
+  // therefore documented here; the caller sizes its L0C tile accordingly.
+  constexpr uint32_t mRound = ((M + 15u) / 16u) * 16u;
+  constexpr uint32_t kRound = ((K + 15u) / 16u) * 16u;
+
+  // ---- Pipelined main loop. Prime/drain the L0A/L0B ping-pong buffers ONCE
+  // and let the ping-pong run continuously across the WHOLE (N-tile, K-tile)
+  // sequence (flattened by tileIdx). Each tile's L1->L0 load goes into the
+  // free buffer while the previous tile's mma runs, so N-tiles overlap with K
+  // exactly like the Ascend C matmul pipeline -- a per-N-tile drain (the first
+  // N-tiling version) instead serialised the tiles. For nL0split == 1 (every
+  // pre-existing caller, and the QK transpose-B path) tileIdx == kL0Idx, so
+  // this is byte-for-byte the original K ping-pong.
   SetFlag<HardEvent::MTE2_MTE1>(L0AB_EVENT);
   WaitFlag<HardEvent::MTE2_MTE1>(L0AB_EVENT);
   SetFlag<HardEvent::FIX_M>(L0AB_EVENT);
@@ -610,35 +671,48 @@ gemm_v0(LocalTensor<T1> const &A, LocalTensor<T1> const &B,
   SetFlag<HardEvent::M_MTE1>(L0AB_EVENT);
   SetFlag<HardEvent::M_MTE1>(L0AB_EVENT + 1);
 
-  for (uint32_t kL0Idx = 0; kL0Idx < kL0split; kL0Idx++) {
-    initflag = (clear && (kL0Idx == 0));
-    uint32_t kSize = (kL0Idx == kL0split - 1) ? kL0Tail : kL0Size;
-    uint32_t pp = (kL0Idx & 1);
+  uint32_t tileIdx = 0;
+  for (uint32_t nL0Idx = 0; nL0Idx < nL0split; nL0Idx++) {
+    // Non-transpose B is zN in L1: its column n0 lives at n0 * roundUp16(K)
+    // (the zN C1 stride), so this N-tile's B sub-block starts at
+    // nL0Idx*nTile*kRound. This column-offset formula is correct only for a zN
+    // B_L1; a different B layout would need a different per-column stride here.
+    uint32_t bNOffset = transpose_B ? 0u : (nL0Idx * nTile * kRound);
+    uint32_t cNOffset = nL0Idx * nTile * mRound;
 
-    uint32_t l0a_base = pp * (M * kL0Size);
-    uint32_t l0b_base = pp * (N * kL0Size);
+    for (uint32_t kL0Idx = 0; kL0Idx < kL0split; kL0Idx++) {
+      // clear THIS N-tile's C column band on its first K-tile (each band is an
+      // independent accumulation over K).
+      initflag = (clear && (kL0Idx == 0));
+      uint32_t kSize = (kL0Idx == kL0split - 1) ? kL0Tail : kL0Size;
+      uint32_t pp = (tileIdx & 1);
 
-    WaitFlag<HardEvent::M_MTE1>(L0AB_EVENT + pp);
-    if constexpr (!transpose_A) {
-      tl::ascend::copy_l1_to_l0a<T1, M, K>(l0a[l0a_base],
-                                           A[kL0Idx * M * kL0Size], M, kSize);
-    } else {
-      tl::ascend::copy_l1_to_l0a<T1, K, M, true>(
-          l0a[l0a_base], A[kL0Idx * 16 * kL0Size], M, kSize);
+      uint32_t l0a_base = pp * (M * kL0Size);
+      uint32_t l0b_base = pp * (nTile * kL0Size);
+
+      WaitFlag<HardEvent::M_MTE1>(L0AB_EVENT + pp);
+      if constexpr (!transpose_A) {
+        tl::ascend::copy_l1_to_l0a<T1, M, K>(l0a[l0a_base],
+                                             A[kL0Idx * M * kL0Size], M, kSize);
+      } else {
+        tl::ascend::copy_l1_to_l0a<T1, K, M, true>(
+            l0a[l0a_base], A[kL0Idx * 16 * kL0Size], M, kSize);
+      }
+      if constexpr (!transpose_B) {
+        tl::ascend::copy_l1_to_l0b<T1, K, N>(
+            l0b[l0b_base], B[bNOffset + kL0Idx * 16 * kL0Size], kSize, nTile);
+      } else {
+        tl::ascend::copy_l1_to_l0b<T1, N, K, true>(
+            l0b[l0b_base], B[kL0Idx * N * kL0Size], kSize, N);
+      }
+      SetFlag<HardEvent::MTE1_M>(L0AB_EVENT + pp);
+      WaitFlag<HardEvent::MTE1_M>(L0AB_EVENT + pp);
+      PipeBarrier<PIPE_M>();
+      tl::ascend::mma<T1, T2, M, nTile>(l0a[l0a_base], l0b[l0b_base],
+                                        C[cNOffset], initflag, kSize);
+      SetFlag<HardEvent::M_MTE1>(L0AB_EVENT + pp);
+      tileIdx++;
     }
-    if constexpr (!transpose_B) {
-      tl::ascend::copy_l1_to_l0b<T1, K, N>(l0b[l0b_base],
-                                           B[kL0Idx * 16 * kL0Size], kSize, N);
-    } else {
-      tl::ascend::copy_l1_to_l0b<T1, N, K, true>(
-          l0b[l0b_base], B[kL0Idx * N * kL0Size], kSize, N);
-    }
-    SetFlag<HardEvent::MTE1_M>(L0AB_EVENT + pp);
-    WaitFlag<HardEvent::MTE1_M>(L0AB_EVENT + pp);
-    PipeBarrier<PIPE_M>();
-    tl::ascend::mma<T1, T2, M, N>(l0a[l0a_base], l0b[l0b_base], C, initflag,
-                                  kSize);
-    SetFlag<HardEvent::M_MTE1>(L0AB_EVENT + pp);
   }
   WaitFlag<HardEvent::M_MTE1>(L0AB_EVENT);
   WaitFlag<HardEvent::M_MTE1>(L0AB_EVENT + 1);

--- a/testing/python/language/test_tilelang_ascend_language_gemm_v0_n_tiling.py
+++ b/testing/python/language/test_tilelang_ascend_language_gemm_v0_n_tiling.py
@@ -1,0 +1,125 @@
+import pytest
+import tilelang
+import tilelang.language as T
+import torch
+
+"""
+Regression test for N-tiling in the AscendC ``gemm_v0`` (src/tl_templates/ascend/common.h).
+
+Feature under test
+------------------
+``gemm_v0`` originally tiled only the K dimension: every ``mma`` loaded the whole
+N of the B operand into a single L0B slot (size ``N * kL0Size``).  L0B is 64KB and
+the kL0 ping-pong halves the per-slot budget to 32KB, so once N is large the B
+sub-tile overflows L0B and the cube crashes at run time.  Concretely an attention
+PV matmul is ``<M = 64, N = headDim = 512, K = window <= 128>``: the B tile is
+``K * N * 2 = 128 * 512 * 2 = 128KB`` -- twice the whole L0B.
+
+The fix adds an inner N-tiling loop (``nTile = 128``, matching the Ascend C
+reference's ``N_SPLIT_SIZE``): each N-tile loads its own ``(kL0Size x nTile)`` B
+sub-block into L0B and accumulates into its own column band of the L0C output.
+The (N-tile, K-tile) sequence is flattened so the L0A/L0B ping-pong is primed and
+drained once and runs continuously across all tiles.
+
+Only the ``transpose_B == false`` path with ``N > nTile`` is tiled; every existing
+caller (``transpose_B``, or ``N <= nTile``) keeps ``nL0split == 1`` and byte-for-byte
+identical codegen.
+
+Coverage (all ``target = ascendc``)
+-----------------------------------
+  * ``N = 512`` (the PV shape) -- the large-N path that overflowed L0B before the
+    fix and now tiles N into 4 sub-blocks.  ``K = 128`` exercises a single K-tile
+    with N-tiling; ``K = 256`` exercises the flattened (N-tile, K-tile) pipeline
+    (kL0split == 2, nL0split == 4 -> 8 tiles).
+  * ``N = 128`` (``<= nTile``) -- the compatibility case: ``nL0split == 1``, the
+    original single-pass behaviour, proving the tiled loop still matches when N
+    is not split.
+
+This targets the ascendc backend only.  The PTO backend has its own separate
+``gemm_v0`` (src/tl_templates/pto/common.h, a different ``gemm_v0_inner`` /
+``TileMatL0B`` implementation) and is tracked independently.
+"""
+
+TARGET = "ascendc"
+
+CUBE_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    """Clear the tilelang cache before the session (a stale kernel could mask a
+    codegen regression -- a rebuilt kernel could otherwise return a cached one)."""
+    tilelang.cache.clear_cache()
+    yield
+
+
+def _torch_dtype(dtype):
+    return {
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+    }[dtype]
+
+
+def gemm_nt(M, N, K, dtype, accum_dtype):
+    """Plain ``C = A @ B`` (transpose_B=False) staged through one L1 tile.
+
+    The whole (M, K) / (K, N) operands are copied into L1 in one shot; ``gemm_v0``
+    then does the K-tiling (kL0Size=128) and -- for large N -- the N-tiling
+    internally.  Mirrors ``full_copy_plain`` in the gm_to_l1 suite (default zN
+    layout, no annotation)."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), dtype),  # type: ignore
+        B: T.Tensor((K, N), dtype),  # type: ignore
+        C: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            A_L1 = T.alloc_L1((M, K), dtype)
+            B_L1 = T.alloc_L1((K, N), dtype)
+            C_L0 = T.alloc_L0C((M, N), accum_dtype)
+            with T.Scope("C"):
+                T.copy(A[0, 0], A_L1)
+                T.copy(B[0, 0], B_L1)
+                T.gemm_v0(A_L1, B_L1, C_L0, init=True)
+                T.copy(C_L0, C[0, 0])
+
+    return main
+
+
+def run_test_gemm_nt(M, N, K, dtype, accum_dtype):
+    torch.manual_seed(0)
+    func = gemm_nt(M, N, K, dtype, accum_dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=CUBE_CONFIGS, target=TARGET)
+    td = _torch_dtype(dtype)
+    a = torch.randn(M, K, dtype=td).npu()
+    b = torch.randn(K, N, dtype=td).npu()
+    torch.npu.synchronize()
+    c = func(a, b)
+    ref = a @ b
+    # bf16 accumulates more rounding over the larger N/K here than fp16.
+    rtol, atol = (2e-2, 2e-2) if dtype == "bfloat16" else (1e-2, 1e-2)
+    torch.testing.assert_close(c, ref, rtol=rtol, atol=atol)
+
+
+# (M, N, K) -- N=512 is the large-N path that overflowed L0B before N-tiling;
+# N=128 (<= nTile) is the single-pass compatibility case.  M=64 keeps the N=512
+# L0C tile (M*N*4) within the 128KB L0C budget, matching the real PV matmul.
+gemm_configs = [
+    (64, 512, 128),  # PV shape: single K-tile, N tiled into 4
+    (64, 512, 256),  # flattened (N-tile, K-tile) pipeline: 2 K-tiles x 4 N-tiles
+    (128, 128, 128),  # N <= nTile: nL0split == 1, original single-pass path
+]
+
+
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+@pytest.mark.parametrize("M,N,K", gemm_configs)
+def test_gemm_v0_n_tiling(M, N, K, dtype):
+    run_test_gemm_nt(M, N, K, dtype, "float")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

`gemm_v0` (the AscendC / non-PTO matmul template in `src/tl_templates/ascend/common.h`) tiled only the K dimension: every `mma` loaded the whole N of the B operand into a single L0B slot (`N * kL0Size`). L0B is 64KB and the kL0 ping-pong halves the per-slot budget to 32KB, so once N is large the B sub-tile overflows L0B and the cube crashes at run time.

Concretely an attention PV matmul is `<M = 64, N = headDim = 512, K = window <= 128>`: the B tile is `128 * 512 * 2 = 128KB`, twice the whole L0B.

## Fix

Add an inner N-tiling loop (`nTile = 128`, the largest N-tile whose `(kL0Size x nTile)` B sub-block fits the 32KB per-ping-pong-slot L0B budget): each N-tile loads its own `(kL0Size x nTile)` B sub-block into L0B and accumulates into its own column band of the L0C output.

The `(N-tile, K-tile)` sequence is flattened and the L0A/L0B ping-pong is primed/drained **once**, running continuously across all tiles, so each tile's L1->L0 load overlaps the previous tile's `mma` (no per-tile serialisation).

Sub-tile offsets come straight from the catlass `tla` fractal layouts (verified against `3rdparty/catlass`, not guessed):
- L0C column `n0` → `n0 * roundUp16(M)` (`tla::MakeLayoutL0C` N1 stride)
- L1 zN B column `n0` → `n0 * roundUp16(K)` (`tla::MakeLayout<zN>` C1 stride)

both consistent with the K-offset `B[kL0Idx*16*kL0Size]` the original loop already used.

## Compatibility

Only `transpose_B=false` with `N > nTile` is tiled. Every existing caller (`transpose_B`, or `N <= nTile`) gets `nL0split == 1`, `tileIdx == kL0Idx`, and **byte-identical codegen**, so no working caller changes. Large-N `transpose_B=false` previously overflowed L0B, so this only adds a path that could not run before. A `static_assert` guards non-divisible N.

## Test

`testing/python/language/test_tilelang_ascend_language_gemm_v0_n_tiling.py` — a plain `C = A @ B` (`transpose_B=false`) staged through L1, checked against torch:
- `N = 512` (the PV shape) — the large-N path that overflowed L0B before this fix. `K = 128` (single K-tile, N tiled into 4) and `K = 256` (flattened 2 K-tiles × 4 N-tiles pipeline).
- `N = 128` (`<= nTile`) — the compatibility case: `nL0split == 1`, original single-pass path.

Verified on Ascend NPU: the new test passes (6/6), and the existing `gemm_v0` suite (`test_tilelang_ascend_language_gm_to_l1.py`, 49 cases) still passes.

## Note on the PTO backend

This targets the **ascendc** backend only. The PTO backend has its own separate `gemm_v0` (`src/tl_templates/pto/common.h`, a different `gemm_v0_inner` / `TileMatL0B<..., N, ...>` implementation) that allocates the whole N in one L0B tile as well, so it has the same large-N L0B-overflow limitation. It is a different abstraction and needs a different change, tracked separately in #1313.

