### PR TITLE
[Fix] Ascend CodeGen: fix BufferStoreNode eval order causing invalid C++ from if_then_else

### DIFF
--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -480,12 +480,16 @@ void CodeGenTileLangAscend::VisitExpr_(const BufferLoadNode *op,
 void CodeGenTileLangAscend::VisitStmt_(const BufferStoreNode *op) {
   auto var_name = var_idmap_[op->buffer->data.get()];
   std::string scope = GetPtrStorageScope(op->buffer->data);
-  this->PrintIndent();
   if (scope == "local.var") {
-    this->stream << var_name << " = " << PrintExpr(op->value) << ";\n";
+    std::string value = PrintExpr(op->value);
+    this->PrintIndent();
+    this->stream << var_name << " = " << value << ";\n";
   } else {
-    this->stream << var_name << ".SetValue(" << PrintExpr(op->indices.back())
-                 << ", " << PrintExpr(op->value) << ");\n";
+    std::string index = PrintExpr(op->indices.back());
+    std::string value = PrintExpr(op->value);
+    this->PrintIndent();
+    this->stream << var_name << ".SetValue(" << index << ", " << value
+                 << ");\n";
   }
 }
 


### PR DESCRIPTION
## Description

Fixes invalid C++ code generation when assigning `T.if_then_else(...)` to a `T.alloc_var` scalar (scope=`local.var`) in Ascend kernels.

`CodeGenTileLangAscend::VisitStmt_(BufferStoreNode*)` evaluated `PrintExpr` **inside** the `<<` stream chain (after `PrintIndent`). Since `if_then_else` emits side-effect statements (`int32_t condval;` + `if/else` block) into `this->stream` during `PrintExpr`, those statements got glued onto the assignment line, producing invalid code like `b_i =   int32_t condval;` and an orphan `condval;`.

This aligns the evaluation order with standard TVM `CodeGenC` (`codegen_c.cc` L834-838): call `PrintExpr` **first** so side effects are emitted at line start with correct indentation, then `PrintIndent()` and emit the assignment. Both the `local.var` and `SetValue` branches are fixed.

## Before (buggy)

```cpp
  b_i =   int32_t condval;          // ← invalid: declaration glued to assignment
  if ((10 <= total_seq_tiles)) {
    condval = 1;
  } else {
    condval = 2;
  }
condval;                            // ← invalid: orphan statement, condval out of scope
```

## After (fixed)

```cpp
  int32_t condval;
  if ((10 <= total_seq_tiles)) {
    condval = 1;
  } else {
    condval = 2;
  }
  b_i = condval;
```

## Reproduction

```python
import torch
import tilelang
import tilelang.language as T

torch.manual_seed(41)
tilelang.disable_cache()
tilelang.cache.clear_cache()


@T.prim_func
def main(
    total_seq_tiles: T.int32
):
    with T.Kernel(24, is_npu=True) as (cid, vid):
        b_i = T.alloc_var("int32", init=0)
        b_i = T.if_then_else(total_seq_tiles >= 10, 1, 2)

print(tilelang.lower(main).kernel_source)
```

## Why existing examples don't trigger this

`if_then_else` is the **only** expression in TVM CodeGen that writes side-effect statements to `this->stream` during `PrintExpr` (`codegen_c.cc` L639-660). Other expressions (constants, arithmetic, buffer load, `Select`, etc.) only write to the passed `os` and are unaffected by evaluation order. Currently `examples/` uses neither `T.alloc_var` nor `T.if_then_else`, so the defect remained latent.

## Verification

- Built `tilelang_module` target and ran the reproduction script above; output matches expected.
- The fix is a minimal reorder (no logic change) mirroring `CodeGenC::VisitStmt_(BufferStoreNode*)`.

Closes #1362
