### PR TITLE
[Fix] Support rank-zero sources in Ascend T.copy

### DIFF
--- a/testing/python/language/test_tilelang_ascend_language_scalar_copy.py
+++ b/testing/python/language/test_tilelang_ascend_language_scalar_copy.py
@@ -1,0 +1,86 @@
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tvm
+
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    tilelang.cache.clear_cache()
+    yield
+
+
+def scalar_copy(dtype):
+    @T.prim_func
+    def main(
+        A: T.Tensor((), dtype),
+        B: T.Tensor((1, 32), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (_cid, _vid):
+            scalar_ub = T.alloc_ub((1,), dtype)
+            output_ub = T.alloc_ub((1, 32), dtype)
+
+            T.copy(A, scalar_ub)
+            T.tile.fill(output_ub, 0)
+            output_ub[0, 0] = scalar_ub[0]
+            T.copy(output_ub, B)
+
+    return main
+
+
+def mismatched_scalar_copy():
+    @T.prim_func
+    def main(A: T.Tensor((2,), "float32")):
+        with T.Kernel(1, is_npu=True) as (_cid, _vid):
+            scalar_ub = T.alloc_ub((1,), "float32")
+            T.copy(A, scalar_ub)
+
+    return main
+
+
+@pytest.mark.parametrize("dtype", ["float16", "float32"])
+def test_scalar_copy(dtype):
+    func = tilelang.compile(
+        scalar_copy(dtype),
+        out_idx=[],
+        pass_configs=PASS_CONFIGS,
+        target="ascendc",
+    )
+
+    a = torch.tensor(2, dtype=getattr(torch, dtype), device="npu")
+    b = torch.empty((1, 32), dtype=getattr(torch, dtype), device="npu")
+    func(a, b)
+    torch.npu.synchronize()
+
+    expected = torch.zeros((1, 32), dtype=getattr(torch, dtype), device="npu")
+    expected[0, 0] = a
+    torch.testing.assert_close(b, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("dtype", ["float16", "float32"])
+def test_scalar_copy_codegen(dtype, target):
+    with tvm.transform.PassContext(opt_level=3, config=PASS_CONFIGS):
+        artifact = tilelang.lower(scalar_copy(dtype), target=target)
+
+    assert "scalar_ub.SetValue(0" in artifact.kernel_source
+    assert "copy_gm_to_ub" not in artifact.kernel_source
+
+
+def test_scalar_copy_rejects_mismatched_shape():
+    with pytest.raises(tvm.error.DiagnosticError):
+        mismatched_scalar_copy()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tilelang/language/ascend.py
+++ b/tilelang/language/ascend.py
@@ -1,11 +1,46 @@
 from __future__ import annotations
 import tilelang.language as T
-from tvm.tir import PrimExpr, Buffer, BufferRegion, Var
+from tvm.tir import PrimExpr, Buffer, BufferLoad, BufferRegion, Var
 from typing import Union, Literal  # noqa: F401, UP035
-from tvm import tir
+from tvm import ir, tir
 
 
 _pipe = Literal["fix", "mte1", "mte2", "mte3", "m", "v", "s"]
+_npu_copy_v2 = T.copy
+
+
+def _copy_rank_zero_source(src, dst) -> bool:
+    """Copy a rank-zero source through scalar load and store operations."""
+    if isinstance(src, Var) and T.has_let_value(src):
+        src = T.get_let_value(src)
+    if isinstance(dst, Var) and T.has_let_value(dst):
+        dst = T.get_let_value(dst)
+    if not isinstance(src, Buffer) or not isinstance(dst, Buffer):
+        return False
+    if len(src.shape) != 0 or dst.scope() != "shared.ub":
+        return False
+
+    src = src.get_flattened_buffer()
+    dst = dst.get_flattened_buffer() if len(dst.shape) == 0 else dst
+    ir.assert_structural_equal(src.shape, dst.shape)
+    T.buffer_store(dst, tir.BufferLoad(src, [0]), [0])
+    return True
+
+
+def copy(
+    src: Buffer | BufferLoad | BufferRegion,
+    dst: Buffer | BufferLoad,
+    enable_relu: bool = False,
+    transpose: bool | None = False,
+    pad_value: float | int | PrimExpr | None = None,
+    tmp: Buffer | BufferLoad | None = None,
+):
+    """Copy data on Ascend, using scalar operations for rank-zero sources."""
+    if not enable_relu and not transpose and pad_value is None and _copy_rank_zero_source(src, dst):
+        return None
+    if tmp is not None:
+        return _npu_copy_v2(src, dst, enable_relu, transpose, pad_value, tmp)
+    return _npu_copy_v2(src, dst, enable_relu, transpose, pad_value)
 
 
 def _dtype(buf):


### PR DESCRIPTION
## Summary

- add an Ascend copy override that lowers default whole-buffer rank-zero sources copied to UB through scalar load/store operations
- delegate every non-scalar path and option to the existing copy implementation, including the latest `tmp` argument
- add real-NPU, dual-codegen, and mismatched-shape regression coverage

## Motivation

`T.copy` rejected a scalar `T.Tensor(())` source when the destination was a one-element UB buffer because `[]` and `[1]` failed structural equality. Merely flattening the source allows lowering, but emits a one-element DMA configuration that is invalid on Ascend hardware. The scalar path therefore uses the source buffer's one-element flat view and emits a scalar store into UB.

## Validation

- full CMake build with Ascend enabled against the latest `ascendc_pto` base
- clean three-way merge with the latest base
- `7 passed` in `test_tilelang_ascend_language_scalar_copy.py` on the merged tree
  - AscendC real-NPU execution for float16 and float32
  - AscendC and PTO lowering/codegen for float16 and float32
  - `(2,) -> (1,)` mismatch remains rejected
- existing float16 GM-to-UB-to-GM AscendC regression passed
- original Task 68 rank-zero epilogue passed on real NPU at shape `(128, 16384)` with max absolute error `0.0`
- Ruff check/format and `git diff --check` passed
