### PR TITLE
[Bugfix] Fixes a segmentation fault in `AscendMemoryPlanning` when the TIR contains a `LetStmt`

### DIFF
--- a/src/transform/ascend_memory_planning.cc
+++ b/src/transform/ascend_memory_planning.cc
@@ -275,6 +275,7 @@ private:
     }
     void VisitStmt_(const WhileNode *op) final { VisitNewScope(op); }
     void VisitStmt_(const AssertStmtNode *op) final { VisitNewScope(op); }
+    void VisitStmt_(const LetStmtNode *op) final { VisitNewScope(op); }
 
     void SetPreAllocBuffer(Map<Var, PrimExpr> external_address_map) {
       for (const auto &kv : external_address_map) {

--- a/testing/python/language/test_ascend_memory_planning.py
+++ b/testing/python/language/test_ascend_memory_planning.py
@@ -28,6 +28,7 @@ import torch
 
 import tilelang
 import tilelang.language as T
+from tilelang import tvm
 
 VEC_NUM = 2
 
@@ -849,6 +850,58 @@ def test_npu_if_else_in_loop_correctness():
     ref_neg = a - a[0, :].unsqueeze(0)
     torch.testing.assert_close(b_pos, ref_pos, rtol=1e-3, atol=1e-3)
     torch.testing.assert_close(b_neg, ref_neg, rtol=1e-3, atol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# 13. LetStmt with BufferLoad(shared) regression (issue #1333)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_letstmt_buffer_load_shared_no_crash(target):
+    """Regression: a scalar read from a shared-scope UB buffer produces a
+    LetStmt whose value is a BufferLoad on a ``shared`` buffer.
+
+    Before the fix, AscendMemoryPlanning did not override
+    VisitStmt_(LetStmtNode) and fell back to the base visitor, which
+    visited the BufferLoad child without pushing a scope_ entry, causing
+    TrackBufferTouch to dereference an empty std::vector -> SIGSEGV.
+
+    Note: the crash only triggers when the LetStmt appears at the top level
+    of the function body (no T.Kernel wrapper).  With T.Kernel the body is
+    nested inside AttrStmt/Block scopes that keep scope_ non-empty, masking
+    the bug.  Therefore this test deliberately uses a bare @T.prim_func and
+    tilelang.lower() instead of tilelang.compile().
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        a_ub = T.alloc_ub((64, 128), "float32")
+        b_ub = T.alloc_ub((64, 128), "float32")
+        T.copy(A[:, :], a_ub)
+        # scalar read from shared buffer -> LetStmt + BufferLoad(shared)
+        s_tmp = a_ub[0, 0]
+        b_ub[0, 0] = s_tmp
+        T.copy(b_ub[:, :], B[:, :])
+
+    with tvm.transform.PassContext(opt_level=3, config=PASS_AUTO):
+        artifact = tilelang.lower(main, target=target)
+    src = artifact.kernel_source
+    offsets = _get_buffer_offsets(src)
+    assert "a_ub" in offsets, f"a_ub missing in {target} source"
+    assert "b_ub" in offsets, f"b_ub missing in {target} source"
+    buf_size = 64 * 128 * 4
+    _assert_no_overlap(
+        "a_ub",
+        offsets["a_ub"],
+        buf_size,
+        "b_ub",
+        offsets["b_ub"],
+        buf_size,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

## 这个 PR 做什么？

修复 `AscendMemoryPlanning` pass 在 TIR 中存在 `LetStmt`（其 value 为 `shared` 作用域 UB buffer 的 `BufferLoad`）时发生的段错误。

此类 IR 由 lowering 合法产生——当用户从 UB buffer 读取一个标量时，例如 `s_tmp = a_ub[0, 0]`。

## 根因

`AscendMemoryPlanner`（位于 `src/transform/ascend_memory_planning.cc`）继承 `StmtExprVisitor`，已覆写 `AttrStmt / IfThenElse / For / While / AssertStmt / BufferStore / Evaluate` 的 `VisitStmt_`，每个都通过 `VisitNewScope()` 在访问子表达式前 `scope_` 压栈。

但**唯独未覆写 `VisitStmt_(const LetStmtNode*)`**。当遇到 `LetStmt` 时，走基类 `StmtExprVisitor` 的默认实现，在未 `scope_.push_back(...)` 的情况下访问绑定的表达式（`shared` buffer 的 `BufferLoad`），触发 `VisitExpr_(BufferLoadNode)` → `TrackBufferTouch()` → `scope_.back()`，对**空** `std::vector` 取 `back()` → 段错误。

## 修复

补上缺失的 override（一行），与其他语句处理器保持一致：

```cpp
void VisitStmt_(const LetStmtNode *op) final { VisitNewScope(op); }
```

## 复现代码

```python
import tilelang.language as T
import tilelang
from tilelang import tvm

@T.prim_func
def main(
    A: T.Tensor((1, 1), "float"),
    B: T.Tensor((1, 1), "float"),
):
    a_ub = T.alloc_ub((1, 1), "float")
    b_ub = T.alloc_ub((1, 1), "float")
    T.copy(A, a_ub)          # MTE2: gm -> ub
    s_tmp = a_ub[0, 0]       # 触发段错误：LetStmt + BufferLoad(shared)
    b_ub[0, 0] = s_tmp
    T.copy(b_ub, B)          # MTE3: ub -> gm

compiled_artifact = tilelang.lower(main)
print("OK")
```

- 修复前：`Segmentation fault (core dumped)`，发生于 `AscendMemoryPlanning`（gdb 调用栈显示 `TrackBufferTouch` ← `VisitStmt_(LetStmtNode)`）
- 修复后：编译成功，开启 `TL_ASCEND_AUTO_SYNC_VS` 时正确插入同步事件（如 `MTE2_S`、`S_V`）

## 验证

- [X] 复现代码不再段错误，`tilelang.lower()` 正常完成
- [X] 新增回归测试 `test_letstmt_buffer_load_shared_no_crash`（位于 `testing/python/language/test_ascend_memory_planning.py`），parametrize 覆盖 `ascendc` 和 `pto` 双后端
- [X] 既有 memory planning 测试无回归（25 passed, 0 failed）

## 改动文件

| 文件                                                       | 改动                                          |
| ---------------------------------------------------------- | --------------------------------------------- |
| `src/transform/ascend_memory_planning.cc`                | +1 行：补`VisitStmt_(LetStmtNode)` override |
| `testing/python/language/test_ascend_memory_planning.py` | +回归测试                                     |

## 备注

段错误仅在 `LetStmt` 出现在函数体顶层（bare `@T.prim_func` + `tilelang.lower()`）时触发。使用 `T.Kernel` wrapper 时，函数体被包裹在 `AttrStmt`/`Block` 作用域内，使 `scope_` 栈非空，掩盖了该 bug。因此回归测试刻意使用 `tilelang.lower()` 而非 `tilelang.compile()`。

Closes #1333
