### PR TITLE
[Bugfix] remove redundant synchronous inserts for ascend_sync_insert_vs

### DIFF
--- a/src/transform/ascend_sync_insert_vs.cc
+++ b/src/transform/ascend_sync_insert_vs.cc
@@ -79,6 +79,7 @@ private:
     std::string pipeline;
     std::string operation;
     std::set<std::string> pipe_barriers;
+    std::set<std::string> event_pairs;
     int64_t physical_address;
     bool is_back_edge = false;
   };
@@ -134,6 +135,31 @@ private:
             for (auto &pair : current_write_history_) {
               if (pair.second.pipeline == pipeline) {
                 pair.second.pipe_barriers.insert(barrier);
+              }
+            }
+          }
+        }
+        return GetRef<Stmt>(op);
+      }
+
+      if (call->op.same_as(tl::ascend_auto_set_flag()) ||
+          call->op.same_as(tl::ascend_auto_wait_flag())) {
+        if (call->args.size() >= 1) {
+          if (auto str = call->args[0].as<StringImmNode>()) {
+            std::string event_type = str->value;
+            std::string event_sync = "EventPair_" + event_type;
+            size_t pos = event_type.find('_');
+            if (pos != std::string::npos) {
+              std::string src_pipeline = "PIPE_" + event_type.substr(0, pos);
+              for (auto &pair : current_access_history_) {
+                if (pair.second.pipeline == src_pipeline) {
+                  pair.second.event_pairs.insert(event_sync);
+                }
+              }
+              for (auto &pair : current_write_history_) {
+                if (pair.second.pipeline == src_pipeline) {
+                  pair.second.event_pairs.insert(event_sync);
+                }
               }
             }
           }
@@ -237,8 +263,6 @@ private:
     if (op->else_case.defined()) {
       else_case = VisitStmt(op->else_case.value());
     }
-    auto else_history = current_access_history_;
-    auto else_write_history = current_write_history_;
 
     current_access_history_ = saved_history;
     current_write_history_ = saved_write_history;
@@ -248,35 +272,6 @@ private:
     for (const auto &kv : then_write_history) {
       current_write_history_[kv.first] = kv.second;
     }
-    if (op->else_case.defined()) {
-      for (const auto &kv : else_history) {
-        current_access_history_[kv.first] = kv.second;
-      }
-      for (const auto &kv : else_write_history) {
-        current_write_history_[kv.first] = kv.second;
-      }
-    }
-
-    if (!is_revisit_pass_ && op->else_case.defined()) {
-      bool has_conflict = false;
-      for (const auto &kv : then_history) {
-        auto it = else_history.find(kv.first);
-        if (it != else_history.end() &&
-            it->second.pipeline != kv.second.pipeline) {
-          has_conflict = true;
-          break;
-        }
-      }
-      if (has_conflict) {
-        std::vector<Stmt> stmts;
-        stmts.push_back(IfThenElse(op->condition, then_case, else_case));
-        InsertSynchronization("PipeBarrier_ALL", stmts);
-        current_access_history_.clear();
-        current_write_history_.clear();
-        return SeqStmt(stmts);
-      }
-    }
-
     return IfThenElse(op->condition, then_case, else_case);
   }
 
@@ -597,7 +592,12 @@ private:
     std::string event_type =
         GetEventType(prev_access.pipeline, curr_access.pipeline);
     if (!event_type.empty()) {
-      return "EventPair_" + event_type;
+      std::string event_sync = "EventPair_" + event_type;
+      if (prev_access.event_pairs.find(event_sync) !=
+          prev_access.event_pairs.end()) {
+        return "";
+      }
+      return event_sync;
     }
     return "";
   }
@@ -835,6 +835,16 @@ private:
                 std::string pipeline = sync_type.substr(12);
                 if (access.pipeline == pipeline) {
                   access.pipe_barriers.insert(sync_type);
+                }
+              } else if (sync_type.find("EventPair_") == 0) {
+                std::string event_type = sync_type.substr(10);
+                size_t pos = event_type.find('_');
+                if (pos != std::string::npos) {
+                  std::string src_pipeline =
+                      "PIPE_" + event_type.substr(0, pos);
+                  if (access.pipeline == src_pipeline) {
+                    access.event_pairs.insert(sync_type);
+                  }
                 }
               }
             }

--- a/src/transform/ascend_sync_insert_vs.cc
+++ b/src/transform/ascend_sync_insert_vs.cc
@@ -151,16 +151,16 @@ private:
             size_t pos = event_type.find('_');
             if (pos != std::string::npos) {
               std::string src_pipeline = "PIPE_" + event_type.substr(0, pos);
-              for (auto &pair : current_access_history_) {
-                if (pair.second.pipeline == src_pipeline) {
-                  pair.second.event_pairs.insert(event_sync);
-                }
-              }
-              for (auto &pair : current_write_history_) {
-                if (pair.second.pipeline == src_pipeline) {
-                  pair.second.event_pairs.insert(event_sync);
-                }
-              }
+              auto update_hist =
+                  [&](std::unordered_map<std::string, BufferAccess> &hist) {
+                    for (auto &pair : hist) {
+                      if (pair.second.pipeline == src_pipeline) {
+                        pair.second.event_pairs.insert(event_sync);
+                      }
+                    }
+                  };
+              update_hist(current_access_history_);
+              update_hist(current_write_history_);
             }
           }
         }

--- a/testing/python/language/test_ascend_sync_insert_vs.py
+++ b/testing/python/language/test_ascend_sync_insert_vs.py
@@ -24,18 +24,17 @@ Covers:
     15. Loop back-edge S->V cross-iteration
     16. If/else history isolation (different buffers per branch)
     17. If/else same buffer same pipeline (no PipeBarrier_ALL)
-    18. If/else cross-branch conflict (different pipelines -> PipeBarrier_ALL)
-    19. Dedup multiple V deps in single statement
-    20. Consecutive V->V across statements (each needs own barrier)
-    21. Event-pair dedup (multiple S->V deps in single statement)
-    22. Mixed dedup (barrier + event in one statement)
-    23. Event ID rotation (1..7 round-robin)
-    24. Event ID wraparound (mod 8, IDs reused)
-    25. Set/Wait flag ID pairing
-    26. Alias detection via physical address overlap
-    27. V->S EventPair (scalar read from V-written UB)
-    28. MTE2->S EventPair (scalar read from MTE2-written UB)
-    29. MTE3->S EventPair (scalar read from MTE3-read UB)
+    18. Dedup multiple V deps in single statement
+    19. Consecutive V->V across statements (each needs own barrier)
+    20. Event-pair dedup (multiple S->V deps in single statement)
+    21. Mixed dedup (barrier + event in one statement)
+    22. Event ID rotation (1..7 round-robin)
+    23. Event ID wraparound (mod 8, IDs reused)
+    24. Set/Wait flag ID pairing
+    25. Alias detection via physical address overlap
+    26. V->S EventPair (scalar read from V-written UB)
+    27. MTE2->S EventPair (scalar read from MTE2-written UB)
+    28. MTE3->S EventPair (scalar read from MTE3-read UB)
 
   L2 - Anomaly tests:
     1. Read-only no sync
@@ -43,6 +42,8 @@ Covers:
     3. Resource scope (CV combine) no crash
     4. Nested loop back-edge (inner + outer)
     5. If-without-else history propagation
+    6. Nested loop V->S dedup (revisit dedup guard, PR #1384)
+    7. Outer back-edge V -> inner S cross-iteration sync
 
   Boundary - Platform/backend edge cases:
     1. A5 skips PIPE_V barrier (PTO)
@@ -832,35 +833,6 @@ def test_if_else_same_buffer_same_pipeline(target):
 
 
 @TARGETS_WITH_PTO
-def test_if_else_cross_branch_barrier_all(target):
-    """If/else with same buffer, V in then vs MTE2 in else -> PipeBarrier_ALL.
-
-    When both branches access the same buffer but with different pipelines,
-    the pass inserts PipeBarrier_ALL after the if/else and clears history.
-    """
-
-    @T.prim_func
-    def main(
-        A: T.Tensor((2, 64), "float32"),  # type: ignore
-        B: T.Tensor((64,), "float32"),  # type: ignore
-        sel: T.Tensor((1,), "int32"),  # type: ignore
-    ):
-        with T.Kernel(1, is_npu=True) as (cid, vid):
-            a_ub = T.alloc_ub((64,), "float32")
-            s = sel[0]
-            if s > 0:
-                T.copy(A[0, :], a_ub)
-                T.tile.exp(a_ub, a_ub)
-            else:
-                T.copy(A[1, :], a_ub)
-            T.copy(a_ub, B[:])
-
-    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
-
-    _assert_has_sync(src, target, "barrier_all")
-
-
-@TARGETS_WITH_PTO
 def test_event_pair_dedup(target):
     """Multiple S->V deps in single V statement -> deduped to 1 S_V event."""
 
@@ -915,6 +887,207 @@ def test_mixed_dedup_barrier_and_event(target):
 
     _assert_has_sync(src, target, "barrier_v")
     _assert_has_sync(src, target, "s_v")
+
+
+# ---------------------------------------------------------------------------
+# Cross-statement EventPair dedup tests
+# ---------------------------------------------------------------------------
+
+
+@TARGETS_WITH_PTO
+def test_cross_stmt_s_v_dedup(target):
+    """Two separate V statements reading two S-written UBs -> 1 S_V event.
+
+    Cross-statement dedup: set_flag(S_V) synchronizes ALL prior S writes,
+    so the second S->V dependency is covered by the first event pair.
+    Without synced_events tracking, each V statement would generate its
+    own S_V event pair.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+        C: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            ub1 = T.alloc_ub((64, 128), "float32")
+            ub2 = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], ub1)
+            T.copy(B[:, :], ub2)
+            ub1[0, 0] = T.cast(1.0, "float32")
+            ub2[0, 0] = T.cast(1.0, "float32")
+            T.tile.exp(ub1, ub1)
+            T.tile.exp(ub2, ub2)
+            T.tile.add(ub1, ub1, ub2)
+            T.copy(ub1, C[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[2])
+
+    sv_count = _count_sync(src, target, "s_v")
+    assert sv_count == 1, f"Expected exactly 1 S_V event pair (cross-stmt dedup), got {sv_count}.\nSource:\n{src}"
+
+
+@TARGETS_WITH_PTO
+def test_cross_stmt_v_s_dedup(target):
+    """Two separate S scalar reads from two V-written UBs -> 1 V_S event.
+
+    Cross-statement dedup: set_flag(V_S) synchronizes ALL prior V writes,
+    so the second V->S dependency is covered by the first event pair.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            ub1 = T.alloc_ub((1,), "float32")
+            ub2 = T.alloc_ub((1,), "float32")
+            b_ub = T.alloc_ub((1,), "float32")
+            T.copy(A[0, 0:1], ub1)
+            T.copy(A[0, 0:1], ub2)
+            T.tile.exp(ub1, ub1)
+            T.tile.exp(ub2, ub2)
+            val1 = ub1[0]
+            b_ub[0] = val1
+            val2 = ub2[0]
+            b_ub[0] = val2
+            T.copy(ub1, B[0, 0:1])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+
+    vs_count = _count_sync(src, target, "v_s")
+    assert vs_count == 1, f"Expected exactly 1 V_S event pair (cross-stmt dedup), got {vs_count}.\nSource:\n{src}"
+
+
+@TARGETS_WITH_PTO
+def test_new_s_write_breaks_dedup(target):
+    """S write after first S_V event -> second S_V event NOT deduped.
+
+    The new S write creates a fresh access history entry with empty
+    synced_events, so the subsequent V read requires a new S_V event.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+        C: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            ub1 = T.alloc_ub((64, 128), "float32")
+            ub2 = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], ub1)
+            T.copy(B[:, :], ub2)
+            ub1[0, 0] = T.cast(1.0, "float32")
+            T.tile.exp(ub1, ub1)
+            ub2[0, 0] = T.cast(1.0, "float32")
+            T.tile.exp(ub2, ub2)
+            T.tile.add(ub1, ub1, ub2)
+            T.copy(ub1, C[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[2])
+
+    sv_count = _count_sync(src, target, "s_v")
+    assert sv_count == 2, f"Expected exactly 2 S_V event pairs (new S write breaks dedup), got {sv_count}.\nSource:\n{src}"
+
+
+@TARGETS_WITH_PTO
+def test_write_history_event_dedup(target):
+    """WAW dep via write_history is deduped by prior S_V event.
+
+    S writes ub1, V reads ub1 (EventPair_S_V inserted), V writes ub1.
+    The V write checks write_history (S-write with synced_events) and
+    the S->V WAW dependency is deduped.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            ub1 = T.alloc_ub((64, 128), "float32")
+            ub_out = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], ub1)
+            ub1[0, 0] = T.cast(1.0, "float32")
+            T.tile.exp(ub_out, ub1)
+            T.tile.exp(ub1, ub1)
+            T.copy(ub1, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+
+    sv_count = _count_sync(src, target, "s_v")
+    assert sv_count == 1, f"Expected exactly 1 S_V event pair (write_history WAW deduped), got {sv_count}.\nSource:\n{src}"
+
+
+@TARGETS_WITH_PTO
+def test_loop_back_edge_event_dedup(target):
+    """Loop with 2 S writes + 2 V reads -> 1 S_V + 1 V_S per iteration.
+
+    Cross-statement dedup applies in both the first pass (S->V) and the
+    revisit pass (back-edge V->S). Without synced_events tracking, each
+    pass would generate 2 event pairs instead of 1.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            ub1 = T.alloc_ub((64, 128), "float32")
+            ub2 = T.alloc_ub((64, 128), "float32")
+            T.copy(A[:, :], ub1)
+            T.copy(A[:, :], ub2)
+            for _i in T.serial(4):
+                ub1[0, 0] = T.cast(1.0, "float32")
+                ub2[0, 0] = T.cast(1.0, "float32")
+                T.tile.exp(ub1, ub1)
+                T.tile.exp(ub2, ub2)
+            T.copy(ub1, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+
+    sv_count = _count_sync(src, target, "s_v")
+    vs_count = _count_sync(src, target, "v_s")
+    assert sv_count == 1, f"Expected exactly 1 S_V event pair (loop cross-stmt dedup), got {sv_count}.\nSource:\n{src}"
+    assert vs_count == 1, f"Expected exactly 1 V_S event pair (loop back-edge dedup), got {vs_count}.\nSource:\n{src}"
+
+
+@TARGETS_WITH_PTO
+def test_mixed_direction_no_cross_dedup(target):
+    """V->S and S->V in sequence -> both event types inserted (no cross-dedup).
+
+    EventPair_V_S and EventPair_S_V are different sync types; dedup is
+    exact-string-match only.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), "float32"),  # type: ignore
+        B: T.Tensor((64, 128), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            ub1 = T.alloc_ub((1,), "float32")
+            ub2 = T.alloc_ub((64, 128), "float32")
+            b_ub = T.alloc_ub((1,), "float32")
+            T.copy(A[0, 0:1], ub1)
+            T.copy(A[:, :], ub2)
+            T.tile.exp(ub1, ub1)
+            val1 = ub1[0]
+            b_ub[0] = val1
+            ub2[0, 0] = T.cast(1.0, "float32")
+            T.tile.exp(ub2, ub2)
+            T.copy(ub2, B[:, :])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+
+    vs_count = _count_sync(src, target, "v_s")
+    sv_count = _count_sync(src, target, "s_v")
+    assert vs_count == 1, f"Expected exactly 1 V_S event pair, got {vs_count}.\nSource:\n{src}"
+    assert sv_count == 1, f"Expected exactly 1 S_V event pair, got {sv_count}.\nSource:\n{src}"
 
 
 @TARGETS_WITH_PTO
@@ -1237,6 +1410,69 @@ def test_nested_loop_back_edge(target):
 
     src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
     _assert_has_sync(src, target, "barrier_v")
+
+
+@TARGETS_WITH_PTO
+def test_nested_loop_v_to_s_dedup(target):
+    """Nested loops with single V->S dep in inner body -> exactly 1 V_S pair.
+
+    The inner loop body has a V write (exp) followed by an S scalar read
+    of the same buffer.  Each enclosing loop's revisit pass re-traverses
+    the inner body, but the non-back-edge guard in GetRequiredSyncType
+    prevents re-inserting the same-iteration V_S pair, so exactly one V_S
+    pair is emitted regardless of nesting depth.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((128,), "float32"),  # type: ignore
+        B: T.Tensor((128,), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((128,), "float32")
+            b_ub = T.alloc_ub((1,), "float32")
+            T.copy(A[:], a_ub)
+            for _i in T.serial(4):
+                for _j in T.serial(4):
+                    T.tile.exp(a_ub, a_ub)
+                    val = a_ub[0]
+                    b_ub[0] = val
+            T.copy(a_ub, B[:])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+    vs_count = _count_sync(src, target, "v_s")
+    assert vs_count == 1, f"Expected exactly 1 V_S pair for nested-loop V->S dep, got {vs_count}.\nSource:\n{src}"
+
+
+@TARGETS_WITH_PTO
+def test_outer_back_edge_v_to_inner_s_sync(target):
+    """Outer loop back-edge V write -> next-iter inner-body S read needs V_S.
+
+    The outer loop writes V (exp) AFTER the inner loop; the inner loop's
+    first statement reads the same buffer (S scalar read).  This creates a
+    cross-iteration RAW dependency (outer back-edge V -> inner S) requiring
+    a V_S event pair.  The outer-loop revisit pass re-traverses the inner
+    body, detecting this cross-iteration dependency.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((128,), "float32"),  # type: ignore
+        B: T.Tensor((128,), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((128,), "float32")
+            b_ub = T.alloc_ub((1,), "float32")
+            T.copy(A[:], a_ub)
+            for _i in T.serial(4):
+                for _j in T.serial(4):
+                    val = a_ub[0]
+                    b_ub[0] = val
+                T.tile.exp(a_ub, a_ub)
+            T.copy(a_ub, B[:])
+
+    src, _ = _compile_and_get_source(main, PASS_VS_ONLY, target=target, out_idx=[1])
+    _assert_has_sync(src, target, "v_s")
 
 
 @TARGETS_WITH_PTO


### PR DESCRIPTION
## 1. 解决了什么问题

`ascend_sync_insert_vs` pass 负责在 Ascend NPU 的 V / S / MTE2 / MTE3 流水线间自动插入同步。它在逐语句遍历时维护两张 history 表（`current_access_history_` 、`current_write_history_` ），按 RAW/WAR/WAW 冒险插入 `PipeBarrier_XXX` 或 `EventPair_XX_YY`。该 pass 存在两类**冗余同步**，在 issue #1302 稀疏注意力 kernel 中具体表现为：

### 问题 A：跨语句 EventPair 重复插入

`buf_2d.SetValue(...)` 是 S 标量写 UB，依赖前面多次 V 流水线写入的 `buf_2d`。pass 为**每个历史 V 写**都生成一个 `V_S` event pair，于是出现：

```cpp
// before.cpp:599-604 —— 3 对，其中后 2 对冗余
SetFlag<HardEvent::V_S>(1); WaitFlag<HardEvent::V_S>(1);
SetFlag<HardEvent::V_S>(2); WaitFlag<HardEvent::V_S>(2);  // 冗余
SetFlag<HardEvent::V_S>(3); WaitFlag<HardEvent::V_S>(3);  // 冗余
```

但硬件语义上，一次 `set_flag<HardEvent::V_S>` 同步的是**所有先前的 V 写**，只需 1 对即可。根因：旧代码的 `DedupSyncRequirements` 只在**单条语句内**去重，跨语句不去重。

### 问题 B：if/else 后误插 `PipeBarrier_ALL`

内层 if/elif 分支访问同一 `buf_2d`，但分别走 V（`T.tile.fill`）和 S（`buf_2d[row,diag_col]=0.0` 标量写）。旧 `VisitStmt_(IfThenElseNode)` 检测到"同 buffer、不同 pipeline"就插入 `PipeBarrier_ALL` 并清空 history（before.cpp:609）。但 if/else 分支**互斥**，分支间不存在真正的跨 pipeline 冒险，PIPE_ALL 属过度同步；且清空 history 还掩盖了本应插入的精确 `PipeBarrier_V`。

---

## 2. 如何解决的

两个机制，与既有的 `pipe_barriers` 去重**对称设计**：

### 机制 A：新增 `event_pairs` 跟踪集合 → 跨语句 EventPair 去重

- `BufferAccess` 增加 `std::set<std::string> event_pairs;`（`src/transform/ascend_sync_insert_vs.cc:82`）。
- **记录时机（两处）**：
  1. `UpdateSyncStatesAfterSync`（cc:839-848）：每次插入 EventPair 后，解析 source pipeline（如 `EventPair_V_S` → `PIPE_V`），标记到 history 中所有匹配条目的 `event_pairs`。
  2. `VisitStmt_(EvaluateNode)`（cc:145-168）：遇到既有的 `ascend_auto_set_flag/wait_flag`（Expert 模式手写 flag）也记录，使去重把手动同步纳入考量。
- **去重判断**在 `GetRequiredSyncType`（cc:596-599）：若 `event_sync` 已在 `prev_access.event_pairs` 中则返回 `""`（跳过插入）。
- 效果：首个 V_S event pair 插入后，后续 S 读 V 写 buffer 不再重复插入。

### 机制 B：移除 if/else 跨分支 `PipeBarrier_ALL` 逻辑

- 删除 `VisitStmt_(IfThenElseNode)` 中 else_history 合并 + 冲突检测 + `PipeBarrier_ALL` 插入 + 清空 history 的整段代码。
- **保留** then_history 合并（cc:269-274），分支后语句仍能看到分支内的访问记录，由正常逐语句依赖分析按需插入精确同步（如 `PipeBarrier_V`）。

修复后 issue_1302 的目标代码变为：3 对 V_S → 1 对；`PIPE_ALL` → 精确 `PipeBarrier_V`（after.cpp:615）。

---

## 3. 影响面分析

### 正向收益

- **同步数量减少、性能提升**：多余 V_S 消除，PIPE_ALL 降级为单 pipeline 屏障。
- **event ID 消耗降低**：减少 ID 轮转池占用，降低 wraparound 风险。
- **并行度提升**：减少全流水线屏障。

### 行为变更（需关注）

- **if/else 后不再自动插 PIPE_ALL**：改由逐语句分析覆盖。因 then/else history 合并仍保留，分支后被另一 pipeline 访问的 buffer 应能被正常捕获——但这是核心风险点，需依赖测试覆盖。
- **跨语句去重依赖 `event_pairs` 标记完整性**：若某 V 写未走 `UpdateSyncStatesAfterSync`（未标记），可能漏插。新增测试专门验证"不误删"场景。

### 测试覆盖（`testing/python/language/test_ascend_sync_insert_vs.py`）

- **删除** `test_if_else_cross_branch_barrier_all`（对应被移除逻辑）。
- **新增 7 个**：跨语句 S_V / V_S dedup、新 S 写打破 dedup（验证不误删）、WAW dedup、loop back-edge dedup、混合方向不跨类型 dedup、嵌套 loop V→S dedup、outer back-edge V→inner S。
- **范围**：仅改动 `ascend_sync_insert_vs.cc` 一个文件，不影响其他 pass；仅在 `TL_ASCEND_AUTO_SYNC_VS: True` 时生效。

---

## 4. before / after 目标代码对比

```diff
--- before.cpp (第 599-609 行)
+++ after.cpp  (第 599-615 行)
   int32_t diag_col = ((((vid * 64) + q_start_1) + row_1) - kv_start);
   if ((0 <= diag_col) & (diag_col < kv_size)) {
     AscendC::SetFlag<AscendC::HardEvent::V_S>(1);
     AscendC::WaitFlag<AscendC::HardEvent::V_S>(1);
-    AscendC::SetFlag<AscendC::HardEvent::V_S>(2);
-    AscendC::WaitFlag<AscendC::HardEvent::V_S>(2);
-    AscendC::SetFlag<AscendC::HardEvent::V_S>(3);
-    AscendC::WaitFlag<AscendC::HardEvent::V_S>(3);
     buf_2d.SetValue(((((int64_t)row_1) * (int64_t)128) + ((int64_t)diag_col)), 0.000000e+00f);
   }
-AscendC::PipeBarrier<PIPE_ALL>();
+  ...
+  AscendC::PipeBarrier<PIPE_V>();   // 精确单 pipeline 屏障，由逐语句分析插入
```

- **V_S event pair**：3 对 → 1 对（跨语句去重生效）。
- **PIPE_ALL** → **PIPE_V**：去除过度屏障，改为精确同步。

---

## 5. 技术要点速查

| 项目 | 修复前 | 修复后 |
|------|--------|--------|
| 跨语句 EventPair 去重 | 无（仅单语句内 `DedupSyncRequirements`） | `event_pairs` 集合跟踪，`GetRequiredSyncType` 跳过已同步 |
| 手写 flag 兼容 | 不感知 Expert 模式 flag | `VisitStmt_(EvaluateNode)` 记录 set/wait_flag |
| if/else 跨分支同步 | 同 buffer 不同 pipeline → `PipeBarrier_ALL` + 清空 history | 移除该逻辑，保留 then_history 合并，逐语句分析 |
| history 清空 | if/else 冲突时清空（丢失精确依赖信息） | 不清空，依赖信息完整保留 |

---

## 附录：相关文件

- 实现文件：`src/transform/ascend_sync_insert_vs.cc`（+42/-32）
- 测试文件：`testing/python/language/test_ascend_sync_insert_vs.py`（+277/-41，本文档未展开）

