### PR TITLE
[Feat] Ascend: add exp_experiment (strided masked exp) for narrow softmax windows

### DIFF
--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -1389,6 +1389,12 @@ TIR_DEFINE_TL_BUILTIN(ascend_row_expand_div_experiment)
     .set_num_inputs(-1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ascend_exp_experiment)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
 TIR_DEFINE_TL_BUILTIN(ascend_copy_cv_experiment)
     .set_num_inputs(3)
     .set_attr<TCallEffectKind>("TCallEffectKind",

--- a/src/op/ascend.h
+++ b/src/op/ascend.h
@@ -259,6 +259,8 @@ TVM_DLL const Op &ascend_row_expand_sub_experiment();
 
 TVM_DLL const Op &ascend_row_expand_div_experiment();
 
+TVM_DLL const Op &ascend_exp_experiment();
+
 // ---------------------------------------------------------------------------
 // Internal tail-aware vector ops produced by AscendTailMaskPropagation. These
 // are never emitted by the front-end; the pass rewrites the corresponding

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -637,6 +637,8 @@ void CodeGenTileLangAscend::VisitExpr_(const CallNode *op, std::ostream &os) {
     RowExpandSubExperimentCodegen(op);
   } else if (op->op.same_as(tl::ascend_row_expand_div_experiment())) {
     RowExpandDivExperimentCodegen(op);
+  } else if (op->op.same_as(tl::ascend_exp_experiment())) {
+    ExpExperimentCodegen(op);
   } else if (op->op.same_as(tl::ascend_wait_cross_flag())) {
     PrintOpCall(op, "AscendC::CrossCoreWaitFlag", {0, 0}, {0, 1});
   } else if (op->op.same_as(tl::ascend_set_cross_flag())) {
@@ -2207,6 +2209,57 @@ void CodeGenTileLangAscend::RowExpandBinOpExperimentCodegen(
                  << ", 1, 1, 0, " << rep_stride << ", " << rep_stride
                  << ", 1);\n";
   }
+}
+
+void CodeGenTileLangAscend::ExpExperimentCodegen(const CallNode *op) {
+  // args[0] = op name string, args[1] = dst, args[2] = src.
+  // Unary mirror of RowExpandBinOpExperimentCodegen: exp the `mask` valid
+  // columns of each row in place, striding by the buffer's physical column
+  // count so one call covers all rows of a 64-column (fp32) chunk of a wider
+  // N-strided score buffer. rep_stride = physical_cols / elems_per_block;
+  // repeat_time = extent / (8 * elems_per_block) = one repeat per row when the
+  // slice is a 64-col chunk.
+  DataType dtype = GetAccessPtrDtype(op->args[1].as<CallNode>());
+  std::string type_str = getType(dtype);
+  int elems_per_block = 256 / dtype.bits();
+
+  auto *dst_access = op->args[1].as<CallNode>();
+  Var dst_var = Downcast<Var>(dst_access->args[1]);
+  int cols = 0;
+  if (buffer_shapes_.count(dst_var)) {
+    auto shape = buffer_shapes_.at(dst_var);
+    if (shape.size() >= 1 && shape[shape.size() - 1].as<IntImmNode>()) {
+      cols = static_cast<int>(shape[shape.size() - 1].as<IntImmNode>()->value);
+    }
+  }
+  int rep_stride = cols / elems_per_block;
+  int repeat_time = 0;
+  if (auto *extent_imm = dst_access->args[3].as<IntImmNode>()) {
+    int extent = static_cast<int>(extent_imm->value);
+    int elems_per_repeat = 8 * elems_per_block;
+    ICHECK(extent > 0 && extent % elems_per_repeat == 0)
+        << "ExpExperimentCodegen: extent=" << extent
+        << " must be a positive multiple of " << elems_per_repeat;
+    repeat_time = extent / elems_per_repeat;
+  } else {
+    ICHECK(false) << "ExpExperimentCodegen: dynamic extent not supported";
+  }
+  ICHECK(repeat_time > 0 && cols > 0)
+      << "ExpExperimentCodegen: failed to derive repeat_time/cols";
+  ICHECK(cols % elems_per_block == 0)
+      << "ExpExperimentCodegen: physical columns " << cols
+      << " must be a multiple of elems_per_block " << elems_per_block;
+
+  uint64_t mask1 = (dtype.bits() == 16) ? 0xFFFFFFFFFFFFFFFF : 0;
+
+  std::string dst_name = PrintBufferOffset(op->args[1].as<CallNode>(), true);
+  std::string src_name = PrintBufferOffset(op->args[2].as<CallNode>(), true);
+
+  this->PrintIndent();
+  this->stream << "tl::ascend::exp_mask<" << type_str << ">(" << dst_name
+               << ", " << src_name << ", 0xFFFFFFFFFFFFFFFF, " << mask1 << ", "
+               << repeat_time << ", 1, 1, " << rep_stride << ", " << rep_stride
+               << ");\n";
 }
 
 void CodeGenTileLangAscend::BroadcastOpCodegen(const CallNode *op) {

--- a/src/target/codegen_ascend.h
+++ b/src/target/codegen_ascend.h
@@ -161,6 +161,8 @@ private:
   void RowExpandBinOpExperimentCodegen(const CallNode *op,
                                        const std::string &mask_op_name);
 
+  void ExpExperimentCodegen(const CallNode *op);
+
   void SetCrossFlagCodegen(const CallNode *op);
 
   void FlagOpCodegen(const CallNode *op, std::string op_name);

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -1400,6 +1400,24 @@ div_mask(const LocalTensor<T> &dst, const LocalTensor<T> &src0,
   AscendC::Div<T, false>(dst, src0, src1, mask, repeatTime, params);
 }
 
+// Strided masked exp for the narrow online-softmax window: exp only the `mask`
+// valid columns of each row, striding `srcRepStride`/`dstRepStride` 32B-blocks
+// between rows so one call touches just the [0:tw] window of a wider,
+// physically-strided score buffer (no compaction). Unary mirror of sub_mask;
+// ExpExperimentCodegen derives repeatTime/rep_stride from the buffer's physical
+// column count, and callers loop 64-column (fp32) chunks over the valid window.
+template <typename T>
+CATLASS_DEVICE void
+exp_mask(const LocalTensor<T> &dst, const LocalTensor<T> &src,
+         const uint64_t mask0, const uint64_t mask1, const uint8_t repeatTime,
+         const uint8_t dstBlkStride, const uint8_t srcBlkStride,
+         const uint8_t dstRepStride, const uint8_t srcRepStride) {
+  uint64_t mask[2] = {mask0, mask1};
+  AscendC::UnaryRepeatParams params(dstBlkStride, srcBlkStride, dstRepStride,
+                                    srcRepStride);
+  AscendC::Exp<T, false>(dst, src, mask, repeatTime, params);
+}
+
 template <typename T1, typename T2, typename LayOutL1, typename LayoutGM,
           uint32_t M, uint32_t N, uint32_t K, uint32_t baseM, uint32_t baseN,
           uint32_t baseK, bool init, bool is_transpose_A = false,

--- a/src/transform/common/operation_config.h
+++ b/src/transform/common/operation_config.h
@@ -284,6 +284,7 @@ GetOperationConfig() {
        {{{1, "write"}, {2, "read"}, {3, "read"}}, "PIPE_V"}},
       {"tl.ascend_row_expand_div_experiment",
        {{{1, "write"}, {2, "read"}, {3, "read"}}, "PIPE_V"}},
+      {"tl.ascend_exp_experiment", {{{1, "write"}, {2, "read"}}, "PIPE_V"}},
 
       // Internal tail-aware ops (AscendTailMaskPropagation). arg0 is the
       // AscendC op-tag string, hence buffer indices start at 1.

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -5142,6 +5142,54 @@ def test_row_expand_div_experiment(dtype, target, shape):
     torch.testing.assert_close(c.cpu(), ref_c.cpu(), rtol=1e-2, atol=1e-2)
 
 
+def exp_experiment_kernel(M, N, col, dtype="float"):
+    # exp_experiment exps a 64-col (fp32) / 128-col (fp16) chunk of every row per
+    # call, striding the buffer's physical column count between rows; callers loop
+    # chunks over the valid window. `col` picks how many chunks fire (1 / 2 / 4).
+    chunk = 64 if dtype == "float" else 128
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        C: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((M, N), dtype)
+            T.copy(A, a_ub)
+            # Strided masked exp over [0:col] in place; the [col:N] tail is untouched.
+            for k in range(col // chunk):
+                sc = k * chunk
+                T.tile.exp_experiment(a_ub[:, sc : sc + chunk], a_ub[:, sc : sc + chunk])
+            T.copy(a_ub, C)
+
+    return main
+
+
+@pytest.mark.parametrize(
+    "dtype,col",
+    [("float", 64), ("float", 128), ("float", 256), ("float16", 128), ("float16", 256)],
+)
+def test_exp_experiment(dtype, col):
+    # exp_experiment is ascendc-only (no PTO counterpart). It exps only the first
+    # `col` columns of a 512-wide N-strided buffer, in place, leaving [col:N] as-is
+    # -- what an online-softmax narrow window needs without compacting to a tile.
+    M, N = 16, 512
+    func = exp_experiment_kernel(M, N, col, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target="ascendc")
+
+    torch_dtype = torch.float16 if dtype == "float16" else torch.float32
+    a = torch.randn(M, N, dtype=torch_dtype).npu()
+    torch.npu.synchronize()
+
+    c = func(a)
+    torch.npu.synchronize()
+
+    ref = a.clone()
+    ref[:, :col] = torch.exp(a[:, :col])  # only the window is exp'd; tail unchanged
+
+    torch.testing.assert_close(c.cpu(), ref.cpu(), rtol=1e-2, atol=1e-2)
+
+
 if __name__ == "__main__":
     current_dir = os.path.dirname(os.path.abspath(__file__))
     elementwise_test_path = os.path.join(current_dir, "test_tilelang_ascend_language_elementwise.py")

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -2416,6 +2416,57 @@ def row_expand_div_experiment(
     )
 
 
+def exp_experiment(dst, src):
+    """Strided masked exp over a 64-column (fp32) chunk of a wider N-strided buffer.
+
+    Exps ``dst[i, 0:64] = exp(src[i, 0:64])`` for every row in one call, striding by
+    the buffer's physical column count (read from the declaration by
+    ExpExperimentCodegen) so it touches just the valid window of an [M, N]-strided
+    score buffer without compaction. Callers loop 64-column chunks over the valid
+    window (same shape row_expand_sub_experiment expects). Unary mirror of the
+    experiment row-ops: emits ``tl::ascend::exp_mask<dtype>(dst, src, ...)``.
+
+    Args:
+        dst: Destination [rows, chunk_cols] buffer region (chunk_cols = 64 for fp32).
+        src: Source buffer region of matching shape (may equal dst for in-place exp).
+    """
+    dst = _normalize_buffer_arg(dst)
+    src = _normalize_buffer_arg(src)
+
+    if isinstance(dst, BufferRegion):
+        dst_ptr, dst_shape = _handle_buffer_region_2d(dst, "w")
+    else:
+        dst_ptr = dst.access_ptr("w")
+        dst_shape = list(dst.shape[-2:])
+
+    if isinstance(src, BufferRegion):
+        src_ptr, src_shape = _handle_buffer_region_2d(src, "r")
+    else:
+        src_ptr = src.access_ptr("r")
+        src_shape = list(src.shape[-2:])
+
+    if len(dst_shape) != 2 or len(src_shape) != 2:
+        raise ValueError("exp_experiment requires 2D buffers for dst and src.")
+    if not _shapes_equal(dst_shape, src_shape):
+        raise ValueError(f"dst and src shapes must match: dst={dst_shape}, src={src_shape}")
+
+    dtype = _dtype(src)
+    if dtype not in ("float16", "half", "float32", "float"):
+        raise ValueError(f"exp_experiment only supports float16 or float32, got {dtype}")
+    expected_chunk = 128 if dtype in ("float16", "half") else 64
+    if not _const_equal(dst_shape[1], expected_chunk):
+        raise ValueError(
+            f"exp_experiment requires the chunk size (last dimension) to be exactly {expected_chunk} for {dtype}, but got {dst_shape[1]}."
+        )
+    return tir.call_intrin(
+        "handle",
+        tir.op.Op.get("tl.ascend_exp_experiment"),
+        f"exp_mask<{dtype}>",
+        dst_ptr,
+        src_ptr,
+    )
+
+
 def sub_experiment(dst: Buffer, src0: Buffer, src1: Buffer, count: PrimExpr):
     """Performs element-wise subtraction(with count function): dst = src0 - src1.
 


### PR DESCRIPTION
## What

Add `exp_experiment`, a strided masked exp for the narrow online-softmax window, as the unary counterpart of the existing `row_expand_{sub,mul,div}_experiment` family (#1255).

## Why

The contiguous `AscendC::Exp(dst, src, count)` walks a flat element count, so it cannot exp only the first `tw` valid columns of a wider N-strided score buffer without folding the row padding into the next row. An online softmax over a narrow window (score buffer physically 512-wide, valid window often <=128) is then forced to either compact to a contiguous tile (extra UB) or run exp over the full padded width (wasted work on Vector, the bound pipe).

`exp_experiment` exps a 64-column (fp32) / 128-column (fp16) chunk of every row in one call, striding the buffer's physical column count between rows, so a caller loops `ceil(tw/64)` chunks over the valid window in place -- the same shape `row_expand_sub_experiment` already expects.

## How

Standard seven-point wiring, purely additive and ascendc-only (non-PTO):
- device template `exp_mask` (`AscendC::Exp<T, false>` + `UnaryRepeatParams`)
- op decl / registration (`ascend.cc` / `ascend.h`)
- codegen dispatch + `ExpExperimentCodegen` (derives `repeat_time` / `rep_stride` from the buffer's physical column count; mirrors `RowExpandBinOpExperimentCodegen`)
- `operation_config` PIPE_V read/write mask
- `T.tile.exp_experiment` frontend

## Test

`test_exp_experiment` in `testing/python/language/test_tilelang_ascend_language_elementwise.py`: exps the first {64, 128, 256} columns of a 512-wide buffer and checks against torch for fp32 and fp16, asserting the `[col:N]` tail is left untouched. 5 cases, all pass.

## Notes

ascendc-only: like the `row_expand_*_experiment` family this targets the ascendc backend; a PTO counterpart can follow if needed.