### PR TITLE
[Feat] Make Bisheng compile flags kernel-scoped (#1386)

### DIFF
--- a/examples/compile_flags/compile_flags_example.py
+++ b/examples/compile_flags/compile_flags_example.py
@@ -1,0 +1,83 @@
+"""Kernel-scoped Bisheng compile flags (issue #1386).
+
+Demonstrates the ``compile_flags`` argument of ``@tilelang.jit`` and shows that
+flags are resolved per kernel: passing ``--cce-auto-sync=off`` / ``-O3`` to one
+kernel does not change how a later kernel with default flags is compiled.
+
+Historically these were driven by the process-wide ``TL_CCE_AUTO_SYNC`` /
+``TL_CCE_OPT_LEVEL`` environment variables, which leaked across kernels compiled
+in the same process. ``compile_flags`` makes them kernel-scoped.
+
+Run: python compile_flags_example.py
+"""
+
+import argparse
+
+import torch
+
+import tilelang
+import tilelang.language as T
+
+tilelang.cache.clear_cache()
+
+parser = argparse.ArgumentParser(description="compile_flags example")
+parser.add_argument("--m", type=int, default=256, help="Matrix M dimension")
+parser.add_argument("--n", type=int, default=256, help="Matrix N dimension")
+args = parser.parse_args()
+
+M, N = args.m, args.n
+VEC_NUM = 2
+
+
+def vec_add(M, N, block_M, block_N, compile_flags, dtype="float"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @tilelang.jit(out_idx=[-1], compile_flags=compile_flags)
+    def build():
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, N), dtype),
+            B: T.Tensor((M, N), dtype),
+            C: T.Tensor((M, N), dtype),
+        ):
+            with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+                bx = cid // n_num
+                by = cid % n_num
+                a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+                b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+                c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+                # Explicit barriers -> correct regardless of --cce-auto-sync.
+                with T.Scope("V"):
+                    T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+                    T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+                    T.barrier_all()
+                    T.tile.add(c_ub, a_ub, b_ub)
+                    T.barrier_all()
+                    T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+        return main
+
+    return build()
+
+
+torch.manual_seed(0)
+a = torch.randn(M, N).npu()
+b = torch.randn(M, N).npu()
+ref = a + b
+
+# Kernel A: per-kernel flags -> bisheng gets --cce-auto-sync=off and -O3.
+kernel_a = vec_add(M, N, 128, 256, compile_flags=["--cce-auto-sync=off", "-O3"])
+# Kernel B: default flags (no compile_flags) -> bisheng gets -O2, auto-sync on.
+# If Kernel A's flags leaked, Kernel B would be miscompiled.
+kernel_b = vec_add(M, N, 128, 256, compile_flags=None)
+
+print("init successful!")
+
+out_a = kernel_a(a, b)
+out_b = kernel_b(a, b)
+
+torch.testing.assert_close(out_a, ref, rtol=1e-2, atol=1e-2)
+torch.testing.assert_close(out_b, ref, rtol=1e-2, atol=1e-2)
+
+print("Kernel Output Match!")

--- a/examples/compile_flags/compile_flags_example.py
+++ b/examples/compile_flags/compile_flags_example.py
@@ -1,12 +1,21 @@
 """Kernel-scoped Bisheng compile flags (issue #1386).
 
-Demonstrates the ``compile_flags`` argument of ``@tilelang.jit`` and shows that
-flags are resolved per kernel: passing ``--cce-auto-sync=off`` / ``-O3`` to one
-kernel does not change how a later kernel with default flags is compiled.
+This example demonstrates two synchronization controls that serve different
+purposes:
 
-Historically these were driven by the process-wide ``TL_CCE_AUTO_SYNC`` /
-``TL_CCE_OPT_LEVEL`` environment variables, which leaked across kernels compiled
-in the same process. ``compile_flags`` makes them kernel-scoped.
+* ``TL_ASCEND_AUTO_SYNC`` makes TileLang insert the synchronization required by
+  a kernel's data dependencies.
+* ``compile_flags`` configures Bisheng for one compiled kernel. In particular,
+  ``--cce-auto-sync=off`` does not replace TileLang's synchronization pass.
+
+Both kernels enable TileLang's synchronization pass and compute a dependent
+Vector-operation chain correctly. The first uses explicit Bisheng flags; the
+second uses defaults and verifies that the first kernel's flags did not leak.
+
+Historically Bisheng options were driven by the process-wide
+``TL_CCE_AUTO_SYNC`` / ``TL_CCE_OPT_LEVEL`` environment variables, which leaked
+across kernels compiled in the same process. ``compile_flags`` makes them
+kernel-scoped.
 
 Run: python compile_flags_example.py
 """
@@ -29,32 +38,43 @@ M, N = args.m, args.n
 VEC_NUM = 2
 
 
-def vec_add(M, N, block_M, block_N, compile_flags, dtype="float"):
-    m_num = M // block_M
-    n_num = N // block_N
+def sigmoid(
+    M: int,
+    N: int,
+    block_M: int,
+    block_N: int,
+    compile_flags: list[str] | None,
+    dtype: str = "float",
+):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+    pass_configs = {
+        tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+        tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    }
 
-    @tilelang.jit(out_idx=[-1], compile_flags=compile_flags)
+    @tilelang.jit(out_idx=[1], pass_configs=pass_configs, compile_flags=compile_flags)
     def build():
         @T.prim_func
-        def main(
-            A: T.Tensor((M, N), dtype),
-            B: T.Tensor((M, N), dtype),
-            C: T.Tensor((M, N), dtype),
-        ):
+        def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
             with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
                 bx = cid // n_num
                 by = cid % n_num
-                a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-                b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-                c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-                # Explicit barriers -> correct regardless of --cce-auto-sync.
-                with T.Scope("V"):
-                    T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
-                    T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
-                    T.barrier_all()
-                    T.tile.add(c_ub, a_ub, b_ub)
-                    T.barrier_all()
-                    T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+                row_offset = bx * block_M + vid * block_M // VEC_NUM
+
+                a_ub = T.alloc_shared((block_M // VEC_NUM, block_N), dtype)
+                b_ub = T.alloc_shared((block_M // VEC_NUM, block_N), dtype)
+                zero_ub = T.alloc_shared((block_M // VEC_NUM, block_N), dtype)
+
+                # This load -> dependent Vector chain -> store has real pipeline
+                # hazards. There are deliberately no manual barriers here.
+                T.copy(A[row_offset, by * block_N], a_ub)
+                T.tile.fill(zero_ub, 0.0)
+                T.tile.sub(a_ub, zero_ub, a_ub)
+                T.tile.exp(a_ub, a_ub)
+                T.tile.add(a_ub, a_ub, 1.0)
+                T.tile.reciprocal(b_ub, a_ub)
+                T.copy(b_ub, B[row_offset, by * block_N])
 
         return main
 
@@ -63,21 +83,23 @@ def vec_add(M, N, block_M, block_N, compile_flags, dtype="float"):
 
 torch.manual_seed(0)
 a = torch.randn(M, N).npu()
-b = torch.randn(M, N).npu()
-ref = a + b
+ref = torch.sigmoid(a)
 
-# Kernel A: per-kernel flags -> bisheng gets --cce-auto-sync=off and -O3.
-kernel_a = vec_add(M, N, 128, 256, compile_flags=["--cce-auto-sync=off", "-O3"])
-# Kernel B: default flags (no compile_flags) -> bisheng gets -O2, auto-sync on.
-# If Kernel A's flags leaked, Kernel B would be miscompiled.
-kernel_b = vec_add(M, N, 128, 256, compile_flags=None)
+custom_flags = ["--cce-auto-sync=off", "-O3"]
+kernel_with_custom_flags = sigmoid(M, N, 64, 64, compile_flags=custom_flags)
 
-print("init successful!")
+# Compiled after the custom-flag kernel: its default flags must remain independent.
+kernel_with_defaults = sigmoid(M, N, 64, 64, compile_flags=None)
 
-out_a = kernel_a(a, b)
-out_b = kernel_b(a, b)
+print("Compilation successful!")
 
-torch.testing.assert_close(out_a, ref, rtol=1e-2, atol=1e-2)
-torch.testing.assert_close(out_b, ref, rtol=1e-2, atol=1e-2)
+out_with_custom_flags = kernel_with_custom_flags(a)
+out_with_defaults = kernel_with_defaults(a)
 
-print("Kernel Output Match!")
+torch.testing.assert_close(out_with_custom_flags, ref, rtol=1e-2, atol=1e-2)
+torch.testing.assert_close(out_with_defaults, ref, rtol=1e-2, atol=1e-2)
+
+print("Custom compile flags: output matches PyTorch.")
+print("Default compile flags: output matches PyTorch.")
+print("Default compile flags remained kernel-scoped.")
+print("Test Passed!")

--- a/testing/python/language/test_ascend_compile_flags.py
+++ b/testing/python/language/test_ascend_compile_flags.py
@@ -1,0 +1,246 @@
+"""Tests for kernel-scoped Bisheng compile flags (issue #1386).
+
+#1346 disabled Bisheng auto-sync by writing TL_CCE_AUTO_SYNC / TL_CCE_OPT_LEVEL
+into ``os.environ`` (process-wide, never restored), so compiling one kernel
+changed how later kernels were compiled. Flags are now derived per kernel and
+threaded through the JIT pipeline, with ``compile_flags`` appended last for
+caller overrides. These tests are hermetic (no NPU / bisheng).
+"""
+
+import types
+from unittest import mock
+
+import pytest
+
+import tilelang
+import tilelang.language as T
+from tilelang.transform.pass_config import (
+    PassConfigKey,
+    normalize_compiler_options,
+    process_default_pass_config,
+)
+from tilelang.jit.adapter.libgen import LibraryGenerator, resolve_compile_flags
+from tilelang.cache.kernel_cache import KernelCache
+
+VS_ON = {PassConfigKey.TL_ASCEND_AUTO_SYNC_VS: True}
+VS_OFF = {PassConfigKey.TL_ASCEND_AUTO_SYNC_VS: False}
+
+
+@pytest.fixture()
+def clean_env():
+    """Run with the TL_CCE_* / TL_PTO_DEBUG env vars absent."""
+    with mock.patch.dict("os.environ", {}, clear=False) as env:
+        for k in ("TL_CCE_AUTO_SYNC", "TL_CCE_OPT_LEVEL", "TL_PTO_DEBUG"):
+            env.pop(k, None)
+        yield
+
+
+def _pc(target, vs):
+    """pass_configs for `target`; vs=None means the target's own default."""
+    return process_default_pass_config(target, None if vs is None else (VS_ON if vs else VS_OFF))
+
+
+# ---------------------------------------------------------------------------
+# resolve_compile_flags: derived defaults, env fallbacks, caller overrides
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "target, vs, env, user, expected",
+    [
+        # framework-derived defaults
+        ("ascendc", False, {}, None, ["-O2"]),
+        ("ascendc", True, {}, None, ["-O3", "--cce-auto-sync=off"]),  # VS pairing (#1346)
+        ("pto", None, {}, None, ["-O3"]),  # pto defaults VS on; never gets the auto-sync flag
+        # env vars are lenient legacy fallbacks
+        ("ascendc", False, {"TL_CCE_AUTO_SYNC": "off"}, None, ["-O2", "--cce-auto-sync=off"]),
+        ("ascendc", False, {"TL_CCE_AUTO_SYNC": "garbage"}, None, ["-O2"]),  # malformed -> on, never raises
+        ("pto", False, {"TL_PTO_DEBUG": "1"}, None, ["-O2", "-D_DEBUG", "--cce-enable-print"]),
+        ("ascendc", False, {"TL_PTO_DEBUG": "1"}, None, ["-O2"]),  # AscendC never gets the PTO debug flags
+        # caller flags are appended last, so they win (bisheng is last-wins)
+        ("ascendc", True, {}, ["-O0"], ["-O3", "--cce-auto-sync=off", "-O0"]),
+        ("ascendc", False, {}, "-O3", ["-O2", "-O3"]),  # a bare str is accepted
+    ],
+)
+def test_resolve_compile_flags(clean_env, target, vs, env, user, expected):
+    with mock.patch.dict("os.environ", env):
+        assert resolve_compile_flags(target, _pc(target, vs), user) == expected
+
+
+def test_env_opt_level_invalid_raises(clean_env):
+    with mock.patch.dict("os.environ", {"TL_CCE_OPT_LEVEL": "9"}), pytest.raises(ValueError):
+        resolve_compile_flags("ascendc")
+
+
+def test_no_environ_mutation(clean_env):
+    import os
+
+    before = dict(os.environ)
+    # pto's VS default previously wrote TL_CCE_* into the environment.
+    resolve_compile_flags("pto", _pc("pto", None))
+    normalize_compiler_options(_pc("ascendc", True))
+    assert dict(os.environ) == before
+    assert not any(k in os.environ for k in ("TL_CCE_AUTO_SYNC", "TL_CCE_OPT_LEVEL", "TL_PTO_DEBUG"))
+
+
+# ---------------------------------------------------------------------------
+# LibraryGenerator: flags reach the bisheng command
+# ---------------------------------------------------------------------------
+
+
+def _bisheng_command(target, compile_flags, env=None):
+    """Build the bisheng command without running it."""
+    captured = {}
+
+    class _Ret:
+        returncode = 0
+
+    def _run(cmd, *a, **k):
+        captured["cmd"] = list(cmd)
+        return _Ret()
+
+    gen = LibraryGenerator(target, "A3", compile_flags)
+    gen.update_lib_code("// x")
+    with (
+        mock.patch("tilelang.jit.adapter.libgen._get_ascend_home_path", return_value="/a"),
+        mock.patch("tilelang.jit.adapter.libgen._get_tl_root", return_value="/t"),
+        mock.patch("tilelang.jit.adapter.libgen.subprocess.run", _run),
+        mock.patch.dict("os.environ", env or {}, clear=True),
+    ):
+        gen.compile_lib()
+    return captured["cmd"]
+
+
+def test_libgen_appends_flags():
+    cmd = _bisheng_command("ascendc", ["-O3", "--cce-auto-sync=off"])
+    assert "-O3" in cmd and "--cce-auto-sync=off" in cmd
+    assert cmd.index("-O3") < cmd.index("-o")  # appended before the output arg
+    # a whitespace-joined flag string is split, matching upstream tilelang
+    assert "--cce-enable-print" in _bisheng_command("pto", ["-D_DEBUG --cce-enable-print"])
+    # a flag already present in the base command is not duplicated
+    assert _bisheng_command("ascendc", ["-fPIC"]).count("-fPIC") == 1
+
+
+def test_libgen_direct_caller_falls_back_to_derived():
+    # compile_flags=None (direct/legacy caller) -> framework defaults, env still honored.
+    assert "-O2" in _bisheng_command("ascendc", None)
+    assert "-O3" in _bisheng_command("ascendc", None, {"TL_CCE_OPT_LEVEL": "3"})
+
+
+# ---------------------------------------------------------------------------
+# compile(): flags resolved once, then threaded down to the kernel
+# ---------------------------------------------------------------------------
+
+
+@T.prim_func
+def _copy_kernel(A: T.Tensor((16, 16), "float16"), B: T.Tensor((16, 16), "float16")):
+    with T.Kernel(1, is_npu=True) as (cid, vid):
+        T.copy(A, B)
+
+
+def test_compile_resolves_and_threads_flags(clean_env):
+    """compile() resolves the flags once and hands them to JITKernel -- the hop
+    that makes them kernel-scoped. Adapter creation (and lowering) is stubbed."""
+    from tilelang.jit.kernel import JITKernel
+
+    seen = {}
+
+    def _spy(self, func, out_idx, workspace_idx):
+        seen["flags"] = self.compile_flags
+        return types.SimpleNamespace(func=lambda *a, **k: None)
+
+    with (
+        mock.patch("tilelang.cache.kernel_cache.is_cache_enabled", return_value=False),
+        mock.patch.object(JITKernel, "_compile_and_create_adapter", _spy),
+    ):
+        tilelang.compile(_copy_kernel, target="ascendc", out_idx=[1], compile_flags=["-O3"])
+
+    # derived "-O2" first, caller "-O3" appended last (last-wins).
+    assert seen["flags"] == ["-O2", "-O3"]
+
+
+# ---------------------------------------------------------------------------
+# Cache key + autotuner disk-restore
+# ---------------------------------------------------------------------------
+
+
+def test_cache_key_scopes_flags(clean_env):
+    def key(flags):
+        return KernelCache()._generate_key(
+            func=_copy_kernel,
+            out_idx=[1],
+            workspace_idx=[],
+            auto_gm_idx=[],
+            execution_backend="cython",
+            args=(),
+            target="ascendc",
+            target_host=None,
+            platform="A3",
+            pass_configs={},
+            compile_flags=flags,
+        )
+
+    # VS-on and VS-off kernels resolve to different flags and must not alias.
+    on = resolve_compile_flags("ascendc", _pc("ascendc", True))
+    off = resolve_compile_flags("ascendc", _pc("ascendc", False))
+    assert on != off and key(on) != key(off)
+    assert key(on) == key(on)  # deterministic
+
+
+def test_autotuner_restore_threads_full_signature(tmp_path):
+    """Regression: the disk-restore call to JITKernel.from_database dropped the
+    now-required platform / workspace_idx / auto_gm_idx args; it must supply every
+    required arg and thread compile_flags + the persisted auto_gm_idx + the
+    resolved platform."""
+    import inspect
+    import json as _json
+
+    import cloudpickle
+
+    from tilelang.jit.kernel import JITKernel
+    from tilelang.autotuner import param as ap
+
+    required = {
+        n
+        for n, p in inspect.signature(JITKernel.from_database).parameters.items()
+        if p.default is inspect.Parameter.empty and n not in ("cls", "self")
+    }
+    (tmp_path / ap.WRAPPED_KERNEL_PATH).write_text("// x")
+    (tmp_path / ap.KERNEL_LIB_PATH).write_bytes(b"")
+    with open(tmp_path / ap.PARAMS_PATH, "wb") as f:
+        cloudpickle.dump(["p"], f)
+    with open(tmp_path / ap.AUTO_GM_IDX_PATH, "w") as f:
+        _json.dump([2], f)
+
+    captured = {}
+
+    def _spy(**kw):
+        captured.update(kw)
+        return "K"
+
+    with mock.patch.object(JITKernel, "from_database", _spy), mock.patch.dict("os.environ", {"TL_PLATFORM": "A5"}):
+        result = ap.AutotuneResult._load_kernel_from_disk(
+            ap.AutotuneResult,
+            tmp_path,
+            target="ascendc",
+            compile_flags=["-O3"],
+            platform="auto",
+        )
+
+    assert result == "K"
+    assert not (required - set(captured))  # all required args supplied (the bug)
+    assert captured["auto_gm_idx"] == [2]  # persisted auto_gm_idx restored
+    assert captured["compile_flags"] == ["-O3"]
+    assert captured["platform"] == "A5"  # "auto" resolved via TL_PLATFORM (sim path)
+
+
+def test_compile_args_hash_scopes_platform_and_flags():
+    from tilelang.autotuner.param import CompileArgs
+
+    # Distinct platforms / compile flags -> distinct auto-tuner cache keys.
+    assert hash(CompileArgs(platform="A2")) != hash(CompileArgs(platform="A3"))
+    assert hash(CompileArgs(compile_flags=["-O3"])) != hash(CompileArgs())
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/testing/python/language/test_ascend_compile_flags.py
+++ b/testing/python/language/test_ascend_compile_flags.py
@@ -4,13 +4,16 @@
 into ``os.environ`` (process-wide, never restored), so compiling one kernel
 changed how later kernels were compiled. Flags are now derived per kernel and
 threaded through the JIT pipeline, with ``compile_flags`` appended last for
-caller overrides. These tests are hermetic (no NPU / bisheng).
+caller overrides. The flag-resolution tests are hermetic (no NPU / bisheng);
+the final NPU-gated regression covers the intentionally unsynchronized runtime
+case.
 """
 
 import types
 from unittest import mock
 
 import pytest
+import torch
 
 import tilelang
 import tilelang.language as T
@@ -240,6 +243,71 @@ def test_compile_args_hash_scopes_platform_and_flags():
     # Distinct platforms / compile flags -> distinct auto-tuner cache keys.
     assert hash(CompileArgs(platform="A2")) != hash(CompileArgs(platform="A3"))
     assert hash(CompileArgs(compile_flags=["-O3"])) != hash(CompileArgs())
+
+
+# ---------------------------------------------------------------------------
+# Runtime regression: negative synchronization case belongs in testing
+# ---------------------------------------------------------------------------
+
+
+def _build_sync_dependency_kernel(auto_sync):
+    M = N = 256
+    block_M = block_N = 64
+    vec_num = 2
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+    pass_configs = {
+        PassConfigKey.TL_ASCEND_AUTO_SYNC: auto_sync,
+        PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    }
+
+    @tilelang.jit(
+        out_idx=[1],
+        target="ascendc",
+        pass_configs=pass_configs,
+        compile_flags=["--cce-auto-sync=off", "-O3"],
+    )
+    def build():
+        @T.prim_func
+        def main(A: T.Tensor((M, N), "float"), B: T.Tensor((M, N), "float")):
+            with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+                bx = cid // n_num
+                by = cid % n_num
+                row_offset = bx * block_M + vid * block_M // vec_num
+
+                a_ub = T.alloc_shared((block_M // vec_num, block_N), "float")
+                b_ub = T.alloc_shared((block_M // vec_num, block_N), "float")
+                zero_ub = T.alloc_shared((block_M // vec_num, block_N), "float")
+
+                T.copy(A[row_offset, by * block_N], a_ub)
+                T.tile.fill(zero_ub, 0.0)
+                T.tile.sub(a_ub, zero_ub, a_ub)
+                T.tile.exp(a_ub, a_ub)
+                T.tile.add(a_ub, a_ub, 1.0)
+                T.tile.reciprocal(b_ub, a_ub)
+                T.copy(b_ub, B[row_offset, by * block_N])
+
+        return main
+
+    return build()
+
+
+@pytest.mark.skipif(
+    not hasattr(torch, "npu") or not torch.npu.is_available(),
+    reason="requires an Ascend NPU",
+)
+def test_auto_sync_pass_prevents_dependency_hazard(clean_env):
+    torch.manual_seed(0)
+    a = torch.randn(256, 256).npu()
+    ref = torch.sigmoid(a)
+
+    kernel_with_sync = _build_sync_dependency_kernel(auto_sync=True)
+    kernel_without_sync = _build_sync_dependency_kernel(auto_sync=False)
+    out_with_sync = kernel_with_sync(a)
+    out_without_sync = kernel_without_sync(a)
+
+    torch.testing.assert_close(out_with_sync, ref, rtol=1e-2, atol=1e-2)
+    assert not torch.allclose(out_without_sync, ref, rtol=1e-2, atol=1e-2)
 
 
 if __name__ == "__main__":

--- a/tilelang/autotuner/param.py
+++ b/tilelang/autotuner/param.py
@@ -1,5 +1,5 @@
-"""The auto-tune parameters.
-"""
+"""The auto-tune parameters."""
+
 from __future__ import annotations
 
 import tilelang
@@ -43,7 +43,7 @@ class CompileArgs:
 
     out_idx: list[int] | int | None = None
     execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython"
-    target: Literal['auto', 'cuda', 'hip'] = 'auto'
+    target: Literal["auto", "cuda", "hip"] = "auto"
     target_host: str | Target = None
     verbose: bool = False
     pass_configs: dict[str, Any] | None = None
@@ -55,24 +55,20 @@ class CompileArgs:
             target=self.target,
             target_host=self.target_host,
             verbose=self.verbose,
-            pass_configs=self.pass_configs)
+            pass_configs=self.pass_configs,
+        )
 
     def __hash__(self):
         data = {
-            "execution_backend":
-                self.execution_backend,
-            "target":
-                str(self.target),
-            "target_host":
-                str(self.target_host) if self.target_host else None,
-            "verbose":
-                self.verbose,
-            "pass_configs":
-                json.dumps(self.pass_configs, sort_keys=True) if self.pass_configs else None,
+            "execution_backend": self.execution_backend,
+            "target": str(self.target),
+            "target_host": str(self.target_host) if self.target_host else None,
+            "verbose": self.verbose,
+            "pass_configs": json.dumps(self.pass_configs, sort_keys=True) if self.pass_configs else None,
         }
 
-        hash_obj = hashlib.sha256(json.dumps(data, sort_keys=True).encode('utf-8'))
-        return int.from_bytes(hash_obj.digest(), byteorder='big')
+        hash_obj = hashlib.sha256(json.dumps(data, sort_keys=True).encode("utf-8"))
+        return int.from_bytes(hash_obj.digest(), byteorder="big")
 
 
 @dataclass(frozen=True)
@@ -97,6 +93,7 @@ class ProfileArgs:
         manual_check_prog: Callable = None
         cache_input_tensors: bool = True
     """
+
     warmup: int = 25
     rep: int = 100
     timeout: int = 30
@@ -120,8 +117,8 @@ class ProfileArgs:
             "atol": self.atol,
             "max_mismatched_ratio": self.max_mismatched_ratio,
         }
-        hash_obj = hashlib.sha256(json.dumps(data, sort_keys=True).encode('utf-8'))
-        return int.from_bytes(hash_obj.digest(), byteorder='big')
+        hash_obj = hashlib.sha256(json.dumps(data, sort_keys=True).encode("utf-8"))
+        return int.from_bytes(hash_obj.digest(), byteorder="big")
 
 
 @dataclass(frozen=True)
@@ -136,6 +133,7 @@ class AutotuneResult:
         func: Optimized function.
         kernel: Compiled kernel function.
     """
+
     latency: float | None = None
     config: dict | None = None
     ref_latency: float | None = None
@@ -292,10 +290,13 @@ class AutotuneResult:
         if verbose:
             logger.debug(f"Saving latency to file: {path / LATENCY_PATH}")
         with open(path / LATENCY_PATH, "w") as f:
-            json.dump({
-                "latency": self.latency,
-                "ref_latency": self.ref_latency,
-            }, f)
+            json.dump(
+                {
+                    "latency": self.latency,
+                    "ref_latency": self.ref_latency,
+                },
+                f,
+            )
 
         # save kernel
         self._save_kernel_to_disk(path, self.kernel)
@@ -325,10 +326,16 @@ class AutotuneResult:
             latency = json.load(f)
             latency, ref_latency = latency["latency"], latency["ref_latency"]
 
-        kernel = cls._load_kernel_from_disk(cls, path, compile_args.target,
-                                            compile_args.target_host, compile_args.out_idx,
-                                            compile_args.execution_backend,
-                                            compile_args.pass_configs, func)
+        kernel = cls._load_kernel_from_disk(
+            cls,
+            path,
+            compile_args.target,
+            compile_args.target_host,
+            compile_args.out_idx,
+            compile_args.execution_backend,
+            compile_args.pass_configs,
+            func,
+        )
         if kernel is None:
             return None
         kernel.update_tuner_result(

--- a/tilelang/autotuner/param.py
+++ b/tilelang/autotuner/param.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from tilelang.jit import JITKernel
+from tilelang.utils.target import determine_platform
 import cloudpickle
 import os
 import shutil
@@ -26,6 +27,7 @@ KERNEL_PATH = "kernel.cu"
 WRAPPED_KERNEL_PATH = "wrapped_kernel.cu"
 KERNEL_LIB_PATH = "kernel_lib.so"
 PARAMS_PATH = "params.pkl"
+AUTO_GM_IDX_PATH = "auto_gm_idx.pkl"
 
 
 @dataclass(frozen=True)
@@ -36,17 +38,23 @@ class CompileArgs:
         execution_backend: Execution backend to use for kernel execution (default: "cython").
         target: Compilation target, either as a string or a TVM Target object (default: "auto").
         target_host: Target host for cross-compilation (default: None).
+        platform: Target hardware platform generation, e.g. "A2"/"A3"/"A5" (default:
+        "auto", resolved via ``TL_PLATFORM`` / device detection). See `tilelang.jit.compile`.
         verbose: Whether to enable verbose output (default: False).
         pass_configs: Additional keyword arguments to pass to the Compiler PassContext.
         Refer to `tilelang.PassConfigKey` for supported options.
+        compile_flags: Extra Bisheng compiler flags (e.g.
+        ``["--cce-auto-sync=off", "-O3"]``). See `tilelang.jit.compile`.
     """
 
     out_idx: list[int] | int | None = None
     execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython"
     target: Literal["auto", "cuda", "hip"] = "auto"
     target_host: str | Target = None
+    platform: str = "auto"
     verbose: bool = False
     pass_configs: dict[str, Any] | None = None
+    compile_flags: list[str] | str | None = None
 
     def compile_program(self, program: PrimFunc):
         return tilelang.compile(
@@ -54,8 +62,10 @@ class CompileArgs:
             out_idx=self.out_idx,
             target=self.target,
             target_host=self.target_host,
+            platform=self.platform,
             verbose=self.verbose,
             pass_configs=self.pass_configs,
+            compile_flags=self.compile_flags,
         )
 
     def __hash__(self):
@@ -63,8 +73,12 @@ class CompileArgs:
             "execution_backend": self.execution_backend,
             "target": str(self.target),
             "target_host": str(self.target_host) if self.target_host else None,
+            # Resolve "auto" so the key is partitioned by concrete platform
+            # (A2/A3/A5), matching KernelCache and respecting TL_PLATFORM.
+            "platform": determine_platform(self.platform),
             "verbose": self.verbose,
             "pass_configs": json.dumps(self.pass_configs, sort_keys=True) if self.pass_configs else None,
+            "compile_flags": json.dumps(self.compile_flags, sort_keys=True) if self.compile_flags else None,
         }
 
         hash_obj = hashlib.sha256(json.dumps(data, sort_keys=True).encode("utf-8"))
@@ -200,6 +214,16 @@ class AutotuneResult:
         except Exception as e:
             logger.error(f"Error saving kernel parameters to disk: {e}")
 
+        # Save auto_gm_idx (workspace reduction indices needed for runtime allocation)
+        try:
+            auto_gm_idx_path = os.path.join(cache_path, AUTO_GM_IDX_PATH)
+            if verbose:
+                logger.debug(f"Saving auto_gm_idx to file: {auto_gm_idx_path}")
+            with open(auto_gm_idx_path, "w") as f:
+                json.dump(kernel.auto_gm_idx, f)
+        except Exception as e:
+            logger.error(f"Error saving auto_gm_idx to disk: {e}")
+
     def _load_kernel_from_disk(
         self,
         cache_path: Path,
@@ -209,6 +233,8 @@ class AutotuneResult:
         execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
         pass_configs: dict = None,
         func: Callable = None,
+        compile_flags: list[str] | str | None = None,
+        platform: str = "auto",
         verbose: bool = False,
     ) -> JITKernel:
         """
@@ -255,6 +281,17 @@ class AutotuneResult:
         except Exception as e:
             logger.error(f"Error loading kernel parameters from disk: {e}")
 
+        # Load auto_gm_idx (workspace reduction indices for runtime allocation).
+        # Missing for cache entries written before this file was persisted.
+        auto_gm_idx = []
+        auto_gm_idx_path = os.path.join(cache_path, AUTO_GM_IDX_PATH)
+        if os.path.exists(auto_gm_idx_path):
+            try:
+                with open(auto_gm_idx_path) as f:
+                    auto_gm_idx = json.load(f) or []
+            except Exception as e:
+                logger.error(f"Error loading auto_gm_idx from disk: {e}")
+
         if kernel_global_source and kernel_params:
             return JITKernel.from_database(
                 func=func,
@@ -263,9 +300,16 @@ class AutotuneResult:
                 params=kernel_params,
                 target=target,
                 target_host=target_host,
+                # Resolve "auto" to the concrete platform (respects TL_PLATFORM,
+                # so sim-mode restores load the right simulator lib). workspace_idx
+                # is not tracked by the auto-tuner (it compiles with the default).
+                platform=determine_platform(platform),
                 out_idx=out_idx,
+                workspace_idx=None,
+                auto_gm_idx=auto_gm_idx,
                 execution_backend=execution_backend,
                 pass_configs=pass_configs,
+                compile_flags=compile_flags,
             )
         else:
             return None
@@ -335,6 +379,8 @@ class AutotuneResult:
             compile_args.execution_backend,
             compile_args.pass_configs,
             func,
+            compile_flags=compile_args.compile_flags,
+            platform=compile_args.platform,
         )
         if kernel is None:
             return None

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -147,8 +147,10 @@ class AutoTuner:
         target: Literal["auto", "cuda", "hip", "ascendc", "pto"] = "auto",
         execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
         target_host: str | Target = None,
+        platform: str = "auto",
         verbose: bool = False,
         pass_configs: dict[str, Any] | None = None,
+        compile_flags: list[str] | str | None = None,
     ):
         """Set compilation arguments for the auto-tuner.
 
@@ -157,8 +159,10 @@ class AutoTuner:
             target: Target platform.
             execution_backend: Execution backend to use for kernel execution.
             target_host: Target host for cross-compilation.
+            platform: Target hardware platform generation (e.g. "A2"/"A3"/"A5"; default "auto").
             verbose: Whether to enable verbose output.
             pass_configs: Additional keyword arguments to pass to the Compiler PassContext.
+            compile_flags: Extra Bisheng compiler flags. See `tilelang.jit.compile`.
 
         Returns:
             AutoTuner: Self for method chaining.
@@ -168,8 +172,10 @@ class AutoTuner:
             target=Target(determine_target(target)),
             execution_backend=execution_backend,
             target_host=target_host,
+            platform=platform,
             verbose=verbose,
             pass_configs=pass_configs,
+            compile_flags=compile_flags,
         )
 
         return self
@@ -634,8 +640,10 @@ class AutoTuneImpl(Generic[_P, _T]):
                 execution_backend=self.jit_impl.execution_backend,
                 target=self.jit_impl.target,
                 target_host=self.jit_impl.target_host,
+                platform=self.jit_impl.platform,
                 verbose=self.jit_impl.verbose,
                 pass_configs=self.jit_impl.pass_configs,
+                compile_flags=self.jit_impl.compile_flags,
             )
         )
         autotuner.run = partial(autotuner.run, self.warmup, self.rep, self.timeout)

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -3,6 +3,7 @@
 This module provides functionality for auto-tuning tilelang programs, including JIT compilation
 and performance optimization through configuration search.
 """
+
 from __future__ import annotations
 from dataclasses import dataclass
 
@@ -14,7 +15,8 @@ from tvm.tir import PrimFunc, Var
 from tvm.target import Target
 import inspect
 from functools import partial
-from typing import (Callable, Generic, Literal, Any, TypeVar, TYPE_CHECKING)
+from typing import Callable, Generic, Literal, Any, TypeVar, TYPE_CHECKING
+
 # Python 3.9 compatibility for ParamSpec
 try:
     from typing import ParamSpec
@@ -76,8 +78,8 @@ def _init_logger_handlers():
     global _logger_handlers_initialized
     if _logger_handlers_initialized:
         return
-    formatter = logging.Formatter('%(asctime)s %(levelname)s:%(message)s')
-    file_handler = logging.FileHandler('autotuner.log', mode='w')
+    formatter = logging.Formatter("%(asctime)s %(levelname)s:%(message)s")
+    file_handler = logging.FileHandler("autotuner.log", mode="w")
     file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(formatter)
     console_handler = logging.StreamHandler(sys.stdout)
@@ -89,8 +91,7 @@ def _init_logger_handlers():
 
 
 def get_available_cpu_count() -> int:
-    """Gets the number of CPU cores available to the current process.
-    """
+    """Gets the number of CPU cores available to the current process."""
     try:
         cpu_count = len(os.sched_getaffinity(0))
     except AttributeError:
@@ -109,6 +110,7 @@ class AutoTuner:
         fn: The function to be auto-tuned.
         configs: List of configurations to try during auto-tuning.
     """
+
     compile_args = CompileArgs()
     profile_args = ProfileArgs()
 
@@ -139,13 +141,15 @@ class AutoTuner:
         """
         return cls(kernel, configs)
 
-    def set_compile_args(self,
-                         out_idx: list[int] | int | None = None,
-                         target: Literal['auto', 'cuda', 'hip', 'ascendc', 'pto'] = 'auto',
-                         execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
-                         target_host: str | Target = None,
-                         verbose: bool = False,
-                         pass_configs: dict[str, Any] | None = None):
+    def set_compile_args(
+        self,
+        out_idx: list[int] | int | None = None,
+        target: Literal["auto", "cuda", "hip", "ascendc", "pto"] = "auto",
+        execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
+        target_host: str | Target = None,
+        verbose: bool = False,
+        pass_configs: dict[str, Any] | None = None,
+    ):
         """Set compilation arguments for the auto-tuner.
 
         Args:
@@ -165,23 +169,26 @@ class AutoTuner:
             execution_backend=execution_backend,
             target_host=target_host,
             verbose=verbose,
-            pass_configs=pass_configs)
+            pass_configs=pass_configs,
+        )
 
         return self
 
-    def set_profile_args(self,
-                         warmup: int = 25,
-                         rep: int = 100,
-                         timeout: int = 30,
-                         supply_type: tilelang.TensorSupplyType = tilelang.TensorSupplyType.Auto,
-                         ref_prog: Callable | None = None,
-                         supply_prog: Callable | None = None,
-                         rtol: float = 1e-2,
-                         atol: float = 1e-2,
-                         max_mismatched_ratio: float = 0.01,
-                         skip_check: bool = False,
-                         manual_check_prog: Callable | None = None,
-                         cache_input_tensors: bool = False):
+    def set_profile_args(
+        self,
+        warmup: int = 25,
+        rep: int = 100,
+        timeout: int = 30,
+        supply_type: tilelang.TensorSupplyType = tilelang.TensorSupplyType.Auto,
+        ref_prog: Callable | None = None,
+        supply_prog: Callable | None = None,
+        rtol: float = 1e-2,
+        atol: float = 1e-2,
+        max_mismatched_ratio: float = 0.01,
+        skip_check: bool = False,
+        manual_check_prog: Callable | None = None,
+        cache_input_tensors: bool = False,
+    ):
         """Set profiling arguments for the auto-tuner.
 
         Args:
@@ -205,9 +212,7 @@ class AutoTuner:
         # the `supply_prog` will be ignored and the `get_autotune_inputs` will be used instead.
         if get_autotune_inputs() is not None:
             if supply_prog is not None:
-                logger.warning(
-                    "`supply_prog` will be ignored as this program is under `with set_autotune_inputs` context."
-                )
+                logger.warning("`supply_prog` will be ignored as this program is under `with set_autotune_inputs` context.")
             supply_prog = lambda _: get_autotune_inputs()  # noqa: E731
 
         self.profile_args = ProfileArgs(
@@ -222,13 +227,13 @@ class AutoTuner:
             cache_input_tensors=cache_input_tensors,
             warmup=warmup,
             rep=rep,
-            timeout=timeout)
+            timeout=timeout,
+        )
 
         # If a custom `supply_prog` is provided, the profiler's `supply_type` setting
         # becomes ineffective. The custom supply program will be used instead.
         if supply_prog is not None and supply_type != tilelang.TensorSupplyType.Auto:
-            logger.warning("Ignoring `supply_type` passed to `set_profile_args` because "
-                           "`supply_prog` is not None.")
+            logger.warning("Ignoring `supply_type` passed to `set_profile_args` because `supply_prog` is not None.")
 
         return self
 
@@ -238,8 +243,7 @@ class AutoTuner:
         self._function_parameters = f_parameters
 
     def generate_cache_key(self, parameters: dict[str, Any]) -> AutotuneResult | None:
-        """Generate a cache key for the auto-tuning process.
-        """
+        """Generate a cache key for the auto-tuning process."""
 
         def _normalize_param(value):
             if isinstance(value, Var):
@@ -304,8 +308,10 @@ class AutoTuner:
             if env.is_cache_enabled():
                 # First check in-memory cache
                 if key in self._memory_cache:
-                    logger.warning("Found kernel in memory cache. For better performance," \
-                                        " consider using `@tilelang.autotune` instead of direct AutoTuner.from_kernel.")
+                    logger.warning(
+                        "Found kernel in memory cache. For better performance,"
+                        " consider using `@tilelang.autotune` instead of direct AutoTuner.from_kernel."
+                    )
                     return self._memory_cache[key]
 
                 # Then check disk cache
@@ -363,8 +369,7 @@ class AutoTuner:
                     self.jit_input_tensors = jit_input_tensors_supply()
                 else:
                     # check if the cached tensors are compatible with the current configuration
-                    assert len(params) == len(
-                        self.jit_input_tensors), "len(params) != len(self.jit_input_tensors)"
+                    assert len(params) == len(self.jit_input_tensors), "len(params) != len(self.jit_input_tensors)"
                     for p, c in zip(params, self.jit_input_tensors):
                         if not isinstance(c, torch.Tensor):
                             # skip non-tensor inputs checking
@@ -373,8 +378,8 @@ class AutoTuner:
                         # Check tensor compatibility using generator expression
                         def shape_equal(a, b):
                             return all(
-                                a_dim == b_dim or isinstance(a_dim, Var) or isinstance(b_dim, Var)
-                                for a_dim, b_dim in zip(a.shape, b.shape))
+                                a_dim == b_dim or isinstance(a_dim, Var) or isinstance(b_dim, Var) for a_dim, b_dim in zip(a.shape, b.shape)
+                            )
 
                         if p.dtype != c.dtype or not shape_equal(p, c):
                             logger.warning(
@@ -385,7 +390,8 @@ class AutoTuner:
                                 "To ensure fresh, compatible inputs are generated for every trial "
                                 "you can disable caching by setting:\n"
                                 "  `cache_input_tensors=False`\n"
-                                "within your `.set_compile_args(...)` call.\n")
+                                "within your `.set_compile_args(...)` call.\n"
+                            )
                             # otherwise, regenerate the input tensors for safety
                             self.jit_input_tensors = jit_input_tensors_supply()
                             break
@@ -394,24 +400,16 @@ class AutoTuner:
 
             if (not skip_check) and (ref_prog is not None):
                 if manual_check_prog is not None:
-                    profiler.manual_assert_close(
-                        ref_prog,
-                        input_tensors=self.jit_input_tensors,
-                        manual_check_prog=manual_check_prog)
+                    profiler.manual_assert_close(ref_prog, input_tensors=self.jit_input_tensors, manual_check_prog=manual_check_prog)
                 else:
                     profiler.assert_allclose(
-                        ref_prog,
-                        input_tensors=self.jit_input_tensors,
-                        rtol=rtol,
-                        atol=atol,
-                        max_mismatched_ratio=max_mismatched_ratio)
-            latency = profiler.do_bench(
-                warmup=warmup, rep=rep, input_tensors=self.jit_input_tensors)
+                        ref_prog, input_tensors=self.jit_input_tensors, rtol=rtol, atol=atol, max_mismatched_ratio=max_mismatched_ratio
+                    )
+            latency = profiler.do_bench(warmup=warmup, rep=rep, input_tensors=self.jit_input_tensors)
 
             if self.ref_latency_cache is None and ref_prog is not None:
                 self.ref_input_tensors = ref_input_tensors_supply()
-                self.ref_latency_cache = profiler.do_bench(
-                    ref_prog, n_warmup=warmup, n_repeat=rep, input_tensors=self.ref_input_tensors)
+                self.ref_latency_cache = profiler.do_bench(ref_prog, n_warmup=warmup, n_repeat=rep, input_tensors=self.ref_input_tensors)
 
             return latency, self.ref_latency_cache
 
@@ -445,17 +443,14 @@ class AutoTuner:
 
             # Check if all tunable arguments have been tuned by comparing config keys with key_kwargs_tuple
             if any(key in top_config for key, _ in key_kwargs_tuple) or any(
-                    check_tunable_argument_value(key, self._function_parameters, key_args_tuple)
-                    for key in tunable_arguments):
+                check_tunable_argument_value(key, self._function_parameters, key_args_tuple) for key in tunable_arguments
+            ):
                 logger.warning(
                     f"Tunable parameters {tunable_arguments} already provided during auto-tuning. Skipping compilation and using direct JIT"
                 )
                 # compile the kernel with the provided parameters
                 jit_kernel = self.jit_compile()
-                autotuner_result = AutotuneResult(
-                    libcode=jit_kernel.get_kernel_source(),
-                    func=jit_kernel.prim_func,
-                    kernel=jit_kernel)
+                autotuner_result = AutotuneResult(libcode=jit_kernel.get_kernel_source(), func=jit_kernel.prim_func, kernel=jit_kernel)
                 self._memory_cache[key] = autotuner_result
                 return autotuner_result
         # get the cpu count
@@ -465,9 +460,7 @@ class AutoTuner:
         max_cpu_count = int(env.TILELANG_AUTO_TUNING_MAX_CPU_COUNT)
         if cpu_counts > 0:
             num_workers = min(cpu_counts, available_cpu_count)
-            logger.info(
-                f"Auto-tuning with {cpu_counts} CPU counts, {available_cpu_count} CPUs available, {num_workers} CPUs will be used"
-            )
+            logger.info(f"Auto-tuning with {cpu_counts} CPU counts, {available_cpu_count} CPUs available, {num_workers} CPUs will be used")
         else:
             num_workers = max(1, int(available_cpu_count * cpu_utilizations))
             logger.info(
@@ -496,7 +489,7 @@ class AutoTuner:
             def inner(**config_arg):
                 torch.npu.set_device(device)
                 return func(**config_arg)
-            
+
             return inner
 
         for i, config_arg in enumerate(config_args):
@@ -506,7 +499,7 @@ class AutoTuner:
                 device = torch.cuda.current_device()
                 compile_func = cuda_device_wrapper(self.jit_compile, device)
             # TODO: whether necessary to specify npu device here
-            elif hasattr(torch, 'npu') and torch.npu.is_available():
+            elif hasattr(torch, "npu") and torch.npu.is_available():
                 device = torch.npu.current_device()
                 compile_func = npu_device_wrapper(self.jit_compile, device)
 
@@ -518,18 +511,14 @@ class AutoTuner:
             future_to_index[future] = i
 
         results_with_configs = []
-        for future in tqdm(
-                concurrent.futures.as_completed(futures),
-                total=len(futures),
-                desc="Compiling configurations"):
+        for future in tqdm(concurrent.futures.as_completed(futures), total=len(futures), desc="Compiling configurations"):
             idx = future_to_index[future]
             config = config_args[idx]
             try:
                 result = future.result()
                 results_with_configs.append((result, config))
             except Exception as e:
-                logger.debug(
-                    f"Compilation failed for config {config} at index {idx} with error: {e}")
+                logger.debug(f"Compilation failed for config {config} at index {idx} with error: {e}")
                 continue
 
         ref_latency = None
@@ -542,14 +531,10 @@ class AutoTuner:
                 # latency, ref_latency = target_fn(jit_kernel)
                 latency, ref_latency = run_with_timeout(target_fn, timeout, jit_kernel)
             except TimeoutException:
-                logger.warning(
-                    f"A timeout occurred while testing config {config}, checkout autotuner.log for more details"
-                )
+                logger.warning(f"A timeout occurred while testing config {config}, checkout autotuner.log for more details")
                 continue
             except Exception:
-                logger.warning(
-                    f"An error occurred while testing config {config}, checkout autotuner.log for more details"
-                )
+                logger.warning(f"An error occurred while testing config {config}, checkout autotuner.log for more details")
                 logger.debug(f"Error: {traceback.format_exc()}")
                 continue
 
@@ -564,8 +549,7 @@ class AutoTuner:
         pool.shutdown()
 
         if best_kernel is None:
-            error_msg = ("Auto-tuning failed: No configuration successfully "
-                         "compiled and passed benchmarking/validation.")
+            error_msg = "Auto-tuning failed: No configuration successfully compiled and passed benchmarking/validation."
             logger.error(error_msg)
             raise RuntimeError(error_msg)
 
@@ -581,7 +565,8 @@ class AutoTuner:
             ref_latency=ref_latency,
             libcode=best_kernel.get_kernel_source(),
             func=best_kernel.prim_func,
-            kernel=best_kernel)
+            kernel=best_kernel,
+        )
 
         if self.compile_args.execution_backend in ("dlpack", "torch"):
             logger.warning("DLPack backend does not support cache saving to disk.")
@@ -603,8 +588,8 @@ class AutoTuner:
         return self.run()
 
 
-_P = ParamSpec('_P')
-_T = TypeVar('_T')
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
 
 
 @dataclass
@@ -631,8 +616,9 @@ class AutoTuneImpl(Generic[_P, _T]):
     def get_tunner(self):
         # Use the real function from jit_impl, not a placeholder
         assert self.jit_impl.func is not None
-        autotuner = AutoTuner(
-            self.jit_impl.func, configs=self.configs).set_profile_args(
+        autotuner = (
+            AutoTuner(self.jit_impl.func, configs=self.configs)
+            .set_profile_args(
                 supply_type=self.supply_type,
                 ref_prog=self.ref_prog,
                 supply_prog=self.supply_prog,
@@ -642,7 +628,8 @@ class AutoTuneImpl(Generic[_P, _T]):
                 skip_check=self.skip_check,
                 manual_check_prog=self.manual_check_prog,
                 cache_input_tensors=self.cache_input_tensors,
-            ).set_compile_args(
+            )
+            .set_compile_args(
                 out_idx=self.jit_impl.out_idx,
                 execution_backend=self.jit_impl.execution_backend,
                 target=self.jit_impl.target,
@@ -650,6 +637,7 @@ class AutoTuneImpl(Generic[_P, _T]):
                 verbose=self.jit_impl.verbose,
                 pass_configs=self.jit_impl.pass_configs,
             )
+        )
         autotuner.run = partial(autotuner.run, self.warmup, self.rep, self.timeout)
         return autotuner
 
@@ -742,8 +730,7 @@ def autotune(  # This is the new public interface
     if callable(func):
         # Case 1: Used as @autotune (func_or_out_idx is the function, others are defaults)
         # This is a placeholder for a real auto tuner implementation
-        raise ValueError(
-            "Use tilelang.autotune to decorate func without arguments is not supported yet.")
+        raise ValueError("Use tilelang.autotune to decorate func without arguments is not supported yet.")
     elif isinstance(func, PrimFunc):
         raise ValueError("Use tilelang.autotune to decorate prim_func is not supported yet.")
     else:
@@ -753,13 +740,13 @@ def autotune(  # This is the new public interface
             # impl could be either:
             # 1. A wrapper function from @jit with __jit_impl__ attribute
             # 2. A _JitImplementation instance directly
-            if callable(impl) and hasattr(impl, '__jit_impl__'):
+            if callable(impl) and hasattr(impl, "__jit_impl__"):
                 # Case 1: wrapper function from @jit decorator
                 jit_impl = impl.__jit_impl__
             else:
                 # Case 2: _JitImplementation instance
                 jit_impl = impl
-            
+
             return AutoTuneImpl(
                 jit_impl=jit_impl,
                 configs=configs,

--- a/tilelang/cache/__init__.py
+++ b/tilelang/cache/__init__.py
@@ -27,6 +27,7 @@ def cached(
     execution_backend: Literal["dlpack", "ctypes", "cython"] | None = "cython",
     verbose: bool | None = False,
     pass_configs: dict | None = None,
+    compile_flags: list[str] | str | None = None,
 ) -> JITKernel:
     """
     Caches and reuses compiled kerne(ls (using KernelCache class).
@@ -43,6 +44,7 @@ def cached(
         execution_backend=execution_backend,
         verbose=verbose,
         pass_configs=pass_configs,
+        compile_flags=compile_flags,
     )
 
 

--- a/tilelang/cache/__init__.py
+++ b/tilelang/cache/__init__.py
@@ -2,7 +2,9 @@
 # Licensed under the MIT License.
 """The cache utils with class and database persistence - Init file"""
 
-from typing import List, Union, Literal, Optional
+from __future__ import annotations
+
+from typing import Literal
 from pathlib import Path
 from tvm.target import Target
 from tvm.tir import PrimFunc
@@ -16,15 +18,15 @@ _kernel_cache_instance = KernelCache()
 
 def cached(
     func: PrimFunc = None,
-    out_idx: List[int] = None,
-    workspace_idx: List[int] = None,
+    out_idx: list[int] = None,
+    workspace_idx: list[int] = None,
     *args,
-    target: Union[str, Target] = "auto",
-    target_host: Union[str, Target] = None,
+    target: str | Target = "auto",
+    target_host: str | Target = None,
     platform: str = "auto",
-    execution_backend: Optional[Literal["dlpack", "ctypes", "cython"]] = "cython",
-    verbose: Optional[bool] = False,
-    pass_configs: Optional[dict] = None,
+    execution_backend: Literal["dlpack", "ctypes", "cython"] | None = "cython",
+    verbose: bool | None = False,
+    pass_configs: dict | None = None,
 ) -> JITKernel:
     """
     Caches and reuses compiled kerne(ls (using KernelCache class).

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -80,6 +80,7 @@ class KernelCache:
         target_host: str | Target = None,
         platform: str = "auto",
         pass_configs: dict = None,
+        compile_flags: list[str] | str | None = None,
     ) -> str:
         """
         Generates a unique hash key for caching compiled kernels.
@@ -112,6 +113,7 @@ class KernelCache:
             "platform": str(platform),
             "execution_backend": execution_backend,
             "pass_configs": pass_configs,
+            "compile_flags": compile_flags,
         }
         key_string = json.dumps(key_data, sort_keys=True)  # Sort keys to ensure consistency
         return sha256(key_string.encode()).hexdigest()  # Use SHA256 to generate hash key
@@ -129,6 +131,7 @@ class KernelCache:
         execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
         verbose: bool = False,
         pass_configs: dict = None,
+        compile_flags: list[str] | str | None = None,
     ) -> JITKernel:
         """
         Caches and reuses compiled kernels to avoid redundant compilation.
@@ -159,6 +162,7 @@ class KernelCache:
                 platform=platform,
                 verbose=verbose,
                 pass_configs=pass_configs,
+                compile_flags=compile_flags,
             )
 
         key = self._generate_key(
@@ -172,6 +176,7 @@ class KernelCache:
             target_host=target_host,
             platform=platform,
             pass_configs=pass_configs,
+            compile_flags=compile_flags,
         )
         with self._lock:
             # First check in-memory cache
@@ -183,7 +188,17 @@ class KernelCache:
 
             # Then check disk cache
             kernel = self._load_kernel_from_disk(
-                key, target, target_host, platform, out_idx, workspace_idx, auto_gm_idx, execution_backend, pass_configs, func
+                key,
+                target,
+                target_host,
+                platform,
+                out_idx,
+                workspace_idx,
+                auto_gm_idx,
+                execution_backend,
+                pass_configs,
+                func,
+                compile_flags,
             )
             if kernel is not None:
                 # Populate memory cache with disk result
@@ -201,6 +216,7 @@ class KernelCache:
             platform=platform,
             verbose=verbose,
             pass_configs=pass_configs,
+            compile_flags=compile_flags,
         )
         if execution_backend == "dlpack":
             self.logger.warning("DLPack backend does not support cache saving to disk.")
@@ -316,6 +332,7 @@ class KernelCache:
         execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
         pass_configs: dict = None,
         func: Callable = None,
+        compile_flags: list[str] | str | None = None,
     ) -> JITKernel:
         """
         Loads a previously compiled kernel from disk cache.
@@ -387,6 +404,7 @@ class KernelCache:
                 auto_gm_idx=auto_gm_idx,
                 execution_backend=execution_backend,
                 pass_configs=pass_configs,
+                compile_flags=compile_flags,
             )
         else:
             return None

--- a/tilelang/jit/__init__.py
+++ b/tilelang/jit/__init__.py
@@ -39,6 +39,7 @@ def compile(
     platform: str = "auto",
     verbose: bool = False,
     pass_configs: dict[str, Any] | None = None,
+    compile_flags: list[str] | str | None = None,
 ) -> JITKernel:
     """
     Compile the given TileLang PrimFunc with TVM and build a JITKernel.
@@ -72,11 +73,21 @@ def compile(
             "tl.disable_safe_memory_legalize": bool, default: False
             "tl.ascend_auto_sync": bool, default: False
             "tl.ascend_memory_planning": bool, default: False
+    compile_flags : list[str] | str, optional
+        Extra Bisheng compiler flags for this kernel, e.g.
+        ``["--cce-auto-sync=off", "-O3"]``. They are appended after the flags the
+        framework derives from ``pass_configs`` and the ``TL_CCE_*`` /
+        ``TL_PTO_DEBUG`` environment variables, and therefore win (bisheng is
+        last-wins for repeated flags). Resolved per kernel; the process
+        environment is never mutated.
     """
 
     from tilelang.transform.pass_config import process_default_pass_config
+    from tilelang.jit.adapter.libgen import resolve_compile_flags
 
     pass_configs = process_default_pass_config(target, pass_configs)
+    # Resolve once here so the same flag list feeds both the cache key and codegen.
+    compile_flags = resolve_compile_flags(target, pass_configs, compile_flags)
 
     return cached(
         func=func,
@@ -88,6 +99,7 @@ def compile(
         platform=platform,
         verbose=verbose,
         pass_configs=pass_configs,
+        compile_flags=compile_flags,
     )
 
 
@@ -100,6 +112,7 @@ class _JitImplementation:
     execution_backend: Literal["dlpack", "ctypes", "cython"]
     verbose: bool
     pass_configs: dict[str, Any] | None
+    compile_flags: list[str] | str | None
     debug_root_path: str | None
     func: Callable | None = None  # Store the original function
     signature: Any | None = None  # Store the signature
@@ -115,6 +128,7 @@ class _JitImplementation:
         execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
         verbose: bool = False,
         pass_configs: dict[str, Any] | None = None,
+        compile_flags: list[str] | str | None = None,
         debug_root_path: str | None = None,
     ):
         """
@@ -162,6 +176,7 @@ class _JitImplementation:
         self.platform = platform
         self.verbose = verbose
         self.pass_configs = pass_configs
+        self.compile_flags = compile_flags
         self.func = None
         self.signature = None
 
@@ -222,6 +237,7 @@ class _JitImplementation:
                     platform=self.platform,
                     verbose=self.verbose,
                     pass_configs=self.pass_configs,
+                    compile_flags=self.compile_flags,
                 )
 
                 if self.debug_root_path:
@@ -257,6 +273,7 @@ def jit(  # This is the new public interface
     execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
     verbose: bool = False,
     pass_configs: dict[str, Any] | None = None,
+    compile_flags: list[str] | str | None = None,
     debug_root_path: str | None = None,
 ):
     """
@@ -285,6 +302,10 @@ def jit(  # This is the new public interface
         Enables verbose logging during compilation. Defaults to False.
     pass_configs : dict[str, Any] | None
         Configurations for TVM's pass context. Defaults to None.
+    compile_flags : list[str] | str | None
+        Extra Bisheng compiler flags for this kernel (e.g.
+        ``["--cce-auto-sync=off", "-O3"]``). Appended after the framework-derived
+        flags and folded into the cache key; see :func:`compile`. Defaults to None.
     debug_root_path : Optional[str], optional
         Directory to save compiled kernel source for debugging. Defaults to None.
 
@@ -306,6 +327,7 @@ def jit(  # This is the new public interface
             execution_backend=execution_backend,
             verbose=verbose,
             pass_configs=pass_configs,
+            compile_flags=compile_flags,
             debug_root_path=debug_root_path,
         )
         return default_decorator(func)
@@ -324,6 +346,7 @@ def jit(  # This is the new public interface
             execution_backend=execution_backend,
             verbose=verbose,
             pass_configs=pass_configs,
+            compile_flags=compile_flags,
             debug_root_path=debug_root_path,
         )
         return configured_decorator

--- a/tilelang/jit/adapter/cython/adapter.py
+++ b/tilelang/jit/adapter/cython/adapter.py
@@ -205,6 +205,8 @@ class CythonKernelAdapter(BaseKernelAdapter):
     buffer_device_map: dict[tir.Var, tuple[int, torch.device]] | None = None
     # Pass configs for the compiler
     pass_configs: dict[str, Any] | None = None
+    # Resolved Bisheng compile flags for this kernel
+    compile_flags: list[str] | str | None = None
 
     def __init__(
         self,
@@ -220,6 +222,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
         kernel_global_source: str | None = None,
         verbose: bool = False,
         pass_configs: dict[str, Any] | None = None,
+        compile_flags: list[str] | str | None = None,
     ):
         """Initialize the adapter with the given TIR function or module.
 
@@ -253,8 +256,9 @@ class CythonKernelAdapter(BaseKernelAdapter):
         self.buffer_device_map = self._process_buffer_device()
 
         self.verbose = verbose
+        self.compile_flags = compile_flags
         self.wrapper = TLWrapper("npu")
-        self.lib_generator = LibraryGenerator(target, platform)
+        self.lib_generator = LibraryGenerator(target, platform, compile_flags)
 
         self.wrapper.assign_optimized_module(self.ir_module)
         self.wrapper.assign_pass_configs(pass_configs)
@@ -296,6 +300,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
         kernel_lib_path: str,
         verbose: bool = False,
         pass_configs: dict[str, Any] | None = None,
+        compile_flags: list[str] | str | None = None,
     ):
         adapter = cls.__new__(cls)
         adapter.params = params
@@ -305,6 +310,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
         adapter.kernel_global_source = kernel_global_source
         adapter.wrapped_source = kernel_global_source
         adapter.pass_configs = pass_configs
+        adapter.compile_flags = compile_flags
 
         if isinstance(func_or_mod, tir.PrimFunc):
             adapter.ir_module = tvm.IRModule({func_or_mod.attrs["global_symbol"]: func_or_mod})
@@ -321,7 +327,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
         adapter.buffer_device_map = adapter._process_buffer_device()
 
         adapter.verbose = verbose
-        adapter.lib_generator = LibraryGenerator(target, platform)
+        adapter.lib_generator = LibraryGenerator(target, platform, compile_flags)
         adapter.lib = adapter.lib_generator.load_lib(lib_path=kernel_lib_path)
 
         # adapter.lib.get_last_error.restype = ctypes.c_char_p

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -78,14 +78,50 @@ def _get_simulator_lib_path(ascend_home: str, platform: str) -> str:
     )
 
 
+def resolve_compile_flags(
+    target: str,
+    pass_configs: dict | None = None,
+    compile_flags: list[str] | str | None = None,
+) -> list[str]:
+    """Resolve the Bisheng flags for one kernel.
+
+    Emits the framework's derived defaults first (see
+    :func:`normalize_compiler_options`: the #1346 VS-sync pairing plus the
+    ``TL_CCE_*`` / ``TL_PTO_DEBUG`` env fallbacks), then appends the caller's
+    ``compile_flags`` last -- bisheng is last-wins for repeated flags, so caller
+    flags override the derived ones (e.g. ``["--cce-auto-sync=on"]`` re-enables
+    auto-sync, ``["-O0"]`` lowers the level). ``os.environ`` is only read.
+
+    Resolved once per kernel in :func:`tilelang.compile` so the same list feeds
+    both the kernel cache key and codegen.
+    """
+    from tilelang.transform.pass_config import normalize_compiler_options
+
+    options = normalize_compiler_options(pass_configs)
+    flags = [f"-O{options['opt_level']}"]
+    if target in ("ascendc", "auto") and not options["cce_auto_sync"]:
+        # AscendC-only: PTO has no auto-sync to disable (its default already
+        # matches --cce-auto-sync=off), so the flag is not emitted there.
+        flags.append("--cce-auto-sync=off")
+    if target == "pto" and options["pto_debug"]:
+        flags += ["-D_DEBUG", "--cce-enable-print"]
+    if compile_flags:
+        flags += [compile_flags] if isinstance(compile_flags, str) else list(compile_flags)
+    return flags
+
+
 class LibraryGenerator:
     srcpath: str | None = None
     libpath: str | None = None
     lib_code: str | None = None
 
-    def __init__(self, target: str, platform: str):
+    def __init__(self, target: str, platform: str, compile_flags: list[str] | str | None = None):
         self.target = target
         self.platform = platform
+        # Fully-resolved Bisheng flags for this kernel (derived defaults + caller
+        # flags). None means a direct/legacy caller: fall back to the derived
+        # defaults in compile_lib.
+        self.compile_flags = compile_flags
 
     def update_lib_code(self, lib_code: str):
         self.lib_code = lib_code
@@ -108,15 +144,15 @@ class LibraryGenerator:
         libpath = src.name.replace(".cpp", ".so")
         ASCEND_HOME_PATH = _get_ascend_home_path()
         TL_ROOT = _get_tl_root()
-        auto_sync = os.environ.get("TL_CCE_AUTO_SYNC", "on").lower()
-        opt_level = os.environ.get("TL_CCE_OPT_LEVEL", "2").lower()
-        if opt_level not in ("0", "1", "2", "3"):
-            raise ValueError(f"Invalid TL_CCE_OPT_LEVEL={opt_level!r}, expected one of: 0, 1, 2, 3")
+        # The JIT pipeline resolves these up front; a direct caller gets the
+        # framework defaults (pass-config-free, env fallbacks still apply).
+        compile_flags = self.compile_flags
+        if compile_flags is None:
+            compile_flags = resolve_compile_flags(self.target)
         if self.target == "ascendc" or self.target == "auto":
             command = [
                 "bisheng",
                 "--npu-arch=dav-2201",
-                f"-O{opt_level}",
                 "-std=c++17",
                 "-xasc",
                 f"-I{ASCEND_HOME_PATH}/include",
@@ -145,12 +181,6 @@ class LibraryGenerator:
                 "--shared",
                 src.name,
             ]
-
-            # pto do not support the compile arg like "--cce-auto-sync=on/off".
-            # pto default behavior equals ascendc "--cce-auto-sync=off".
-            # so auto_sync only affect ascendc
-            if auto_sync == "off":
-                command.append("--cce-auto-sync=off")
         elif self.target == "pto":
             ccec = "dav-c310" if self.platform == "A5" else "dav-c220"
             memory = "REGISTER_BASE" if self.platform == "A5" else "MEMORY_BASE"
@@ -158,7 +188,6 @@ class LibraryGenerator:
                 "bisheng",
                 f"--cce-aicore-arch={ccec}",
                 f"-D{memory}",
-                f"-O{opt_level}",
                 "-std=gnu++17",
                 "-xcce",
                 "-mllvm",
@@ -197,8 +226,6 @@ class LibraryGenerator:
                 "--shared",
                 src.name,
             ]
-            if os.environ.get("TL_PTO_DEBUG") == "1":
-                command += ["-D_DEBUG", "--cce-enable-print"]
 
         # --- camodel (simulator) support ---
         run_mode = os.environ.get("TL_RUN_MODE", "npu")
@@ -225,6 +252,10 @@ class LibraryGenerator:
             except ValueError:
                 pass
             logger.info("camodel sim mode: using %s", sim_lib_path)
+
+        # Append the resolved flags last so they win (bisheng is last-wins);
+        # whitespace-split and de-duplicated, matching upstream tilelang.
+        command += [item for flag in compile_flags for item in flag.split() if item not in command]
 
         command += ["-o", libpath]
 

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -54,6 +54,7 @@ class JITKernel:
         platform: str = "auto",
         verbose: bool = False,
         pass_configs: dict[str, Any] | None = None,
+        compile_flags: list[str] | str | None = None,
         from_database: bool = False,
     ):
         """
@@ -97,6 +98,7 @@ class JITKernel:
         if pass_configs is None:
             pass_configs = {}
         self.pass_configs = pass_configs
+        self.compile_flags = compile_flags
 
         # Validate the execution backend.
         assert execution_backend in [
@@ -134,6 +136,7 @@ class JITKernel:
         auto_gm_idx: list[int] | int,
         execution_backend: Literal["dlpack", "ctypes", "cython"],
         pass_configs: dict[str, Any] | None = None,
+        compile_flags: list[str] | str | None = None,
     ):
         """
         Alternative constructor to create a TorchFunction directly from a database.
@@ -147,6 +150,7 @@ class JITKernel:
             target_host=target_host,
             platform=platform,
             pass_configs=pass_configs,
+            compile_flags=compile_flags,
             from_database=True,
         )
 
@@ -161,6 +165,7 @@ class JITKernel:
             kernel_global_source=kernel_global_source,
             kernel_lib_path=kernel_lib_path,
             pass_configs=pass_configs,
+            compile_flags=compile_flags,
         )
         instance.torch_function = instance.adapter.func
         return instance
@@ -277,6 +282,7 @@ class JITKernel:
                 kernel_global_source=artifact.kernel_source,
                 verbose=verbose,
                 pass_configs=pass_configs,
+                compile_flags=self.compile_flags,
             )
         else:
             # Handle invalid backend.
@@ -296,6 +302,7 @@ class JITKernel:
         kernel_global_source: str,
         kernel_lib_path: str,
         pass_configs: dict[str, Any] | None = None,
+        compile_flags: list[str] | str | None = None,
     ) -> BaseKernelAdapter:
         target = self.target
         execution_backend = self.execution_backend
@@ -325,6 +332,7 @@ class JITKernel:
                 kernel_global_source=kernel_global_source,
                 kernel_lib_path=kernel_lib_path,
                 pass_configs=pass_configs,
+                compile_flags=compile_flags,
             )
         else:
             # Handle invalid backend.

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -170,16 +170,52 @@ def _apply_target_pass_defaults(
     return configs
 
 
-def _process_for_auto_sync_insert_vs(pass_configs):
-    vs_enabled = bool(pass_configs and pass_configs.get(PassConfigKey.TL_ASCEND_AUTO_SYNC_VS, False))
-    if vs_enabled:
-        if "TL_CCE_AUTO_SYNC" not in environ:
-            environ["TL_CCE_AUTO_SYNC"] = "off"
-        if "TL_CCE_OPT_LEVEL" not in environ:
-            environ["TL_CCE_OPT_LEVEL"] = "3"
+# Framework-derived Bisheng options for a single kernel. Historically the VS-sync
+# pairing (#1346) was applied by writing TL_CCE_* into ``os.environ``, which leaked
+# across kernels (#1386); it is now derived per kernel here and turned into compile
+# flags by ``LibraryGenerator.resolve_compile_flags``. ``os.environ`` is only read.
+_DEFAULT_COMPILER_OPTIONS = {"cce_auto_sync": True, "opt_level": 2, "pto_debug": False}
+
+
+def _coerce_opt_level(value) -> int:
+    text = str(value).strip()
+    if text not in ("0", "1", "2", "3"):
+        raise ValueError(f"Invalid opt_level={value!r}, expected one of: 0, 1, 2, 3")
+    return int(text)
+
+
+def normalize_compiler_options(pass_configs=None) -> dict:
+    """Derive a kernel's Bisheng options: ``{cce_auto_sync, opt_level, pto_debug}``.
+
+    Resolved from ``pass_configs`` (``TL_ASCEND_AUTO_SYNC_VS`` pairs with
+    ``cce_auto_sync=False`` / ``opt_level=3``, preserving #1346) and the
+    ``TL_CCE_AUTO_SYNC`` / ``TL_CCE_OPT_LEVEL`` / ``TL_PTO_DEBUG`` env vars. The env
+    vars are lenient read-only fallbacks keeping their exact pre-existing semantics
+    -- only ``"off"`` disables auto-sync, only ``"1"`` enables PTO debug -- so a
+    malformed value never raises and a stray env var cannot break a compile for a
+    target that ignores the option. Never mutates ``os.environ``.
+
+    These are the framework's defaults; callers override the resulting flags via
+    ``compile_flags``, which are appended last (bisheng is last-wins).
+    """
+    resolved = dict(_DEFAULT_COMPILER_OPTIONS)
+
+    # VS sync pairs with cce-auto-sync=off + O3 (#1346).
+    if pass_configs and pass_configs.get(PassConfigKey.TL_ASCEND_AUTO_SYNC_VS, False):
+        resolved.update(cce_auto_sync=False, opt_level=3)
+
+    env_auto_sync = environ.get("TL_CCE_AUTO_SYNC")
+    if env_auto_sync is not None:
+        resolved["cce_auto_sync"] = env_auto_sync.strip().lower() != "off"
+    env_opt_level = environ.get("TL_CCE_OPT_LEVEL")
+    if env_opt_level is not None:
+        resolved["opt_level"] = _coerce_opt_level(env_opt_level)
+    env_pto_debug = environ.get("TL_PTO_DEBUG")
+    if env_pto_debug is not None:
+        resolved["pto_debug"] = env_pto_debug.strip() == "1"
+
+    return resolved
 
 
 def process_default_pass_config(target, pass_configs):
-    pass_configs = _apply_target_pass_defaults(target, pass_configs)
-    _process_for_auto_sync_insert_vs(pass_configs)
-    return pass_configs
+    return _apply_target_pass_defaults(target, pass_configs)


### PR DESCRIPTION
Fixes #1386.

## How to review

- [Commit 1 — skip](https://github.com/tile-ai/tilelang-ascend/pull/1389/commits/87f02d8dda4ff567a9572e66dc67d175bca72db1): ruff 0.15.21 formatting + typing modernization. No behavior change.
- [Commit 2 — review this](https://github.com/tile-ai/tilelang-ascend/pull/1389/commits/57da5d1d99d1563ebd8e1c1a7bd624894b19a1d2): the kernel-scoped compile-flags implementation.
- [Commit 3 — reviewer follow-up](https://github.com/tile-ai/tilelang-ascend/pull/1389/commits/30dd9c307941e0e68b30f46367e04e0554f1185c): finalizes synchronization coverage in two files. The example contains only successful, automatically synchronized usage; the NPU-gated pytest owns the pass-on/pass-off negative regression.

## Problem

#1346 writes `TL_CCE_AUTO_SYNC` and `TL_CCE_OPT_LEVEL` into `os.environ` at pass-config time. These variables are process-wide and never restored, so compiling one kernel with VS sync ON leaks `-O3 --cce-auto-sync=off` into every subsequent compile in the same process. `TL_PTO_DEBUG` has the same scope problem.

## Solution

Derive Bisheng flags per kernel instead of mutating the environment. The public API is `compile_flags`, matching upstream [tile-ai/tilelang](https://github.com/tile-ai/tilelang/blob/main/tilelang/jit/__init__.py):

```python
@tilelang.jit(target="ascendc", compile_flags=["--cce-auto-sync=off", "-O3"])
@tilelang.jit(target="pto", compile_flags=["-D_DEBUG", "--cce-enable-print"])
```

### How flags are built

`resolve_compile_flags(target, pass_configs, compile_flags)` produces the final flag list:

1. **Framework-derived defaults** (`normalize_compiler_options`): `-O2` by default; the #1346 VS-sync pairing (`TL_ASCEND_AUTO_SYNC_VS` → `-O3 --cce-auto-sync=off`); then the `TL_CCE_AUTO_SYNC` / `TL_CCE_OPT_LEVEL` / `TL_PTO_DEBUG` env vars as lenient read-only fallbacks.
2. **Caller's `compile_flags`** appended last — Bisheng is last-wins for repeated flags, so caller flags override the defaults.

The resolved list is computed once in `compile()` and threaded through cache → `JITKernel` → `LibraryGenerator`, folded into the cache key. `os.environ` is never written.

### File-by-file guide

| File | What to look for |
|------|------------------|
| `transform/pass_config.py` | `normalize_compiler_options()` derives `{cce_auto_sync, opt_level, pto_debug}` from `pass_configs` + env. Removes `_process_for_auto_sync_insert_vs`. |
| `jit/adapter/libgen.py` | `resolve_compile_flags()` turns the dict into flags + appends caller flags. `LibraryGenerator` appends (whitespace-split, de-duplicated) instead of hardcoding. |
| `jit/__init__.py` | `compile()` calls `resolve_compile_flags` once; `jit()` / `_JitImplementation` thread `compile_flags`. |
| `jit/kernel.py` | `JITKernel` stores `compile_flags` and passes to adapter. |
| `cache/__init__.py`, `cache/kernel_cache.py` | `compile_flags` in the cache key. |
| `jit/adapter/cython/adapter.py` | Forwards `compile_flags` to `LibraryGenerator`. |
| `autotuner/param.py` | `CompileArgs` gains `compile_flags` + `platform`; `_load_kernel_from_disk` fixes the stale `from_database()` call (see below); `auto_gm_idx` now persisted. |
| `autotuner/tuner.py` | `set_compile_args` exposes `compile_flags` + `platform`; `@autotune` inherits both from `@tilelang.jit`. |

### PTO compatibility

- `--cce-auto-sync` is AscendC-only and never emitted for PTO (whose default already matches `=off`).
- `-D_DEBUG --cce-enable-print` is PTO-only and never emitted for AscendC.
- Env fallbacks are lenient: only `"off"` disables auto-sync, only `"1"` enables PTO debug. A malformed value never raises — matching the pre-existing behavior, so a stray env var cannot break a PTO compile.
- Caller `compile_flags` are passed through to Bisheng without target filtering. This is intentional: the caller explicitly chose them, and Bisheng silently tolerates cross-target flags.

### Auto-tuner disk-restore bugfix

`AutotuneResult._load_kernel_from_disk` called `JITKernel.from_database()` with a stale argument list — missing `platform`, `workspace_idx`, `auto_gm_idx` — so restoring a tuned kernel from disk raised `TypeError`. This PR supplies the missing args, persists/restores `auto_gm_idx`, and resolves `platform` via `determine_platform` (sim-mode restores load the correct simulator lib).

### Reviewer notes

- **Cache-key change**: the resolved flag list is now part of the key. Two kernels differing only in Bisheng flags will no longer alias to the same cached artifact (a one-time invalidation for existing Ascend kernel caches).
- **Not ported from upstream**: `func.attrs["tilelang_compile_flags"]` and `pass_configs[TL_DEVICE_COMPILE_FLAGS]` — neither mechanism exists in this repo; orthogonal to #1386.

### Reviewer follow-up: synchronization coverage

The final layout follows [fengz72's review guidance](https://github.com/tile-ai/tilelang-ascend/pull/1389#discussion_r3602086298):

- `examples/compile_flags/compile_flags_example.py` contains only successful usage. It has no `T.barrier_all()` or explicit execution scope, enables `TL_ASCEND_AUTO_SYNC`, and verifies both explicit and default Bisheng flags against PyTorch.
- `testing/python/language/test_ascend_compile_flags.py` owns the negative regression. The same dependency-chain kernel is compiled under identical Bisheng flags with `TL_ASCEND_AUTO_SYNC` enabled and disabled; the synchronized output matches PyTorch, while the intentionally unsynchronized output does not.

## Tests

- `testing/python/language/test_ascend_compile_flags.py` — 17 hermetic flag-resolution/JIT/cache/autotuner instances plus one NPU-gated synchronization regression.
- `examples/compile_flags/compile_flags_example.py` — positive-only on-device demonstration. Two synchronized kernels use explicit and default Bisheng flags respectively; both match PyTorch, verifying correctness and kernel-scoped flag isolation. Auto-collected by `bench_test.sh`.