### PR TITLE
[Feat] Ascend: add copy_pa primitive for paged KV load

### DIFF
--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -1174,6 +1174,11 @@ TIR_DEFINE_TL_BUILTIN(ascend_gemm_v1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
+TIR_DEFINE_TL_BUILTIN(ascend_copy_pa)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
 TIR_DEFINE_TL_BUILTIN(ascend_printf)
     .set_num_inputs(-1)
     .set_attr<TCallEffectKind>("TCallEffectKind",

--- a/src/op/ascend.h
+++ b/src/op/ascend.h
@@ -188,6 +188,8 @@ TVM_DLL const Op &ascend_gemm_v0();
 
 TVM_DLL const Op &ascend_gemm_v1();
 
+TVM_DLL const Op &ascend_copy_pa();
+
 TVM_DLL const Op &ascend_printf();
 
 TVM_DLL const Op &ascend_dump_tensor();

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -638,6 +638,8 @@ void CodeGenTileLangAscend::VisitExpr_(const CallNode *op, std::ostream &os) {
     PrintOpCall(op, "AscendC::SyncAll<false>", {0, 0}, {0, 0});
   } else if (op->op.same_as(tl::ascend_gemm_v0())) {
     GemmOpCodegen(op);
+  } else if (op->op.same_as(tl::ascend_copy_pa())) {
+    CopyPACodegen(op);
   } else if (op->op.same_as(tl::ascend_printf())) {
     PrintfOpCodegen(op, "AscendC::PRINTF");
   } else if (op->op.same_as(tl::ascend_dump_tensor())) {
@@ -2259,6 +2261,30 @@ void CodeGenTileLangAscend::GemmOpCodegen(const CallNode *op) {
                << "[" << b_offset << "], " << c_name << "[" << c_offset
                << "], ascend_l0a, ascend_l0b, " << PrintExpr(op->args[4])
                << ");\n";
+}
+
+void CodeGenTileLangAscend::CopyPACodegen(const CallNode *op) {
+  // args: [0]=template op-name string, [1]=dst L1, [2]=kv GM, [3]=block_table
+  // GM (all tvm_access_ptr CallNodes), [4..]=scalar params forwarded verbatim.
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+
+  auto dst_var = op->args[1].as<CallNode>()->args[1].as<VarNode>();
+  auto kv_var = op->args[2].as<CallNode>()->args[1].as<VarNode>();
+  auto bt_var = op->args[3].as<CallNode>()->args[1].as<VarNode>();
+
+  auto dst_offset = PrintExpr(op->args[1].as<CallNode>()->args[2]);
+  auto kv_offset = PrintExpr(op->args[2].as<CallNode>()->args[2]);
+  auto bt_offset = PrintExpr(op->args[3].as<CallNode>()->args[2]);
+
+  this->PrintIndent();
+  this->stream << op_name << "(" << var_idmap_[dst_var] << "[" << dst_offset
+               << "], " << var_idmap_[kv_var] << "[" << kv_offset << "], "
+               << var_idmap_[bt_var] << "[" << bt_offset << "]";
+  for (size_t i = 4; i < op->args.size(); ++i) {
+    this->stream << ", " << PrintExpr(op->args[i]);
+  }
+  this->stream << ");\n";
 }
 
 void CodeGenTileLangAscend::PrintfOpCodegen(const CallNode *op,

--- a/src/target/codegen_ascend.h
+++ b/src/target/codegen_ascend.h
@@ -160,6 +160,7 @@ private:
   void PipeBarrierCodegen(const CallNode *op);
 
   void GemmOpCodegen(const CallNode *op);
+  void CopyPACodegen(const CallNode *op);
 
   void PrintfOpCodegen(const CallNode *op, const std::string &op_name);
 

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -85,6 +85,57 @@ copy_gm_to_l1(LocalTensor<T> dstTensor, GlobalTensor<T> srcTensor,
   tileCopier(dst, src);
 }
 
+// Paged-attention KV load: gather `copyRowNum` rows of a paged KV cache from GM
+// straight into L1 (NZ), resolving each page through `blockTableGm`. This is a
+// faithful port of the reference op's DataCopyPA (PA_ND branch,
+// sparse_attn_sharedkv_common.h): it walks the window one *page* at a time --
+// look up the page id in the block table, Nd2Nz-copy the contiguous run of rows
+// that fall inside that page, advance, repeat -- so a <=128-row window that
+// sits in one page is a single DataCopy (vs a per-row gather). Runs on the
+// cube, L1-direct, so it needs no UB staging and no GM "workspace_kv"
+// round-trip. PA_ND layout only (headNum/n2Idx/dIdx kept for parity with the
+// reference signature; SWA passes n2Idx=dIdx=0, headNum=1).
+template <typename T>
+CATLASS_DEVICE void
+copy_pa(LocalTensor<T> dstTensor, GlobalTensor<T> srcTensor,
+        GlobalTensor<int32_t> blockTableGm, uint32_t blockSize,
+        uint32_t headNum, uint32_t headDim, uint32_t kvStride,
+        uint32_t maxblockNumPerBatch, uint32_t actHeadDim, uint32_t copyRowNum,
+        uint32_t copyRowNumAlign, uint32_t bIdx, uint32_t n2Idx, uint32_t s2Idx,
+        uint32_t dIdx) {
+  (void)headNum; // PA_ND offset uses n2Idx/headDim/blockSize; kept for parity
+  uint32_t copyFinishRowCnt = 0;
+  uint64_t blockTableBaseOffset = (uint64_t)bIdx * maxblockNumPerBatch;
+  uint32_t curS2Idx = s2Idx;
+  uint32_t blockElementCnt = 32 / sizeof(T);
+  while (copyFinishRowCnt < copyRowNum) {
+    uint64_t blockIdOffset = curS2Idx / blockSize;
+    uint64_t reaminRowCnt = curS2Idx % blockSize;
+    uint64_t idInBlockTable =
+        blockTableGm.GetValue(blockTableBaseOffset + blockIdOffset);
+    uint32_t copyRowCnt = blockSize - reaminRowCnt; // one block at a time
+    if (copyFinishRowCnt + copyRowCnt > copyRowNum) {
+      copyRowCnt = copyRowNum - copyFinishRowCnt;
+    }
+    uint64_t offset = (uint64_t)idInBlockTable * kvStride +
+                      (uint64_t)n2Idx * headDim * blockSize +
+                      reaminRowCnt * headDim + dIdx;
+    AscendC::Nd2NzParams nd2nzPara;
+    nd2nzPara.ndNum = 1;
+    nd2nzPara.nValue = copyRowCnt;
+    nd2nzPara.dValue = actHeadDim;
+    nd2nzPara.srcDValue = headDim;
+    nd2nzPara.dstNzC0Stride = copyRowNumAlign;
+    nd2nzPara.dstNzNStride = 1;
+    nd2nzPara.srcNdMatrixStride = 0;
+    nd2nzPara.dstNzMatrixStride = 0;
+    AscendC::DataCopy(dstTensor[copyFinishRowCnt * blockElementCnt],
+                      srcTensor[offset], nd2nzPara);
+    copyFinishRowCnt += copyRowCnt;
+    curS2Idx += copyRowCnt;
+  }
+}
+
 template <typename T, uint32_t srcM, uint32_t srcN, bool transpose = false>
 CATLASS_DEVICE void copy_l1_to_l0a(LocalTensor<T> dstTensor,
                                    LocalTensor<T> srcTensor, uint32_t dstM,

--- a/src/transform/ascend_combinecv.cc
+++ b/src/transform/ascend_combinecv.cc
@@ -789,6 +789,7 @@ private:
   Map<Var, String> &location_map_;
   std::unordered_map<std::string, std::string> callnodeMapPos_ = {
       {"copy_gm_to_l1", "cube"},
+      {"copy_pa", "cube"},
       {"gemm_v0", "cube"},
       {"copy_l1_to_l0a", "cube"},
       {"copy_l1_to_l0b", "cube"},

--- a/src/transform/common/operation_config.h
+++ b/src/transform/common/operation_config.h
@@ -59,6 +59,7 @@ GetOperationConfig() {
       {"mma", {{{0, "read"}, {1, "read"}, {2, "write"}}, "PIPE_M"}},
       {"gemm_v0", {{{0, "read"}, {1, "read"}, {2, "write"}}, "PIPE_M"}},
       {"gemm_v1", {{{0, "read"}, {1, "read"}, {2, "write"}}, "PIPE_M"}},
+      {"copy_pa", {{{0, "write"}, {1, "read"}, {2, "read"}}, "PIPE_MTE2"}},
       {"AscendC::Add", {{{0, "write"}, {1, "read"}, {2, "read"}}, "PIPE_V"}},
       {"AscendC::Adds", {{{0, "write"}, {1, "read"}, {2, "read"}}, "PIPE_V"}},
       {"AscendC::Mul", {{{0, "write"}, {1, "read"}, {2, "read"}}, "PIPE_V"}},

--- a/testing/python/language/test_tilelang_ascend_language_copy_pa.py
+++ b/testing/python/language/test_tilelang_ascend_language_copy_pa.py
@@ -1,0 +1,177 @@
+import pytest
+import tilelang
+import tilelang.language as T
+from tilelang.intrinsics import make_zn_layout, make_nz_layout
+import torch
+
+"""
+Regression test for the ``copy_pa`` primitive (paged-attention KV load) on the
+AscendC backend.
+
+Feature under test
+------------------
+``T.copy_pa`` (src/tl_templates/ascend/common.h ``copy_pa<T>``) loads ``copy_row_num``
+rows of a *paged* KV cache straight from GM into an L1 tile, resolving each page
+through a ``block_table``.  It is a faithful port of the reference op's
+``DataCopyPA`` (PA_ND): the window is walked one page at a time, and each page's
+contiguous row run is Nd2Nz-copied into L1, so a window that spans several pages
+becomes several ``DataCopy`` calls (a runtime ``while`` loop over pages).  Running
+on the cube (L1-direct) it needs no UB staging and no GM workspace round-trip.
+
+Why it needs a primitive: the page walk is data-dependent -- the loop trip count,
+the per-page row count, and the sub-window offset are all runtime values (they
+depend on ``s2_idx`` and the ``block_table`` contents), which ``T.serial`` /
+``T.copy`` (compile-time extents) and ``gemm_v0`` (no runtime-offset operands)
+cannot express.
+
+How this test exercises it
+--------------------------
+The kernel mirrors the reference dataflow: ``copy_pa`` loads the KV window into an
+L1 tile, which is then consumed by a QK matmul (``q @ kv^T``, ``transpose_B=True``,
+reusing the verified gm_to_l1 QK pattern).  The QK output is checked against a
+torch reference that gathers the same window by hand through the ``block_table``.
+If ``copy_pa`` reads the wrong physical rows (bad page indirection, wrong per-page
+count, or a missed page boundary) the QK result diverges.
+
+The KV cache is laid out as ``[num_phys_blocks * block_size, head_dim]`` (physical
+page ``p`` occupies rows ``[p*block_size, (p+1)*block_size)``); the ``block_table``
+maps a logical page to a physical page and is deliberately shuffled to exercise the
+indirection.  ``N = win <= 128`` so the QK matmul stays on the single-pass
+(``nL0split == 1``) gemm_v0 path and does not depend on any N-tiling.
+
+Coverage (all ``target = ascendc``)
+-----------------------------------
+  * single page   -- window fits one page (``while`` runs once)
+  * cross 2 pages -- window straddles a page boundary (``while`` runs twice)
+  * cross 3 pages -- window starts mid-page and spans three pages (``while`` runs
+    three times), stressing the runtime per-page row count and offset
+
+This targets the ascendc backend only.
+"""
+
+TARGET = "ascendc"
+
+DEV_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    """Clear the tilelang cache before the session (a stale kernel could mask a
+    codegen regression -- a rebuilt kernel could otherwise return a cached one)."""
+    tilelang.cache.clear_cache()
+    yield
+
+
+def _torch_dtype(dtype):
+    return {
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+    }[dtype]
+
+
+def copy_pa_qk(block_M, win, dim, block_size, num_phys, s2_idx, dtype, accum_dtype):
+    """``copy_pa`` loads a paged KV window into L1, then QK (``q @ kv^T``) consumes
+    it.  ``win`` (== the QK N dimension) is the window row count and fills the whole
+    ``k_l1`` tile; ``head_num``/``n2_idx``/``d_idx`` are the PA_ND parity values SWA
+    uses (1 / 0 / 0)."""
+    kv_rows = num_phys * block_size
+    max_block_num = num_phys  # logical pages == physical pages here
+
+    @T.prim_func
+    def main(
+        Q: T.Tensor([1, block_M, dim], dtype),  # type: ignore
+        KV: T.Tensor([kv_rows, dim], dtype),  # type: ignore  paged cache
+        BT: T.Tensor([max_block_num], "int32"),  # type: ignore  block table
+        S: T.Tensor([1, block_M, win], accum_dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            q_l1 = T.alloc_L1([block_M, dim], dtype)
+            k_l1 = T.alloc_L1([win, dim], dtype)
+            l0c = T.alloc_L0C([block_M, win], accum_dtype)
+            T.annotate_layout(
+                {
+                    q_l1: make_zn_layout(q_l1),
+                    k_l1: make_nz_layout(k_l1),
+                }
+            )
+            T.copy(Q[0, :, :], q_l1[:, :])
+            # Load the paged window [s2_idx, s2_idx + win) into k_l1 via the block
+            # table.  head_num=1, n2_idx=0, d_idx=0 (PA_ND parity); kv_stride is one
+            # physical page = block_size * head_num * head_dim; copy_row_num_align =
+            # win (k_l1 row capacity).
+            T.copy_pa(
+                k_l1[:, :],
+                KV,
+                BT,
+                block_size,
+                1,
+                dim,
+                block_size * dim,
+                max_block_num,
+                dim,
+                win,
+                win,
+                0,
+                0,
+                s2_idx,
+                0,
+            )
+            T.gemm_v0(q_l1, k_l1, l0c, transpose_B=True, init=True)
+            T.copy(l0c, S[0, :, :])
+
+    return main
+
+
+def _ref_qk(q, kv_2d, bt, block_size, s2_idx, win):
+    """Golden: gather the window row-by-row through the block table, then q @ kv^T."""
+    gathered = torch.empty((win, kv_2d.shape[1]), dtype=torch.float32)
+    for i in range(win):
+        r = s2_idx + i
+        logical_page = r // block_size
+        row_in_page = r % block_size
+        phys_page = int(bt[logical_page])
+        gathered[i] = kv_2d[phys_page * block_size + row_in_page].float()
+    return q.float() @ gathered.t()  # (block_M, win)
+
+
+def run_test_copy_pa(block_M, win, dim, block_size, num_phys, s2_idx, bt_list, dtype):
+    torch.manual_seed(0)
+    accum_dtype = "float"
+    func = copy_pa_qk(block_M, win, dim, block_size, num_phys, s2_idx, dtype, accum_dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=DEV_CONFIGS, target=TARGET)
+    td = _torch_dtype(dtype)
+    q = torch.randn(1, block_M, dim, dtype=td).npu()
+    kv = torch.randn(num_phys * block_size, dim, dtype=td).npu()
+    bt = torch.tensor(bt_list, dtype=torch.int32).npu()
+    torch.npu.synchronize()
+    s = func(q, kv, bt)
+    ref = _ref_qk(q[0].cpu(), kv.cpu(), bt.cpu(), block_size, s2_idx, win)
+    rtol, atol = (2e-2, 2e-2) if dtype == "bfloat16" else (1e-2, 1e-2)
+    torch.testing.assert_close(s[0].cpu(), ref, rtol=rtol, atol=atol)
+
+
+# (block_size, num_phys, s2_idx, block_table) -- win=64, so:
+#   single page  : block_size=64, window [0,64) fits logical page 0        -> while 1x
+#   cross 2 pages: block_size=32, window [0,64) = pages 0,1                 -> while 2x
+#   cross 3 pages: block_size=32, window [16,80) = pages 0(16..),1,2(..16)  -> while 3x
+# block tables are shuffled so the physical page != logical page (tests indirection).
+copy_pa_configs = [
+    (64, 2, 0, [1, 0]),  # single page
+    (32, 4, 0, [2, 0, 3, 1]),  # cross 2 pages, aligned
+    (32, 4, 16, [2, 0, 3, 1]),  # cross 3 pages, mid-page start
+]
+
+
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+@pytest.mark.parametrize("block_size,num_phys,s2_idx,bt_list", copy_pa_configs)
+def test_copy_pa(block_size, num_phys, s2_idx, bt_list, dtype):
+    run_test_copy_pa(32, 64, 128, block_size, num_phys, s2_idx, bt_list, dtype)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tilelang/language/ascend.py
+++ b/tilelang/language/ascend.py
@@ -415,6 +415,61 @@ def gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False):
     )
 
 
+def copy_pa(
+    dst,
+    kv,
+    block_table,
+    block_size,
+    head_num,
+    head_dim,
+    kv_stride,
+    max_block_num_per_batch,
+    act_head_dim,
+    copy_row_num,
+    copy_row_num_align,
+    b_idx,
+    n2_idx,
+    s2_idx,
+    d_idx,
+):
+    """Paged-attention KV load: gather ``copy_row_num`` rows of the paged KV
+    cache ``kv`` (GM) straight into ``dst`` (L1), resolving each page via
+    ``block_table`` (GM). Faithful port of the reference op's ``DataCopyPA``
+    (PA_ND): walks the window one page at a time and Nd2Nz-copies each page's
+    row run, so a window inside one page is a single DataCopy. Runs on the cube
+    (L1-direct), so it needs no UB staging and no GM workspace round-trip.
+
+    Returns:
+        tvm.tir.Call: A TIR intrinsic call to ``tl.ascend_copy_pa``.
+    """
+    dst = _legalize_arguments(dst)
+    kv = _legalize_arguments(kv)
+    block_table = _legalize_arguments(block_table)
+    dst_ptr = _retrieve_ptr(dst, "w")
+    kv_ptr = _retrieve_ptr(kv, "r")
+    bt_ptr = _retrieve_ptr(block_table, "r")
+    return T.call_intrin(
+        "handle",
+        tir.op.Op.get("tl.ascend_copy_pa"),
+        f"copy_pa<{_dtype(kv)}>",
+        dst_ptr,
+        kv_ptr,
+        bt_ptr,
+        block_size,
+        head_num,
+        head_dim,
+        kv_stride,
+        max_block_num_per_batch,
+        act_head_dim,
+        copy_row_num,
+        copy_row_num_align,
+        b_idx,
+        n2_idx,
+        s2_idx,
+        d_idx,
+    )
+
+
 def printf(format_str: str, *args):
     """
     Prints formatted output.


### PR DESCRIPTION
## What

Add a `copy_pa` primitive (`T.copy_pa`) that loads a window of a **paged** KV cache straight from GM into an L1 tile, resolving each page through a `block_table`. The window is walked one page at a time, and each page's contiguous run of rows is Nd2Nz-copied into L1, so a window that sits in one page is a single `DataCopy`. Running on the cube (L1-direct) it needs no UB staging and no GM workspace round-trip — it replaces a per-row gather (GM→UB→GM through a workspace) that is the single largest source of the performance gap on paged attention.

## Why this needs a primitive (it can't be composed from existing ones)

The core of a paged KV load is a **data-dependent, per-page `while` loop**:

```c
while (rows_done < window) {
    page     = blockTable[s2Idx / blockSize];        // indirect page lookup
    copyRows = blockSize - (s2Idx % blockSize);      // runtime rows this page
    DataCopy(L1[rows_done], kv[page*kvStride + ...], Nd2Nz(copyRows rows));
    s2Idx += copyRows;  rows_done += copyRows;
}
```

Composing this from existing TileLang primitives fails on **three independent runtime dimensions**, plus a missing operand:

1. **The loop trip count is runtime.** How many pages a window spans depends on `s2Idx` (different per token), but `T.serial(N)` requires a *compile-time* `N`. Even bounding the page count to a compile-time upper bound and fully unrolling does not escape (2) and (3).
2. **The per-page row count is runtime** (`blockSize - s2Idx % blockSize`). `T.copy`'s transfer extent must be compile-time (it feeds the `DataCopy` / `Nd2Nz` parameters), so it cannot accept a runtime row count.
3. **The sub-window offset into the matmul is runtime.** Even if a whole fixed-size page were staged into L1 and the matmul asked to take `[brow : brow+window]`, the start `brow` is runtime — and `gemm_v0` rejects sliced / runtime-offset operands (`Unsupported BufferLoad`).

On top of those, **`T.copy` has no block-table operand at all** — it only selects `copy_gm_to_l1` etc. by scope, so paged indirect addressing simply cannot be expressed with it.

The only "kernel-side" alternative — a fixed-size batch copy that assumes the window never crosses a page — holds only in a degenerate config (where `blockSize` is large enough that the window happens to fit one page), still needs the runtime `brow` slice of (3), and does not model the paged dataflow (which loops per page and may cross pages).

## Generality (not specific to one op)

A paged KV load is the **general** paged-attention data path: a paged KV cache + block table is the standard PagedAttention layout, and "read a paged window straight into L1" is what any paged-attention cube side must do. Wrapping a C template as a primitive **is** how the TileLang Ascend backend already works — `gemm_v0`, `copy_gm_to_l1`, `copy_l1_to_l0a`, every `T.tile.*` is a `common.h` template exposed via builtin + codegen + Python binding. `copy_pa` is isomorphic to them.

## Compatibility

Pure addition: a new op (`ascend_copy_pa`), a new `common.h` template, a new codegen branch, two config-table rows, and the `T.copy_pa` Python binding. No existing op, template, or codegen path changes.

## Test

`testing/python/language/test_tilelang_ascend_language_copy_pa.py` builds a paged KV cache with a **shuffled** block table (physical page ≠ logical page, to exercise the indirection), loads a window via `copy_pa`, and checks a QK matmul consuming the L1 tile against a hand-gathered torch reference. Coverage (ascendc target):

- single page — window fits one page (`while` runs once)
- cross 2 pages — window straddles a page boundary (`while` runs twice)
- cross 3 pages, mid-page start — runtime per-page row count + offset (`while` runs three times)

Verified on Ascend NPU: the new test passes 6/6, and the existing `gemm_v0` suite (`test_tilelang_ascend_language_gm_to_l1.py`, 49 cases) still passes.

## Note on the PTO backend

This targets the **ascendc** backend only. The PTO backend has no paged KV load primitive (there is no `copy_pa` equivalent in `src/tl_templates/pto/common.h` or its codegen); it is a different abstraction and needs a different implementation, tracked separately in #1331.
