### PR TITLE
[Feature] add sync_insert_vs pass

### DIFF
--- a/src/transform/ascend_sync_insert_vs.cc
+++ b/src/transform/ascend_sync_insert_vs.cc
@@ -1,0 +1,911 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+
+/*!
+ * \file ascend_sync_insert_vs.cc
+ * \brief Simplified sync insertion for Ascend NPU.
+ *        Tracks PIPE_V / PIPE_S / PIPE_MTE2 / PIPE_MTE3 only.
+ *        Inserts sync when at least one side is PIPE_V or PIPE_S.
+ */
+
+#include <algorithm>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "arith/ir_mutator_with_analyzer.h"
+
+#include <tvm/runtime/registry.h>
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/buffer.h>
+#include <tvm/tir/builtin.h>
+#include <tvm/tir/expr.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+#include <tvm/tir/utils.h>
+
+#include "../op/ascend.h"
+#include "./common/operation_config.h"
+
+#include "tir/transforms/ir_utils.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+using namespace tir::transform;
+
+static constexpr const char *kAscendAutoSyncVs = "tl.ascend_auto_sync_vs";
+
+TVM_REGISTER_PASS_CONFIG_OPTION(kAscendAutoSyncVs, Bool);
+
+class AscendSyncInsertVS : public arith::IRMutatorWithAnalyzer {
+public:
+  static PrimFunc Substitute(PrimFunc f, PassContext ctx, Target target,
+                             std::string platform) {
+    bool enabled = ctx->GetConfig<Bool>(kAscendAutoSyncVs, Bool(false)).value();
+    if (!enabled) {
+      return f;
+    }
+
+    arith::Analyzer analyzer;
+    AscendSyncInsertVS mutator(&analyzer, target, platform);
+
+    auto address_map = f->GetAttr<Map<Var, PrimExpr>>("address_map")
+                           .value_or(Map<Var, PrimExpr>());
+    auto size_map = f->GetAttr<Map<Var, PrimExpr>>("size_map")
+                        .value_or(Map<Var, PrimExpr>());
+    mutator.InitConfig(address_map, size_map);
+
+    PrimFuncNode *fptr = f.CopyOnWrite();
+    fptr->body = mutator(f->body);
+    return f;
+  }
+
+  explicit AscendSyncInsertVS(arith::Analyzer *analyzer, Target target,
+                              std::string platform)
+      : arith::IRMutatorWithAnalyzer(analyzer), target_(target),
+        platform_(platform) {}
+
+private:
+  using arith::IRMutatorWithAnalyzer::IRMutatorWithAnalyzer;
+
+  struct BufferAccess {
+    std::string buffer_name;
+    bool is_write;
+    std::string pipeline;
+    std::string operation;
+    std::set<std::string> pipe_barriers;
+    int64_t physical_address;
+    bool is_back_edge = false;
+  };
+
+  struct SyncRequirement {
+    std::string sync_type;
+    std::string buffer_name;
+  };
+
+  struct BufferInfo {
+    std::string buffer_name;
+    bool is_read;
+    bool is_write;
+  };
+
+  void InitConfig(const Map<Var, PrimExpr> &address_map,
+                  const Map<Var, PrimExpr> &size_map) {
+    event_id_counter_ = 0;
+    address_map_ = address_map;
+    size_map_ = size_map;
+    event_mapping_ = GetEventMapping();
+    operation_config_ = GetOperationConfig();
+  }
+
+  // ==================== VisitStmt overrides ====================
+
+  Stmt VisitStmt_(const SeqStmtNode *op) override {
+    std::vector<Stmt> new_stmts;
+    for (const Stmt &stmt : op->seq) {
+      new_stmts.push_back(VisitStmt(stmt));
+    }
+    if (new_stmts.empty()) {
+      return Evaluate(0);
+    }
+    if (new_stmts.size() == 1) {
+      return new_stmts[0];
+    }
+    return SeqStmt(new_stmts);
+  }
+
+  Stmt VisitStmt_(const EvaluateNode *op) override {
+    if (auto call = op->value.as<CallNode>()) {
+      if (call->op.same_as(tl::ascend_auto_barrier())) {
+        if (call->args.size() >= 1) {
+          if (auto str = call->args[0].as<StringImmNode>()) {
+            std::string pipeline = str->value;
+            std::string barrier = "PipeBarrier_" + pipeline;
+            for (auto &pair : current_access_history_) {
+              if (pair.second.pipeline == pipeline) {
+                pair.second.pipe_barriers.insert(barrier);
+              }
+            }
+            for (auto &pair : current_write_history_) {
+              if (pair.second.pipeline == pipeline) {
+                pair.second.pipe_barriers.insert(barrier);
+              }
+            }
+          }
+        }
+        return GetRef<Stmt>(op);
+      }
+    }
+
+    auto current_accesses = AnalyzeStmtAccesses(GetRef<Stmt>(op));
+
+    auto scalar_reads = ScanBufferLoads(op->value);
+    for (const auto &read : scalar_reads) {
+      bool found = false;
+      for (const auto &acc : current_accesses) {
+        if (acc.buffer_name == read.buffer_name) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        current_accesses.push_back(read);
+      }
+    }
+
+    return ProcessStatement(GetRef<Stmt>(op), current_accesses);
+  }
+
+  Stmt VisitStmt_(const BufferStoreNode *op) override {
+    std::string scope = GetPtrStorageScope(op->buffer->data);
+
+    std::vector<BufferAccess> current_accesses;
+
+    if (scope != "local.var" && scope != "n") {
+      BufferAccess write_access;
+      write_access.buffer_name = op->buffer->data->name_hint;
+      write_access.is_write = true;
+      write_access.pipeline = "PIPE_S";
+      write_access.operation = "BufferStore";
+      write_access.physical_address =
+          GetPhysicalAddress(write_access.buffer_name);
+      current_accesses.push_back(write_access);
+    }
+
+    auto scalar_reads = ScanBufferLoads(op->value);
+    for (const auto &read : scalar_reads) {
+      bool found = false;
+      for (const auto &acc : current_accesses) {
+        if (acc.buffer_name == read.buffer_name) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        current_accesses.push_back(read);
+      }
+    }
+
+    if (current_accesses.empty()) {
+      return GetRef<Stmt>(op);
+    }
+
+    return ProcessStatement(GetRef<Stmt>(op), current_accesses);
+  }
+
+  Stmt VisitStmt_(const LetStmtNode *op) override {
+    auto scalar_reads = ScanBufferLoads(op->value);
+
+    if (scalar_reads.empty()) {
+      Stmt new_body = VisitStmt(op->body);
+      return LetStmt(op->var, op->value, new_body);
+    }
+
+    return ProcessLetStatement(op, scalar_reads);
+  }
+
+  Stmt VisitStmt_(const AttrStmtNode *op) override {
+    if (op->attr_key == "resource_scope") {
+      auto saved_access_history = current_access_history_;
+      auto saved_write_history = current_write_history_;
+      current_access_history_.clear();
+      current_write_history_.clear();
+      Stmt new_body = VisitStmt(op->body);
+      current_access_history_ = saved_access_history;
+      current_write_history_ = saved_write_history;
+      return AttrStmt(op->node, op->attr_key, op->value, new_body);
+    }
+    Stmt new_body = VisitStmt(op->body);
+    return AttrStmt(op->node, op->attr_key, op->value, new_body);
+  }
+
+  Stmt VisitStmt_(const IfThenElseNode *op) override {
+    auto saved_history = current_access_history_;
+    auto saved_write_history = current_write_history_;
+    Stmt then_case = VisitStmt(op->then_case);
+
+    auto then_history = current_access_history_;
+    auto then_write_history = current_write_history_;
+    current_access_history_ = saved_history;
+    current_write_history_ = saved_write_history;
+    Optional<Stmt> else_case;
+    if (op->else_case.defined()) {
+      else_case = VisitStmt(op->else_case.value());
+    }
+    auto else_history = current_access_history_;
+    auto else_write_history = current_write_history_;
+
+    current_access_history_ = saved_history;
+    current_write_history_ = saved_write_history;
+    for (const auto &kv : then_history) {
+      current_access_history_[kv.first] = kv.second;
+    }
+    for (const auto &kv : then_write_history) {
+      current_write_history_[kv.first] = kv.second;
+    }
+    if (op->else_case.defined()) {
+      for (const auto &kv : else_history) {
+        current_access_history_[kv.first] = kv.second;
+      }
+      for (const auto &kv : else_write_history) {
+        current_write_history_[kv.first] = kv.second;
+      }
+    }
+
+    if (!is_revisit_pass_ && op->else_case.defined()) {
+      bool has_conflict = false;
+      for (const auto &kv : then_history) {
+        auto it = else_history.find(kv.first);
+        if (it != else_history.end() &&
+            it->second.pipeline != kv.second.pipeline) {
+          has_conflict = true;
+          break;
+        }
+      }
+      if (has_conflict) {
+        std::vector<Stmt> stmts;
+        stmts.push_back(IfThenElse(op->condition, then_case, else_case));
+        InsertSynchronization("PipeBarrier_ALL", stmts);
+        current_access_history_.clear();
+        current_write_history_.clear();
+        return SeqStmt(stmts);
+      }
+    }
+
+    return IfThenElse(op->condition, then_case, else_case);
+  }
+
+  Stmt VisitStmt_(const ForNode *op) override {
+    if (is_revisit_pass_) {
+      Stmt new_body = VisitStmt(op->body);
+      return For(op->loop_var, op->min, op->extent, op->kind, new_body,
+                 op->thread_binding, op->annotations);
+    }
+
+    auto saved_history = current_access_history_;
+    auto saved_write_history = current_write_history_;
+    Stmt first_body = VisitStmt(op->body);
+    auto end_history = current_access_history_;
+    auto end_write_history = current_write_history_;
+
+    current_access_history_ = saved_history;
+    current_write_history_ = saved_write_history;
+    for (const auto &kv : end_history) {
+      BufferAccess back_edge_access = kv.second;
+      back_edge_access.is_back_edge = true;
+      current_access_history_[kv.first] = back_edge_access;
+    }
+    for (const auto &kv : end_write_history) {
+      BufferAccess back_edge_access = kv.second;
+      back_edge_access.is_back_edge = true;
+      current_write_history_[kv.first] = back_edge_access;
+    }
+
+    is_revisit_pass_ = true;
+    Stmt final_body = VisitStmt(first_body);
+    is_revisit_pass_ = false;
+
+    current_access_history_ = end_history;
+    current_write_history_ = end_write_history;
+
+    return For(op->loop_var, op->min, op->extent, op->kind, final_body,
+               op->thread_binding, op->annotations);
+  }
+
+  Stmt VisitStmt_(const AllocateNode *op) override {
+    Stmt new_body = VisitStmt(op->body);
+    return Allocate(op->buffer_var, op->dtype, op->extents, op->condition,
+                    new_body);
+  }
+
+  // ==================== Core processing ====================
+
+  void CheckBufferDependency(const BufferAccess &current_access,
+                             const std::string &buffer_name,
+                             std::vector<SyncRequirement> &sync_requirements) {
+    // 1. Check last access (same-pipeline barrier, cross-pipeline WAR/WAW/RAW)
+    auto access_it = current_access_history_.find(buffer_name);
+    bool last_access_is_write = false;
+    if (access_it != current_access_history_.end()) {
+      const auto &latest = access_it->second;
+      last_access_is_write = latest.is_write;
+      if (HasDataDependency(latest, current_access)) {
+        std::string sync_type = GetRequiredSyncType(latest, current_access);
+        if (!sync_type.empty()) {
+          sync_requirements.push_back({sync_type, current_access.buffer_name});
+        }
+      }
+    }
+
+    // 2. Check last write (recovers RAW/WAW lost when a read overwrote the
+    //    write in current_access_history_).  Skip when the last access IS a
+    //    write — it was already checked above and is the same entry.
+    if (!last_access_is_write) {
+      auto write_it = current_write_history_.find(buffer_name);
+      if (write_it != current_write_history_.end()) {
+        const auto &last_write = write_it->second;
+        if (HasDataDependency(last_write, current_access)) {
+          std::string sync_type =
+              GetRequiredSyncType(last_write, current_access);
+          if (!sync_type.empty()) {
+            sync_requirements.push_back(
+                {sync_type, current_access.buffer_name});
+          }
+        }
+      }
+    }
+  }
+
+  Stmt ProcessStatement(const Stmt &stmt,
+                        const std::vector<BufferAccess> &current_accesses) {
+    std::vector<BufferAccess> supported;
+    for (const auto &access : current_accesses) {
+      if (IsSupportedPipeline(access.pipeline)) {
+        supported.push_back(access);
+      }
+    }
+
+    if (supported.empty()) {
+      return stmt;
+    }
+
+    std::vector<SyncRequirement> sync_requirements;
+    for (const auto &current_access : supported) {
+      std::vector<std::string> related =
+          FindRelatedBuffers(current_access.buffer_name);
+      for (const auto &buffer_name : related) {
+        CheckBufferDependency(current_access, buffer_name, sync_requirements);
+      }
+    }
+
+    auto optimized_syncs = DedupSyncRequirements(sync_requirements);
+
+    std::vector<Stmt> stmts;
+    for (const auto &sync_type : optimized_syncs) {
+      InsertSynchronization(sync_type, stmts);
+    }
+
+    UpdateSyncStatesAfterSync(optimized_syncs);
+    stmts.push_back(stmt);
+    UpdateLatestAccessHistory(supported);
+
+    if (stmts.size() == 1) {
+      return stmts[0];
+    }
+    return SeqStmt(stmts);
+  }
+
+  Stmt ProcessLetStatement(const LetStmtNode *op,
+                           const std::vector<BufferAccess> &scalar_reads) {
+    std::vector<SyncRequirement> sync_requirements;
+    for (const auto &current_access : scalar_reads) {
+      std::vector<std::string> related =
+          FindRelatedBuffers(current_access.buffer_name);
+      for (const auto &buffer_name : related) {
+        CheckBufferDependency(current_access, buffer_name, sync_requirements);
+      }
+    }
+
+    auto optimized_syncs = DedupSyncRequirements(sync_requirements);
+
+    std::vector<Stmt> stmts;
+    for (const auto &sync_type : optimized_syncs) {
+      InsertSynchronization(sync_type, stmts);
+    }
+
+    UpdateSyncStatesAfterSync(optimized_syncs);
+    UpdateLatestAccessHistory(scalar_reads);
+
+    Stmt new_body = VisitStmt(op->body);
+    stmts.push_back(LetStmt(op->var, op->value, new_body));
+
+    if (stmts.size() == 1) {
+      return stmts[0];
+    }
+    return SeqStmt(stmts);
+  }
+
+  // ==================== Analysis ====================
+
+  std::vector<BufferAccess> AnalyzeStmtAccesses(const Stmt &stmt) {
+    std::vector<BufferAccess> accesses;
+
+    auto eval = stmt.as<EvaluateNode>();
+    if (!eval) {
+      return accesses;
+    }
+
+    auto call = eval->value.as<CallNode>();
+    if (!call) {
+      return accesses;
+    }
+
+    if (call->op.same_as(builtin::call_extern())) {
+      std::string func_name = Downcast<StringImm>(call->args[0])->value;
+      std::string normalized = NormalizeFunctionName(func_name);
+      auto config_it = operation_config_.find(normalized);
+      if (config_it != operation_config_.end()) {
+        CollectBufferAccesses(config_it->second, normalized, call->args, 1,
+                              accesses);
+      }
+    } else {
+      auto *op_ptr = call->op.as<OpNode>();
+      if (op_ptr) {
+        std::string op_name = op_ptr->name;
+        auto config_it = operation_config_.find(op_name);
+        if (config_it != operation_config_.end()) {
+          CollectBufferAccesses(config_it->second, op_name, call->args, 0,
+                                accesses);
+        }
+      }
+    }
+
+    return accesses;
+  }
+
+  void CollectBufferAccesses(const OperationConfig &config,
+                             const std::string &op_name,
+                             const Array<PrimExpr> &call_args, size_t offset,
+                             std::vector<BufferAccess> &accesses) {
+    std::unordered_map<std::string, BufferAccess> buffer_access_map;
+
+    for (const auto &buffer_config : config.buffer_accesses) {
+      size_t arg_index = buffer_config.first + offset;
+      const std::string &access_type = buffer_config.second;
+
+      if (arg_index >= call_args.size()) {
+        continue;
+      }
+
+      auto buf_info = ExtractBufferInfoFromAccessPtr(call_args[arg_index]);
+      if (buf_info.buffer_name.empty()) {
+        continue;
+      }
+
+      bool is_write = (access_type == "write");
+      auto it = buffer_access_map.find(buf_info.buffer_name);
+      if (it != buffer_access_map.end()) {
+        if (is_write) {
+          it->second.is_write = true;
+        }
+      } else {
+        BufferAccess access;
+        access.buffer_name = buf_info.buffer_name;
+        access.is_write = is_write;
+        access.pipeline = config.default_pipeline;
+        access.operation = op_name;
+        access.physical_address = GetPhysicalAddress(buf_info.buffer_name);
+        buffer_access_map[buf_info.buffer_name] = access;
+      }
+    }
+
+    for (const auto &pair : buffer_access_map) {
+      accesses.push_back(pair.second);
+    }
+  }
+
+  // ExprVisitor-based collector that finds all BufferLoad nodes anywhere in
+  // an expression tree (including inside Add/Mul/Cast/Select/Call, etc.).
+  // The previous hand-rolled recursion only visited BufferLoadNode and
+  // CallNode, silently missing loads nested in arithmetic or logical ops.
+  class BufferLoadCollector : public ExprVisitor {
+  public:
+    BufferLoadCollector(std::vector<BufferAccess> *accesses,
+                        AscendSyncInsertVS *pass)
+        : accesses_(accesses), pass_(pass) {}
+
+    void VisitExpr_(const BufferLoadNode *op) override {
+      std::string scope = GetPtrStorageScope(op->buffer->data);
+      if (scope != "local.var" && scope != "n") {
+        BufferAccess access;
+        access.buffer_name = op->buffer->data->name_hint;
+        access.is_write = false;
+        access.pipeline = "PIPE_S";
+        access.operation = "BufferLoad";
+        access.physical_address = pass_->GetPhysicalAddress(access.buffer_name);
+        accesses_->push_back(access);
+      }
+      ExprVisitor::VisitExpr_(op);
+    }
+
+  private:
+    std::vector<BufferAccess> *accesses_;
+    AscendSyncInsertVS *pass_;
+  };
+
+  std::vector<BufferAccess> ScanBufferLoads(const PrimExpr &expr) {
+    std::vector<BufferAccess> accesses;
+    BufferLoadCollector collector(&accesses, this);
+    collector(expr);
+    return accesses;
+  }
+
+  bool HasDataDependency(const BufferAccess &prev, const BufferAccess &curr) {
+    bool shares_memory = false;
+
+    if (prev.buffer_name == curr.buffer_name) {
+      shares_memory = true;
+    } else if (prev.physical_address != -1 && curr.physical_address != -1) {
+      int64_t prev_size = GetBufferSize(prev.buffer_name);
+      int64_t curr_size = GetBufferSize(curr.buffer_name);
+      if (prev_size > 0 && curr_size > 0) {
+        int64_t prev_end = prev.physical_address + prev_size;
+        int64_t curr_end = curr.physical_address + curr_size;
+        shares_memory = (prev.physical_address < curr_end &&
+                         curr.physical_address < prev_end);
+      } else {
+        shares_memory = (prev.physical_address == curr.physical_address);
+      }
+    }
+
+    if (shares_memory) {
+      // Only WAW, RAW, WAR are real hazards. RAR (both reads) has no hazard.
+      // Cross-pipeline RAW/WAR dependencies that were lost when a read
+      // overwrote a write in current_access_history_ are recovered via
+      // current_write_history_ in ProcessStatement/ProcessLetStatement.
+      if (prev.is_write || curr.is_write) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  std::string GetRequiredSyncType(const BufferAccess &prev_access,
+                                  const BufferAccess &curr_access) {
+    if (!ShouldSync(prev_access.pipeline, curr_access.pipeline)) {
+      return "";
+    }
+
+    if (is_revisit_pass_ && !prev_access.is_back_edge) {
+      return "";
+    }
+
+    if (prev_access.pipeline == curr_access.pipeline) {
+      std::string barrier = "PipeBarrier_" + prev_access.pipeline;
+      if (prev_access.pipe_barriers.find(barrier) !=
+          prev_access.pipe_barriers.end()) {
+        return "";
+      }
+      return barrier;
+    }
+
+    std::string event_type =
+        GetEventType(prev_access.pipeline, curr_access.pipeline);
+    if (!event_type.empty()) {
+      return "EventPair_" + event_type;
+    }
+    return "";
+  }
+
+  std::string GetEventType(const std::string &src_pipeline,
+                           const std::string &dst_pipeline) {
+    std::string key = src_pipeline + "_" + dst_pipeline;
+    auto it = event_mapping_.find(key);
+    return it != event_mapping_.end() ? it->second : "";
+  }
+
+  // ==================== Address / size / scope ====================
+
+  int64_t GetPhysicalAddress(const std::string &buffer_name) {
+    for (const auto &pair : address_map_) {
+      if (pair.first->name_hint == buffer_name) {
+        if (auto int_imm = pair.second.as<IntImmNode>()) {
+          return int_imm->value;
+        }
+      }
+    }
+    return -1;
+  }
+
+  int64_t GetBufferSize(const std::string &buffer_name) {
+    for (const auto &pair : size_map_) {
+      if (pair.first->name_hint == buffer_name) {
+        if (auto int_imm = pair.second.as<IntImmNode>()) {
+          return int_imm->value;
+        }
+      }
+    }
+    return -1;
+  }
+
+  std::string GetBufferScope(const std::string &buffer_name) {
+    for (const auto &pair : address_map_) {
+      if (pair.first->name_hint == buffer_name) {
+        return GetPtrStorageScope(pair.first);
+      }
+    }
+    return "";
+  }
+
+  std::vector<std::string> FindRelatedBuffers(const std::string &buffer_name) {
+    std::vector<std::string> related;
+    int64_t target_addr = GetPhysicalAddress(buffer_name);
+
+    if (target_addr == -1) {
+      related.push_back(buffer_name);
+      return related;
+    }
+
+    std::string target_scope = GetBufferScope(buffer_name);
+    int64_t target_size = GetBufferSize(buffer_name);
+
+    if (target_size <= 0) {
+      for (const auto &pair : address_map_) {
+        if (auto int_imm = pair.second.as<IntImmNode>()) {
+          if (GetPtrStorageScope(pair.first) != target_scope) {
+            continue;
+          }
+          int64_t other_addr = int_imm->value;
+          int64_t other_size = GetBufferSize(pair.first->name_hint);
+          if (other_size > 0) {
+            if (other_addr <= target_addr &&
+                target_addr < other_addr + other_size) {
+              related.push_back(pair.first->name_hint);
+            }
+          } else if (other_addr == target_addr) {
+            related.push_back(pair.first->name_hint);
+          }
+        }
+      }
+      return related;
+    }
+
+    int64_t target_end = target_addr + target_size;
+
+    for (const auto &pair : address_map_) {
+      if (auto int_imm = pair.second.as<IntImmNode>()) {
+        if (GetPtrStorageScope(pair.first) != target_scope) {
+          continue;
+        }
+        int64_t other_addr = int_imm->value;
+        int64_t other_size = GetBufferSize(pair.first->name_hint);
+        if (other_size <= 0) {
+          if (other_addr == target_addr) {
+            related.push_back(pair.first->name_hint);
+          }
+          continue;
+        }
+        int64_t other_end = other_addr + other_size;
+        if (target_addr < other_end && other_addr < target_end) {
+          related.push_back(pair.first->name_hint);
+        }
+      }
+    }
+    return related;
+  }
+
+  // ==================== Name extraction ====================
+
+  std::string NormalizeFunctionName(const std::string &func_name) {
+    std::string result = func_name;
+    size_t template_pos = result.find('<');
+    if (template_pos != std::string::npos) {
+      result = result.substr(0, template_pos);
+    }
+    size_t ns_pos = result.find("tl::ascend::");
+    if (ns_pos != std::string::npos) {
+      result = result.substr(ns_pos + 12);
+    }
+    return result;
+  }
+
+  BufferInfo ExtractBufferInfoFromAccessPtr(const PrimExpr &expr) {
+    BufferInfo info = {"", false, false};
+
+    if (auto var = expr.as<VarNode>()) {
+      info.buffer_name = var->name_hint;
+      return info;
+    }
+
+    auto call = expr.as<CallNode>();
+    if (!call) {
+      return info;
+    }
+
+    if (call->op.same_as(builtin::tvm_access_ptr())) {
+      if (call->args.size() >= 5) {
+        if (auto var = call->args[1].as<VarNode>()) {
+          info.buffer_name = var->name_hint;
+        }
+        if (auto access_mask = call->args[4].as<IntImmNode>()) {
+          int mask = access_mask->value;
+          info.is_read = (mask & 1) != 0;
+          info.is_write = (mask & 2) != 0;
+        }
+      }
+    } else {
+      if (call->args.size() >= 2) {
+        if (auto var = call->args[1].as<VarNode>()) {
+          info.buffer_name = var->name_hint;
+          info.is_read = true;
+          info.is_write = true;
+        }
+      }
+    }
+
+    return info;
+  }
+
+  // ==================== Sync generation ====================
+
+  void InsertSynchronization(const std::string &sync_type,
+                             std::vector<Stmt> &stmts) {
+    if (sync_type == "PipeBarrier_ALL") {
+      stmts.push_back(CreatePipeBarrier("PIPE_ALL"));
+    } else if (sync_type.find("PipeBarrier_") == 0) {
+      std::string pipeline = sync_type.substr(12);
+      if (pipeline == "PIPE_V" && platform_ == "A5") {
+        // A5 does not support pipe_barrier(PIPE_V);
+        // raise error: the range of 1st parameter must be [4, 6]
+        // use V_V event pair
+        int event_id = AllocateEventId();
+        stmts.push_back(CreateSetFlag("V_V", event_id));
+        stmts.push_back(CreateWaitFlag("V_V", event_id));
+      } else {
+        stmts.push_back(CreatePipeBarrier(pipeline));
+      }
+    } else if (sync_type.find("EventPair_") == 0) {
+      std::string event_type = sync_type.substr(10);
+      int event_id = AllocateEventId();
+      stmts.push_back(CreateSetFlag(event_type, event_id));
+      stmts.push_back(CreateWaitFlag(event_type, event_id));
+    }
+  }
+
+  int AllocateEventId() {
+    event_id_counter_ = (event_id_counter_ + 1) % 8;
+    return event_id_counter_;
+  }
+
+  Stmt CreatePipeBarrier(const std::string &pipeline) {
+    Array<PrimExpr> args = {StringImm(pipeline)};
+    return Evaluate(
+        Call(DataType::Handle(), Op::Get("tl.ascend_auto_barrier"), args));
+  }
+
+  Stmt CreateSetFlag(const std::string &event_type, int event_id) {
+    Array<PrimExpr> args = {StringImm(event_type),
+                            IntImm(DataType::Int(32), event_id)};
+    return Evaluate(
+        Call(DataType::Handle(), Op::Get("tl.ascend_auto_set_flag"), args));
+  }
+
+  Stmt CreateWaitFlag(const std::string &event_type, int event_id) {
+    Array<PrimExpr> args = {StringImm(event_type),
+                            IntImm(DataType::Int(32), event_id)};
+    return Evaluate(
+        Call(DataType::Handle(), Op::Get("tl.ascend_auto_wait_flag"), args));
+  }
+
+  // ==================== State management ====================
+
+  std::vector<std::string>
+  DedupSyncRequirements(std::vector<SyncRequirement> &requirements) {
+    if (requirements.empty()) {
+      return {};
+    }
+
+    std::sort(requirements.begin(), requirements.end(),
+              [](const SyncRequirement &a, const SyncRequirement &b) {
+                return a.sync_type < b.sync_type;
+              });
+
+    std::vector<std::string> unique_syncs;
+    for (const auto &req : requirements) {
+      if (unique_syncs.empty() || unique_syncs.back() != req.sync_type) {
+        unique_syncs.push_back(req.sync_type);
+      }
+    }
+    return unique_syncs;
+  }
+
+  void
+  UpdateSyncStatesAfterSync(const std::vector<std::string> &inserted_syncs) {
+    auto update_hist =
+        [&](std::unordered_map<std::string, BufferAccess> &hist) {
+          for (auto &pair : hist) {
+            BufferAccess &access = pair.second;
+            for (const auto &sync_type : inserted_syncs) {
+              if (sync_type.find("PipeBarrier_") == 0) {
+                std::string pipeline = sync_type.substr(12);
+                if (access.pipeline == pipeline) {
+                  access.pipe_barriers.insert(sync_type);
+                }
+              }
+            }
+          }
+        };
+    update_hist(current_access_history_);
+    update_hist(current_write_history_);
+  }
+
+  void
+  UpdateLatestAccessHistory(const std::vector<BufferAccess> &current_accesses) {
+    for (const auto &access : current_accesses) {
+      if (is_revisit_pass_) {
+        auto it = current_access_history_.find(access.buffer_name);
+        if (it != current_access_history_.end() && it->second.is_back_edge &&
+            !ShouldSync(it->second.pipeline, access.pipeline)) {
+          continue;
+        }
+      }
+      current_access_history_[access.buffer_name] = access;
+      if (access.is_write) {
+        current_write_history_[access.buffer_name] = access;
+      }
+    }
+  }
+
+  // ==================== Pipeline filtering ====================
+
+  bool IsSupportedPipeline(const std::string &p) {
+    return p == "PIPE_V" || p == "PIPE_S" || p == "PIPE_MTE2" ||
+           p == "PIPE_MTE3";
+  }
+
+  bool ShouldSync(const std::string &a, const std::string &b) {
+    if (!IsSupportedPipeline(a) || !IsSupportedPipeline(b)) {
+      return false;
+    }
+    // V->V (same pipeline)
+    if (a == "PIPE_V" && b == "PIPE_V") {
+      return true;
+    }
+    // S <-> other (but not S->S, scalar pipeline is in-order)
+    if ((a == "PIPE_S" || b == "PIPE_S") && a != b) {
+      return true;
+    }
+    return false;
+  }
+
+  // ==================== Members ====================
+
+  int event_id_counter_ = 0;
+  bool is_revisit_pass_ = false;
+  std::unordered_map<std::string, std::string> event_mapping_;
+  std::unordered_map<std::string, OperationConfig> operation_config_;
+  std::unordered_map<std::string, BufferAccess> current_access_history_;
+  std::unordered_map<std::string, BufferAccess> current_write_history_;
+  Map<Var, PrimExpr> address_map_;
+  Map<Var, PrimExpr> size_map_;
+  std::string platform_;
+  Target target_;
+};
+
+tvm::transform::Pass AscendSyncInsertVS(Target target, std::string platform) {
+  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+    return AscendSyncInsertVS::Substitute(std::move(f), ctx, target, platform);
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.AscendSyncInsertVS", {});
+}
+
+TVM_REGISTER_GLOBAL("tl.transform.AscendSyncInsertVS")
+    .set_body_typed(AscendSyncInsertVS);
+
+} // namespace tl
+} // namespace tvm

--- a/testing/python/language/test_ascend_sync_insert_vs.py
+++ b/testing/python/language/test_ascend_sync_insert_vs.py
@@ -1,0 +1,1550 @@
+"""Comprehensive tests for AscendSyncInsertVS pass.
+
+Covers:
+  L0 - Threshold tests (smoke):
+    1. Config disabled is a no-op
+    2. V->V barrier inserted
+    3. No sync for independent buffers
+
+  L1 - Functional tests (full trigger matrix + mechanisms):
+    1.  V->V PipeBarrier
+    2.  S->V EventPair
+    3.  S->MTE2 EventPair
+    4.  S->MTE3 EventPair
+    5.  No MTE2->V sync (core negative)
+    6.  No V->MTE3 sync (core negative)
+    7.  No S->S sync (scalar pipeline is in-order)
+    8.  No MTE2->MTE2 sync (same non-S, non-V pipeline)
+    9.  No MTE3->MTE3 sync (same non-S, non-V pipeline)
+    10. No MTE2->MTE3 / MTE3->MTE2 sync
+    11. PIPE_M (GEMM) ignored — no M_V / V_M events
+    12. S->S write-then-read no sync
+    13. Loop back-edge V->V barrier
+    14. Loop back-edge V->V preserved with preceding MTE2 (back-edge overwrite guard)
+    15. Loop back-edge S->V cross-iteration
+    16. If/else history isolation (different buffers per branch)
+    17. If/else same buffer same pipeline (no PipeBarrier_ALL)
+    18. If/else cross-branch conflict (different pipelines -> PipeBarrier_ALL)
+    19. Dedup multiple V deps in single statement
+    20. Consecutive V->V across statements (each needs own barrier)
+    21. Event-pair dedup (multiple S->V deps in single statement)
+    22. Mixed dedup (barrier + event in one statement)
+    23. Event ID rotation (1..7 round-robin)
+    24. Event ID wraparound (mod 8, IDs reused)
+    25. Set/Wait flag ID pairing
+    26. Alias detection via physical address overlap
+    27. V->S EventPair (scalar read from V-written UB)
+    28. MTE2->S EventPair (scalar read from MTE2-written UB)
+    29. MTE3->S EventPair (scalar read from MTE3-read UB)
+
+  L2 - Anomaly tests:
+    1. Read-only no sync
+    2. Single statement no crash
+    3. Resource scope (CV combine) no crash
+    4. Nested loop back-edge (inner + outer)
+    5. If-without-else history propagation
+
+  Boundary - Platform/backend edge cases:
+    1. A5 skips PIPE_V barrier (PTO)
+    2. A5 skips PIPE_V barrier (AscendC)
+    3. A5 still emits event pairs (S->V)
+    4. Both backends consistent
+    5. PTO auto-enabled by default
+    6. AscendC defaults to VS-OFF
+    7. Platform "auto" inserts V barrier (non-A5)
+    8. Full pipeline integration smoke
+    9. Pre-existing barrier recognition (sibling + VS, no duplicate)
+    10. VS with CV combine OFF
+    11. VS with memory planning OFF
+
+Strategy:
+  - VS-only mode (sibling AscendSyncInsert OFF, VS ON) for isolation.
+  - CombineCV is enabled by default (TL_ASCEND_AUTO_CV_COMBINE: True) as it is
+    required for correct pipeline tracking.  A dedicated test verifies the
+    CV-combine-OFF path.
+  - Differential testing: compile same kernel with VS ON vs OFF, assert delta.
+  - Inspect generated source via kernel.get_kernel_source() + regex assertions.
+  - Parametrized over ascendc and pto backends.
+
+"""
+
+import re
+
+import pytest
+
+import tilelang
+import tilelang.language as T
+
+# ---------------------------------------------------------------------------
+# Pass configuration dicts
+# ---------------------------------------------------------------------------
+
+PASS_VS_ONLY = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC_VS: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+}
+
+PASS_NO_SYNC = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC_VS: False,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+}
+
+PASS_FULL = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC_VS: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+}
+
+PASS_VS_NO_CV = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC_VS: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: False,
+}
+
+PASS_VS_NO_PLAN = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC_VS: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+}
+
+
+# ---------------------------------------------------------------------------
+# Parametrize helper
+# ---------------------------------------------------------------------------
+
+TARGETS = ["ascendc", "pto"]
+TARGETS_WITH_PTO = pytest.mark.parametrize("target", TARGETS)
+
+
+# ---------------------------------------------------------------------------
+# Sync pattern definitions for each backend
+# ---------------------------------------------------------------------------
+
+_SYNC_PATTERNS = {
+    "barrier_v": {
+        "ascendc": r"AscendC::PipeBarrier<PIPE_V>",
+        "pto": r"pipe_barrier\(PIPE_V\)",
+    },
+    "barrier_all": {
+        "ascendc": r"AscendC::PipeBarrier<PIPE_ALL>",
+        "pto": r"pipe_barrier\(PIPE_ALL\)",
+    },
+    "v_v": {
+        "ascendc": r"AscendC::SetFlag<AscendC::HardEvent::V_V>",
+        "pto": r"set_flag\(PIPE_V,\s*PIPE_V",
+    },
+    "s_v": {
+        "ascendc": r"AscendC::SetFlag<AscendC::HardEvent::S_V>",
+        "pto": r"set_flag\(PIPE_S,\s*PIPE_V",
+    },
+    "v_s": {
+        "ascendc": r"AscendC::SetFlag<AscendC::HardEvent::V_S>",
+        "pto": r"set_flag\(PIPE_V,\s*PIPE_S",
+    },
+    "s_mte2": {
+        "ascendc": r"AscendC::SetFlag<AscendC::HardEvent::S_MTE2>",
+        "pto": r"set_flag\(PIPE_S,\s*PIPE_MTE2",
+    },
+    "mte2_s": {
+        "ascendc": r"AscendC::SetFlag<AscendC::HardEvent::MTE2_S>",
+        "pto": r"set_flag\(PIPE_MTE2,\s*PIPE_S",
+    },
+    "s_mte3": {
+        "ascendc": r"AscendC::SetFlag<AscendC::HardEvent::S_MTE3>",
+        "pto": r"set_flag\(PIPE_S,\s*PIPE_MTE3",
+    },
+    "mte3_s": {
+        "ascendc": r"AscendC::SetFlag<AscendC::HardEvent::MTE3_S>",
+        "pto": r"set_flag\(PIPE_MTE3,\s*PIPE_S",
+    },
+}
+
+# Generic patterns to detect ANY auto sync inserted by VS
+_ANY_BARRIER = {
+    "ascendc": r"AscendC::PipeBarrier<PIPE_",
+    "pto": r"pipe_barrier\(PIPE_",
+}
+_ANY_SETFLAG = {
+    "ascendc": r"AscendC::SetFlag<AscendC::HardEvent::",
+    "pto": r"set_flag\(PIPE_",
+}
+_ANY_WAITFLAG = {
+    "ascendc": r"AscendC::WaitFlag<AscendC::HardEvent::",
+    "pto": r"wait_flag\(PIPE_",
+}
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    tilelang.disable_cache()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def _compile_and_get_source(program, pass_configs, target="ascendc", platform="auto", out_idx=None):
+    kwargs = {"pass_configs": pass_configs, "target": target, "platform": platform}
+    if out_idx is not None:
+        kwargs["out_idx"] = out_idx
+    kernel = tilelang.compile(program, **kwargs)
+    return kernel.get_kernel_source(), kernel
+
+
+def _count_pattern(src, pattern):
+    return len(re.findall(pattern, src))
+
+
+def _get_sync_pattern(target, sync_kind):
+    patterns = _SYNC_PATTERNS.get(sync_kind, {})
+    return patterns.get(target, "")
+
+
+def _count_sync(src, target, sync_kind):
+    pattern = _get_sync_pattern(target, sync_kind)
+    if not pattern:
+        return 0
+    return _count_pattern(src, pattern)
+
+
+def _assert_has_sync(src, target, sync_kind):
+    count = _count_sync(src, target, sync_kind)
+    assert count > 0, f"Expected sync '{sync_kind}' in {target} source, but not found.\nSource:\n{src}"
+
+
+def _assert_no_sync(src, target, sync_kind):
+    count = _count_sync(src, target, sync_kind)
+    assert count == 0, f"Expected NO sync '{sync_kind}' in {target} source, but found {count}.\nSource:\n{src}"
+
+
+def _count_any_auto_sync(src, target):
+    """Count total auto sync operations (barriers + set_flags + wait_flags)."""
+    total = 0
+    for pat in [_ANY_BARRIER, _ANY_SETFLAG, _ANY_WAITFLAG]:
+        total += _count_pattern(src, pat[target])
+    return total
+
+
+def _assert_no_auto_sync(src, target):
+    """Assert that NO auto sync operations exist in the source."""
+    total = _count_any_auto_sync(src, target)
+    assert total == 0, f"Expected NO auto sync in {target} source, but found {total} sync operations.\nSource:\n{src}"
+
+
+# ---------------------------------------------------------------------------
+# L0 - Threshold tests (smoke)
+# ---------------------------------------------------------------------------
+
+
+@TARGETS_WITH_PTO
+def test_config_disabled_is_noop(target):
+    """VS pass disabled -> no sync operations in output."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.tile.exp(b_ub, a_ub)
+            T.tile.exp(b_ub, b_ub)
+
+    src, _ = _compile_and_get_source(main, PASS_NO_SYNC, target=target, out_idx=[])
+    _assert_no_auto_sync(src, target)
+
+
+@TARGETS_WITH_PTO
+def test_v_to_v_barrier_inserted(target):
+    """V->V dependency on same buffer -> PipeBarrier<PIPE_V> inserted."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.tile.exp(b_ub, a_ub)
+            T.tile.exp(b_ub, b_ub)
+
+    src_on, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[])
+    src_off, _ = _compile_and_get_source(main, PASS_NO_SYNC, target=target, out_idx=[])
+
+    _assert_has_sync(src_on, target, "barrier_v")
+    _assert_no_sync(src_off, target, "barrier_v")
+
+
+@TARGETS_WITH_PTO
+def test_no_sync_independent_buffers(target):
+    """V ops on different buffers -> no V->V barrier."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.copy(B[:, :], b_ub)
+            T.tile.exp(a_ub, a_ub)
+            T.tile.exp(b_ub, b_ub)
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[])
+    _assert_no_sync(src, target, "barrier_v")
+
+
+# ---------------------------------------------------------------------------
+# L1 - Functional tests
+# ---------------------------------------------------------------------------
+
+
+@TARGETS_WITH_PTO
+def test_v_to_v_pipe_barrier(target):
+    """V write -> V read+write same buffer -> PipeBarrier<PIPE_V>."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.tile.exp(b_ub, a_ub)
+            T.tile.exp(b_ub, b_ub)
+            T.copy(b_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+    _assert_has_sync(src, target, "barrier_v")
+
+
+@TARGETS_WITH_PTO
+def test_s_to_v_event_pair(target):
+    """S write to UB -> V read same UB -> SetFlag/WaitFlag S_V."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            a_ub[0, 0] = T.cast(1.0, "float32")
+            T.tile.exp(b_ub, a_ub)
+            T.copy(b_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+    _assert_has_sync(src, target, "s_v")
+
+
+@TARGETS_WITH_PTO
+def test_s_to_mte2_event(target):
+    """S write to UB -> MTE2 write same UB -> SetFlag/WaitFlag S_MTE2."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            a_ub[0, 0] = T.cast(1.0, "float32")
+            T.copy(A[:, :], a_ub)
+            T.copy(a_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+    _assert_has_sync(src, target, "s_mte2")
+
+
+@TARGETS_WITH_PTO
+def test_s_to_mte3_event(target):
+    """S write to UB -> MTE3 read same UB -> SetFlag/WaitFlag S_MTE3."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            a_ub[0, 0] = T.cast(1.0, "float32")
+            T.copy(a_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+    _assert_has_sync(src, target, "s_mte3")
+
+
+@TARGETS_WITH_PTO
+def test_no_mte2_to_v_sync(target):
+    """MTE2 write UB -> V read same UB -> NO sync (VS core negative)."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.tile.exp(b_ub, a_ub)
+            T.copy(b_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+
+    _assert_no_auto_sync(src, target)
+
+
+@TARGETS_WITH_PTO
+def test_no_v_to_mte3_sync(target):
+    """V write UB -> MTE3 read same UB -> NO sync (VS core negative)."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.tile.exp(a_ub, a_ub)
+            T.copy(a_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+
+    _assert_no_auto_sync(src, target)
+
+
+@TARGETS_WITH_PTO
+def test_no_s_to_s_sync(target):
+    """S write -> S write same buffer -> NO S_S sync (scalar in-order).
+
+    Note: MTE2->S and S->MTE3 syncs ARE expected (they involve different
+    pipelines). This test only asserts the absence of S_S event pairs.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            a_ub[0, 0] = T.cast(1.0, "float32")
+            a_ub[0, 1] = T.cast(2.0, "float32")
+            T.copy(a_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+
+    # S->S should NOT produce any sync (ShouldSync returns false for S,S)
+    s_s_pattern = {
+        "ascendc": r"HardEvent::S_S",
+        "pto": r"set_flag\(PIPE_S,\s*PIPE_S",
+    }
+    assert _count_pattern(src, s_s_pattern[target]) == 0
+
+
+@TARGETS_WITH_PTO
+def test_loop_back_edge_v_to_v(target):
+    """Loop body with only V ops -> cross-iteration V->V -> barrier."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((128,), "float32"),  # type: ignore
+        B: T.Tensor((128,), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((128,), "float32")
+            T.copy(A[:], a_ub)
+            for _i in T.serial(4):
+                T.tile.exp(a_ub, a_ub)
+            T.copy(a_ub, B[:])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+    _assert_has_sync(src, target, "barrier_v")
+
+
+@TARGETS_WITH_PTO
+def test_loop_back_edge_v_to_v_with_mte2(target):
+    """Loop back-edge V->V preserved when MTE2 precedes V in loop body.
+
+    The MTE2 copy (GM->UB) at the start of each iteration overwrites the
+    same buffer that the V op (exp) writes at the end.  Without the
+    back-edge preservation fix, the MTE2 access would overwrite the V
+    back-edge in the access history, causing the cross-iteration V->V
+    dependency to be missed.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((128,), "float32"),  # type: ignore
+        B: T.Tensor((128,), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((128,), "float32")
+            T.copy(A[:], a_ub)
+            for _i in T.serial(4):
+                T.copy(A[:], a_ub)
+                T.tile.exp(a_ub, a_ub)
+            T.copy(a_ub, B[:])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+    _assert_has_sync(src, target, "barrier_v")
+
+
+@TARGETS_WITH_PTO
+def test_if_else_history_isolation(target):
+    """If/else branches each have V->V barrier; no cross-branch sync."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((2, 64), "float32"),  # type: ignore
+        B: T.Tensor((2, 64), "float32"),  # type: ignore
+        sel: T.Tensor((1,), "int32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            s = sel[0]
+            if s > 0:
+                x_ub = T.alloc_ub((64,), "float32")
+                T.copy(A[0, :], x_ub)
+                T.tile.exp(x_ub, x_ub)
+                T.tile.mul(x_ub, x_ub, x_ub)
+                T.copy(x_ub, B[0, :])
+            else:
+                y_ub = T.alloc_ub((64,), "float32")
+                T.copy(A[1, :], y_ub)
+                T.tile.exp(y_ub, y_ub)
+                T.tile.mul(y_ub, y_ub, y_ub)
+                T.copy(y_ub, B[1, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+
+    _assert_has_sync(src, target, "barrier_v")
+    _assert_no_sync(src, target, "s_v")
+    _assert_no_sync(src, target, "v_s")
+
+
+@TARGETS_WITH_PTO
+def test_dedup_multiple_v_deps(target):
+    """Single V op with multiple V->V deps -> deduped to 1 barrier."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+        C: T.Tensor((64, 128), "float32"),  # type: ignore
+        D: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            ub1 = T.alloc_ub((64, 128), "float32")
+            ub2 = T.alloc_ub((64, 128), "float32")
+            ub3 = T.alloc_ub((64, 128), "float32")
+            ub_out = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], ub1)
+            T.copy(B[:, :], ub2)
+            T.copy(C[:, :], ub3)
+            T.tile.exp(ub1, ub1)
+            T.tile.exp(ub2, ub2)
+            T.tile.exp(ub3, ub3)
+            T.tile.add(ub_out, ub1, ub2)
+            T.copy(ub_out, D[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[3])
+
+    barrier_count = _count_sync(src, target, "barrier_v")
+    assert barrier_count == 1, (
+        f"Expected exactly 1 V barrier (3 V->V deps on ub1/ub2/ub3 deduped to 1 in the add statement), got {barrier_count}.\nSource:\n{src}"
+    )
+
+
+@TARGETS_WITH_PTO
+def test_consecutive_v_to_v_each_needs_barrier(target):
+    """exp(b_ub,b_ub) -> mul(b_ub,b_ub,b_ub): 2 V->V deps across separate
+    statements, each needs its own barrier.
+
+    PipeBarrier<PIPE_V> ensures pre-barrier V ops complete before post-barrier
+    V ops begin, but does NOT order ops within the post-barrier region. Since
+    both exp and mul execute after barrier #1, mul may start before exp's write
+    commits — a second barrier is required for the RAW/WAW hazard.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.tile.exp(b_ub, a_ub)
+            T.tile.exp(b_ub, b_ub)
+            T.tile.mul(b_ub, b_ub, b_ub)
+            T.copy(b_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+
+    barrier_count = _count_sync(src, target, "barrier_v")
+    assert barrier_count == 2, (
+        f"Expected exactly 2 V barriers (one per V->V dependency across separate statements), got {barrier_count}.\nSource:\n{src}"
+    )
+
+
+@TARGETS_WITH_PTO
+def test_event_id_rotation(target):
+    """Multiple S->V EventPairs -> event IDs are unique (rotation)."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((3, 64), "float32"),  # type: ignore
+        B: T.Tensor((3, 64), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            ub1 = T.alloc_ub((64,), "float32")
+            ub2 = T.alloc_ub((64,), "float32")
+            ub3 = T.alloc_ub((64,), "float32")
+            T.copy(A[0, :], ub1)
+            T.copy(A[1, :], ub2)
+            T.copy(A[2, :], ub3)
+            ub1[0] = T.cast(1.0, "float32")
+            T.tile.exp(ub1, ub1)
+            ub2[0] = T.cast(1.0, "float32")
+            T.tile.exp(ub2, ub2)
+            ub3[0] = T.cast(1.0, "float32")
+            T.tile.exp(ub3, ub3)
+            T.copy(ub1, B[0, :])
+            T.copy(ub2, B[1, :])
+            T.copy(ub3, B[2, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+
+    if target == "ascendc":
+        ids = re.findall(r"AscendC::SetFlag<AscendC::HardEvent::S_V>\((\d+)\)", src)
+    else:
+        ids = re.findall(r"set_flag\(PIPE_S,\s*PIPE_V,\s*EVENT_ID(\d+)\)", src)
+
+    assert len(ids) >= 2, f"Expected at least 2 S_V event IDs, got {len(ids)}.\nSource:\n{src}"
+    assert len(set(ids)) == len(ids), f"Event IDs should be unique, got {ids}"
+
+
+@TARGETS_WITH_PTO
+def test_alias_detection_via_address(target):
+    """Two sequential UB buffers with non-overlapping lifetimes may share
+    address. VS should handle aliasing without crash.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+        C: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            ub1 = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], ub1)
+            T.tile.exp(ub1, ub1)
+            T.copy(ub1, B[:, :])
+
+            ub2 = T.alloc_ub((64, 128), "float32")
+            T.copy(C[:, :], ub2)
+            T.tile.exp(ub2, ub2)
+            T.copy(ub2, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+    assert len(src) > 0, "Expected non-empty source"
+
+
+@TARGETS_WITH_PTO
+def test_mte2_to_mte2_no_sync(target):
+    """Two MTE2 writes to same UB -> NO sync (ShouldSync(MTE2,MTE2)=false)."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+        C: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.copy(B[:, :], a_ub)
+            T.copy(a_ub, C[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[2])
+    _assert_no_auto_sync(src, target)
+
+
+@TARGETS_WITH_PTO
+def test_mte3_to_mte3_no_sync(target):
+    """Two MTE3 reads from same UB -> NO sync (ShouldSync(MTE3,MTE3)=false)."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+        C: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.copy(a_ub, B[:, :])
+            T.copy(a_ub, C[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1, 2])
+    _assert_no_auto_sync(src, target)
+
+
+@TARGETS_WITH_PTO
+def test_mte2_to_mte3_no_sync(target):
+    """MTE2 write UB -> MTE3 read same UB -> NO sync (neither is S or V->V)."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.copy(a_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+    _assert_no_auto_sync(src, target)
+
+
+@TARGETS_WITH_PTO
+def test_s_to_s_write_then_read_no_sync(target):
+    """S write -> S read same buffer -> NO S_S sync (scalar in-order).
+
+    Note: MTE2->S and S->MTE3 syncs ARE expected.  This test only asserts
+    the absence of S_S event pairs.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((1, 128), "float32"),  # type: ignore
+        B: T.Tensor((1, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((1, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            a_ub[0, 0] = T.cast(1.0, "float32")
+            val = a_ub[0, 0]  # noqa: F841  intentional scalar read (S pipeline)
+            T.copy(a_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+
+    s_s_pattern = {
+        "ascendc": r"HardEvent::S_S",
+        "pto": r"set_flag\(PIPE_S,\s*PIPE_S",
+    }
+    assert _count_pattern(src, s_s_pattern[target]) == 0
+
+
+def test_pipe_m_ignored():
+    """GEMM (PIPE_M) -> V on different buffer -> NO M_V / V_M sync.
+
+    PIPE_M is not in IsSupportedPipeline, so GEMM ops are invisible to VS.
+    No M_V or V_M event pairs should ever be inserted.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((128, 128), "float16"),  # type: ignore
+        B: T.Tensor((128, 128), "float16"),  # type: ignore
+        C: T.Tensor((128, 128), "float16"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            A_L1 = T.alloc_shared((128, 128), "float16")
+            B_L1 = T.alloc_shared((128, 128), "float16")
+            C_L0 = T.alloc_fragment((128, 128), "float32")
+            c_ub = T.alloc_shared((128, 128), "float16")
+
+            T.copy(A[:, :], A_L1)
+            T.copy(B[:, :], B_L1)
+            T.gemm_v0(A_L1, B_L1, C_L0, init=True)
+            T.copy(C_L0, c_ub)
+            T.tile.exp(c_ub, c_ub)
+            T.copy(c_ub, C[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target="ascendc", out_idx=[2])
+
+    m_v_pattern = r"HardEvent::M_V"
+    v_m_pattern = r"HardEvent::V_M"
+    assert _count_pattern(src, m_v_pattern) == 0, f"PIPE_M should be ignored, but M_V event found.\nSource:\n{src}"
+    assert _count_pattern(src, v_m_pattern) == 0, f"PIPE_M should be ignored, but V_M event found.\nSource:\n{src}"
+
+
+@TARGETS_WITH_PTO
+def test_if_else_same_buffer_same_pipeline(target):
+    """If/else with same buffer, V in both branches -> V->V barrier, no
+    PipeBarrier_ALL (same pipeline, no cross-branch conflict).
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((2, 64), "float32"),  # type: ignore
+        B: T.Tensor((64,), "float32"),  # type: ignore
+        sel: T.Tensor((1,), "int32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64,), "float32")
+            s = sel[0]
+            if s > 0:
+                T.copy(A[0, :], a_ub)
+                T.tile.exp(a_ub, a_ub)
+                T.tile.mul(a_ub, a_ub, a_ub)
+            else:
+                T.copy(A[1, :], a_ub)
+                T.tile.exp(a_ub, a_ub)
+                T.tile.mul(a_ub, a_ub, a_ub)
+            T.copy(a_ub, B[:])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+
+    _assert_has_sync(src, target, "barrier_v")
+    _assert_no_sync(src, target, "barrier_all")
+
+
+@TARGETS_WITH_PTO
+def test_if_else_cross_branch_barrier_all(target):
+    """If/else with same buffer, V in then vs MTE2 in else -> PipeBarrier_ALL.
+
+    When both branches access the same buffer but with different pipelines,
+    the pass inserts PipeBarrier_ALL after the if/else and clears history.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((2, 64), "float32"),  # type: ignore
+        B: T.Tensor((64,), "float32"),  # type: ignore
+        sel: T.Tensor((1,), "int32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64,), "float32")
+            s = sel[0]
+            if s > 0:
+                T.copy(A[0, :], a_ub)
+                T.tile.exp(a_ub, a_ub)
+            else:
+                T.copy(A[1, :], a_ub)
+            T.copy(a_ub, B[:])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+
+    _assert_has_sync(src, target, "barrier_all")
+
+
+@TARGETS_WITH_PTO
+def test_event_pair_dedup(target):
+    """Multiple S->V deps in single V statement -> deduped to 1 S_V event."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+        C: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            ub1 = T.alloc_ub((64, 128), "float32")
+            ub2 = T.alloc_ub((64, 128), "float32")
+            ub_out = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], ub1)
+            T.copy(B[:, :], ub2)
+            ub1[0, 0] = T.cast(1.0, "float32")
+            ub2[0, 0] = T.cast(1.0, "float32")
+            T.tile.add(ub_out, ub1, ub2)
+            T.copy(ub_out, C[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[2])
+
+    sv_count = _count_sync(src, target, "s_v")
+    assert sv_count == 1, f"Expected exactly 1 S_V event pair (deduped from 2 S->V deps), got {sv_count}.\nSource:\n{src}"
+
+
+@TARGETS_WITH_PTO
+def test_mixed_dedup_barrier_and_event(target):
+    """Single V statement with V->V (barrier) + S->V (event) -> both inserted.
+
+    The dedup logic should keep both sync types since they are different.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+        C: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            ub1 = T.alloc_ub((64, 128), "float32")
+            ub2 = T.alloc_ub((64, 128), "float32")
+            ub_out = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], ub1)
+            T.tile.exp(ub1, ub1)
+            T.copy(B[:, :], ub2)
+            ub2[0, 0] = T.cast(1.0, "float32")
+            T.tile.add(ub_out, ub1, ub2)
+            T.copy(ub_out, C[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[2])
+
+    _assert_has_sync(src, target, "barrier_v")
+    _assert_has_sync(src, target, "s_v")
+
+
+@TARGETS_WITH_PTO
+def test_event_id_wraparound(target):
+    """9+ S->V event pairs -> event IDs wrap around mod 8.
+
+    AllocateEventId does (counter + 1) % 8, cycling 1..7, 0, 1..  After 8
+    allocations ID 0 is used, and subsequent IDs repeat.  This test verifies
+    the wrap occurs and IDs are reused.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((9, 64), "float32"),  # type: ignore
+        B: T.Tensor((9, 64), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            ub0 = T.alloc_ub((64,), "float32")
+            ub1 = T.alloc_ub((64,), "float32")
+            ub2 = T.alloc_ub((64,), "float32")
+            ub3 = T.alloc_ub((64,), "float32")
+            ub4 = T.alloc_ub((64,), "float32")
+            ub5 = T.alloc_ub((64,), "float32")
+            ub6 = T.alloc_ub((64,), "float32")
+            ub7 = T.alloc_ub((64,), "float32")
+            ub8 = T.alloc_ub((64,), "float32")
+            T.copy(A[0, :], ub0)
+            ub0[0] = T.cast(1.0, "float32")
+            T.tile.exp(ub0, ub0)
+            T.copy(ub0, B[0, :])
+            T.copy(A[1, :], ub1)
+            ub1[0] = T.cast(1.0, "float32")
+            T.tile.exp(ub1, ub1)
+            T.copy(ub1, B[1, :])
+            T.copy(A[2, :], ub2)
+            ub2[0] = T.cast(1.0, "float32")
+            T.tile.exp(ub2, ub2)
+            T.copy(ub2, B[2, :])
+            T.copy(A[3, :], ub3)
+            ub3[0] = T.cast(1.0, "float32")
+            T.tile.exp(ub3, ub3)
+            T.copy(ub3, B[3, :])
+            T.copy(A[4, :], ub4)
+            ub4[0] = T.cast(1.0, "float32")
+            T.tile.exp(ub4, ub4)
+            T.copy(ub4, B[4, :])
+            T.copy(A[5, :], ub5)
+            ub5[0] = T.cast(1.0, "float32")
+            T.tile.exp(ub5, ub5)
+            T.copy(ub5, B[5, :])
+            T.copy(A[6, :], ub6)
+            ub6[0] = T.cast(1.0, "float32")
+            T.tile.exp(ub6, ub6)
+            T.copy(ub6, B[6, :])
+            T.copy(A[7, :], ub7)
+            ub7[0] = T.cast(1.0, "float32")
+            T.tile.exp(ub7, ub7)
+            T.copy(ub7, B[7, :])
+            T.copy(A[8, :], ub8)
+            ub8[0] = T.cast(1.0, "float32")
+            T.tile.exp(ub8, ub8)
+            T.copy(ub8, B[8, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+
+    if target == "ascendc":
+        sv_ids = re.findall(r"AscendC::SetFlag<AscendC::HardEvent::S_V>\((\d+)\)", src)
+    else:
+        sv_ids = re.findall(r"set_flag\(PIPE_S,\s*PIPE_V,\s*EVENT_ID(\d+)\)", src)
+
+    assert len(sv_ids) >= 9, f"Expected at least 9 S_V event IDs, got {len(sv_ids)}.\nSource:\n{src}"
+    assert "0" in sv_ids, f"Expected ID 0 (wrap-around after 8 allocations), got IDs {sv_ids}.\nSource:\n{src}"
+    assert len(set(sv_ids)) < len(sv_ids), f"Expected some IDs to be reused after wrap, all unique: {sv_ids}"
+
+
+@TARGETS_WITH_PTO
+def test_set_wait_flag_pairing(target):
+    """Each set_flag must have a matching wait_flag with the same event ID."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((3, 64), "float32"),  # type: ignore
+        B: T.Tensor((3, 64), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            ub1 = T.alloc_ub((64,), "float32")
+            ub2 = T.alloc_ub((64,), "float32")
+            ub3 = T.alloc_ub((64,), "float32")
+            T.copy(A[0, :], ub1)
+            ub1[0] = T.cast(1.0, "float32")
+            T.tile.exp(ub1, ub1)
+            T.copy(ub1, B[0, :])
+            T.copy(A[1, :], ub2)
+            ub2[0] = T.cast(1.0, "float32")
+            T.tile.exp(ub2, ub2)
+            T.copy(ub2, B[1, :])
+            T.copy(A[2, :], ub3)
+            ub3[0] = T.cast(1.0, "float32")
+            T.tile.exp(ub3, ub3)
+            T.copy(ub3, B[2, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+
+    if target == "ascendc":
+        set_ids = re.findall(r"AscendC::SetFlag<AscendC::HardEvent::(\w+)>\((\d+)\)", src)
+        wait_ids = re.findall(r"AscendC::WaitFlag<AscendC::HardEvent::(\w+)>\((\d+)\)", src)
+    else:
+        set_ids = re.findall(r"set_flag\(PIPE_\w+,\s*PIPE_\w+,\s*EVENT_ID(\d+)\)", src)
+        wait_ids = re.findall(r"wait_flag\(PIPE_\w+,\s*PIPE_\w+,\s*EVENT_ID(\d+)\)", src)
+
+    if target == "ascendc":
+        set_pairs = [(et, eid) for et, eid in set_ids]
+        wait_pairs = [(et, eid) for et, eid in wait_ids]
+    else:
+        set_pairs = [("any", eid) for eid in set_ids]
+        wait_pairs = [("any", eid) for eid in wait_ids]
+
+    assert len(set_pairs) == len(wait_pairs), f"set_flag count ({len(set_pairs)}) != wait_flag count ({len(wait_pairs)}).\nSource:\n{src}"
+
+    for sp in set_pairs:
+        assert sp in wait_pairs, f"set_flag {sp} has no matching wait_flag.\nset: {set_pairs}\nwait: {wait_pairs}\nSource:\n{src}"
+
+
+@TARGETS_WITH_PTO
+def test_loop_back_edge_s_to_v(target):
+    """Loop body with S write -> V read+write -> cross-iteration V->S sync.
+
+    In the revisit pass, the back-edge (V from prev iteration) triggers a
+    V->S event pair before the S write in the next iteration.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((128,), "float32"),  # type: ignore
+        B: T.Tensor((128,), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((128,), "float32")
+            T.copy(A[:], a_ub)
+            for _i in T.serial(4):
+                a_ub[0] = T.cast(1.0, "float32")
+                T.tile.exp(a_ub, a_ub)
+            T.copy(a_ub, B[:])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+    _assert_has_sync(src, target, "v_s")
+
+
+@TARGETS_WITH_PTO
+def test_v_to_s_scalar_read(target):
+    """V write to UB -> S scalar read same UB -> SetFlag/WaitFlag V_S."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((1,), "float32")
+            b_ub = T.alloc_ub((1,), "float32")
+            T.copy(A[0, 0:1], a_ub)
+            T.tile.exp(a_ub, a_ub)
+            val = a_ub[0]
+            b_ub[0] = val
+            T.copy(a_ub, B[0, 0:1])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+    _assert_has_sync(src, target, "v_s")
+
+
+@TARGETS_WITH_PTO
+def test_mte2_to_s_scalar_read(target):
+    """MTE2 write to UB -> S scalar read same UB -> SetFlag/WaitFlag MTE2_S."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((1,), "float32")
+            b_ub = T.alloc_ub((1,), "float32")
+            T.copy(A[0, 0:1], a_ub)
+            val = a_ub[0]
+            b_ub[0] = val
+            T.copy(a_ub, B[0, 0:1])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+    _assert_has_sync(src, target, "mte2_s")
+
+
+@TARGETS_WITH_PTO
+def test_mte3_to_s_scalar_read(target):
+    """MTE2 write UB -> MTE3 read UB -> S scalar read same UB.
+
+    With write-history tracking, the S read is synced directly to the
+    MTE2 write (MTE2_S, correct RAW) rather than to the intervening
+    MTE3 read (which was an invalid RAR proxy since MTE2->MTE3 is
+    unsynced by the VS pass).
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((1,), "float32")
+            b_ub = T.alloc_ub((1,), "float32")
+            T.copy(A[0, 0:1], a_ub)
+            T.copy(a_ub, B[0, 0:1])
+            val = a_ub[0]
+            b_ub[0] = val
+            T.copy(a_ub, B[0, 1:2])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+    _assert_has_sync(src, target, "mte2_s")
+
+
+# ---------------------------------------------------------------------------
+# L2 - Anomaly tests
+# ---------------------------------------------------------------------------
+
+
+@TARGETS_WITH_PTO
+def test_read_only_no_sync(target):
+    """V read-only ops on same buffer -> no V->V barrier."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+        C: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            c_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.copy(B[:, :], b_ub)
+            T.tile.add(c_ub, a_ub, b_ub)
+            T.copy(c_ub, C[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[2])
+
+    _assert_no_sync(src, target, "barrier_v")
+    _assert_no_sync(src, target, "s_v")
+    _assert_no_sync(src, target, "v_s")
+
+
+@TARGETS_WITH_PTO
+def test_single_stmt_no_crash(target):
+    """Single T.copy pair -> no crash."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.copy(a_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+    assert len(src) > 0
+
+
+def test_resource_scope_no_crash():
+    """Kernel with CV combine (resource_scope) -> VS handles without crash.
+
+    Uses a GEMM + Vector fusion kernel that triggers CombineCV to split
+    into resource_scope=0 (Cube) and resource_scope=1 (Vector) blocks.
+    The VS pass must handle the resource_scope boundary without crash.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((128, 128), "float16"),  # type: ignore
+        B: T.Tensor((128, 128), "float16"),  # type: ignore
+        C: T.Tensor((128, 128), "float16"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            A_L1 = T.alloc_shared((128, 128), "float16")
+            B_L1 = T.alloc_shared((128, 128), "float16")
+            C_L0 = T.alloc_fragment((128, 128), "float32")
+            c_ub = T.alloc_shared((128, 128), "float16")
+
+            T.copy(A[:, :], A_L1)
+            T.copy(B[:, :], B_L1)
+            T.gemm_v0(A_L1, B_L1, C_L0, init=True)
+            T.copy(C_L0, c_ub)
+            T.tile.exp(c_ub, c_ub)
+            T.copy(c_ub, C[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target="ascendc", out_idx=[2])
+    assert len(src) > 0
+
+
+@TARGETS_WITH_PTO
+def test_nested_loop_back_edge(target):
+    """Nested loops with V ops in inner body -> V->V barriers from back-edges.
+
+    Both the inner loop and the outer loop produce V->V back-edge dependencies
+    that should result in PipeBarrier<PIPE_V>.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((128,), "float32"),  # type: ignore
+        B: T.Tensor((128,), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((128,), "float32")
+            T.copy(A[:], a_ub)
+            for _i in T.serial(4):
+                for _j in T.serial(4):
+                    T.tile.exp(a_ub, a_ub)
+            T.copy(a_ub, B[:])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+    _assert_has_sync(src, target, "barrier_v")
+
+
+@TARGETS_WITH_PTO
+def test_if_without_else_propagation(target):
+    """If-without-else -> then-branch history propagates, no PipeBarrier_ALL.
+
+    The then-branch has V->V barrier.  No else means no cross-branch conflict
+    check, so no PipeBarrier_ALL.  After the if, the then-branch's V history
+    is merged into current_access_history_.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((2, 64), "float32"),  # type: ignore
+        B: T.Tensor((64,), "float32"),  # type: ignore
+        sel: T.Tensor((1,), "int32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64,), "float32")
+            s = sel[0]
+            T.copy(A[0, :], a_ub)
+            if s > 0:
+                T.tile.exp(a_ub, a_ub)
+                T.tile.mul(a_ub, a_ub, a_ub)
+            T.copy(a_ub, B[:])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+
+    _assert_has_sync(src, target, "barrier_v")
+    _assert_no_sync(src, target, "barrier_all")
+
+
+# ---------------------------------------------------------------------------
+# Boundary - Platform/backend edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_a5_pto_pipe_v_v_barrier():
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.tile.exp(b_ub, a_ub)
+            T.tile.exp(b_ub, b_ub)
+            T.copy(b_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target="pto", platform="A5", out_idx=[1])
+    _assert_has_sync(src, "pto", "v_v")
+
+
+@TARGETS_WITH_PTO
+def test_both_backends_consistent(target):
+    """Same V->V kernel -> all backends have PipeBarrier<PIPE_V>."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.tile.exp(b_ub, a_ub)
+            T.tile.exp(b_ub, b_ub)
+            T.copy(b_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+    _assert_has_sync(src, target, "barrier_v")
+
+
+def test_pto_auto_enabled_by_default():
+    """PTO target without explicit VS config -> VS auto-enabled."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.tile.exp(b_ub, a_ub)
+            T.tile.exp(b_ub, b_ub)
+            T.copy(b_ub, B[:, :])
+
+    pass_configs = {
+        tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False,
+        tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+        tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    }
+    src, _ = _compile_and_get_source(main, pass_configs, target="pto", out_idx=[1])
+    _assert_has_sync(src, "pto", "barrier_v")
+
+
+@TARGETS_WITH_PTO
+def test_full_pipeline_integration(target):
+    """Full pipeline (sibling + VS + CV + planning) -> no crash, has sync."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.tile.exp(b_ub, a_ub)
+            T.tile.exp(b_ub, b_ub)
+            T.tile.mul(b_ub, b_ub, b_ub)
+            T.copy(b_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_FULL, target=target, out_idx=[1])
+    assert len(src) > 0
+    assert _count_pattern(src, _ANY_BARRIER[target]) > 0 or _count_pattern(src, _ANY_SETFLAG[target]) > 0
+
+
+@TARGETS_WITH_PTO
+def test_preexisting_barrier_recognition(target):
+    """Sibling pass ON + VS ON -> VS does not duplicate V->V barriers.
+
+    The sibling AscendSyncInsert pass runs first and inserts barriers.
+    VS should recognize pre-existing ascend_auto_barrier calls and avoid
+    duplicating V->V barriers for the same dependency.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.tile.exp(b_ub, a_ub)
+            T.tile.exp(b_ub, b_ub)
+            T.copy(b_ub, B[:, :])
+
+    src_full, _ = _compile_and_get_source(main, PASS_FULL, target=target, out_idx=[1])
+    src_vs, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+
+    barrier_full = _count_sync(src_full, target, "barrier_v")
+    barrier_vs = _count_sync(src_vs, target, "barrier_v")
+
+    assert barrier_vs == 1, f"VS-only should insert exactly 1 V->V barrier, got {barrier_vs}.\nSource:\n{src_vs}"
+    assert barrier_full <= barrier_vs + 1, (
+        f"With sibling ON, VS should not duplicate barriers. Full={barrier_full}, VS-only={barrier_vs}.\nSource:\n{src_full}"
+    )
+
+
+def test_vs_with_cv_combine_off():
+    """VS ON + CV combine OFF -> V->V barrier still inserted (no resource_scope).
+
+    Without CV combine, there are no resource_scope AttrStmt boundaries.
+    VS should still insert V->V barriers based on name matching.
+
+    Note: PTO backend has a known compilation issue with CV combine OFF
+    (unrelated to VS pass), so this test only runs on ascendc.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.tile.exp(b_ub, a_ub)
+            T.tile.exp(b_ub, b_ub)
+            T.copy(b_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_NO_CV, target="ascendc", out_idx=[1])
+    _assert_has_sync(src, "ascendc", "barrier_v")
+
+
+@TARGETS_WITH_PTO
+def test_vs_with_memory_planning_off(target):
+    """VS ON + memory planning OFF -> V->V barrier still inserted (name-based).
+
+    Without memory planning, address_map/size_map are empty, so
+    GetPhysicalAddress returns -1 for all buffers.  Alias detection is
+    disabled, but name-based dependency tracking still works.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.tile.exp(b_ub, a_ub)
+            T.tile.exp(b_ub, b_ub)
+            T.copy(b_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_NO_PLAN, target=target, out_idx=[1])
+    _assert_has_sync(src, target, "barrier_v")
+
+
+def test_a5_ascendc_pipe_v_v_barrier():
+    """Platform A5 + ascendc + V->V -> no PipeBarrier<PIPE_V>."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.tile.exp(b_ub, a_ub)
+            T.tile.exp(b_ub, b_ub)
+            T.copy(b_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target="ascendc", platform="A5", out_idx=[1])
+    _assert_has_sync(src, "ascendc", "v_v")
+
+
+def test_a5_still_emits_event_pairs():
+    """Platform A5 + S->V dependency -> S_V event pair still inserted.
+
+    A5 only skips PipeBarrier<PIPE_V>.  Event pairs (S_V, etc.) should
+    still be emitted.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            a_ub[0, 0] = T.cast(1.0, "float32")
+            T.tile.exp(b_ub, a_ub)
+            T.copy(b_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target="pto", platform="A5", out_idx=[1])
+    _assert_has_sync(src, "pto", "s_v")
+
+
+def test_ascendc_default_vs_off():
+    """AscendC target without explicit VS config -> VS not auto-enabled.
+
+    Unlike PTO, ascendc's _TARGET_PASS_DEFAULTS is empty, so VS is OFF
+    by default.  No auto sync should appear.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.tile.exp(b_ub, a_ub)
+            T.tile.exp(b_ub, b_ub)
+            T.copy(b_ub, B[:, :])
+
+    pass_configs = {
+        tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False,
+        tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+        tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    }
+    src, _ = _compile_and_get_source(main, pass_configs, target="ascendc", out_idx=[1])
+    _assert_no_auto_sync(src, "ascendc")
+
+
+def test_platform_auto_inserts_v_barrier():
+    """Platform "auto" + V->V -> PipeBarrier<PIPE_V> inserted (non-A5).
+
+    "auto" should resolve to a non-A5 platform, so PIPE_V barriers are
+    NOT skipped (unlike A5).
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], a_ub)
+            T.tile.exp(b_ub, a_ub)
+            T.tile.exp(b_ub, b_ub)
+            T.copy(b_ub, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target="pto", platform="auto", out_idx=[1])
+    _assert_has_sync(src, "pto", "barrier_v")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-n", "8"])

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -108,5 +108,6 @@ def OptimizeForTarget(mod: IRModule, target: Target, platform: str) -> IRModule:
     mod = tir.transform.HoistIfThenElse()(mod)
     mod = tilelang.transform.AscendMemoryPlanning()(mod)
     mod = tilelang.transform.AscendSyncInsert(target, platform)(mod)
+    mod = tilelang.transform.AscendSyncInsertVS(target, platform)(mod)
     # print(mod)
     return mod

--- a/tilelang/jit/__init__.py
+++ b/tilelang/jit/__init__.py
@@ -1,21 +1,18 @@
 # Copyright (c) Tile-AI Corporation.
 # Licensed under the MIT License.
 """
-This module provides an auto-tuning infrastructure for TileLang (tl) programs. 
-It includes functionality to JIT-compile TileLang programs into a runnable 
+This module provides an auto-tuning infrastructure for TileLang (tl) programs.
+It includes functionality to JIT-compile TileLang programs into a runnable
 kernel adapter using TVM.
 """
 
+from __future__ import annotations
+
 from typing import (
     Any,
-    List,
-    Union,
     Callable,
-    Tuple,
     overload,
     Literal,
-    Dict,  # For type hinting dicts
-    Optional,
 )
 from tilelang import tvm as tvm
 from tvm.tir import PrimFunc
@@ -28,21 +25,20 @@ from logging import getLogger
 import functools
 import inspect
 from tilelang.jit.param import Kernel, _P, _RProg
-from tilelang.utils.target import determine_platform
 
 logger = getLogger(__name__)
 
 
 def compile(
     func: PrimFunc = None,
-    out_idx: Union[List[int], int, None] = None,
-    workspace_idx: Union[List[int], int, None] = None,
+    out_idx: list[int] | int | None = None,
+    workspace_idx: list[int] | int | None = None,
     execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
-    target: Union[str, Target] = "auto",
-    target_host: Union[str, Target] = None,
+    target: str | Target = "auto",
+    target_host: str | Target = None,
     platform: str = "auto",
     verbose: bool = False,
-    pass_configs: Optional[Dict[str, Any]] = None,
+    pass_configs: dict[str, Any] | None = None,
 ) -> JITKernel:
     """
     Compile the given TileLang PrimFunc with TVM and build a JITKernel.
@@ -50,9 +46,9 @@ def compile(
     ----------
     func : tvm.tir.PrimFunc, optional
         The TileLang TIR function to compile and wrap.
-    out_idx : Union[List[int], int], optional
+    out_idx : Union[list[int], int], optional
         Index(es) of the output tensors to return (default: None).
-    workspace_idx : Union[List[int], int], optional
+    workspace_idx : Union[list[int], int], optional
         Index(es) of the auto-allocated workspace tensors.
     execution_backend : Literal["dlpack", "ctypes"], optional
         Execution backend to use for kernel execution (default: "dlpack").
@@ -78,6 +74,10 @@ def compile(
             "tl.ascend_memory_planning": bool, default: False
     """
 
+    from tilelang.transform.pass_config import process_default_pass_config
+
+    pass_configs = process_default_pass_config(target, pass_configs)
+
     return cached(
         func=func,
         out_idx=out_idx,
@@ -92,30 +92,31 @@ def compile(
 
 
 class _JitImplementation:
-
     out_idx: Any
     workspace_idx: Any
-    target: Union[str, Target]
-    target_host: Union[str, Target]
+    target: str | Target
+    target_host: str | Target
     platform: str
     execution_backend: Literal["dlpack", "ctypes", "cython"]
     verbose: bool
-    pass_configs: Optional[Dict[str, Any]]
-    debug_root_path: Optional[str]
-    func: Optional[Callable] = None  # Store the original function
-    signature: Optional[Any] = None  # Store the signature
-    wrapper: Optional[Callable] = None  # Store the wrapped function for autotuner access
+    pass_configs: dict[str, Any] | None
+    debug_root_path: str | None
+    func: Callable | None = None  # Store the original function
+    signature: Any | None = None  # Store the signature
+    wrapper: Callable | None = None  # Store the wrapped function for autotuner access
 
-    def __init__(self,
-                 out_idx: Any = None,
-                 workspace_idx: Any = None,
-                 target: Union[str, Target] = "auto",
-                 target_host: Union[str, Target] = None,
-                 platform: str = "auto",
-                 execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
-                 verbose: bool = False,
-                 pass_configs: Optional[Dict[str, Any]] = None,
-                 debug_root_path: Optional[str] = None):
+    def __init__(
+        self,
+        out_idx: Any = None,
+        workspace_idx: Any = None,
+        target: str | Target = "auto",
+        target_host: str | Target = None,
+        platform: str = "auto",
+        execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
+        verbose: bool = False,
+        pass_configs: dict[str, Any] | None = None,
+        debug_root_path: str | None = None,
+    ):
         """
         Initializes the JIT compiler decorator.
 
@@ -141,7 +142,7 @@ class _JitImplementation:
             (default: "cython").
         verbose : bool, optional
             If True, enables verbose logging during compilation (default: False).
-        pass_configs : Optional[Dict[str, Any]], optional
+        pass_configs : Optional[dict[str, Any]], optional
             A dictionary of configurations for TVM's pass context. These can fine-tune
             the compilation process. Examples include "tir.disable_vectorize"
             (default: None).
@@ -173,22 +174,20 @@ class _JitImplementation:
             except NameError:
                 self.debug_root_path = path.abspath(self.debug_root_path)
 
-        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self._kernel_cache: dict[tuple, Kernel] = {}
 
     # This tells the type checker what the *wrapper* function will return.
     # this is for linting, please do not remove it.
     @overload
-    def __call__(self, func: Callable[_P, _RProg]) -> Callable[_P, Tuple[_RProg, Kernel]]:
-        ...
+    def __call__(self, func: Callable[_P, _RProg]) -> Callable[_P, tuple[_RProg, Kernel]]: ...
 
     @overload
-    def __call__(self, func: Callable[_P, _RProg]) -> Callable[_P, Kernel]:
-        ...
+    def __call__(self, func: Callable[_P, _RProg]) -> Callable[_P, Kernel]: ...
 
     # Actual implementation of __call__
     def __call__(
         self,
-        func: Callable[_P, _RProg]  # func is Union[Callable[_P, _RProg], PrimFunc] in original
+        func: Callable[_P, _RProg],  # func is Union[Callable[_P, _RProg], PrimFunc] in original
     ) -> Callable[_P, Any]:
         # Store the function and its signature for autotuner access
         self.func = func
@@ -197,7 +196,7 @@ class _JitImplementation:
         @functools.wraps(func)
         def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> Any:
             # Separate out the tuning parameters from the user's kwargs
-            tune_params = kwargs.pop('__tune_params', {})
+            tune_params = kwargs.pop("__tune_params", {})
 
             key_args_tuple = args
             key_kwargs_tuple = tuple(sorted(kwargs.items()))
@@ -226,13 +225,13 @@ class _JitImplementation:
                 )
 
                 if self.debug_root_path:
-                    func_name = getattr(func, '__name__', 'jit_kernel')  # Use func for name
-                    kernel_file = f'tilelang_jit_kernel_{func_name}.c'
-                    program_file = f'tilelang_jit_program_{func_name}.py'
+                    func_name = getattr(func, "__name__", "jit_kernel")  # Use func for name
+                    kernel_file = f"tilelang_jit_kernel_{func_name}.c"
+                    program_file = f"tilelang_jit_program_{func_name}.py"
                     makedirs(self.debug_root_path, exist_ok=True)
-                    with open(path.join(self.debug_root_path, kernel_file), 'w') as f:
+                    with open(path.join(self.debug_root_path, kernel_file), "w") as f:
                         print(kernel_result.get_kernel_source(), file=f)
-                    with open(path.join(self.debug_root_path, program_file), 'w') as f:
+                    with open(path.join(self.debug_root_path, program_file), "w") as f:
                         print(program_result.script(), file=f)
 
                 self._kernel_cache[key] = kernel_result
@@ -248,17 +247,18 @@ class _JitImplementation:
 
 
 def jit(  # This is the new public interface
-        func: Union[Callable[_P, _RProg], PrimFunc, None] = None,
-        *,  # Indicates subsequent arguments are keyword-only
-        out_idx: Any = None,
-        workspace_idx: Any = None,
-        target: Union[str, Target] = "auto",
-        target_host: Union[str, Target] = None,
-        platform: str = "auto",
-        execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
-        verbose: bool = False,
-        pass_configs: Optional[Dict[str, Any]] = None,
-        debug_root_path: Optional[str] = None):
+    func: Callable[_P, _RProg] | PrimFunc | None = None,
+    *,  # Indicates subsequent arguments are keyword-only
+    out_idx: Any = None,
+    workspace_idx: Any = None,
+    target: str | Target = "auto",
+    target_host: str | Target = None,
+    platform: str = "auto",
+    execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
+    verbose: bool = False,
+    pass_configs: dict[str, Any] | None = None,
+    debug_root_path: str | None = None,
+):
     """
     Just-In-Time (JIT) compiler decorator for TileLang functions.
 
@@ -283,7 +283,7 @@ def jit(  # This is the new public interface
         Backend for kernel execution and argument passing. Defaults to "cython".
     verbose : bool, optional
         Enables verbose logging during compilation. Defaults to False.
-    pass_configs : Optional[Dict[str, Any]], optional
+    pass_configs : Optional[dict[str, Any]], optional
         Configurations for TVM's pass context. Defaults to None.
     debug_root_path : Optional[str], optional
         Directory to save compiled kernel source for debugging. Defaults to None.
@@ -306,7 +306,8 @@ def jit(  # This is the new public interface
             execution_backend=execution_backend,
             verbose=verbose,
             pass_configs=pass_configs,
-            debug_root_path=debug_root_path)
+            debug_root_path=debug_root_path,
+        )
         return default_decorator(func)
     elif isinstance(func, PrimFunc):
         raise ValueError("Use tilelang.jit to decorate prim_func is not supported yet.")
@@ -323,5 +324,6 @@ def jit(  # This is the new public interface
             execution_backend=execution_backend,
             verbose=verbose,
             pass_configs=pass_configs,
-            debug_root_path=debug_root_path)
+            debug_root_path=debug_root_path,
+        )
         return configured_decorator

--- a/tilelang/jit/__init__.py
+++ b/tilelang/jit/__init__.py
@@ -46,9 +46,9 @@ def compile(
     ----------
     func : tvm.tir.PrimFunc, optional
         The TileLang TIR function to compile and wrap.
-    out_idx : Union[list[int], int], optional
+    out_idx : list[int] | int | None
         Index(es) of the output tensors to return (default: None).
-    workspace_idx : Union[list[int], int], optional
+    workspace_idx : list[int] | int | None
         Index(es) of the auto-allocated workspace tensors.
     execution_backend : Literal["dlpack", "ctypes"], optional
         Execution backend to use for kernel execution (default: "dlpack").
@@ -142,7 +142,7 @@ class _JitImplementation:
             (default: "cython").
         verbose : bool, optional
             If True, enables verbose logging during compilation (default: False).
-        pass_configs : Optional[dict[str, Any]], optional
+        pass_configs : dict[str, Any] | None
             A dictionary of configurations for TVM's pass context. These can fine-tune
             the compilation process. Examples include "tir.disable_vectorize"
             (default: None).
@@ -283,7 +283,7 @@ def jit(  # This is the new public interface
         Backend for kernel execution and argument passing. Defaults to "cython".
     verbose : bool, optional
         Enables verbose logging during compilation. Defaults to False.
-    pass_configs : Optional[dict[str, Any]], optional
+    pass_configs : dict[str, Any] | None
         Configurations for TVM's pass context. Defaults to None.
     debug_root_path : Optional[str], optional
         Directory to save compiled kernel source for debugging. Defaults to None.

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -110,6 +110,8 @@ class LibraryGenerator:
         TL_ROOT = _get_tl_root()
         auto_sync = os.environ.get("TL_CCE_AUTO_SYNC", "on").lower()
         opt_level = os.environ.get("TL_CCE_OPT_LEVEL", "2").lower()
+        if opt_level not in ("0", "1", "2", "3"):
+            raise ValueError(f"Invalid TL_CCE_OPT_LEVEL={opt_level!r}, expected one of: 0, 1, 2, 3")
         if self.target == "ascendc" or self.target == "auto":
             command = [
                 "bisheng",

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -108,11 +108,13 @@ class LibraryGenerator:
         libpath = src.name.replace(".cpp", ".so")
         ASCEND_HOME_PATH = _get_ascend_home_path()
         TL_ROOT = _get_tl_root()
+        auto_sync = os.environ.get("TL_CCE_AUTO_SYNC", "on").lower()
+        opt_level = os.environ.get("TL_CCE_OPT_LEVEL", "2").lower()
         if self.target == "ascendc" or self.target == "auto":
             command = [
                 "bisheng",
                 "--npu-arch=dav-2201",
-                "-O2",
+                f"-O{opt_level}",
                 "-std=c++17",
                 "-xasc",
                 f"-I{ASCEND_HOME_PATH}/include",
@@ -141,6 +143,12 @@ class LibraryGenerator:
                 "--shared",
                 src.name,
             ]
+
+            # pto do not support the compile arg like "--cce-auto-sync=on/off".
+            # pto default behavior equals ascendc "--cce-auto-sync=off".
+            # so auto_sync only affect ascendc
+            if auto_sync == "off":
+                command.append("--cce-auto-sync=off")
         elif self.target == "pto":
             ccec = "dav-c310" if self.platform == "A5" else "dav-c220"
             memory = "REGISTER_BASE" if self.platform == "A5" else "MEMORY_BASE"
@@ -148,7 +156,7 @@ class LibraryGenerator:
                 "bisheng",
                 f"--cce-aicore-arch={ccec}",
                 f"-D{memory}",
-                "-O2",
+                f"-O{opt_level}",
                 "-std=gnu++17",
                 "-xcce",
                 "-mllvm",

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -380,6 +380,18 @@ def AscendSyncInsert(target: Target, platform: str):
     return _ffi_api.AscendSyncInsert(target, platform)  # type: ignore
 
 
+def AscendSyncInsertVS(target: Target, platform: str):
+    """As a supplement to AscendSyncInsert, auto insert sync for Ascend (V→V, S↔Others).
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    ----
+    """
+    return _ffi_api.AscendSyncInsertVS(target, platform)  # type: ignore
+
+
 def CombineCV():
     """CombineCV
 

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -2,11 +2,14 @@
 # Licensed under the MIT License.
 # TODO: Add more documentation for each pass config
 
+from __future__ import annotations
+
 from enum import Enum
 
 
 class PassConfigKey(str, Enum):
     """Pass configuration keys for TileLang compiler."""
+
     # TileLang specific configs
     TL_SIMPLIFY = "tl.Simplify"
     """Enable/disable TileLang simplification passes. Default: True"""
@@ -31,10 +34,13 @@ class PassConfigKey(str, Enum):
 
     TL_DEBUG_MERGE_SHARED_MEMORY_ALLOCATIONS = "tl.debug_merge_shared_memory_allocations"
     """Enable debug information for merge shared memory allocations. Default: False"""
-    
+
     TL_ASCEND_AUTO_SYNC = "tl.ascend_auto_sync"
     """Enable/disable TileLang AscendSyncInsert pass. Default: False"""
-    
+
+    TL_ASCEND_AUTO_SYNC_VS = "tl.ascend_auto_sync_vs"
+    """Enable/disable TileLang AscendSyncInsertVS pass. Default value setted dynamically according target"""
+
     TL_ASCEND_MEMORY_PLANNING = "tl.ascend_memory_planning"
     """Enable/disable TileLang AscendMemoryPlanning pass. Default: False"""
 
@@ -77,3 +83,94 @@ class PassConfigKey(str, Enum):
 
     CUDA_KERNELS_OUTPUT_DIR = "cuda.kernels_output_dir"
     """Output directory for generated CUDA kernels. Default: empty string"""
+
+
+from tvm.target import Target
+from os import environ
+from logging import getLogger
+
+logger = getLogger(__name__)
+
+_TARGET_PASS_DEFAULTS: dict[str, dict[str, bool]] = {
+    "ascendc": {},
+    "pto": {
+        PassConfigKey.TL_ASCEND_AUTO_SYNC_VS: True,
+    },
+}
+
+
+def _resolve_target_model(target: str | Target) -> str:
+    """Extract the effective target model string from a target argument.
+
+    Returns one of: 'ascendc', 'pto', 'auto', 'cuda', 'hip', 'llvm', etc.
+    For :class:`tvm.target.Target` inputs, returns ``target.model``;
+    for strings, returns the string as-is.
+
+    Parameters
+    ----------
+    target : Union[str, Target]
+        User-specified target. May be ``"auto"``, ``"ascendc"``, ``"pto"``,
+        a TVM ``Target`` object, or other backend strings.
+
+    Returns
+    -------
+    str
+        The effective target model string. Empty string if target is falsy.
+    """
+    if isinstance(target, Target):
+        return getattr(target, "model", "") or ""
+    return target or ""
+
+
+def _apply_target_pass_defaults(
+    target: str | Target,
+    pass_configs: dict | None,
+) -> dict:
+    """Fill in per-target default values for pass_configs keys not set by the user.
+
+    Returns a new dict; the input is not modified. User-explicit settings
+    always take priority over per-target defaults.
+
+    Parameters
+    ----------
+    target : Union[str, Target]
+        User-specified target. ``"auto"`` is treated as ``"ascendc"``
+    pass_configs : Optional[dict]
+        User-provided pass_configs dict. May be ``None``.
+
+    Returns
+    -------
+    dict
+        A new dict with per-target defaults applied for any keys the user
+        did not explicitly set.
+    """
+    configs = {}
+    if pass_configs:
+        for k, v in pass_configs.items():
+            configs[k.value if hasattr(k, "value") else k] = v
+
+    model = _resolve_target_model(target)
+    effective = "ascendc" if model in ("auto", "") else model
+    defaults = _TARGET_PASS_DEFAULTS.get(effective, {})
+
+    for key_str, val in defaults.items():
+        raw_key = key_str.value if hasattr(key_str, "value") else key_str
+        if raw_key not in configs:
+            configs[raw_key] = val
+
+    return configs
+
+
+def _process_for_auto_sync_insert_vs(pass_configs):
+    vs_enabled = bool(pass_configs and pass_configs.get(PassConfigKey.TL_ASCEND_AUTO_SYNC_VS, False))
+    if vs_enabled:
+        if "TL_CCE_AUTO_SYNC" not in environ:
+            environ["TL_CCE_AUTO_SYNC"] = "off"
+        if "TL_CCE_OPT_LEVEL" not in environ:
+            environ["TL_CCE_OPT_LEVEL"] = "3"
+
+
+def process_default_pass_config(target, pass_configs):
+    pass_configs = _apply_target_pass_defaults(target, pass_configs)
+    _process_for_auto_sync_insert_vs(pass_configs)
+    return pass_configs


### PR DESCRIPTION
## 核心目标

新增自动插同步 Pass `AscendSyncInsertVS`，与原 `AscendSyncInsert` **互补协同**（非互斥，可同开），
`AscendSyncInsertVS` 仅跟踪 4 条流水线：`PIPE_V` / `PIPE_S` / `PIPE_MTE2` / `PIPE_MTE3`，PIPE_M/MTE1/FIX 透明穿透。
同时、配套环境变量 `TL_CCE_AUTO_SYNC=off`， `TL_CCE_OPT_LEVEL=3` 来控制编译选项。


## 背景与痛点

1. **CCE 自带同步偏保守**：昇腾 `bisheng` 编译器默认 `--cce-auto-sync=on`，会自动插入同步指令，
   但策略保守（过度同步），带来性能损耗；期望通过 `--cce-auto-sync=off` 关闭以提升性能。
2. **关闭后出现同步盲区**：一旦关闭 CCE 自带同步，TileLang 原有 `AscendSyncInsert` 并不覆盖
   **V→V 同流水线** 与 **S↔其他 流水线** 两类场景，导致这些依赖点缺失同步，运行结果错误或死锁。
3. **缺轻量补位方案**：需要一个能精准补上这两类盲区、又不过度同步的 Pass，与 `--cce-auto-sync=off` 配套。
4. **编译优化等级保守**: 当前优化等级默认固定为`-O2`, 期望可配置为激进等级`-O3`

## 应对方案

新增 `AscendSyncInsertVS` Pass，精准补位 `AscendSyncInsert` 未覆盖的两类场景：

- **V→V 同流水线**：插入 `PipeBarrier_V`
- **S↔其他 流水线**（不含 S→S，标量流水线本身保序）：插入 `EventPair_<src>_<dst>`

**核心思路：** 新增 `AscendSyncInsertVS` Pass，接管 V→V 和 S↔Others 的同步插入，关闭编译器内置 auto-sync，同时将优化等级从 O2 提升到 O3。

**`AscendSyncInsertVS` 开启/关闭策略：**

- `ascendc` 后端, 默认`关闭 `
- `pto` 后端，默认`开启`

-  `AscendSyncInsertVS` 开启时，`CCE 自动插同步` 默认：关闭； `优化等级` 默认：3 
-  `AscendSyncInsertVS` 关闭时，`CCE 自动插同步` 默认：开启； `优化等级` 默认：2

### 同步对矩阵

| prev\curr | V | S | MTE2 | MTE3 |
|-----------|---|---|------|------|
| **V** | PipeBarrier_V | EventPair_V_S | 穿透 | 穿透 |
| **S** | EventPair_S_V | 不插 | S_MTE2 | S_MTE3 |
| **MTE2** | 穿透 | MTE2_S | — | — |
| **MTE3** | 穿透 | MTE3_S | — | — |

关联Issue #1302 