### PR TITLE
feat(gemm_v0): add kL0Size parameter for K-axis L1→L0 tile size control

### DIFF
--- a/docs/TileLang-Ascend Programming Guide.md
+++ b/docs/TileLang-Ascend Programming Guide.md
@@ -641,7 +641,7 @@ fragment层级的存储对应偏上的寄存器级别的存储单元，一般用
 
 ##### 4.1.3.1 矩阵计算
 
-- `T.gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False):`
+- `T.gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False, kL0Size=128):`
 
   **参数**：
 
@@ -658,6 +658,8 @@ fragment层级的存储对应偏上的寄存器级别的存储单元，一般用
     transpose_B：是否要对B输入矩阵进行转置
 
     init：在计算前下对累加矩阵C进行清零，一般情况下由于需要对矩阵进行切片，第一次计算需要对累加矩阵清零，后续在基础上累加。
+
+    kL0Size（高级参数，optional）：L1→L0 数据搬运时的 K 轴切分大小。控制 K 维度从 L1 搬到 L0A/L0B 时的切分粒度。必须是 16 的倍数，默认 128。通常不需要修改此参数。当 L0C 利用率不高（如 block_M × block_N × 4 < 128KB）或 kL0Size=128 导致 L0A/L0B 双缓冲溢出时，可以考虑调小 kL0Size。更小的 kL0Size 允许更大的 block_M/block_N（提高 L0C 利用率），代价是更多的 L1→L0 搬运次数。对于 half 精度，block_M=128, block_N=256 时推荐 kL0Size=64。
 
   **功能说明**：gemm操作用来实现两个tile的矩阵乘操作，特别的是它的左矩阵（A_shared）和右矩阵（B_shared）都是位于shared存储层级，输出（C_fragment）位于fragment存储层级，A_shared和B_shared的进行矩阵乘操作，然后结果和C_fragment已有值进行累加并赋值到C_fragment。
 

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -51,7 +51,7 @@ constexpr int kAlignment16Bytes = 16;
 constexpr int kUbAlignmentMask = kUbAlignmentBytes - 1;
 constexpr int kVectorRepeatBytes = 256;
 constexpr int kEleNumPerC0 = 16;
-constexpr int kL0SliceSize = 128;
+constexpr int kDefaultL0SliceSize = 128;
 constexpr int kL0CSliceElements = 256;
 constexpr int kSortBlockSize = 32;
 constexpr int kTransposeTileSize = 16;
@@ -817,8 +817,8 @@ extractTemplateParams(const std::string &input) {
     params.push_back(param);
   }
   std::vector<std::string> paramNames = {
-      "data_type_input", "data_type_output", "M", "N", "K",
-      "transpose_A",     "transpose_B"};
+      "data_type_input", "data_type_output", "M",      "N", "K",
+      "transpose_A",     "transpose_B",      "kL0Size"};
   for (size_t i = 0; i < params.size() && i < paramNames.size(); ++i) {
     result[paramNames[i]] = params[i];
   }
@@ -1824,8 +1824,10 @@ void CodeGenTileLangAscendPto::GemmV0Codegen(const CallNode *op) {
   uint32_t K = std::stoi(params["K"]);
   bool transpose_A = (params["transpose_A"] == "true");
   bool transpose_B = (params["transpose_B"] == "true");
-  uint32_t kL0split = (K + kL0SliceSize - 1) / kL0SliceSize;
-  uint32_t kL0Tail = K - (kL0split - 1) * kL0SliceSize;
+  uint32_t kL0Size = params.count("kL0Size") ? std::stoi(params["kL0Size"])
+                                             : kDefaultL0SliceSize;
+  uint32_t kL0split = (K + kL0Size - 1) / kL0Size;
+  uint32_t kL0Tail = K - (kL0split - 1) * kL0Size;
 
   auto override_slice = [](ShapeInfo &info, int32_t slice_row,
                            int32_t slice_col) {
@@ -1859,8 +1861,8 @@ void CodeGenTileLangAscendPto::GemmV0Codegen(const CallNode *op) {
                << params["data_type_output"] << ", " << GetValid16BytesShape(M)
                << ", " << GetValid16BytesShape(N) << ", "
                << GetValidShape(K, data_type_input) << ", " << M << ", " << N
-               << ", " << K << ", " << kL0Tail << ", " << params["transpose_A"]
-               << ", " << params["transpose_B"] << ">"
+               << ", " << K << ", " << kL0Tail << ", " << kL0Size << ", "
+               << params["transpose_A"] << ", " << params["transpose_B"] << ">"
                << "(";
   this->stream << a_name << ", " << b_name << ", " << c_name << ", "
                << PrintExpr(op->args[4]) << ");\n";

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -1040,16 +1040,17 @@ CATLASS_DEVICE void tail_reduce_min(LocalTensor<T> out, LocalTensor<T> src,
 static constexpr uint32_t L0AB_EVENT = 0;
 
 template <typename T1, typename T2, uint32_t M, uint32_t N, uint32_t K,
-          bool transpose_A = false, bool transpose_B = false>
+          bool transpose_A = false, bool transpose_B = false,
+          uint32_t kL0Size = 128>
 CATLASS_DEVICE void
 gemm_v0(LocalTensor<T1> const &A, LocalTensor<T1> const &B,
         LocalTensor<T2> const &C, // this must be located in l0c
         AscendC::TBuf<AscendC::TPosition::A2> &l0a_,
         AscendC::TBuf<AscendC::TPosition::B2> &l0b_, bool clear) {
+  static_assert(kL0Size % 16 == 0, "kL0Size must be a multiple of 16");
+  constexpr uint32_t kL0split = (K + kL0Size - 1) / kL0Size;
   auto l0a = l0a_.Get<T1>();
   auto l0b = l0b_.Get<T1>();
-  constexpr uint32_t kL0Size = 128;
-  uint32_t kL0split = (K + kL0Size - 1) / kL0Size;
   uint32_t kL0Tail = K - (kL0split - 1) * kL0Size;
   bool initflag = false;
 

--- a/src/tl_templates/pto/common.h
+++ b/src/tl_templates/pto/common.h
@@ -141,7 +141,7 @@ AICORE PTO_INLINE void mma(TileMatL0A<T1, M, K> l0a, TileMatL0B<T1, K, N> l0b,
 
 template <typename T1, typename T2, uint32_t M, uint32_t N, uint32_t K,
           uint32_t validM, uint32_t validN, uint32_t validK, uint32_t CurrentK,
-          bool transpose_A, bool transpose_B>
+          uint32_t kL0Size, bool transpose_A, bool transpose_B>
 AICORE PTO_INLINE void gemm_v0_inner(
     std::conditional_t<transpose_A, TileMatL1<T1, K, M, validK, validM>,
                        TileMatL1<T1, M, K, validM, validK>> &A,
@@ -163,18 +163,18 @@ AICORE PTO_INLINE void gemm_v0_inner(
   }
 
   if constexpr (!transpose_A) {
-    copy_l1_to_l0a<T1, M, CurrentK, M, K, false>(l0a, A, 0, kL0Idx * CurrentK);
+    copy_l1_to_l0a<T1, M, CurrentK, M, K, false>(l0a, A, 0, kL0Idx * kL0Size);
   } else {
     TileMatL1ZN<T1, M, K, validM, validK> A_t;
     pto::TRESHAPE(A_t, A);
-    copy_l1_to_l0a<T1, M, CurrentK, M, K, true>(l0a, A_t, 0, kL0Idx * CurrentK);
+    copy_l1_to_l0a<T1, M, CurrentK, M, K, true>(l0a, A_t, 0, kL0Idx * kL0Size);
   }
   if constexpr (!transpose_B) {
-    copy_l1_to_l0b<T1, CurrentK, N, K, N, false>(l0b, B, kL0Idx * CurrentK, 0);
+    copy_l1_to_l0b<T1, CurrentK, N, K, N, false>(l0b, B, kL0Idx * kL0Size, 0);
   } else {
     TileMatL1ZN<T1, K, N, validK, validN> B_t;
     pto::TRESHAPE(B_t, B);
-    copy_l1_to_l0b<T1, CurrentK, N, K, N, true>(l0b, B_t, kL0Idx * CurrentK, 0);
+    copy_l1_to_l0b<T1, CurrentK, N, K, N, true>(l0b, B_t, kL0Idx * kL0Size, 0);
   }
 
   set_flag(PIPE_MTE1, PIPE_M, war_event_id);
@@ -194,16 +194,16 @@ AICORE PTO_INLINE void gemm_v0_inner(
 
 template <typename T1, typename T2, uint32_t M, uint32_t N, uint32_t K,
           uint32_t validM = M, uint32_t validN = N, uint32_t validK = K,
-          uint32_t K_tail, bool transpose_A = false, bool transpose_B = false>
+          uint32_t K_tail, uint32_t kL0Size = 128, bool transpose_A = false,
+          bool transpose_B = false>
 AICORE PTO_INLINE void
 gemm_v0(std::conditional_t<transpose_A, TileMatL1<T1, K, M, validK, validM>,
                            TileMatL1<T1, M, K, validM, validK>> &A,
         std::conditional_t<transpose_B, TileMatL1<T1, N, K, validN, validK>,
                            TileMatL1<T1, K, N, validK, validN>> &B,
         pto::TileAcc<T2, M, N, validM, validN> &C, bool clear) {
-  constexpr uint32_t kL0Size =
-      128; // L0 slice size, adapted to 64K memory limit
-  const uint32_t kL0split = (K + kL0Size - 1) / kL0Size; // Number of slices
+  static_assert(kL0Size % 16 == 0, "kL0Size must be a multiple of 16");
+  constexpr uint32_t kL0split = (K + kL0Size - 1) / kL0Size;
   auto war_event_id = (event_t)(((int)EVENT_ID0 + 1) % 8);
 
   set_flag(PIPE_MTE2, PIPE_MTE1, war_event_id);
@@ -214,11 +214,11 @@ gemm_v0(std::conditional_t<transpose_A, TileMatL1<T1, K, M, validK, validM>,
     const bool is_tail_block = (kL0Idx == kL0split - 1);
 
     if (is_tail_block) {
-      gemm_v0_inner<T1, T2, M, N, K, validM, validN, validK, K_tail,
+      gemm_v0_inner<T1, T2, M, N, K, validM, validN, validK, K_tail, kL0Size,
                     transpose_A, transpose_B>(A, B, C, kL0Idx, initflag,
                                               war_event_id, true);
     } else {
-      gemm_v0_inner<T1, T2, M, N, K, validM, validN, validK, kL0Size,
+      gemm_v0_inner<T1, T2, M, N, K, validM, validN, validK, kL0Size, kL0Size,
                     transpose_A, transpose_B>(A, B, C, kL0Idx, initflag,
                                               war_event_id, false);
     }

--- a/testing/python/language/test_tilelang_ascend_language_gemm_v0.py
+++ b/testing/python/language/test_tilelang_ascend_language_gemm_v0.py
@@ -1,0 +1,205 @@
+import pytest
+import tilelang
+import tilelang.language as T
+import torch
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+SHAPE_CONFIGS = {
+    "A": (1024, 1024, 1024, 128, 256, 128),
+    "B": (1024, 1024, 1024, 128, 256, 64),
+    "C": (256, 256, 192, 128, 128, 192),
+    "D": (1024, 1024, 1024, 128, 128, 256),
+}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    tilelang.disable_cache()
+    yield
+
+
+def _compile(program, target):
+    return tilelang.compile(program, pass_configs=PASS_CONFIGS, target=target)
+
+
+def _gemm_v0_kernel(
+    M, N, K, block_M, block_N, K_L1, dtype="float16", accum_dtype="float", kL0Size=128, transpose_A=False, transpose_B=False
+):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    a_gm_shape = (K, M) if transpose_A else (M, K)
+    b_gm_shape = (N, K) if transpose_B else (K, N)
+    a_l1_shape = (K_L1, block_M) if transpose_A else (block_M, K_L1)
+    b_l1_shape = (block_N, K_L1) if transpose_B else (K_L1, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor(a_gm_shape, dtype),
+        B: T.Tensor(b_gm_shape, dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+
+            A_L1 = T.alloc_L1(a_l1_shape, dtype)
+            B_L1 = T.alloc_L1(b_l1_shape, dtype)
+            C_L0 = T.alloc_L0C((block_M, block_N), accum_dtype)
+
+            with T.Scope("C"):
+                loop_k = T.ceildiv(K, K_L1)
+                for k in T.serial(loop_k):
+                    if transpose_A:
+                        T.copy(A[k * K_L1, bx * block_M], A_L1)
+                    else:
+                        T.copy(A[bx * block_M, k * K_L1], A_L1)
+                    if transpose_B:
+                        T.copy(B[by * block_N, k * K_L1], B_L1)
+                    else:
+                        T.copy(B[k * K_L1, by * block_N], B_L1)
+
+                    T.barrier_all()
+                    T.gemm_v0(A_L1, B_L1, C_L0, transpose_A=transpose_A, transpose_B=transpose_B, init=(k == 0), kL0Size=kL0Size)
+                    T.barrier_all()
+
+                for i, j in T.Parallel(block_M, block_N):
+                    C[bx * block_M + i, by * block_N + j] = C_L0[i, j]
+
+    return main
+
+
+def _run_precision_case(target, kL0Size, shape_group):
+    full_M, full_N, full_K, block_M, block_N, K_L1 = SHAPE_CONFIGS[shape_group]
+    dtype = "float16"
+    accum_dtype = "float"
+
+    program = _gemm_v0_kernel(full_M, full_N, full_K, block_M, block_N, K_L1, dtype, accum_dtype, kL0Size=kL0Size)
+    kernel = _compile(program, target)
+
+    a = torch.randn(full_M, full_K, dtype=torch.float16, device="npu")
+    b = torch.randn(full_K, full_N, dtype=torch.float16, device="npu")
+    c = torch.zeros(full_M, full_N, dtype=torch.float16, device="npu")
+
+    torch.npu.synchronize()
+    kernel(a, b, c)
+    torch.npu.synchronize()
+
+    ref_c = a @ b
+    torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="gemm_v0 correctness requires an Ascend NPU runtime",
+)
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("kL0Size", [128, 64])
+@pytest.mark.parametrize("shape_group", ["A", "B", "C", "D"])
+def test_gemm_v0_precision(target, kL0Size, shape_group):
+    _run_precision_case(target, kL0Size, shape_group)
+
+
+def _run_transpose_case(target, transpose_A, transpose_B):
+    M, N, K = 128, 256, 128
+    block_M, block_N, K_L1 = 128, 256, 128
+    dtype = "float16"
+    accum_dtype = "float"
+    kL0Size = 64
+
+    program = _gemm_v0_kernel(
+        M, N, K, block_M, block_N, K_L1, dtype, accum_dtype, kL0Size=kL0Size, transpose_A=transpose_A, transpose_B=transpose_B
+    )
+    kernel = _compile(program, target)
+
+    a_gm_shape = (K, M) if transpose_A else (M, K)
+    b_gm_shape = (N, K) if transpose_B else (K, N)
+
+    a = torch.randn(*a_gm_shape, dtype=torch.float16, device="npu")
+    b = torch.randn(*b_gm_shape, dtype=torch.float16, device="npu")
+    c = torch.zeros(M, N, dtype=torch.float16, device="npu")
+
+    torch.npu.synchronize()
+    kernel(a, b, c)
+    torch.npu.synchronize()
+
+    a_ref = a.T if transpose_A else a
+    b_ref = b.T if transpose_B else b
+    ref_c = a_ref @ b_ref
+
+    torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="gemm_v0 correctness requires an Ascend NPU runtime",
+)
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("transpose_A,transpose_B", [(False, True), (True, False)])
+def test_gemm_v0_transpose(target, transpose_A, transpose_B):
+    _run_transpose_case(target, transpose_A, transpose_B)
+
+
+def _run_default_case(target):
+    full_M, full_N, full_K, block_M, block_N, K_L1 = SHAPE_CONFIGS["A"]
+    dtype = "float16"
+    accum_dtype = "float"
+
+    program = _gemm_v0_kernel(full_M, full_N, full_K, block_M, block_N, K_L1, dtype, accum_dtype)
+    kernel = _compile(program, target)
+
+    a = torch.randn(full_M, full_K, dtype=torch.float16, device="npu")
+    b = torch.randn(full_K, full_N, dtype=torch.float16, device="npu")
+    c = torch.zeros(full_M, full_N, dtype=torch.float16, device="npu")
+
+    torch.npu.synchronize()
+    kernel(a, b, c)
+    torch.npu.synchronize()
+
+    ref_c = a @ b
+    torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="gemm_v0 correctness requires an Ascend NPU runtime",
+)
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_gemm_v0_default_kL0Size(target):
+    _run_default_case(target)
+
+
+def test_gemm_v0_invalid_kL0Size_zero(capfd):
+    with pytest.raises(Exception):  # noqa: B017
+        _gemm_v0_kernel(128, 128, 256, 128, 128, 256, "float16", "float", kL0Size=0)
+    captured = capfd.readouterr()
+    assert "must be a positive integer" in captured.err
+
+
+def test_gemm_v0_invalid_kL0Size_negative(capfd):
+    with pytest.raises(Exception):  # noqa: B017
+        _gemm_v0_kernel(128, 128, 256, 128, 128, 256, "float16", "float", kL0Size=-16)
+    captured = capfd.readouterr()
+    assert "must be a positive integer" in captured.err
+
+
+def test_gemm_v0_invalid_kL0Size_not_aligned(capfd):
+    with pytest.raises(Exception):  # noqa: B017
+        _gemm_v0_kernel(128, 128, 256, 128, 128, 256, "float16", "float", kL0Size=100)
+    captured = capfd.readouterr()
+    assert "multiple of 16" in captured.err
+
+
+def test_gemm_v0_invalid_kL0Size_exceeds_mmad_limit(capfd):
+    with pytest.raises(Exception):  # noqa: B017
+        _gemm_v0_kernel(128, 128, 256, 128, 128, 256, "float16", "float", kL0Size=4096)
+    captured = capfd.readouterr()
+    assert "4095" in captured.err
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-n", "8"])

--- a/tilelang/language/ascend.py
+++ b/tilelang/language/ascend.py
@@ -340,7 +340,7 @@ def shmem_ub_get_nbi(dst: Buffer, src: Buffer, nelems: PrimExpr, newPe: PrimExpr
     )
 
 
-def gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False):
+def gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False, kL0Size=128):
     """
     Performs a block-level General Matrix Multiplication (GEMM).
 
@@ -358,6 +358,17 @@ def gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False):
         transpose_B (bool, optional): Whether to transpose matrix B. Defaults to False.
         init (bool, optional): Whether to initialize the accumulator matrix C (typically to zero)
             before computation. Defaults to False.
+        kL0Size (int, optional, advanced): K-axis tile size for L1->L0 data movement.
+            Controls how the K dimension is split when copying from L1 to L0A/L0B.
+            Must be a multiple of 16. Defaults to 128.
+
+            Normally you don't need to change this. Consider tuning it when:
+            - L0C is underutilized (e.g., block_M x block_N x 4 < 128KB)
+            - You want to enable double-buffer but kL0Size=128 makes L0A/L0B too full
+
+            Smaller kL0Size allows larger block_M/block_N (more L0C utilization)
+            at the cost of more L1->L0 copy iterations. For half precision with
+            block_M=128, block_N=256, kL0Size=64 is recommended.
 
     Returns:
         tvm.tir.Call: A TIR intrinsic call to `tl.ascend_gemm_v0`.
@@ -399,6 +410,10 @@ def gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False):
     K_B = B_shape[-1] if transpose_B else B_shape[-2]
     assert K == K_B, f"T.gemm K shape check failed: K_A = {K}, K_B = {K_B}"
 
+    assert kL0Size > 0, f"kL0Size={kL0Size} must be a positive integer"
+    assert kL0Size % 16 == 0, f"kL0Size={kL0Size} must be a multiple of 16"
+    assert kL0Size <= 4095, f"kL0Size={kL0Size} exceeds PTO MMAD upper limit 4095"
+
     Aptr = _retrieve_ptr(A, "r")
     Bptr = _retrieve_ptr(B, "r")
     Cptr = _retrieve_ptr(C, "w" if init is True else "rw")
@@ -407,7 +422,7 @@ def gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False):
     return T.call_intrin(
         "handle",
         tir.op.Op.get("tl.ascend_gemm_v0"),
-        f"gemm_v0<{_dtype(A)}, {_dtype(C)}, {M}, {N}, {K}, {str(transpose_A).lower()}, {str(transpose_B).lower()}>",
+        f"gemm_v0<{_dtype(A)}, {_dtype(C)}, {M}, {N}, {K}, {str(transpose_A).lower()}, {str(transpose_B).lower()}, {kL0Size}>",
         Aptr,
         Bptr,
         Cptr,
@@ -500,7 +515,6 @@ def dump_tensor(tensor: Buffer, desc: int, dump_size: int, shape_info: tuple = (
 
 
 def reinterpretcast(dst: Buffer, src: Buffer, casttype: str):
-
     # return T.call_extern("handle", f"ReinterpretCast", dst.access_ptr("w"), src.access_ptr("r"),
     #                      casttype)
     return T.call_intrin("handle", tir.op.Op.get("tl.ascend_reinterpretcast"), dst.access_ptr("w"), src.access_ptr("r"), casttype)

--- a/tilelang/language/pto.py
+++ b/tilelang/language/pto.py
@@ -224,7 +224,7 @@ def _retrieve_ptr(object: Buffer | BufferRegion, access_type: str = "r") -> Prim
         raise ValueError(f"Unsupported argument type: {type(object)} for buffer {object}")
 
 
-def gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False):
+def gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False, kL0Size=128):
     """
     Performs a block-level General Matrix Multiplication (GEMM).
 
@@ -242,6 +242,17 @@ def gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False):
         transpose_B (bool, optional): Whether to transpose matrix B. Defaults to False.
         init (bool, optional): Whether to initialize the accumulator matrix C (typically to zero)
             before computation. Defaults to False.
+        kL0Size (int, optional, advanced): K-axis tile size for L1->L0 data movement.
+            Controls how the K dimension is split when copying from L1 to L0A/L0B.
+            Must be a multiple of 16. Defaults to 128.
+
+            Normally you don't need to change this. Consider tuning it when:
+            - L0C is underutilized (e.g., block_M x block_N x 4 < 128KB)
+            - You want to enable double-buffer but kL0Size=128 makes L0A/L0B too full
+
+            Smaller kL0Size allows larger block_M/block_N (more L0C utilization)
+            at the cost of more L1->L0 copy iterations. For half precision with
+            block_M=128, block_N=256, kL0Size=64 is recommended.
 
     Returns:
         tvm.tir.Call: A TIR intrinsic call to `tl.ascend_gemm_v0`.
@@ -273,6 +284,10 @@ def gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False):
     K_B = B_shape[-1] if transpose_B else B_shape[-2]
     assert K == K_B, f"T.gemm K shape check failed: K_A = {K}, K_B = {K_B}"
 
+    assert kL0Size > 0, f"kL0Size={kL0Size} must be a positive integer"
+    assert kL0Size % 16 == 0, f"kL0Size={kL0Size} must be a multiple of 16"
+    assert kL0Size <= 4095, f"kL0Size={kL0Size} exceeds PTO MMAD upper limit 4095"
+
     Aptr = _retrieve_ptr(A, "r")
     Bptr = _retrieve_ptr(B, "r")
     Cptr = _retrieve_ptr(C, "w" if init is True else "rw")
@@ -281,7 +296,7 @@ def gemm_v0(A, B, C, transpose_A=False, transpose_B=False, init=False):
     return T.call_intrin(
         "handle",
         tir.op.Op.get("tl.ascend_gemm_v0"),
-        f"gemm_v0<{_dtype(A)}, {_dtype(C)}, {M}, {N}, {K}, {str(transpose_A).lower()}, {str(transpose_B).lower()}>",
+        f"gemm_v0<{_dtype(A)}, {_dtype(C)}, {M}, {N}, {K}, {str(transpose_A).lower()}, {str(transpose_B).lower()}, {kL0Size}>",
         Aptr,
         Bptr,
         Cptr,


### PR DESCRIPTION
Resolve #1280 

## 背景

`gemm_v0` 在 L1→L0 搬运时按 K 轴切分，切分大小 `kL0Size` 写死为 128，分布在三处代码中（AscendC 模板、PTO 模板、PTO codegen），用户无法调整。

问题在于：L0A/L0B 各 64KB，双缓冲下每半区只有 32KB。`kL0Size=128` + half 精度时，L0B 只能容纳 `N ≤ 128`，导致 128KB 的 L0C 只能用到一半。将 `kL0Size` 改为 64 后，N 的上限翻倍，L0C 可以打满。最优值取决于 M/N/dtype 的组合，不可能用一个写死的值覆盖所有场景。

##  PR 内容

为 `T.gemm_v0()` 增加 `kL0Size` 参数（默认 128），通过现有的模板字符串机制逐层传递到 C++ 模板，不新增 TIR 参数。

### 各层改动

**Python 前端**（`ascend.py`、`pto.py`）：
- `gemm_v0()` 签名增加 `kL0Size=128`
- 三条 `assert` 校验：正整数、16 的倍数、≤ 4095（PTO MMAD 上限）
- 模板字符串末尾追加 kL0Size：`gemm_v0<..., tA, tB, kL0Size>`

**PTO codegen**（`codegen_ascend_pto.cc`）：
- `extractTemplateParams` 解析模板字符串中的 `kL0Size`
- `GemmV0Codegen` 读取 `kL0Size`（用 `params.count()` 判断是否存在，旧 IR 不存在时 fallback 到 128），用于计算 `kL0Tail`，替代硬编码常量（`kL0SliceSize` 改名为 `kDefaultL0SliceSize`）
- 输出模板字符串中在 `K_tail` 之后、`transpose_A` 之前追加 `kL0Size`

**C++ 模板**（`ascend/common.h`、`pto/common.h`）：
- `kL0Size` 作为模板参数（默认 128），替代函数内的 `constexpr uint32_t kL0Size = 128`
- `static_assert(kL0Size % 16 == 0)` 编译期兜底（与 `copy_ub_to_l1` 中已有的 `static_assert(M % 16 == 0)` 风格一致）

### PTO 尾块 bug 修复

在构建测试时发现一个预先存在的 PTO bug：当 K 不能被 `kL0Size` 整除时（如 K=192, kL0Size=128, K_tail=64），PTO 输出 100% 错误。根因：`gemm_v0_inner` 计算 L1→L0 搬运偏移量时用了 `kL0Idx * CurrentK` 而非 `kL0Idx * kL0Size`——尾块时 `CurrentK=64`，导致从错误位置读取数据。此 bug 在本 PR 之前就存在（用默认 kL0Size=128 即可复现）。修复方式：为 `gemm_v0_inner` 新增 `kL0Size` 模板参数，4 处偏移量改为 `kL0Idx * kL0Size`。

### 向后兼容

- 默认 `kL0Size=128`，所有现有调用方行为不变
- 旧 IR（模板字符串不含 kL0Size）→ PTO codegen 通过 `params.count()` fallback 到 128
- AOT 示例（`example_gemm.cpp`）→ 无需修改（C++ 模板默认参数自动兼容）

## 测试

 同时为 `gemm_v0` 建立了**首个专用测试文件**。在此之前 `gemm_v0` 没有系统性测试覆盖——仅有 `parallel_auto_copy.py` 末尾两个临时冒烟测试（单 shape、单 dtype、且有死代码）和 `tile_atomic_add.py` 中作为 setup 的间接调用（不验证 gemm_v0 本身）。

**新文件**：`testing/python/language/test_tilelang_ascend_language_gemm_v0.py`，共 26 个测试，全部通过：

| 类别 | 数量 | 说明 |
|------|------|------|
| 精度测试 | 16 | 2 后端（ascendc/pto）× 2 kL0Size（128/64）× 4 组 shape |
| Transpose 测试 | 4 | 2 后端 × 2 种 transpose 组合（transpose_A、transpose_B） |
| 默认值兼容 | 2 | 2 后端，不传 kL0Size，验证向后兼容 |
| 参数校验 | 4 | 非法输入：kL0Size=0、负值、非 16 对齐、>4095 |

4 组 shape 覆盖：默认场景（kL0split=1）、kL0Size≥K 边界、K 不能被 kL0Size 整除（尾块）、双缓冲生效场景。

**回归测试**：现有 `test_matmul`、`test_matmul_k_1`、`test_tile_atomic_add`（8 个测试）均通过。

**关于 int8**：未包含 int8 测试——int8 gemm 在当前硬件/驱动下输出全零，这是预先存在的问题，与 kL0Size 无关（用默认 kL0Size=128 在改动前代码即可复现）。

##说明

- **PTO 模板参数顺序**：`kL0Size` 位于 `K_tail` 之后、`transpose_A` 之前。这是因为 PTO codegen 生成调用时显式列出所有模板参数（不能像 C++ 那样省略有默认值的尾部参数），位置必须与声明严格对应。
- **`pto.py` 同步**：`pto.py` 虽已废弃但仍存在于代码仓中，与 `ascend.py` 保持同步以避免不一致。
- **异常测试模式**：测试使用 `pytest.raises(Exception)` + `capfd` 验证错误消息，因为 TVM 的 `@T.prim_func` 解析器会将 `AssertionError` 包装为 `DiagnosticError`——错误文本输出到 stderr 而非异常 message，因此无法使用 `pytest.raises(match=...)`。
