### PR TITLE
[Fix] Generate conditional Ascend buffer stores safely

### DIFF
--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -439,12 +439,17 @@ void CodeGenTileLangAscend::VisitExpr_(const BufferLoadNode *op,
 void CodeGenTileLangAscend::VisitStmt_(const BufferStoreNode *op) {
   auto var_name = var_idmap_[op->buffer->data.get()];
   std::string scope = GetPtrStorageScope(op->buffer->data);
+  std::string value = PrintExpr(op->value);
+  std::string index;
+  if (scope != "local.var") {
+    index = PrintExpr(op->indices.back());
+  }
   this->PrintIndent();
   if (scope == "local.var") {
-    this->stream << var_name << " = " << PrintExpr(op->value) << ";\n";
+    this->stream << var_name << " = " << value << ";\n";
   } else {
-    this->stream << var_name << ".SetValue(" << PrintExpr(op->indices.back())
-                 << ", " << PrintExpr(op->value) << ");\n";
+    this->stream << var_name << ".SetValue(" << index << ", " << value
+                 << ");\n";
   }
 }
 

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -730,18 +730,22 @@ void CodeGenTileLangAscendPto::VisitExpr_(const BufferLoadNode *op,
 
 void CodeGenTileLangAscendPto::VisitStmt_(const BufferStoreNode *op) {
   auto var_name = var_idmap_[op->buffer->data.get()];
-  this->PrintIndent();
   std::string scope = op->buffer.scope();
+  std::string value = PrintExpr(op->value);
+  std::string index;
+  if (scope != "local.var") {
+    index = PrintExpr(op->indices.back());
+  }
+  this->PrintIndent();
 
   if (scope == "" || scope == "global") {
-    this->stream << "*(" << var_name << "_handle + "
-                 << PrintExpr(op->indices.back())
-                 << ") = " << PrintExpr(op->value) << ";\n";
+    this->stream << "*(" << var_name << "_handle + " << index << ") = " << value
+                 << ";\n";
   } else if (scope == "local.var") {
-    this->stream << var_name << " = " << PrintExpr(op->value) << ";\n";
+    this->stream << var_name << " = " << value << ";\n";
   } else {
-    this->stream << var_name << ".SetValue(" << PrintExpr(op->indices.back())
-                 << ", " << PrintExpr(op->value) << ");\n";
+    this->stream << var_name << ".SetValue(" << index << ", " << value
+                 << ");\n";
   }
 }
 

--- a/testing/python/language/test_tilelang_ascend_language_if_then_else.py
+++ b/testing/python/language/test_tilelang_ascend_language_if_then_else.py
@@ -1,0 +1,86 @@
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+
+NUMEL = 32
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+def if_then_else_buffer_store(dtype):
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((NUMEL,), dtype),  # type: ignore
+        B: T.Tensor((NUMEL,), dtype),  # type: ignore
+        Selector: T.Tensor((NUMEL,), "int32"),  # type: ignore
+        C: T.Tensor((NUMEL,), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((NUMEL,), dtype)
+            b_ub = T.alloc_ub((NUMEL,), dtype)
+            selector_ub = T.alloc_ub((NUMEL,), "int32")
+            c_ub = T.alloc_ub((NUMEL,), dtype)
+
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            T.copy(Selector, selector_ub)
+
+            for i in T.serial(NUMEL):
+                c_ub[i] = T.if_then_else(
+                    selector_ub[i] > 0,
+                    T.if_then_else(selector_ub[i] > 1, a_ub[i], b_ub[i]),
+                    b_ub[i],
+                )
+
+            c_ub[T.if_then_else(selector_ub[0] > 0, 0, 1)] = T.if_then_else(selector_ub[1] > 1, a_ub[1], b_ub[1])
+            T.copy(c_ub, C)
+
+    return main
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_if_then_else_buffer_store_codegen(dtype, target):
+    with tilelang.tvm.transform.PassContext(opt_level=3, config=PASS_CONFIGS):
+        artifact = tilelang.lower(if_then_else_buffer_store(dtype), target=target)
+
+    source = artifact.kernel_source
+    first_binding = source.find("condval")
+    store_lines = [line for line in source.splitlines() if ".SetValue(" in line]
+    assert first_binding >= 0
+    assert len(store_lines) == 2
+    assert all("condval" in line and line.rstrip().endswith(");") for line in store_lines)
+    assert all(first_binding < source.find(line) for line in store_lines)
+
+
+@pytest.mark.parametrize(
+    "dtype,torch_dtype",
+    [("float", torch.float32), ("float16", torch.float16)],
+)
+def test_if_then_else_buffer_store_npu(dtype, torch_dtype):
+    func = tilelang.compile(
+        if_then_else_buffer_store(dtype),
+        out_idx=[-1],
+        pass_configs=PASS_CONFIGS,
+        target="ascendc",
+    )
+
+    a = torch.tensor([3.0, 1.0] * (NUMEL // 2), dtype=torch_dtype).npu()
+    b = torch.tensor([1.0, 4.0] * (NUMEL // 2), dtype=torch_dtype).npu()
+    selector = torch.tensor([2, 1, 0, -1] * (NUMEL // 4), dtype=torch.int32).npu()
+    torch.npu.synchronize()
+
+    actual = func(a, b, selector)
+    torch.npu.synchronize()
+
+    expected = torch.where(selector > 0, torch.where(selector > 1, a, b), b)
+    expected[0] = torch.where(selector[1] > 1, a[1], b[1])
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)


### PR DESCRIPTION
## Summary

- generate buffer-store value and index expressions before emitting target store syntax
- apply the same ordering to the AscendC and PTO backends
- add nested-value and dynamic-index `T.if_then_else` codegen coverage, plus AscendC NPU correctness coverage for float32 and float16

## Root cause

The custom Ascend `BufferStore` visitors emitted the `SetValue(` or pointer-store prefix before calling `PrintExpr`. Expressions such as `tir.if_then_else` may emit temporary declarations and `if`/`else` statements into the main stream. That interleaved statements inside the unfinished store call and produced invalid C++.

The fix evaluates the value and index expressions first, then writes the complete store. This matches the generic `CodeGenC` ordering and preserves lazy branch bindings.

## Validation

- `cmake --build build -j8`
- `python3 -m pytest -q testing/python/language/test_tilelang_ascend_language_if_then_else.py` — 6 passed
- `python3 -m pytest -q testing/python/language/test_ascend_memory_planning.py -k if_then_else -vv` — all 4 AscendC/codegen/NPU cases passed
- `python3 -m pytest -q testing/python/language/test_tilelang_ascend_language_alloc_codegen.py` — 10 passed
- `python3 -m pytest -q -n 2 testing/python/language/test_tilelang_ascend_language_if_then_else.py -k codegen` — 4 passed
- local YAPF 0.40.2, Ruff lint, codespell 2.3.0, and diff checks passed
- GitHub `format-check` with Ruff 0.15.21 and clang-format 18 passed

PTO source generation is covered for both float32 and float16. PTO device compilation cannot run with the local CANN 8.3 toolchain because the checked-in PTO ISA headers require unsupported `__biasbuf__` / `[aicore]` syntax; the same environment failure occurs in existing PTO tests before reaching this change.

## CI follow-up

The first full NPU run completed 1058 tests successfully and failed one pre-existing PTO transpose case because the new test module cleared the process-wide TileLang cache while pytest-xdist workers were active. The unnecessary autouse cache-clearing fixture has been removed, so this regression test no longer mutates shared test state. The replacement full NPU run is queued.