### PR TITLE
[Fix] Lower scalar T.log stores on Ascend

### DIFF
--- a/src/transform/ascend_lower_parallel_to_vector.cc
+++ b/src/transform/ascend_lower_parallel_to_vector.cc
@@ -164,8 +164,8 @@ private:
 
     // Determine the shape based on the actual computation size (loop extent)
     Array<PrimExpr> shape;
-    if (ref->shape.size() == 1) {
-      // 1D case: just the total elements
+    if (ref->shape.size() <= 1) {
+      // Scalar and 1D cases: just the total elements
       shape.push_back(IntImm(DataType::Int(32), num_elements));
     } else if (ref->shape.size() >= 2) {
       // 2D or higher: use the computation dimensions
@@ -237,6 +237,53 @@ private:
       return GetRef<PrimExpr>(op);
     }
   };
+
+  Optional<Stmt> TryLowerScalarLogStore(const BufferStoreNode *store) {
+    Buffer output_buffer = store->buffer;
+    DataType dtype = output_buffer->dtype;
+    if (!IsUnifiedBuffer(output_buffer) || !dtype.is_float() ||
+        (dtype.bits() != 16 && dtype.bits() != 32)) {
+      return NullOpt;
+    }
+
+    Op unary_op_type;
+    Optional<Buffer> input_buffer;
+    const std::unordered_set<const VarNode *> no_parallel_vars;
+    if (!IsUnaryOp(store->value, &unary_op_type, &input_buffer, nullptr,
+                   no_parallel_vars) ||
+        !unary_op_type.same_as(tl::ascend_ln()) || !input_buffer.defined() ||
+        !IsUnifiedBuffer(input_buffer.value()) ||
+        input_buffer.value()->dtype != dtype) {
+      return NullOpt;
+    }
+
+    const auto *input_load =
+        store->value.as<CallNode>()->args[0].as<BufferLoadNode>();
+    if (input_load == nullptr) {
+      return NullOpt;
+    }
+
+    // AscendC vector intrinsics require 32-byte-aligned LocalTensor starts.
+    // Route arbitrary scalar offsets through aligned UB allocations.
+    Buffer aligned_input = CreateTempBufferLike(output_buffer, 1);
+    Buffer aligned_output = CreateTempBufferLike(output_buffer, 1);
+    PrimExpr zero = IntImm(DataType::Int(32), 0);
+    Stmt load_input =
+        BufferStore(aligned_input, GetRef<PrimExpr>(input_load), {zero});
+    Stmt lower_log = GenerateUnaryVectorCall(unary_op_type, aligned_output,
+                                             zero, aligned_input, zero, 1);
+    Stmt write_output = BufferStore(
+        output_buffer, BufferLoad(aligned_output, {zero}), store->indices);
+    return SeqStmt::Flatten(load_input, lower_log, write_output);
+  }
+
+  Stmt VisitStmt_(const BufferStoreNode *op) override {
+    Optional<Stmt> scalar_log = TryLowerScalarLogStore(op);
+    if (scalar_log.defined()) {
+      return scalar_log.value();
+    }
+    return arith::IRMutatorWithAnalyzer::VisitStmt_(op);
+  }
 
   Stmt VisitStmt_(const ForNode *op) override {
     // Sequence of store statements (handles both single stores and sequences)

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -2791,6 +2791,98 @@ def test_ln(dtype, target, shape):
     run_test_ln(M, N, block_M, block_N, dtype, target)
 
 
+@pytest.mark.parametrize("dtype", ["float", "float16"])
+def test_scalar_log(dtype):
+    block_size = 8 if dtype == "float" else 16
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((block_size,), dtype),  # type: ignore
+        B: T.Tensor((block_size,), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((block_size,), dtype)
+            b_ub = T.alloc_ub((block_size,), dtype)
+
+            T.copy(A, a_ub)
+            b_ub[2] = T.log(a_ub[1])
+            a_ub[3] = T.log(a_ub[3])
+            b_ub[3] = a_ub[3]
+            T.copy(b_ub, B)
+
+    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target="ascendc")
+    torch_dtype = torch.float32 if dtype == "float" else torch.float16
+    a = torch.arange(1, block_size + 1, dtype=torch_dtype).npu()
+
+    b = func(a)
+    torch.npu.synchronize()
+
+    ln_calls = [line for line in func.get_kernel_source().splitlines() if "AscendC::Ln(" in line]
+    assert len(ln_calls) == 2 and all(line.rstrip().endswith(", 1);") for line in ln_calls)
+    torch.testing.assert_close(b[2], torch.log(a[1]), rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(b[3], torch.log(a[3]), rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16"])
+def test_rank_zero_scalar_log(dtype):
+    block_size = 8 if dtype == "float" else 16
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((block_size,), dtype),  # type: ignore
+        B: T.Tensor((block_size,), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_vec = T.alloc_ub((block_size,), dtype)
+            b_vec = T.alloc_ub((block_size,), dtype)
+            a_ub = T.alloc_ub((), dtype)
+            b_ub = T.alloc_ub((), dtype)
+
+            T.copy(A, a_vec)
+            a_ub[()] = a_vec[0]
+            b_ub[()] = T.log(a_ub[()])
+            b_vec[0] = b_ub[()]
+            T.copy(b_vec, B)
+
+    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target="ascendc")
+    torch_dtype = torch.float32 if dtype == "float" else torch.float16
+    a = torch.full((block_size,), 2.0, dtype=torch_dtype).npu()
+
+    b = func(a)
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(b[0], torch.log(a[0]), rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16"])
+def test_scalar_log_after_reduce(dtype):
+    block_size = 64
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((block_size,), dtype),  # type: ignore
+        B: T.Tensor((block_size,), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((block_size,), dtype)
+            sum_ub = T.alloc_ub((1,), dtype)
+            b_ub = T.alloc_ub((block_size,), dtype)
+
+            T.copy(A, a_ub)
+            T.reduce_sum(a_ub, sum_ub, -1, [1, block_size])
+            b_ub[0] = T.log(sum_ub[0])
+            T.copy(b_ub, B)
+
+    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target="ascendc")
+    torch_dtype = torch.float32 if dtype == "float" else torch.float16
+    a = torch.ones((block_size,), dtype=torch_dtype).npu()
+
+    b = func(a)
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(b[0], torch.log(a.sum()), rtol=1e-2, atol=1e-2)
+
+
 def gathermask_fixed_mode(M, N, block_M, block_N, dtype="int32"):
     m_num = M // block_M
     n_num = N // block_N


### PR DESCRIPTION
## What changed

- Lower non-parallel UB scalar `T.log(BufferLoad)` stores to `tl.ascend_ln`.
- Route scalar operands through aligned one-element UB temporaries so arbitrary element offsets satisfy AscendC LocalTensor alignment requirements.
- Handle rank-0 UB buffers when creating temporary storage.
- Keep the change limited to fp16/fp32 UB-to-UB direct buffer loads; other expression and memory forms are left unchanged.

## Why

`AscendLowerParallelToVector` previously lowered `tir.log` only while visiting `T.Parallel` loops. A scalar store such as `dst[0] = T.log(src[0])`, including the result of a reduction, bypassed that path and left raw `tir.log` for Ascend codegen.

This is distinct from explicit `T.tile.ln`: device testing confirmed `AscendC::Ln(..., 1)` is correct when automatic synchronization is enabled, so this PR does not change the tile intrinsic or synchronization defaults.

## Validation

- `cmake --build build -j8`
- Scalar-log NPU regression matrix: fp16/fp32 × unaligned offsets and exact alias, rank-0 buffers, and reduction outputs (`6 passed`)
- Existing parallel `T.log` NPU test (`1 passed`)
- Existing AscendC `T.tile.ln` fp16/fp32 NPU tests (`2 passed`)
- Diagnostic `T.tile.ln` matrix: fp16/fp32 × count 1/full 32B × alias/non-alias × auto-sync on/off, five repetitions each; all synchronized cases passed and all unsynchronized cases reproduced the pipeline race
- Ruff format/lint, clang-format 18, codespell, and `git diff --check`
