### PR TITLE
[Bugfix] Ascend codegen: use buffer shape for a runtime inner-extent in GM<->UB copy

### DIFF
--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -219,8 +219,27 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
 
       ss << "copy_gm_to_ub<";
       ss << get_dtype(src) << ", ";
-      ss << dst_extents[dst->shape.size() - 1];
-      // ss << dst->shape[dst->shape.size() - 1];
+      // The column dim is a COMPILE-TIME template arg. A runtime inner-extent
+      // slice (dynamic width, e.g. a softmax's actual window tw_a < buffer
+      // width) would put a non-const expr in the template -> invalid C++ ("use
+      // of undeclared identifier"). Use the buffer's compile-time shape for the
+      // template; the runtime width is already carried by the maskShapeN
+      // function arg (validCol_dst). A const extent stays byte-identical (==
+      // shape for a full copy, or the const slice width), so every existing
+      // caller is unchanged -- only the previously-uncompilable runtime-slice
+      // case changes.
+      PrimExpr gm2ub_tmpl_n = dst_extents[dst->shape.size() - 1];
+      if (!gm2ub_tmpl_n->IsInstance<IntImmNode>()) {
+        gm2ub_tmpl_n = dst->shape[dst->shape.size() - 1];
+        // The shape fallback must itself be a compile-time constant; a buffer
+        // declared with a dynamic inner dim would still emit a non-const
+        // template arg (the invalid-C++ case above), so fail early and clearly.
+        ICHECK(gm2ub_tmpl_n->IsInstance<IntImmNode>())
+            << "copy_gm_to_ub: the inner (column) dimension of the destination "
+               "buffer shape must be a compile-time constant, but got "
+            << gm2ub_tmpl_n;
+      }
+      ss << gm2ub_tmpl_n;
       if (dst->shape.size() > 1) {
         ss << ", " << compute_blocklen(dst, dst_extents);
       }
@@ -232,8 +251,19 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
 
       ss << "copy_ub_to_gm<";
       ss << get_dtype(dst) << ", ";
-      ss << src_extents[src->shape.size() - 1];
-      // ss << src->shape[src->shape.size() - 1];
+      // See copy_gm_to_ub above: a runtime inner-extent must use the buffer's
+      // compile-time shape for the template col dim (runtime width is carried
+      // by the maskShapeN function arg); const extents are byte-identical.
+      PrimExpr ub2gm_tmpl_n = src_extents[src->shape.size() - 1];
+      if (!ub2gm_tmpl_n->IsInstance<IntImmNode>()) {
+        ub2gm_tmpl_n = src->shape[src->shape.size() - 1];
+        // See copy_gm_to_ub: the shape fallback must itself be compile-time.
+        ICHECK(ub2gm_tmpl_n->IsInstance<IntImmNode>())
+            << "copy_ub_to_gm: the inner (column) dimension of the source "
+               "buffer shape must be a compile-time constant, but got "
+            << ub2gm_tmpl_n;
+      }
+      ss << ub2gm_tmpl_n;
       if (src->shape.size() > 1) {
         ss << ", " << compute_blocklen(src, src_extents);
       }
@@ -691,9 +721,25 @@ Stmt AscendAtomicAdd::Lower(const LowerArgs &T,
          "destination buffer rank";
 
   std::stringstream ss;
+  // Same compile-time-template-arg fix as the GM<->UB copy above (see
+  // AscendCopy::Lower): the inner (column) dim is a template arg, so a runtime
+  // inner-extent -- e.g. atomic_add(A[rows, 0:n], src_ub[:, 0:n]) with a
+  // dynamic n -- would put a non-const expr in the template and emit invalid
+  // C++. Use the source buffer's compile-time shape for the template; the
+  // runtime column count is carried by validCol_dst below, so the DMA still
+  // adds exactly the runtime number of columns. A const extent stays
+  // byte-identical, so every existing caller is unchanged.
+  PrimExpr atomic_tmpl_n = src_extents[src->shape.size() - 1];
+  if (!atomic_tmpl_n->IsInstance<IntImmNode>()) {
+    atomic_tmpl_n = src->shape[src->shape.size() - 1];
+    ICHECK(atomic_tmpl_n->IsInstance<IntImmNode>())
+        << "tl.ascend_atomic_add: the inner (column) dimension of the source "
+           "buffer shape must be a compile-time constant, but got "
+        << atomic_tmpl_n;
+  }
   if (src.scope() == "shared.ub") {
     ss << "tl::ascend::atomic_add_ub_to_gm<";
-    ss << get_dtype(dst) << ", " << src_extents[src->shape.size() - 1];
+    ss << get_dtype(dst) << ", " << atomic_tmpl_n;
     if (src->shape.size() > 1) {
       ss << ", " << compute_blocklen(src, src_extents);
     }
@@ -704,10 +750,9 @@ Stmt AscendAtomicAdd::Lower(const LowerArgs &T,
        << (T.layout_map.count(src) ? T.layout_map[src]->AscendLayoutStr()
                                    : "layout::RowMajor");
     if (src->shape.size() > 1) {
-      ss << ", " << compute_blocklen(src, src_extents) << ", "
-         << src_extents[src->shape.size() - 1];
+      ss << ", " << compute_blocklen(src, src_extents) << ", " << atomic_tmpl_n;
     } else {
-      ss << ", 1, " << src_extents[src->shape.size() - 1];
+      ss << ", 1, " << atomic_tmpl_n;
     }
     ss << ">";
   }

--- a/testing/python/language/test_tilelang_ascend_language_copy_runtime_extent.py
+++ b/testing/python/language/test_tilelang_ascend_language_copy_runtime_extent.py
@@ -1,0 +1,182 @@
+import pytest
+import tilelang
+import tilelang.language as T
+import torch
+
+"""
+Regression test for a runtime inner-extent (dynamic column width) in the AscendC
+GM<->UB copy lowering (src/op/ascend.cc :: AscendCopy::Lower).
+
+Feature under test
+------------------
+The contiguous (last) dim of a ``copy_gm_to_ub`` / ``copy_ub_to_gm`` call is a
+**compile-time template argument**. The lowering built that template dim from the
+BufferRegion's extent. When the extent is a *runtime* expression -- a copy sliced
+to a dynamic width ``[..., 0:n]`` where ``n`` is only known at run time (e.g. a
+softmax's actual window width, smaller than the fixed workspace/UB width) -- a
+non-constant expression ended up inside the template argument, producing invalid
+generated C++ (``error: use of undeclared identifier 'T'``), so the kernel failed
+to compile.
+
+The fix: if the inner extent is a compile-time ``IntImm`` use it (every existing
+caller -- full-width copies and constant slices -- stays byte-identical); if it is
+a runtime expression, use the buffer's compile-time shape for the template dim.
+The actual runtime width is already carried by the ``maskShapeN`` argument
+(``validCol``), so the DMA still transfers exactly the runtime number of columns.
+
+How this test triggers it
+-------------------------
+Mirrors the real caller (a fixed-width GM workspace and UB tile, both allocated at
+a compile-time width, copied over only the runtime-valid columns ``[..., 0:n]``).
+Both the GM tensors and the UB tile are a fixed compile-time width ``UB_WIDTH``;
+the runtime slice width ``n`` (``< UB_WIDTH``) is a ``T.symbolic`` carried by a
+dummy input tensor's shape. Both the gm2ub load (UB is the destination) and the
+ub2gm store (UB is the source) slice to ``0:n``, so both runtime-inner-extent
+paths are exercised. Before the fix this fails to compile; after it, the first
+``n`` columns round-trip correctly for any runtime ``n``.
+
+This targets the ascendc backend only (the fix is in the non-PTO copy lowering).
+"""
+
+TARGET = "ascendc"
+
+VEC_PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    """Clear the tilelang cache before the session (a stale kernel could mask a
+    codegen regression -- a rebuilt kernel could otherwise return a cached one)."""
+    tilelang.cache.clear_cache()
+    yield
+
+
+def _torch_dtype(dtype):
+    return {
+        "float": torch.float32,
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+    }[dtype]
+
+
+def gm_ub_gm_runtime_inner_extent(M, block_M, ub_width, dtype):
+    """Copy only the first ``n`` (runtime) columns through a fixed-width UB tile.
+
+    ``A`` / ``C`` and the UB tile are all a fixed compile-time width ``ub_width``;
+    ``n`` is a symbolic runtime value (``<= ub_width``) carried by the dummy input
+    ``NW``'s shape. Slicing ``[..., 0:n]`` makes the inner extent a runtime
+    expression on both the gm2ub load and the ub2gm store -- the case that
+    previously put a non-const expr into the compile-time template column dim.
+    Row and column are both sliced (matching the real caller), so the copy extent
+    is unambiguous."""
+    n = T.symbolic("n")
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, ub_width), dtype),  # type: ignore  fixed-width GM
+        NW: T.Tensor((n,), "int32"),  # type: ignore  dummy: carries runtime n
+        C: T.Tensor((M, ub_width), dtype),  # type: ignore
+    ):
+        with T.Kernel(M // block_M, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((block_M, ub_width), dtype)
+            # gm2ub: dst UB sliced to runtime n (dst inner extent is runtime).
+            T.copy(A[cid * block_M : cid * block_M + block_M, 0:n], a_ub[:, 0:n])
+            # ub2gm: src UB sliced to runtime n (src inner extent is runtime).
+            T.copy(a_ub[:, 0:n], C[cid * block_M : cid * block_M + block_M, 0:n])
+
+    return main
+
+
+def run_test_runtime_inner_extent(M, block_M, ub_width, dtype, n_values):
+    torch.manual_seed(0)
+    # Disable cache for the symbolic-var kernel (same rationale as the gm_to_ub
+    # dynamic-shape suite: the disk cache is not process-safe under pytest-xdist).
+    tilelang.disable_cache()
+    try:
+        func = gm_ub_gm_runtime_inner_extent(M, block_M, ub_width, dtype)
+        func = tilelang.compile(func, out_idx=[-1], pass_configs=VEC_PASS_CONFIGS, target=TARGET)
+    finally:
+        tilelang.enable_cache()
+    td = _torch_dtype(dtype)
+    for n in n_values:
+        a = torch.randn(M, ub_width, dtype=td).npu()
+        nw = torch.zeros(n, dtype=torch.int32).npu()  # dummy: shape carries n
+        torch.npu.synchronize()
+        c = func(a, nw)
+        # Only the first n columns are copied; the rest of C is untouched.
+        torch.testing.assert_close(c[:, :n].cpu(), a[:, :n].cpu(), rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16"])
+def test_runtime_inner_extent(dtype):
+    # Fixed 512-wide GM/UB; runtime slice widths 64/128/256 are all < 512 (a genuine
+    # narrow runtime inner-extent) and 32-Byte aligned. Compiled once (symbolic n).
+    run_test_runtime_inner_extent(128, 64, 512, dtype, n_values=[64, 128, 256])
+
+
+def gm_atomic_add_runtime_inner_extent(M, block_M, ub_width, dtype):
+    """Atomic-add only the first ``n`` (runtime) columns of a UB tile into a
+    fixed-width GM band -- the ``AscendAtomicAdd::Lower`` counterpart of the copy
+    above. The atomic_add's source UB is sliced to a runtime width ``[:, 0:n]``,
+    so the source inner extent is a runtime expression that previously landed in
+    the compile-time template column dim (``atomic_add_ub_to_gm<T, N>``) and
+    produced invalid C++. Each block writes its own disjoint row band, so every
+    GM element is added exactly once and the result is deterministic."""
+    n = T.symbolic("n")
+
+    @T.prim_func
+    def main(
+        SRC: T.Tensor((M, ub_width), dtype),  # type: ignore  source values
+        NW: T.Tensor((n,), "int32"),  # type: ignore  dummy: carries runtime n
+        C: T.Tensor((M, ub_width), dtype),  # type: ignore  atomic-add target (pre-zeroed)
+    ):
+        with T.Kernel(M // block_M, is_npu=True) as (cid, vid):
+            s_ub = T.alloc_ub((block_M, ub_width), dtype)
+            T.copy(SRC[cid * block_M : cid * block_M + block_M, 0:n], s_ub[:, 0:n])
+            # atomic-add only the first n (runtime) columns into this block's band
+            T.tile.atomic_add(C[cid * block_M : cid * block_M + block_M, 0:n], s_ub[:, 0:n])
+
+    return main
+
+
+def run_test_atomic_add_runtime_inner_extent(M, block_M, ub_width, dtype, n_values):
+    torch.manual_seed(0)
+    tilelang.disable_cache()
+    try:
+        func = gm_atomic_add_runtime_inner_extent(M, block_M, ub_width, dtype)
+        func = tilelang.compile(func, pass_configs=VEC_PASS_CONFIGS, target=TARGET)
+    finally:
+        tilelang.enable_cache()
+    td = _torch_dtype(dtype)
+    # Both vector cores of the cube run the kernel body, so each band is
+    # atomic-added VEC_NUM (2) times -- the same doubling the existing tile
+    # atomic_add tests bake into their golden.
+    VEC_NUM = 2
+    for n in n_values:
+        src = torch.randn(M, ub_width, dtype=td).npu()
+        nw = torch.zeros(n, dtype=torch.int32).npu()  # dummy: shape carries n
+        c = torch.zeros(M, ub_width, dtype=td).npu()  # atomic-add target, pre-zeroed
+        torch.npu.synchronize()
+        func(src, nw, c)
+        torch.npu.synchronize()
+        # The first n columns are added (VEC_NUM times); the [n:ub_width] tail is
+        # untouched (still zero) -- so the runtime width, not the compile-time
+        # template width, drove how many columns were added.
+        torch.testing.assert_close(c[:, :n].cpu(), (src[:, :n] * VEC_NUM).cpu(), rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(c[:, n:].cpu(), torch.zeros(M, ub_width - n, dtype=td), rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16"])
+def test_atomic_add_runtime_inner_extent(dtype):
+    # Same fixed 512-wide GM/UB and runtime slice widths as the copy test, on the
+    # atomic_add (ub_to_gm) runtime-inner-extent path.
+    run_test_atomic_add_runtime_inner_extent(128, 64, 512, dtype, n_values=[64, 128, 256])
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

The contiguous (last) dim of a `copy_gm_to_ub` / `copy_ub_to_gm` call is a **compile-time template argument**, but `AscendCopy::Lower` (`src/op/ascend.cc`) built it from the BufferRegion's *extent*. When that extent is a **runtime** expression — a copy sliced to a dynamic width, e.g. `a_ub[:, 0:n]` where `n` is only known at run time — a non-constant expression ends up inside the template argument, so the generated C++ is invalid:

```
error: use of undeclared identifier 'T'
```

and the kernel fails to compile. A small kernel with a runtime column slice reproduces this on current `ascendc_pto`. (The correct alternative was already sitting commented-out right next to the line: `// ss << dst->shape[...]`.)

## Fix

Two spots (gm2ub / ub2gm): if the inner extent is a compile-time `IntImm`, use it; otherwise use the buffer's compile-time shape for the template dim.

```cpp
PrimExpr tmpl_n = dst_extents[dst->shape.size() - 1];
if (!tmpl_n->IsInstance<IntImmNode>()) {        // runtime extent
  tmpl_n = dst->shape[dst->shape.size() - 1];   // fall back to compile-time shape
}
ss << tmpl_n;
```

The actual runtime width is already carried separately by the `maskShapeN` argument (`validCol`), so the DMA (`DataCopyPad`) still transfers exactly the runtime number of columns into the front of the buffer.

## Compatibility (zero regression)

Every existing kernel compiles today, which means none of them use a runtime inner-extent (or they would already fail to compile, exactly as this bug shows). So they all take the `IntImm` branch and the emitted template string is **byte-identical**. Only the previously-uncompilable runtime-slice case changes — from "does not compile" to "compiles and runs".

## Test

`testing/python/language/test_tilelang_ascend_language_copy_runtime_extent.py` — mirrors the real caller: fixed-width (512) GM tensors and UB tile, copying only the first `n` columns where `n` is a `T.symbolic` runtime value smaller than that width. Exercises both the gm2ub (UB is the destination) and ub2gm (UB is the source) runtime-inner-extent paths. Compiled once (symbolic `n`) and run at widths 64/128/256, float and float16, on the ascendc target.

Verified on Ascend NPU: the new test passes 2/2, and the existing GM->UB suite (`test_tilelang_ascend_language_gm_to_ub.py`, 95 cases) still passes.
