### PR TITLE
[Fix] PTO CodeGen: fix BufferStoreNode eval order causing invalid C++ from if_then_else

### DIFF
--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -783,18 +783,23 @@ void CodeGenTileLangAscendPto::VisitExpr_(const BufferLoadNode *op,
 
 void CodeGenTileLangAscendPto::VisitStmt_(const BufferStoreNode *op) {
   auto var_name = var_idmap_[op->buffer->data.get()];
-  this->PrintIndent();
   std::string scope = op->buffer.scope();
-
   if (scope == "" || scope == "global") {
-    this->stream << "*(" << var_name << "_handle + "
-                 << PrintExpr(op->indices.back())
-                 << ") = " << PrintExpr(op->value) << ";\n";
+    std::string index = PrintExpr(op->indices.back());
+    std::string value = PrintExpr(op->value);
+    this->PrintIndent();
+    this->stream << "*(" << var_name << "_handle + " << index << ") = " << value
+                 << ";\n";
   } else if (scope == "local.var") {
-    this->stream << var_name << " = " << PrintExpr(op->value) << ";\n";
+    std::string value = PrintExpr(op->value);
+    this->PrintIndent();
+    this->stream << var_name << " = " << value << ";\n";
   } else {
-    this->stream << var_name << ".SetValue(" << PrintExpr(op->indices.back())
-                 << ", " << PrintExpr(op->value) << ");\n";
+    std::string index = PrintExpr(op->indices.back());
+    std::string value = PrintExpr(op->value);
+    this->PrintIndent();
+    this->stream << var_name << ".SetValue(" << index << ", " << value
+                 << ");\n";
   }
 }
 


### PR DESCRIPTION
[Fix] **PTO** CodeGen: fix BufferStoreNode eval order causing invalid C++ from if_then_else

also see: Ascend CodeGen PR: #1364