### PR TITLE
[Feat] Ascend gemm_v0/mma: runtime n_actual (variable output-column count)

### DIFF
--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -1211,7 +1211,7 @@ TIR_DEFINE_TL_BUILTIN(ascend_sync_all)
                                Integer(CallEffectKind::kOpaque));
 
 TIR_DEFINE_TL_BUILTIN(ascend_gemm_v0)
-    .set_num_inputs(5)
+    .set_num_inputs(6)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -2354,7 +2354,7 @@ void CodeGenTileLangAscend::GemmOpCodegen(const CallNode *op) {
   this->stream << op_name << "(" << a_name << "[" << a_offset << "], " << b_name
                << "[" << b_offset << "], " << c_name << "[" << c_offset
                << "], ascend_l0a, ascend_l0b, " << PrintExpr(op->args[4])
-               << ");\n";
+               << ", " << PrintExpr(op->args[5]) << ");\n";
 }
 
 void CodeGenTileLangAscend::PrintfOpCodegen(const CallNode *op,

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -133,10 +133,14 @@ CATLASS_DEVICE void copy_l1_to_l0b(LocalTensor<T> dstTensor,
 template <typename T1, typename T2, uint32_t M, uint32_t N>
 CATLASS_DEVICE void mma(LocalTensor<T1> const A, LocalTensor<T1> const B,
                         LocalTensor<T2> const C, bool init, uint32_t K,
-                        uint8_t unitFlag = 0) {
+                        uint32_t n_actual = N, uint8_t unitFlag = 0) {
+  // n_actual: runtime number of output columns to compute (<= N). Defaults to
+  // the compile-time N, so existing callers are byte-identical. Enables
+  // variable-N gemm (e.g. QK over the actual window length), mirroring how K is
+  // already a runtime arg.
   MmadParams mmadParams;
   mmadParams.m = M;
-  mmadParams.n = N;
+  mmadParams.n = n_actual;
   mmadParams.k = K;
   mmadParams.cmatrixInitVal = init;
   // mmadParams.unitFlag = unitFlag;
@@ -1046,7 +1050,14 @@ CATLASS_DEVICE void
 gemm_v0(LocalTensor<T1> const &A, LocalTensor<T1> const &B,
         LocalTensor<T2> const &C, // this must be located in l0c
         AscendC::TBuf<AscendC::TPosition::A2> &l0a_,
-        AscendC::TBuf<AscendC::TPosition::B2> &l0b_, bool clear) {
+        AscendC::TBuf<AscendC::TPosition::B2> &l0b_, bool clear,
+        uint32_t n_actual = N) {
+  // n_actual: runtime output-column count (<= N), only honoured on the
+  // transpose_B (QK) path -- computes/loads just the real window columns
+  // instead of the full template N. Defaults to N, so all existing callers are
+  // byte-identical. Physical L0B/L0C layout and the template N/K stay
+  // compile-time; only "how many columns are actually computed" changes (dual
+  // to the runtime K already threaded through mma).
   static_assert(kL0Size % 16 == 0, "kL0Size must be a multiple of 16");
   constexpr uint32_t kL0split = (K + kL0Size - 1) / kL0Size;
   auto l0a = l0a_.Get<T1>();
@@ -1154,14 +1165,20 @@ gemm_v0(LocalTensor<T1> const &A, LocalTensor<T1> const &B,
         tl::ascend::copy_l1_to_l0b<T1, K, N>(
             l0b[l0b_base], B[bNOffset + kL0Idx * 16 * kL0Size], kSize, nTile);
       } else {
+        // transpose_B (QK): load only the n_actual real output columns; the
+        // [n_actual:N] columns stay unloaded (masked downstream). n_actual
+        // defaults to N (full width) -> byte-identical for non-window callers.
         tl::ascend::copy_l1_to_l0b<T1, N, K, true>(
-            l0b[l0b_base], B[kL0Idx * N * kL0Size], kSize, N);
+            l0b[l0b_base], B[kL0Idx * N * kL0Size], kSize, n_actual);
       }
       SetFlag<HardEvent::MTE1_M>(L0AB_EVENT + pp);
       WaitFlag<HardEvent::MTE1_M>(L0AB_EVENT + pp);
       PipeBarrier<PIPE_M>();
+      // transpose_B (QK) computes only n_actual columns (window width); the
+      // non-transpose path keeps the full template N (nTile per N-tile).
       tl::ascend::mma<T1, T2, M, nTile>(l0a[l0a_base], l0b[l0b_base],
-                                        C[cNOffset], initflag, kSize);
+                                        C[cNOffset], initflag, kSize,
+                                        transpose_B ? n_actual : nTile);
       SetFlag<HardEvent::M_MTE1>(L0AB_EVENT + pp);
       tileIdx++;
     }

--- a/testing/python/language/test_tilelang_ascend_language_gemm_v0_n_actual.py
+++ b/testing/python/language/test_tilelang_ascend_language_gemm_v0_n_actual.py
@@ -1,0 +1,126 @@
+import pytest
+import tilelang
+import tilelang.language as T
+from tilelang.intrinsics import make_zn_layout, make_nz_layout
+import torch
+
+"""
+gemm_v0 runtime n_actual (variable output-column count) correctness suite.
+
+Feature under test
+------------------
+``T.gemm_v0(..., transpose_B=True, n_actual=win)`` computes only the first
+``win`` output columns of the M x N result -- the "QK over the actual window
+length" pattern -- instead of the full compile-time ``N``.  ``n_actual``
+defaults to ``N``, so every existing caller is byte-identical.  This is the dual
+of the runtime ``K`` already threaded through ``mma`` (``mma<M,N>(A,B,C,init,K,
+n_actual)``): the template ``M/N/K`` and the physical L0B/L0C layout stay
+compile-time; only *how many output columns are actually computed* becomes a
+runtime value.
+
+Why an ordinary gemm_v0 cannot express this
+-------------------------------------------
+Before this change the output-column count is the compile-time template ``N``:
+``copy_l1_to_l0b`` loads ``N`` columns and ``mma`` sets ``mmadParams.n = N``.
+There is no way to compute only a runtime ``win`` columns; a caller had to
+compute the full ``N`` and mask the ``[win:N]`` tail downstream.  ``n_actual``
+adds that runtime column count, mirroring runtime ``K``.
+
+Scenarios (ascendc target, transpose_B GEMM ``S = Q @ K^T``)
+------------------------------------------------------------
+  * ``n_actual = None`` -> defaults to ``N``: full ``S == Q @ K^T`` (compat:
+    the default path is byte-identical to before this change).
+  * ``n_actual = win < N``: only ``S[:, :win]`` is computed by ``mma``; the
+    ``[win:N]`` columns are never marked ready (left at the L0C init value,
+    "masked downstream" by the caller), so only the computed band is asserted.
+
+``n_actual`` must be a multiple of 16 (the fractal column granularity), matching
+how the operator rounds the runtime window length up to 16 before passing it in.
+
+NOTE: executes on real NPU hardware (``.npu()``); ascendc target only (the PTO
+backend has its own gemm_v0 codegen that ignores this trailing arg).
+"""
+
+TARGET = "ascendc"
+
+DEV_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    """Clear tilelang cache before the session."""
+    tilelang.cache.clear_cache()
+    yield
+
+
+def _torch_dtype(dtype):
+    return {"float": torch.float32, "float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
+
+
+def qk_gemm(block_M, block_N, dim, dtype, accum_dtype, n_actual):
+    """transpose_B QK gemm ``S = Q @ K^T`` computing only ``n_actual`` output
+    columns.  ``n_actual=None`` -> full ``N`` (default).  Mirrors
+    gm_to_l1::full_copy_annotated with the ``n_actual`` arg added."""
+
+    @T.prim_func
+    def main(
+        Q: T.Tensor([1, block_M, dim], dtype),  # type: ignore
+        K: T.Tensor([1, block_N, dim], dtype),  # type: ignore
+        S: T.Tensor([1, block_M, block_N], accum_dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            q_l1 = T.alloc_L1([block_M, dim], dtype)
+            k_l1 = T.alloc_L1([block_N, dim], dtype)
+            l0c = T.alloc_L0C([block_M, block_N], accum_dtype)
+            T.annotate_layout(
+                {
+                    q_l1: make_zn_layout(q_l1),
+                    k_l1: make_nz_layout(k_l1),
+                }
+            )
+            T.copy(Q[0, :, :], q_l1[:, :])
+            T.copy(K[0, :, :], k_l1[:, :])
+            T.gemm_v0(q_l1, k_l1, l0c, transpose_B=True, init=True, n_actual=n_actual)
+            T.copy(l0c, S[0, :, :])
+
+    return main
+
+
+def run_qk(block_M, block_N, dim, dtype, accum_dtype, n_actual):
+    torch.manual_seed(0)
+    win = block_N if n_actual is None else n_actual
+    func = qk_gemm(block_M, block_N, dim, dtype, accum_dtype, n_actual)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=DEV_CONFIGS, target=TARGET)
+    td = _torch_dtype(dtype)
+    q = torch.randn(1, block_M, dim, dtype=td).npu()
+    k = torch.randn(1, block_N, dim, dtype=td).npu()
+    torch.npu.synchronize()
+    s = func(q, k)
+    ref = torch.einsum("bqd,bkd->bqk", q.float(), k.float())
+    # Only the first `win` output columns are computed; [win:N] are left at the
+    # L0C init value (masked downstream), so assert only the computed band.
+    torch.testing.assert_close(s[:, :, :win], ref[:, :, :win], rtol=1e-2, atol=1e-2)
+
+
+# (block_M, block_N, dim, n_actual) -- n_actual is a multiple of 16 (or None).
+configs = [
+    (64, 128, 128, None),  # default n_actual = N: full result (compat)
+    (64, 128, 128, 64),  # window 64 < 128
+    (64, 128, 128, 112),  # window 112 (7*16), a non-trivial partial < 128
+    (64, 256, 128, 128),  # N=256, window 128 < 256
+]
+
+
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+@pytest.mark.parametrize("block_M,block_N,dim,n_actual", configs)
+def test_qk_n_actual(block_M, block_N, dim, n_actual, dtype):
+    run_qk(block_M, block_N, dim, dtype, "float", n_actual)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tilelang/language/ascend.py
+++ b/tilelang/language/ascend.py
@@ -340,7 +340,7 @@ def shmem_ub_get_nbi(dst: Buffer, src: Buffer, nelems: PrimExpr, newPe: PrimExpr
     )
 
 
-def gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False, kL0Size=128):
+def gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False, kL0Size=128, n_actual=None):
     """
     Performs a block-level General Matrix Multiplication (GEMM).
 
@@ -369,6 +369,11 @@ def gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False, kL0Size=1
             Smaller kL0Size allows larger block_M/block_N (more L0C utilization)
             at the cost of more L1->L0 copy iterations. For half precision with
             block_M=128, block_N=256, kL0Size=64 is recommended.
+        n_actual (int, optional): Runtime number of output columns to compute (<= N
+            and a multiple of 16), honoured only on the transpose_B path (variable-N
+            gemm, e.g. QK over the actual window length). None -> compile-time N
+            (byte-identical to before). A compile-time-constant value is validated;
+            a runtime tir expression is the caller's responsibility.
 
     Returns:
         tvm.tir.Call: A TIR intrinsic call to `tl.ascend_gemm_v0`.
@@ -419,6 +424,18 @@ def gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False, kL0Size=1
     Cptr = _retrieve_ptr(C, "w" if init is True else "rw")
 
     # assert _dtype(A) == _dtype(B), f"gemm A and B dtype mismatch: {_dtype(A)} vs {_dtype(B)}"
+    # n_actual: runtime output-column count (<= N), honoured on the transpose_B
+    # (QK) path; None -> compile-time N (byte-identical to before).
+    if n_actual is None:
+        n_actual = N  # full N, the existing template contract -- no extra check
+    else:
+        # Validate a compile-time-constant n_actual early (runtime tir
+        # expressions are the caller's responsibility): it must fit the template
+        # N and be a multiple of the 16-column fractal granularity.
+        _na = n_actual.value if isinstance(n_actual, tir.IntImm) else n_actual
+        if isinstance(_na, int):
+            assert 0 < _na <= N, f"gemm_v0 n_actual ({_na}) must be in (0, N={N}]"
+            assert _na % 16 == 0, f"gemm_v0 n_actual ({_na}) must be a multiple of 16 (fractal column granularity)"
     return T.call_intrin(
         "handle",
         tir.op.Op.get("tl.ascend_gemm_v0"),
@@ -427,6 +444,7 @@ def gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False, kL0Size=1
         Bptr,
         Cptr,
         init,
+        n_actual,
     )
 
 


### PR DESCRIPTION
Add an optional `n_actual` runtime argument to `mma` and `gemm_v0`: the number
of output columns to actually compute, defaulting to the compile-time template
`N`. On the transpose_B path (QK-style gemm) `copy_l1_to_l0b` loads only
`n_actual` columns and `mma` sets `mmadParams.n = n_actual`; the non-transpose
path keeps the full `N`. The template M/N/K and the physical L0B/L0C layout stay
compile-time -- only "how many columns are computed" becomes a runtime value.

This is the dual of the runtime `K` already threaded through `mma`
(`mma<M,N>(A,B,C,init,K)`), completing gemm_v0's "M template / K runtime /
N runtime" variable-shape support -- useful for variable-length attention (QK
over the actual window) and dynamic-shape matmul.

Compatibility: `n_actual` defaults to `N`, so all existing callers are
byte-identical. The front-end fills it (= N when not given); set_num_inputs goes
5->6 and GemmOpCodegen emits the extra arg for the ascendc target.

The PTO backend is unaffected by this change: it has its own front-end and
codegen and keeps its 5-arg path (set_num_inputs is not enforced, and PTO's
gemm_v0 codegen reads only args[0..4]). Note that the PTO backend's gemm_v0
computes a compile-time N with no equivalent runtime output-column path; a
follow-up issue tracks adding the same capability there.

Adds testing/python/language/test_tilelang_ascend_language_gemm_v0_n_actual.py:
transpose_B QK gemm with n_actual = None (full, compat) and n_actual < N (64,
112, 128<256) across fp16/bf16, asserting the computed column band matches
Q @ K^T.
