### PR TITLE
[Ascend] Vector tail-block scheme: guarded valid-region reduction support (AscendC)

### DIFF
--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -2285,7 +2285,7 @@ void CodeGenTileLangAscend::TailReduceOpCodegen(const CallNode *op) {
   std::string dtype = getType(GetAccessPtrDtype(op->args[1].as<CallNode>()));
   std::string out = PrintBufferOffset(op->args[1].as<CallNode>());
   std::string src = PrintBufferOffset(op->args[2].as<CallNode>());
-  std::string tmp = PrintBufferOffset(op->args[3].as<CallNode>(), false);
+  std::string tmp = PrintBufferOffset(op->args[3].as<CallNode>());
   // Bind valid-region expressions first (see TailUnaryOpCodegen).
   std::string dim_str = PrintExpr(op->args[4]);
   std::string vrow = PrintExpr(op->args[5]);

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -912,23 +912,13 @@ CATLASS_DEVICE void tail_reduce_sum(LocalTensor<T> out, LocalTensor<T> src,
   // path: every row writes one scalar to contiguous out[r].  The native
   // Pattern-AR path is intentionally not used here because its runtime-shape
   // output layout has not yet been validated for tail blocks.
-  // clear == false is handled by backing up the old result and merging.
-  constexpr uint32_t kTailMaxRows = 256;
-  T backup[kTailMaxRows];
-  bool merge = (!clear) && (validRow <= kTailMaxRows);
-  if (merge) {
-    for (uint32_t r = 0; r < validRow; ++r)
-      backup[r] = out.GetValue(r);
-  }
   for (uint32_t r = 0; r < validRow; ++r) {
     T acc = static_cast<T>(0);
     for (uint32_t c = 0; c < validCol; ++c)
       acc = static_cast<T>(acc + src.GetValue(r * physCol + c));
+    if (!clear)
+      acc = static_cast<T>(out.GetValue(r) + acc);
     out.SetValue(r, acc);
-  }
-  if (merge) {
-    for (uint32_t r = 0; r < validRow; ++r)
-      out.SetValue(r, static_cast<T>(out.GetValue(r) + backup[r]));
   }
 }
 
@@ -951,33 +941,18 @@ CATLASS_DEVICE void tail_reduce_max(LocalTensor<T> out, LocalTensor<T> src,
     }
     return;
   }
-  // dim == -1: reduce each row over its valid columns (Pattern-AR).
-  constexpr uint32_t kTailMaxRows = 256;
-  T backup[kTailMaxRows];
-  bool merge = (!clear) && (validRow <= kTailMaxRows);
-  if (merge) {
-    for (uint32_t r = 0; r < validRow; ++r)
-      backup[r] = out.GetValue(r);
-  }
-  if (validCol == physCol) {
-    uint32_t shape[2] = {validRow, validCol};
-    AscendC::ReduceMax<T, AscendC::Pattern::Reduce::AR>(out, src, tmp, shape,
-                                                        true);
-  } else {
-    // validCol != physCol (tail columns): scalar fallback (see
-    // tail_reduce_sum).
-    for (uint32_t r = 0; r < validRow; ++r) {
-      T acc = src.GetValue(r * physCol);
-      for (uint32_t c = 1; c < validCol; ++c) {
-        T v = src.GetValue(r * physCol + c);
-        acc = reduce_scalar_max_safe(acc, v);
-      }
-      out.SetValue(r, acc);
+  // dim == -1: reduce each row over its valid columns with an explicit
+  // contiguous out[r] layout.
+  (void)tmp;
+  for (uint32_t r = 0; r < validRow; ++r) {
+    T acc = src.GetValue(r * physCol);
+    for (uint32_t c = 1; c < validCol; ++c) {
+      T v = src.GetValue(r * physCol + c);
+      acc = reduce_scalar_max_safe(acc, v);
     }
-  }
-  if (merge) {
-    for (uint32_t r = 0; r < validRow; ++r)
-      out.SetValue(r, reduce_scalar_max_safe(out.GetValue(r), backup[r]));
+    if (!clear)
+      acc = reduce_scalar_max_safe(out.GetValue(r), acc);
+    out.SetValue(r, acc);
   }
 }
 
@@ -1000,33 +975,18 @@ CATLASS_DEVICE void tail_reduce_min(LocalTensor<T> out, LocalTensor<T> src,
     }
     return;
   }
-  // dim == -1: reduce each row over its valid columns (Pattern-AR).
-  constexpr uint32_t kTailMaxRows = 256;
-  T backup[kTailMaxRows];
-  bool merge = (!clear) && (validRow <= kTailMaxRows);
-  if (merge) {
-    for (uint32_t r = 0; r < validRow; ++r)
-      backup[r] = out.GetValue(r);
-  }
-  if (validCol == physCol) {
-    uint32_t shape[2] = {validRow, validCol};
-    AscendC::ReduceMin<T, AscendC::Pattern::Reduce::AR>(out, src, tmp, shape,
-                                                        true);
-  } else {
-    // validCol != physCol (tail columns): scalar fallback (see
-    // tail_reduce_sum).
-    for (uint32_t r = 0; r < validRow; ++r) {
-      T acc = src.GetValue(r * physCol);
-      for (uint32_t c = 1; c < validCol; ++c) {
-        T v = src.GetValue(r * physCol + c);
-        acc = reduce_scalar_min_safe(acc, v);
-      }
-      out.SetValue(r, acc);
+  // dim == -1: reduce each row over its valid columns with an explicit
+  // contiguous out[r] layout.
+  (void)tmp;
+  for (uint32_t r = 0; r < validRow; ++r) {
+    T acc = src.GetValue(r * physCol);
+    for (uint32_t c = 1; c < validCol; ++c) {
+      T v = src.GetValue(r * physCol + c);
+      acc = reduce_scalar_min_safe(acc, v);
     }
-  }
-  if (merge) {
-    for (uint32_t r = 0; r < validRow; ++r)
-      out.SetValue(r, reduce_scalar_min_safe(out.GetValue(r), backup[r]));
+    if (!clear)
+      acc = reduce_scalar_min_safe(out.GetValue(r), acc);
+    out.SetValue(r, acc);
   }
 }
 

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -911,7 +911,9 @@ CATLASS_DEVICE void tail_reduce_sum(LocalTensor<T> out, LocalTensor<T> src,
   // Keep a single explicit layout contract for the first enabled tail-reduce
   // path: every row writes one scalar to contiguous out[r].  The native
   // Pattern-AR path is intentionally not used here because its runtime-shape
-  // output layout has not yet been validated for tail blocks.
+  // output layout has not yet been validated for tail blocks. This GetValue /
+  // SetValue fallback runs on the scalar unit and is intentionally correctness
+  // first; replace it with a vector reduction once that layout is validated.
   for (uint32_t r = 0; r < validRow; ++r) {
     T acc = static_cast<T>(0);
     for (uint32_t c = 0; c < validCol; ++c)
@@ -941,8 +943,8 @@ CATLASS_DEVICE void tail_reduce_max(LocalTensor<T> out, LocalTensor<T> src,
     }
     return;
   }
-  // dim == -1: reduce each row over its valid columns with an explicit
-  // contiguous out[r] layout.
+  // dim == -1: correctness-first scalar fallback with an explicit contiguous
+  // out[r] layout. It is slower than a vector reduction; see tail_reduce_sum.
   (void)tmp;
   for (uint32_t r = 0; r < validRow; ++r) {
     T acc = src.GetValue(r * physCol);
@@ -975,8 +977,8 @@ CATLASS_DEVICE void tail_reduce_min(LocalTensor<T> out, LocalTensor<T> src,
     }
     return;
   }
-  // dim == -1: reduce each row over its valid columns with an explicit
-  // contiguous out[r] layout.
+  // dim == -1: correctness-first scalar fallback with an explicit contiguous
+  // out[r] layout. It is slower than a vector reduction; see tail_reduce_sum.
   (void)tmp;
   for (uint32_t r = 0; r < validRow; ++r) {
     T acc = src.GetValue(r * physCol);

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -892,6 +892,7 @@ CATLASS_DEVICE void tail_reduce_sum(LocalTensor<T> out, LocalTensor<T> src,
                                     LocalTensor<uint8_t> tmp, int dim,
                                     uint32_t validRow, uint32_t validCol,
                                     uint32_t physCol, bool clear) {
+  (void)tmp;
   if (validRow == 0 || validCol == 0)
     return;
   if (dim == 0) {
@@ -907,8 +908,10 @@ CATLASS_DEVICE void tail_reduce_sum(LocalTensor<T> out, LocalTensor<T> src,
     return;
   }
   // dim == -1: reduce each row over its valid columns -> out[0..validRow).
-  // Use the proven Pattern-AR reduce: one contiguous block reduce when
-  // validCol == physCol, otherwise per-row (each row is contiguous internally).
+  // Keep a single explicit layout contract for the first enabled tail-reduce
+  // path: every row writes one scalar to contiguous out[r].  The native
+  // Pattern-AR path is intentionally not used here because its runtime-shape
+  // output layout has not yet been validated for tail blocks.
   // clear == false is handled by backing up the old result and merging.
   constexpr uint32_t kTailMaxRows = 256;
   T backup[kTailMaxRows];
@@ -917,21 +920,11 @@ CATLASS_DEVICE void tail_reduce_sum(LocalTensor<T> out, LocalTensor<T> src,
     for (uint32_t r = 0; r < validRow; ++r)
       backup[r] = out.GetValue(r);
   }
-  if (validCol == physCol) {
-    uint32_t shape[2] = {validRow, validCol};
-    AscendC::ReduceSum<T, AscendC::Pattern::Reduce::AR>(out, src, tmp, shape,
-                                                        true);
-  } else {
-    // validCol != physCol (tail columns): AR-pattern ReduceSum with a sub-tile
-    // shape {1, validCol} triggers aicore exceptions on some tiles, so fall
-    // back to explicit scalar accumulation (always correct; tail validCol is
-    // small so the cost is bounded). merge (clear==false) handled below.
-    for (uint32_t r = 0; r < validRow; ++r) {
-      T acc = static_cast<T>(0);
-      for (uint32_t c = 0; c < validCol; ++c)
-        acc = static_cast<T>(acc + src.GetValue(r * physCol + c));
-      out.SetValue(r, acc);
-    }
+  for (uint32_t r = 0; r < validRow; ++r) {
+    T acc = static_cast<T>(0);
+    for (uint32_t c = 0; c < validCol; ++c)
+      acc = static_cast<T>(acc + src.GetValue(r * physCol + c));
+    out.SetValue(r, acc);
   }
   if (merge) {
     for (uint32_t r = 0; r < validRow; ++r)

--- a/src/transform/ascend_tail_mask_propagation.cc
+++ b/src/transform/ascend_tail_mask_propagation.cc
@@ -151,6 +151,8 @@ private:
   std::unordered_set<const VarNode *> active_loop_vars_;
 
   bool HasOutOfScopeLoopVar(const PrimExpr &e) const {
+    if (!e.defined())
+      return false;
     bool found = false;
     PostOrderVisit(e, [&](const ObjectRef &n) {
       if (const auto *v = n.as<VarNode>()) {
@@ -505,17 +507,30 @@ private:
   }
 
   static int ParseReduceDim(const std::string &tag) {
-    // tag like "reduce_sum<float, 16, 32, -1>"; dim is the last template field.
+    // tag like "reduce_sum<float, 16, 32, -1>"; dim is the fourth template
+    // field. Parse it from the known row/column fields instead of assuming it
+    // remains the final field if the tag gains more metadata later.
     size_t lt = tag.find('<');
     size_t gt = tag.rfind('>');
     if (lt == std::string::npos || gt == std::string::npos || gt <= lt)
       return 2;
     std::string inner = tag.substr(lt + 1, gt - lt - 1);
-    size_t comma = inner.rfind(',');
-    std::string dim_str =
-        comma == std::string::npos ? inner : inner.substr(comma + 1);
+    size_t dtype_end = inner.find(',');
+    if (dtype_end == std::string::npos)
+      return 2;
+    size_t row_end = inner.find(',', dtype_end + 1);
+    if (row_end == std::string::npos)
+      return 2;
+    size_t col_end = inner.find(',', row_end + 1);
+    if (col_end == std::string::npos)
+      return 2;
+    size_t dim_end = inner.find(',', col_end + 1);
+    std::string dim_str = inner.substr(col_end + 1, dim_end - (col_end + 1));
     try {
-      return std::stoi(dim_str);
+      size_t parsed = 0;
+      int dim = std::stoi(dim_str, &parsed);
+      return dim_str.find_first_not_of(" \t", parsed) == std::string::npos ? dim
+                                                                           : 2;
     } catch (...) {
       return 2;
     }

--- a/src/transform/ascend_tail_mask_propagation.cc
+++ b/src/transform/ascend_tail_mask_propagation.cc
@@ -406,7 +406,21 @@ private:
     // The valid_row/valid_col must also not reference loop vars that have
     // already gone out of scope (e.g. a copy seeded inside `for by` whose
     // valid_col = f(by), but the reduce runs outside the loop).
-    bool ok = rewrite_reduce_ && CleanTail(PtrExtent(call->args[2]), in) &&
+    // Batch 1.1 deliberately enables only the smallest validated reduce
+    // contract: reduce_sum over the last axis with clear=true and a contiguous
+    // output vector.  Other kinds, axes and accumulation semantics keep using
+    // the established full-tile + pad path until they have dedicated tests.
+    DataType src_dtype = PtrDtype(call->args[2]);
+    PrimExpr out_extent = PtrExtent(call->args[1]);
+    bool supported_contract =
+        call->args.size() == 5 && kind == "reduce_sum" &&
+        (raw_dim == 1 || raw_dim == -1) && is_one(call->args[4]) &&
+        src_dtype == DataType::Float(32) &&
+        PtrDtype(call->args[1]) == src_dtype && out_extent.defined() &&
+        in.physical_row.defined() &&
+        analyzer_->CanProveEqual(out_extent, in.physical_row);
+    bool ok = rewrite_reduce_ && supported_contract &&
+              CleanTail(PtrExtent(call->args[2]), in) &&
               SupportedTailDtype(PtrDtype(call->args[2])) &&
               !HasOutOfScopeLoopVar(in.valid_row) &&
               !HasOutOfScopeLoopVar(in.valid_col) && !IsBroadcastScalarMask(in);
@@ -494,7 +508,7 @@ private:
     size_t lt = tag.find('<');
     size_t gt = tag.rfind('>');
     if (lt == std::string::npos || gt == std::string::npos || gt <= lt)
-      return -1;
+      return 2;
     std::string inner = tag.substr(lt + 1, gt - lt - 1);
     size_t comma = inner.rfind(',');
     std::string dim_str =
@@ -502,7 +516,7 @@ private:
     try {
       return std::stoi(dim_str);
     } catch (...) {
-      return -1;
+      return 2;
     }
   }
 };

--- a/src/transform/ascend_tail_mask_propagation.cc
+++ b/src/transform/ascend_tail_mask_propagation.cc
@@ -409,7 +409,9 @@ private:
     // already gone out of scope (e.g. a copy seeded inside `for by` whose
     // valid_col = f(by), but the reduce runs outside the loop).
     // Enable the contracts whose output layout is explicit and validated:
-    // float32 sum/max/min, clear=true, reducing either axis of a 2D tile.
+    // float32 sum/max/min, clear=true, reducing rows (axis 0/-2) of a 2D tile.
+    // The scalar last-axis fallback is not device-reliable for a full 32-row
+    // tile, so keep that contract on the established native path.
     // Accumulating reductions and lower-precision accumulation keep using the
     // established full-tile + pad path until their backend semantics are
     // validated independently.
@@ -417,8 +419,7 @@ private:
     PrimExpr out_extent = PtrExtent(call->args[1]);
     bool supported_kind =
         kind == "reduce_sum" || kind == "reduce_max" || kind == "reduce_min";
-    bool supported_dim =
-        raw_dim == 0 || raw_dim == -2 || raw_dim == 1 || raw_dim == -1;
+    bool supported_dim = raw_dim == 0 || raw_dim == -2;
     PrimExpr expected_out_extent =
         (raw_dim == 0 || raw_dim == -2) ? in.physical_col : in.physical_row;
     bool supported_contract =

--- a/src/transform/ascend_tail_mask_propagation.cc
+++ b/src/transform/ascend_tail_mask_propagation.cc
@@ -18,10 +18,10 @@
  * valid_row/valid_col/physical_col) so the codegen emits a tl::ascend::tail_*
  * helper that computes only over the valid region.
  *
- * Batch 1 rewrites: unary / binary / scalar(immediate) / reduce.
- * Batch 1 propagates-but-does-not-rewrite: cast / broadcast / copy_ub_to_ub
- * (they are per-lane or shape-only, so the full-tile path stays numerically
- * correct; the mask still flows through to a downstream reduce).
+ * Rewrites: unary / binary / scalar(immediate), plus a conservative allow-list
+ * of 2D reduce contracts. Propagates-but-does-not-rewrite: cast / broadcast /
+ * copy_ub_to_ub (they are per-lane or shape-only, so the full-tile path stays
+ * numerically correct; the mask still flows through to a downstream reduce).
  */
 
 #include "arith/ir_mutator_with_analyzer.h"
@@ -406,19 +406,26 @@ private:
     // The valid_row/valid_col must also not reference loop vars that have
     // already gone out of scope (e.g. a copy seeded inside `for by` whose
     // valid_col = f(by), but the reduce runs outside the loop).
-    // Batch 1.1 deliberately enables only the smallest validated reduce
-    // contract: reduce_sum over the last axis with clear=true and a contiguous
-    // output vector.  Other kinds, axes and accumulation semantics keep using
-    // the established full-tile + pad path until they have dedicated tests.
+    // Enable the contracts whose output layout is explicit and validated:
+    // float32 sum/max/min, clear=true, reducing either axis of a 2D tile.
+    // Accumulating reductions and lower-precision accumulation keep using the
+    // established full-tile + pad path until their backend semantics are
+    // validated independently.
     DataType src_dtype = PtrDtype(call->args[2]);
     PrimExpr out_extent = PtrExtent(call->args[1]);
+    bool supported_kind =
+        kind == "reduce_sum" || kind == "reduce_max" || kind == "reduce_min";
+    bool supported_dim =
+        raw_dim == 0 || raw_dim == -2 || raw_dim == 1 || raw_dim == -1;
+    PrimExpr expected_out_extent =
+        (raw_dim == 0 || raw_dim == -2) ? in.physical_col : in.physical_row;
     bool supported_contract =
-        call->args.size() == 5 && kind == "reduce_sum" &&
-        (raw_dim == 1 || raw_dim == -1) && is_one(call->args[4]) &&
-        src_dtype == DataType::Float(32) &&
+        call->args.size() == 5 && supported_kind && supported_dim &&
+        is_one(call->args[4]) && src_dtype == DataType::Float(32) &&
         PtrDtype(call->args[1]) == src_dtype && out_extent.defined() &&
-        in.physical_row.defined() &&
-        analyzer_->CanProveEqual(out_extent, in.physical_row);
+        expected_out_extent.defined() &&
+        analyzer_->CanProveEqual(out_extent, expected_out_extent) &&
+        ReduceShapeMatchesPhysical(reduce_tag, in);
     bool ok = rewrite_reduce_ && supported_contract &&
               CleanTail(PtrExtent(call->args[2]), in) &&
               SupportedTailDtype(PtrDtype(call->args[2])) &&
@@ -428,19 +435,13 @@ private:
     // Output rectangle for downstream propagation (only when rewriting).
     TailMaskInfo out;
     if (ok) {
-      out.kind = TailMaskKind::kTail;
       if (dim == 0) {
-        out.valid_row = IntImm(DataType::Int(32), 1);
-        out.valid_col = in.valid_col;
-        out.physical_row = IntImm(DataType::Int(32), 1);
-        out.physical_col = in.physical_col;
+        PrimExpr one = IntImm(DataType::Int(32), 1);
+        out = MakeCopyMask(one, in.valid_col, one, in.physical_col, analyzer_);
       } else { // dim == -1 (reduce last axis) -> column vector
-        out.valid_row = in.valid_row;
-        out.valid_col = IntImm(DataType::Int(32), 1);
-        out.physical_row = in.physical_row;
-        out.physical_col = IntImm(DataType::Int(32), 1);
+        PrimExpr one = IntImm(DataType::Int(32), 1);
+        out = MakeCopyMask(in.valid_row, one, in.physical_row, one, analyzer_);
       }
-      out.storage_col = out.physical_col;
     }
     if (out_v != nullptr)
       state_[out_v] = out;
@@ -517,6 +518,46 @@ private:
       return std::stoi(dim_str);
     } catch (...) {
       return 2;
+    }
+  }
+
+  bool ReduceShapeMatchesPhysical(const std::string &tag,
+                                  const TailMaskInfo &in) {
+    if (!in.physical_row.defined() || !in.physical_col.defined())
+      return false;
+    size_t lt = tag.find('<');
+    size_t gt = tag.rfind('>');
+    if (lt == std::string::npos || gt == std::string::npos || gt <= lt)
+      return false;
+    std::string inner = tag.substr(lt + 1, gt - lt - 1);
+    size_t dtype_end = inner.find(',');
+    if (dtype_end == std::string::npos)
+      return false;
+    size_t row_end = inner.find(',', dtype_end + 1);
+    if (row_end == std::string::npos)
+      return false;
+    size_t col_end = inner.find(',', row_end + 1);
+    if (col_end == std::string::npos)
+      return false;
+    try {
+      auto parse_int = [](const std::string &token, int *value) {
+        size_t parsed = 0;
+        *value = std::stoi(token, &parsed);
+        return token.find_first_not_of(" \t", parsed) == std::string::npos;
+      };
+      int row = 0;
+      int col = 0;
+      if (!parse_int(inner.substr(dtype_end + 1, row_end - dtype_end - 1),
+                     &row) ||
+          !parse_int(inner.substr(row_end + 1, col_end - row_end - 1), &col))
+        return false;
+      return row > 0 && col > 0 &&
+             analyzer_->CanProveEqual(in.physical_row, row) &&
+             analyzer_->CanProveEqual(in.physical_col, col);
+    } catch (...) {
+      // Dynamic or otherwise unparseable explicit real_shape stays on the
+      // established native reduce path.
+      return false;
     }
   }
 };

--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -345,13 +345,18 @@ def test_reduce_max_tail(rows_valid, rows_phys, cols, dtype, target, tail_mask):
 
 
 # =============================================================================
-# Group 2d - AscendC last-axis tail reduce_sum   [risk: high]
-# Version 1 intentionally covers only sum, dim=-1 and clear=true. Each N tile
-# produces one partial row sum, so the output shape is [M, ceildiv(N, block_N)].
+# Group 2d - AscendC 2D tail reductions   [risk: high]
+# Covers sum/max/min with clear=true on both axes. Each tile writes one partial
+# reduction, so different blocks never race on the output.
 # =============================================================================
-def reduce_sum_last_axis_tail(M, N, block_M, block_N, dtype="float"):
+def reduce_last_axis_tail(M, N, block_M, block_N, kind, dtype="float"):
     m_num = T.ceildiv(M, block_M)
     n_num = T.ceildiv(N, block_N)
+    reduce_fn = {
+        "sum": T.reduce_sum,
+        "max": T.reduce_max,
+        "min": T.reduce_min,
+    }[kind]
 
     @T.prim_func
     def main(
@@ -365,15 +370,16 @@ def reduce_sum_last_axis_tail(M, N, block_M, block_N, dtype="float"):
             out_ub = T.alloc_ub((block_M, 1), dtype)
 
             T.copy(Input[bx * block_M, by * block_N], in_ub)
-            T.reduce_sum(in_ub, out_ub, dim=-1, clear=True)
+            reduce_fn(in_ub, out_ub, dim=-1, clear=True)
             T.copy(out_ub, Output[bx * block_M, by])
 
     return main
 
 
-def test_reduce_sum_last_axis_tail_ascendc():
+@pytest.mark.parametrize("kind", ["sum", "max", "min"])
+def test_reduce_last_axis_tail_ascendc(kind):
     M, N, block_M, block_N = 34, 130, 32, 32
-    func = reduce_sum_last_axis_tail(M, N, block_M, block_N)
+    func = reduce_last_axis_tail(M, N, block_M, block_N, kind)
     func = tilelang.compile(
         func, out_idx=[-1], pass_configs=_vec_configs(tail_mask=True), target="ascendc"
     )
@@ -385,7 +391,57 @@ def test_reduce_sum_last_axis_tail_ascendc():
     n_num = (N + block_N - 1) // block_N
     ref = torch.empty((M, n_num), dtype=torch.float32, device=a.device)
     for by in range(n_num):
-        ref[:, by] = a[:, by * block_N : min((by + 1) * block_N, N)].sum(dim=-1)
+        tile = a[:, by * block_N : min((by + 1) * block_N, N)]
+        reduced = getattr(tile, kind)(dim=-1)
+        ref[:, by] = reduced if kind == "sum" else reduced.values
+    torch.testing.assert_close(out, ref, rtol=1e-4, atol=1e-4)
+
+
+def reduce_axis0_tail(M, N, block_M, block_N, kind, dtype="float"):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+    reduce_fn = {
+        "sum": T.reduce_sum,
+        "max": T.reduce_max,
+        "min": T.reduce_min,
+    }[kind]
+
+    @T.prim_func
+    def main(
+        Input: T.Tensor((M, N), dtype),  # type: ignore
+        Output: T.Tensor((m_num, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            in_ub = T.alloc_ub((block_M, block_N), dtype)
+            out_ub = T.alloc_ub((1, block_N), dtype)
+
+            T.copy(Input[bx * block_M, by * block_N], in_ub)
+            reduce_fn(in_ub, out_ub, dim=0, clear=True)
+            T.copy(out_ub, Output[bx, by * block_N])
+
+    return main
+
+
+@pytest.mark.parametrize("kind", ["sum", "max", "min"])
+def test_reduce_axis0_tail_ascendc(kind):
+    M, N, block_M, block_N = 34, 130, 32, 32
+    func = reduce_axis0_tail(M, N, block_M, block_N, kind)
+    func = tilelang.compile(
+        func, out_idx=[-1], pass_configs=_vec_configs(tail_mask=True), target="ascendc"
+    )
+
+    torch.manual_seed(0)
+    a = torch.randn(M, N, dtype=torch.float32).npu()
+    out = func(a)
+
+    m_num = (M + block_M - 1) // block_M
+    ref = torch.empty((m_num, N), dtype=torch.float32, device=a.device)
+    for bx in range(m_num):
+        tile = a[bx * block_M : min((bx + 1) * block_M, M), :]
+        reduced = getattr(tile, kind)(dim=0)
+        ref[bx, :] = reduced if kind == "sum" else reduced.values
     torch.testing.assert_close(out, ref, rtol=1e-4, atol=1e-4)
 
 

--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -345,6 +345,51 @@ def test_reduce_max_tail(rows_valid, rows_phys, cols, dtype, target, tail_mask):
 
 
 # =============================================================================
+# Group 2d - AscendC last-axis tail reduce_sum   [risk: high]
+# Version 1 intentionally covers only sum, dim=-1 and clear=true. Each N tile
+# produces one partial row sum, so the output shape is [M, ceildiv(N, block_N)].
+# =============================================================================
+def reduce_sum_last_axis_tail(M, N, block_M, block_N, dtype="float"):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+
+    @T.prim_func
+    def main(
+        Input: T.Tensor((M, N), dtype),  # type: ignore
+        Output: T.Tensor((M, n_num), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            in_ub = T.alloc_ub((block_M, block_N), dtype)
+            out_ub = T.alloc_ub((block_M, 1), dtype)
+
+            T.copy(Input[bx * block_M, by * block_N], in_ub)
+            T.reduce_sum(in_ub, out_ub, dim=-1, clear=True)
+            T.copy(out_ub, Output[bx * block_M, by])
+
+    return main
+
+
+def test_reduce_sum_last_axis_tail_ascendc():
+    M, N, block_M, block_N = 34, 130, 32, 32
+    func = reduce_sum_last_axis_tail(M, N, block_M, block_N)
+    func = tilelang.compile(
+        func, out_idx=[-1], pass_configs=_vec_configs(tail_mask=True), target="ascendc"
+    )
+
+    torch.manual_seed(0)
+    a = torch.randn(M, N, dtype=torch.float32).npu()
+    out = func(a)
+
+    n_num = (N + block_N - 1) // block_N
+    ref = torch.empty((M, n_num), dtype=torch.float32, device=a.device)
+    for by in range(n_num):
+        ref[:, by] = a[:, by * block_N : min((by + 1) * block_N, N)].sum(dim=-1)
+    torch.testing.assert_close(out, ref, rtol=1e-4, atol=1e-4)
+
+
+# =============================================================================
 # Group 3 - CV fusion (matmul + add) tail   [risk: medium]
 # Mirrors examples/simple_fusion/matmul_add.py, but the grid uses T.ceildiv with
 # non-divisible M/N. C-scope (cube) tails ride gm2l1/l0c2gm; V-scope (vector,

--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -371,7 +371,13 @@ def reduce_last_axis_tail(M, N, block_M, block_N, kind, dtype="float"):
 
             T.copy(Input[bx * block_M, by * block_N], in_ub)
             reduce_fn(in_ub, out_ub, dim=-1, clear=True)
-            T.copy(out_ub, Output[bx * block_M, by])
+            T.copy(
+                out_ub,
+                Output[
+                    bx * block_M : (bx + 1) * block_M,
+                    by : by + 1,
+                ],
+            )
 
     return main
 

--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -380,9 +380,7 @@ def reduce_last_axis_tail(M, N, block_M, block_N, kind, dtype="float"):
 def test_reduce_last_axis_tail_ascendc(kind):
     M, N, block_M, block_N = 34, 130, 32, 32
     func = reduce_last_axis_tail(M, N, block_M, block_N, kind)
-    func = tilelang.compile(
-        func, out_idx=[-1], pass_configs=_vec_configs(tail_mask=True), target="ascendc"
-    )
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=_vec_configs(tail_mask=True), target="ascendc")
 
     torch.manual_seed(0)
     a = torch.randn(M, N, dtype=torch.float32).npu()
@@ -428,9 +426,7 @@ def reduce_axis0_tail(M, N, block_M, block_N, kind, dtype="float"):
 def test_reduce_axis0_tail_ascendc(kind):
     M, N, block_M, block_N = 34, 130, 32, 32
     func = reduce_axis0_tail(M, N, block_M, block_N, kind)
-    func = tilelang.compile(
-        func, out_idx=[-1], pass_configs=_vec_configs(tail_mask=True), target="ascendc"
-    )
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=_vec_configs(tail_mask=True), target="ascendc")
 
     torch.manual_seed(0)
     a = torch.randn(M, N, dtype=torch.float32).npu()

--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -345,62 +345,10 @@ def test_reduce_max_tail(rows_valid, rows_phys, cols, dtype, target, tail_mask):
 
 
 # =============================================================================
-# Group 2d - AscendC 2D tail reductions   [risk: high]
-# Covers sum/max/min with clear=true on both axes. Each tile writes one partial
+# Group 2d - AscendC axis-0 tail reductions   [risk: high]
+# Covers sum/max/min with clear=true. Each tile writes one partial
 # reduction, so different blocks never race on the output.
 # =============================================================================
-def reduce_last_axis_tail(M, N, block_M, block_N, kind, dtype="float"):
-    m_num = T.ceildiv(M, block_M)
-    n_num = T.ceildiv(N, block_N)
-    reduce_fn = {
-        "sum": T.reduce_sum,
-        "max": T.reduce_max,
-        "min": T.reduce_min,
-    }[kind]
-
-    @T.prim_func
-    def main(
-        Input: T.Tensor((M, N), dtype),  # type: ignore
-        Output: T.Tensor((M, n_num), dtype),  # type: ignore
-    ):
-        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
-            bx = cid // n_num
-            by = cid % n_num
-            in_ub = T.alloc_ub((block_M, block_N), dtype)
-            out_ub = T.alloc_ub((block_M, 1), dtype)
-
-            T.copy(Input[bx * block_M, by * block_N], in_ub)
-            reduce_fn(in_ub, out_ub, dim=-1, clear=True)
-            T.copy(
-                out_ub,
-                Output[
-                    bx * block_M : (bx + 1) * block_M,
-                    by : by + 1,
-                ],
-            )
-
-    return main
-
-
-@pytest.mark.parametrize("kind", ["sum", "max", "min"])
-def test_reduce_last_axis_tail_ascendc(kind):
-    M, N, block_M, block_N = 34, 130, 32, 32
-    func = reduce_last_axis_tail(M, N, block_M, block_N, kind)
-    func = tilelang.compile(func, out_idx=[-1], pass_configs=_vec_configs(tail_mask=True), target="ascendc")
-
-    torch.manual_seed(0)
-    a = torch.randn(M, N, dtype=torch.float32).npu()
-    out = func(a)
-
-    n_num = (N + block_N - 1) // block_N
-    ref = torch.empty((M, n_num), dtype=torch.float32, device=a.device)
-    for by in range(n_num):
-        tile = a[:, by * block_N : min((by + 1) * block_N, N)]
-        reduced = getattr(tile, kind)(dim=-1)
-        ref[:, by] = reduced if kind == "sum" else reduced.values
-    torch.testing.assert_close(out, ref, rtol=1e-4, atol=1e-4)
-
-
 def reduce_axis0_tail(M, N, block_M, block_N, kind, dtype="float"):
     m_num = T.ceildiv(M, block_M)
     n_num = T.ceildiv(N, block_N)

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -56,9 +56,14 @@ def _tail_add(M, N, block_M, block_N, dtype="float"):
     return main
 
 
-def _tail_reduce(M, N, block_M, block_N, dtype="float"):
+def _tail_reduce(M, N, block_M, block_N, dtype="float", kind="sum", clear=True):
     m_num = T.ceildiv(M, block_M)
     n_num = T.ceildiv(N, block_N)
+    reduce_fn = {
+        "sum": T.reduce_sum,
+        "max": T.reduce_max,
+        "min": T.reduce_min,
+    }[kind]
 
     @T.prim_func
     def main(
@@ -71,8 +76,29 @@ def _tail_reduce(M, N, block_M, block_N, dtype="float"):
             a_ub = T.alloc_ub((block_M, block_N), dtype)
             r_ub = T.alloc_ub((block_M, 1), dtype)
             T.copy(A[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N], a_ub)
-            T.reduce_sum(a_ub, r_ub, dim=-1)
+            reduce_fn(a_ub, r_ub, dim=-1, clear=clear)
             T.copy(r_ub, B[bx * block_M : (bx + 1) * block_M, by : by + 1])
+
+    return main
+
+
+def _tail_reduce_axis0(M, N, block_M, block_N, dtype="float"):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((m_num, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+            r_ub = T.alloc_ub((1, block_N), dtype)
+            T.copy(A[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N], a_ub)
+            T.reduce_sum(a_ub, r_ub, dim=0)
+            T.copy(r_ub, B[bx : bx + 1, by * block_N : (by + 1) * block_N])
 
     return main
 
@@ -162,13 +188,36 @@ def test_tail_scalar_emits_tail_helper(target):
     assert _emit_marker(target, "scalar") in src, src
 
 
-@pytest.mark.parametrize("target", ["ascendc", "pto"])
-def test_tail_reduce_not_rewritten(target):
-    # reduce is currently NOT rewritten to a tail variant (rewrite_reduce=False):
-    # it stays on the full-tile + pad_value/real_shape path, so neither backend
-    # emits its tail marker for a reduce-only kernel.
-    src = _source(_tail_reduce(34, 130, 32, 32, "float"), target=target)
-    assert _no_tail_marker(target) not in src, src
+def test_tail_reduce_sum_last_axis_emits_ascendc_helper():
+    src = _source(_tail_reduce(34, 130, 32, 32, "float"), target="ascendc")
+    assert "tl::ascend::tail_reduce_sum" in src, src
+
+
+def test_tail_reduce_sum_not_rewritten_for_pto():
+    src = _source(_tail_reduce(34, 130, 32, 32, "float"), target="pto")
+    assert _no_tail_marker("pto") not in src, src
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        _tail_reduce(34, 130, 32, 32, "float", kind="max"),
+        _tail_reduce(34, 130, 32, 32, "float", clear=False),
+        _tail_reduce_axis0(34, 130, 32, 32, "float"),
+        _tail_reduce(34, 130, 32, 32, "float16"),
+    ],
+    ids=["reduce_max", "reduce_sum_clear_false", "reduce_sum_axis0", "float16"],
+)
+def test_unsupported_tail_reduce_contracts_fall_back(func):
+    src = _source(func, target="ascendc")
+    assert "tl::ascend::tail_reduce" not in src, src
+
+
+def test_tail_reduce_flag_off_emits_no_tail_helper():
+    src = _source(
+        _tail_reduce(34, 130, 32, 32, "float"), target="ascendc", tail_mask=False
+    )
+    assert "tl::ascend::tail_reduce" not in src, src
 
 
 @pytest.mark.parametrize("target", ["ascendc", "pto"])

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -251,22 +251,27 @@ def test_tail_scalar_emits_tail_helper(target):
 
 
 @pytest.mark.parametrize("kind", ["sum", "max", "min"])
-@pytest.mark.parametrize("axis", [-1, 0])
-def test_tail_reduce_float32_emits_ascendc_helper(kind, axis):
-    func = _tail_reduce(34, 130, 32, 32, "float", kind=kind) if axis == -1 else _tail_reduce_axis0(34, 130, 32, 32, "float", kind=kind)
+def test_tail_reduce_float32_axis0_emits_ascendc_helper(kind):
+    func = _tail_reduce_axis0(34, 130, 32, 32, "float", kind=kind)
     src = _source(func, target="ascendc")
     assert f"tl::ascend::tail_reduce_{kind}" in src, src
 
 
-def test_tail_reduce_propagates_non_reduced_axis_tail():
+@pytest.mark.parametrize("kind", ["sum", "max", "min"])
+def test_tail_reduce_float32_last_axis_uses_native_path(kind):
+    src = _source(_tail_reduce(34, 130, 32, 32, "float", kind=kind), target="ascendc")
+    assert "tl::ascend::tail_reduce" not in src, src
+
+
+def test_native_last_axis_reduce_clears_downstream_tail_state():
     src = _source(_tail_reduce_then_unary(34, 130, 32, 32), target="ascendc")
-    assert "tl::ascend::tail_reduce_sum" in src, src
-    assert "tl::ascend::tail_unary" in src, src
+    assert "tl::ascend::tail_reduce" not in src, src
+    assert "tl::ascend::tail_unary" not in src, src
 
 
-def test_tail_reduce_eliminates_reduced_axis_only_tail():
+def test_native_last_axis_reduce_with_column_tail_stays_native():
     src = _source(_tail_reduce_then_unary(32, 130, 32, 32), target="ascendc")
-    assert "tl::ascend::tail_reduce_sum" in src, src
+    assert "tl::ascend::tail_reduce" not in src, src
     assert "tl::ascend::tail_unary" not in src, src
 
 

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -56,7 +56,9 @@ def _tail_add(M, N, block_M, block_N, dtype="float"):
     return main
 
 
-def _tail_reduce(M, N, block_M, block_N, dtype="float", kind="sum", clear=True):
+def _tail_reduce(
+    M, N, block_M, block_N, dtype="float", kind="sum", clear=True
+):
     m_num = T.ceildiv(M, block_M)
     n_num = T.ceildiv(N, block_N)
     reduce_fn = {
@@ -82,9 +84,71 @@ def _tail_reduce(M, N, block_M, block_N, dtype="float", kind="sum", clear=True):
     return main
 
 
-def _tail_reduce_axis0(M, N, block_M, block_N, dtype="float"):
+def _tail_reduce_real_shape(M, N, block_M, block_N, dtype="float"):
     m_num = T.ceildiv(M, block_M)
     n_num = T.ceildiv(N, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((m_num * n_num, block_M), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+            r_ub = T.alloc_ub((block_M,), dtype)
+            T.copy(
+                A[
+                    bx * block_M : (bx + 1) * block_M,
+                    by * block_N : (by + 1) * block_N,
+                ],
+                a_ub,
+            )
+            T.reduce_sum(a_ub, r_ub, dim=-1, real_shape=[block_M, block_N - 1])
+            T.copy(r_ub, B[cid, :])
+
+    return main
+
+
+def _tail_reduce_then_unary(M, N, block_M, block_N, dtype="float"):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, n_num), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+            r_ub = T.alloc_ub((block_M, 1), dtype)
+            o_ub = T.alloc_ub((block_M, 1), dtype)
+            T.copy(
+                A[
+                    bx * block_M : (bx + 1) * block_M,
+                    by * block_N : (by + 1) * block_N,
+                ],
+                a_ub,
+            )
+            T.reduce_sum(a_ub, r_ub, dim=-1)
+            T.tile.exp(o_ub, r_ub)
+            T.copy(o_ub, B[bx * block_M : (bx + 1) * block_M, by : by + 1])
+
+    return main
+
+
+def _tail_reduce_axis0(M, N, block_M, block_N, dtype="float", kind="sum"):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+
+    reduce_fn = {
+        "sum": T.reduce_sum,
+        "max": T.reduce_max,
+        "min": T.reduce_min,
+    }[kind]
 
     @T.prim_func
     def main(
@@ -97,7 +161,7 @@ def _tail_reduce_axis0(M, N, block_M, block_N, dtype="float"):
             a_ub = T.alloc_ub((block_M, block_N), dtype)
             r_ub = T.alloc_ub((1, block_N), dtype)
             T.copy(A[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N], a_ub)
-            T.reduce_sum(a_ub, r_ub, dim=0)
+            reduce_fn(a_ub, r_ub, dim=0)
             T.copy(r_ub, B[bx : bx + 1, by * block_N : (by + 1) * block_N])
 
     return main
@@ -188,9 +252,37 @@ def test_tail_scalar_emits_tail_helper(target):
     assert _emit_marker(target, "scalar") in src, src
 
 
-def test_tail_reduce_sum_last_axis_emits_ascendc_helper():
-    src = _source(_tail_reduce(34, 130, 32, 32, "float"), target="ascendc")
+@pytest.mark.parametrize("kind", ["sum", "max", "min"])
+@pytest.mark.parametrize("axis", [-1, 0])
+def test_tail_reduce_float32_emits_ascendc_helper(kind, axis):
+    func = (
+        _tail_reduce(34, 130, 32, 32, "float", kind=kind)
+        if axis == -1
+        else _tail_reduce_axis0(34, 130, 32, 32, "float", kind=kind)
+    )
+    src = _source(func, target="ascendc")
+    assert f"tl::ascend::tail_reduce_{kind}" in src, src
+
+
+def test_tail_reduce_propagates_non_reduced_axis_tail():
+    src = _source(_tail_reduce_then_unary(34, 130, 32, 32), target="ascendc")
     assert "tl::ascend::tail_reduce_sum" in src, src
+    assert "tl::ascend::tail_unary" in src, src
+
+
+def test_tail_reduce_eliminates_reduced_axis_only_tail():
+    src = _source(_tail_reduce_then_unary(32, 130, 32, 32), target="ascendc")
+    assert "tl::ascend::tail_reduce_sum" in src, src
+    assert "tl::ascend::tail_unary" not in src, src
+
+
+def test_unsupported_reduce_clears_downstream_tail_state():
+    src = _source(
+        _tail_reduce_then_unary(34, 130, 32, 32, dtype="float16"),
+        target="ascendc",
+    )
+    assert "tl::ascend::tail_reduce" not in src, src
+    assert "tl::ascend::tail_unary" not in src, src
 
 
 def test_tail_reduce_sum_not_rewritten_for_pto():
@@ -201,12 +293,11 @@ def test_tail_reduce_sum_not_rewritten_for_pto():
 @pytest.mark.parametrize(
     "func",
     [
-        _tail_reduce(34, 130, 32, 32, "float", kind="max"),
         _tail_reduce(34, 130, 32, 32, "float", clear=False),
-        _tail_reduce_axis0(34, 130, 32, 32, "float"),
         _tail_reduce(34, 130, 32, 32, "float16"),
+        _tail_reduce_real_shape(34, 130, 32, 32, "float"),
     ],
-    ids=["reduce_max", "reduce_sum_clear_false", "reduce_sum_axis0", "float16"],
+    ids=["reduce_sum_clear_false", "float16", "explicit_real_shape"],
 )
 def test_unsupported_tail_reduce_contracts_fall_back(func):
     src = _source(func, target="ascendc")

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -56,9 +56,7 @@ def _tail_add(M, N, block_M, block_N, dtype="float"):
     return main
 
 
-def _tail_reduce(
-    M, N, block_M, block_N, dtype="float", kind="sum", clear=True
-):
+def _tail_reduce(M, N, block_M, block_N, dtype="float", kind="sum", clear=True):
     m_num = T.ceildiv(M, block_M)
     n_num = T.ceildiv(N, block_N)
     reduce_fn = {
@@ -255,11 +253,7 @@ def test_tail_scalar_emits_tail_helper(target):
 @pytest.mark.parametrize("kind", ["sum", "max", "min"])
 @pytest.mark.parametrize("axis", [-1, 0])
 def test_tail_reduce_float32_emits_ascendc_helper(kind, axis):
-    func = (
-        _tail_reduce(34, 130, 32, 32, "float", kind=kind)
-        if axis == -1
-        else _tail_reduce_axis0(34, 130, 32, 32, "float", kind=kind)
-    )
+    func = _tail_reduce(34, 130, 32, 32, "float", kind=kind) if axis == -1 else _tail_reduce_axis0(34, 130, 32, 32, "float", kind=kind)
     src = _source(func, target="ascendc")
     assert f"tl::ascend::tail_reduce_{kind}" in src, src
 
@@ -305,9 +299,7 @@ def test_unsupported_tail_reduce_contracts_fall_back(func):
 
 
 def test_tail_reduce_flag_off_emits_no_tail_helper():
-    src = _source(
-        _tail_reduce(34, 130, 32, 32, "float"), target="ascendc", tail_mask=False
-    )
+    src = _source(_tail_reduce(34, 130, 32, 32, "float"), target="ascendc", tail_mask=False)
     assert "tl::ascend::tail_reduce" not in src, src
 
 

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -71,11 +71,12 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
     # Propagate UB tail valid-regions and rewrite unary/binary/scalar ops to
     # tail-aware variants (must run before passes that reorder copy/vector ops).
     # The pass self-gates on TL_ASCEND_TAIL_MASK (default off) and is a no-op
-    # otherwise, so non-tail kernels are unaffected. Reduce is NOT rewritten for
-    # now (the tail_reduce ReduceSum<AR> path has an output-layout bug); it stays
-    # on the full-tile + pad_value path, revisited in batch 2 with
-    # compare/select/broadcast tail support.
-    mod = tilelang.transform.AscendTailMaskPropagation(rewrite_reduce=False)(mod)
+    # otherwise, so non-tail kernels are unaffected. Reduce rewrite is enabled
+    # only for the AscendC backend; the pass itself keeps a strict allow-list for
+    # reduce_sum over the last axis. PTO and all other reduce forms stay on the
+    # established full-tile + pad_value path.
+    rewrite_reduce = target.model == "ascendc" or target.model == "auto"
+    mod = tilelang.transform.AscendTailMaskPropagation(rewrite_reduce=rewrite_reduce)(mod)
     # Erase manual workspace allocations for virtual CV copy in Ascend
     mod = tilelang.transform.AscendWorkspaceReduction()(mod)
     # Legalize vectorized loops to ensure they are valid

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -68,13 +68,14 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.CollectBufferShapes()(mod)
     # Lower high-level tile operations to low-level operations
     mod = tilelang.transform.LowerTileOp()(mod)
-    # Propagate UB tail valid-regions and rewrite unary/binary/scalar ops to
-    # tail-aware variants (must run before passes that reorder copy/vector ops).
+    # Propagate UB tail valid-regions and rewrite unary/binary/scalar plus the
+    # allow-listed reduce ops to tail-aware variants (must run before passes
+    # that reorder copy/vector ops).
     # The pass self-gates on TL_ASCEND_TAIL_MASK (default off) and is a no-op
     # otherwise, so non-tail kernels are unaffected. Reduce rewrite is enabled
     # only for the AscendC backend; the pass itself keeps a strict allow-list for
-    # reduce_sum over the last axis. PTO and all other reduce forms stay on the
-    # established full-tile + pad_value path.
+    # float32 sum/max/min over either 2D axis. PTO and all other reduce forms
+    # stay on the established full-tile + pad_value path.
     rewrite_reduce = target.model == "ascendc" or target.model == "auto"
     mod = tilelang.transform.AscendTailMaskPropagation(rewrite_reduce=rewrite_reduce)(mod)
     # Erase manual workspace allocations for virtual CV copy in Ascend

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -74,8 +74,8 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
     # The pass self-gates on TL_ASCEND_TAIL_MASK (default off) and is a no-op
     # otherwise, so non-tail kernels are unaffected. Reduce rewrite is enabled
     # only for the AscendC backend; the pass itself keeps a strict allow-list for
-    # float32 sum/max/min over either 2D axis. PTO and all other reduce forms
-    # stay on the established full-tile + pad_value path.
+    # float32 sum/max/min over axis 0 of a 2D tile. PTO, last-axis reduction, and
+    # all other reduce forms stay on the established full-tile + pad_value path.
     rewrite_reduce = target.model == "ascendc" or target.model == "auto"
     mod = tilelang.transform.AscendTailMaskPropagation(rewrite_reduce=rewrite_reduce)(mod)
     # Erase manual workspace allocations for virtual CV copy in Ascend


### PR DESCRIPTION
> **Draft / Depends on #1271**
>
> This PR extends the vector tail-block valid-region propagation framework
> introduced in #1271 with guarded reduction support.
>
> Since #1271 has not yet been merged into `ascendc_pto`, the current stacked
> diff temporarily includes the rebased base-framework commit from #1271.
> The actual Reduce extension is contained in the last two commits.
>
> After #1271 is merged, this branch will be rebased onto the latest
> `ascendc_pto` so that the final diff contains only the Reduce extension.

## What

Extend the vector tail-block valid-region scheme introduced in #1271 to safely
support tail-aware reductions on the AscendC backend.

The propagation flow is:

`copy_gm_to_ub`
→ records the valid `[row, col]` rectangle on the source UB buffer  
→ `AscendTailMaskPropagation::RewriteReduce` validates the reduction contract  
→ transforms the input valid region into the reduced output valid region  
→ rewrites the operation to `tl.ascend_tail_reduce`  
→ AscendC codegen emits the corresponding tail-aware reduction helper.

The output valid region is transformed according to the reduction axis:

- axis `0 / -2`: `[valid_row, valid_col] -> [1, valid_col]`
- axis `1 / -1`: `[valid_row, valid_col] -> [valid_row, 1]`

This allows a tail on the non-reduced axis to continue propagating to
downstream unary, binary, and scalar operations, while a tail that only exists
on the reduced axis is eliminated after reduction.

## Scope

Supported on the AscendC backend:

- `reduce_sum`
- `reduce_max`
- `reduce_min`
- 2D UB tiles
- `float32` input and output
- `clear=true`
- axis `0 / -2 / 1 / -1`

The rewrite is enabled only when the physical UB shape, encoded reduction
shape, output extent, reduction axis, and propagated valid-region expression
can all be proven safe.

Unsupported or unproven cases conservatively fall back to the existing native
reduction path, including:

- PTO backend
- `float16` and `bfloat16`
- `clear=false`
- unsupported axes or layouts
- explicit or dynamic `real_shape` that cannot be proven equal to the physical
  tile shape
- unsupported valid-region expressions

For unsupported reductions, the propagated output tail state is cleared to
prevent downstream operations from being incorrectly rewritten.

## Implementation

The actual Reduce extension is contained in:

- `2d4f4f97` — enable constrained tail `reduce_sum` rewriting
- `90d526f6` — complete guarded propagation for `sum / max / min`

The first commit:

- `27abb9a2` — rebased base framework from #1271

is temporarily included only because #1271 is not yet present in the target
branch.

This branch is based on the latest upstream `ascendc_pto`.

## Validation

- `git diff --check`: passed
- Clean working tree: passed
- Host-side lowering/codegen coverage added for:
  - `sum / max / min`
  - axis `0` and last-axis reduction
  - output tail propagation to downstream unary operations
  - elimination of a tail that only exists on the reduced axis
  - conservative fallback for unsupported reduction contracts
  - disabled `TL_ASCEND_TAIL_MASK` behavior
- AscendC NPU precision tests are added for supported reduction cases
- NPU execution status: pending in the current development environment