### PR TITLE
[Fix] Support rank-zero sources in Ascend T.copy

### DIFF
--- a/testing/python/language/test_tilelang_ascend_language_scalar_copy.py
+++ b/testing/python/language/test_tilelang_ascend_language_scalar_copy.py
@@ -1,0 +1,86 @@
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tvm
+
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    tilelang.cache.clear_cache()
+    yield
+
+
+def scalar_copy(dtype):
+    @T.prim_func
+    def main(
+        A: T.Tensor((), dtype),
+        B: T.Tensor((1, 32), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (_cid, _vid):
+            scalar_ub = T.alloc_ub((1,), dtype)
+            output_ub = T.alloc_ub((1, 32), dtype)
+
+            T.copy(A, scalar_ub)
+            T.tile.fill(output_ub, 0)
+            output_ub[0, 0] = scalar_ub[0]
+            T.copy(output_ub, B)
+
+    return main
+
+
+def mismatched_scalar_copy():
+    @T.prim_func
+    def main(A: T.Tensor((2,), "float32")):
+        with T.Kernel(1, is_npu=True) as (_cid, _vid):
+            scalar_ub = T.alloc_ub((1,), "float32")
+            T.copy(A, scalar_ub)
+
+    return main
+
+
+@pytest.mark.parametrize("dtype", ["float16", "float32"])
+def test_scalar_copy(dtype):
+    func = tilelang.compile(
+        scalar_copy(dtype),
+        out_idx=[],
+        pass_configs=PASS_CONFIGS,
+        target="ascendc",
+    )
+
+    a = torch.tensor(2, dtype=getattr(torch, dtype), device="npu")
+    b = torch.empty((1, 32), dtype=getattr(torch, dtype), device="npu")
+    func(a, b)
+    torch.npu.synchronize()
+
+    expected = torch.zeros((1, 32), dtype=getattr(torch, dtype), device="npu")
+    expected[0, 0] = a
+    torch.testing.assert_close(b, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("dtype", ["float16", "float32"])
+def test_scalar_copy_codegen(dtype, target):
+    with tvm.transform.PassContext(opt_level=3, config=PASS_CONFIGS):
+        artifact = tilelang.lower(scalar_copy(dtype), target=target)
+
+    assert "scalar_ub.SetValue(0" in artifact.kernel_source
+    assert "copy_gm_to_ub" not in artifact.kernel_source
+
+
+def test_scalar_copy_rejects_mismatched_shape():
+    with pytest.raises(tvm.error.DiagnosticError):
+        mismatched_scalar_copy()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -50,7 +50,7 @@ from .allocate import (
     alloc_L1,  # noqa: F401
     alloc_ub,  # noqa: F401
 )
-from .copy import copy, c2d_im2col, npu_copy_v2 as copy  # noqa: F401, F811
+from .copy_op import copy, c2d_im2col, npu_copy_v2 as copy  # noqa: F401, F811
 from .gemm import GemmWarpPolicy, gemm  # noqa: F401
 
 # from .fill import fill, clear  # noqa: F401

--- a/tilelang/language/copy_op.py
+++ b/tilelang/language/copy_op.py
@@ -79,6 +79,24 @@ def buffer_region_to_tile_region(buffer_region: tir.BufferRegion, access_type: s
     return region(T.BufferLoad(buffer_region.buffer, mins), access_type, *region_extents)
 
 
+def _copy_rank_zero_source(src, dst) -> bool:
+    """Copy a rank-zero source through scalar load and store operations."""
+    if isinstance(src, tir.Var) and T.has_let_value(src):
+        src = T.get_let_value(src)
+    if isinstance(dst, tir.Var) and T.has_let_value(dst):
+        dst = T.get_let_value(dst)
+    if not isinstance(src, tir.Buffer) or not isinstance(dst, tir.Buffer):
+        return False
+    if len(src.shape) != 0 or dst.scope() != "shared.ub":
+        return False
+
+    src = src.get_flattened_buffer()
+    dst = dst.get_flattened_buffer() if len(dst.shape) == 0 else dst
+    ir.assert_structural_equal(src.shape, dst.shape)
+    T.buffer_store(dst, tir.BufferLoad(src, [0]), [0])
+    return True
+
+
 def copy(
     src: tir.Buffer | tir.BufferLoad | tir.BufferRegion,
     dst: tir.Buffer | tir.BufferLoad,
@@ -217,6 +235,9 @@ def npu_copy_v2(
     Returns:
         tir.Call: A handle to the copy operation
     """
+    if not enable_relu and not transpose and pad_value is None and _copy_rank_zero_source(src, dst):
+        return None
+
     if isinstance(src, tir.Buffer) and isinstance(dst, tir.Buffer) and not transpose:
         ir.assert_structural_equal(src.shape, dst.shape)
 


### PR DESCRIPTION
## Summary

- lower default whole-buffer rank-zero sources copied to UB through scalar load/store operations
- preserve strict shape validation and leave all non-scalar DMA paths unchanged
- add real-NPU, dual-codegen, and mismatched-shape regression coverage

## Motivation

`T.copy` rejected a scalar `T.Tensor(())` source when the destination was a one-element UB buffer because `[]` and `[1]` failed structural equality. Merely flattening the source allows lowering, but emits a one-element DMA configuration that is invalid on Ascend hardware. The scalar path therefore uses the source buffer's one-element flat view and emits a scalar store into UB.

## Validation

- full CMake build with Ascend enabled against the latest `ascendc_pto` base
- `7 passed` in `test_tilelang_ascend_language_scalar_copy.py`
  - AscendC real-NPU execution for float16 and float32
  - AscendC and PTO lowering/codegen for float16 and float32
  - `(2,) -> (1,)` mismatch remains rejected
- existing float16 GM-to-UB-to-GM AscendC regression passed
- original Task 68 rank-zero epilogue passed on real NPU at shape `(128, 16384)` with max absolute error `0.0`
- Ruff check/format and `git diff --check` passed
