### PR TITLE
[Bugfix] Fix `gemm_v0` hardcoded fractal size 16 breaking int8 when `kL0split > 1`

### DIFF
--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -1048,6 +1048,11 @@ gemm_v0(LocalTensor<T1> const &A, LocalTensor<T1> const &B,
         AscendC::TBuf<AscendC::TPosition::A2> &l0a_,
         AscendC::TBuf<AscendC::TPosition::B2> &l0b_, bool clear) {
   static_assert(kL0Size % 16 == 0, "kL0Size must be a multiple of 16");
+  // Elements per C0 block (32 bytes). Equals 16 only for half; for int8 it is
+  // 32, for float it is 8. The fractal (zN/zZ/nZ) K-stride used below to step
+  // between L0 K-tiles is ELE_NUM_PER_C0 * kL0Size, so hardcoding 16 breaks
+  // int8 (and any dtype where sizeof(T1) != 2) once kL0split > 1.
+  constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(T1);
   constexpr uint32_t kL0split = (K + kL0Size - 1) / kL0Size;
   auto l0a = l0a_.Get<T1>();
   auto l0b = l0b_.Get<T1>();
@@ -1071,7 +1076,7 @@ gemm_v0(LocalTensor<T1> const &A, LocalTensor<T1> const &B,
   //   L0C column n0  ->  n0 * roundUp16(M)   (tla::MakeLayoutL0C N1 stride)
   //   L1 zN B col n0 ->  n0 * roundUp16(K)   (tla::MakeLayout<zN>  C1 stride)
   // both of which are consistent with the original K-offset
-  // B[kL0Idx*16*kL0Size] (zN K-row stride) already used below.
+  // B[kL0Idx*ELE_NUM_PER_C0*kL0Size] (zN K-row stride) already used below.
   constexpr uint32_t nMaxByL0B = (32u * 1024u) / (kL0Size * sizeof(T1));
   constexpr uint32_t nTile = (transpose_B || N <= nMaxByL0B) ? N : nMaxByL0B;
   static_assert(transpose_B || (N % nTile == 0),
@@ -1148,11 +1153,11 @@ gemm_v0(LocalTensor<T1> const &A, LocalTensor<T1> const &B,
                                              A[kL0Idx * M * kL0Size], M, kSize);
       } else {
         tl::ascend::copy_l1_to_l0a<T1, K, M, true>(
-            l0a[l0a_base], A[kL0Idx * 16 * kL0Size], M, kSize);
+            l0a[l0a_base], A[kL0Idx * ELE_NUM_PER_C0 * kL0Size], M, kSize);
       }
       if constexpr (!transpose_B) {
         tl::ascend::copy_l1_to_l0b<T1, K, N>(
-            l0b[l0b_base], B[bNOffset + kL0Idx * 16 * kL0Size], kSize, nTile);
+            l0b[l0b_base], B[bNOffset + kL0Idx * ELE_NUM_PER_C0 * kL0Size], kSize, nTile);
       } else {
         tl::ascend::copy_l1_to_l0b<T1, N, K, true>(
             l0b[l0b_base], B[kL0Idx * N * kL0Size], kSize, N);

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -1157,7 +1157,8 @@ gemm_v0(LocalTensor<T1> const &A, LocalTensor<T1> const &B,
       }
       if constexpr (!transpose_B) {
         tl::ascend::copy_l1_to_l0b<T1, K, N>(
-            l0b[l0b_base], B[bNOffset + kL0Idx * ELE_NUM_PER_C0 * kL0Size], kSize, nTile);
+            l0b[l0b_base], B[bNOffset + kL0Idx * ELE_NUM_PER_C0 * kL0Size],
+            kSize, nTile);
       } else {
         tl::ascend::copy_l1_to_l0b<T1, N, K, true>(
             l0b[l0b_base], B[kL0Idx * N * kL0Size], kSize, N);

--- a/testing/python/language/test_tilelang_ascend_language_gemm_v0.py
+++ b/testing/python/language/test_tilelang_ascend_language_gemm_v0.py
@@ -253,9 +253,13 @@ def _gemm_v0_int8_kernel(M, N, K, block_M, block_N, K_L1, transpose_A=False, tra
 
                     T.barrier_all()
                     T.gemm_v0(
-                        A_L1, B_L1, C_L0,
-                        transpose_A=transpose_A, transpose_B=transpose_B,
-                        init=(k == 0), kL0Size=kL0Size,
+                        A_L1,
+                        B_L1,
+                        C_L0,
+                        transpose_A=transpose_A,
+                        transpose_B=transpose_B,
+                        init=(k == 0),
+                        kL0Size=kL0Size,
                     )
                     T.barrier_all()
 
@@ -274,8 +278,15 @@ def _run_int8_kl0split_case(transpose_A, transpose_B, kL0Size, K_L1):
     block_M, block_N = 128, 128
 
     program = _gemm_v0_int8_kernel(
-        M, N, K, block_M, block_N, K_L1,
-        transpose_A=transpose_A, transpose_B=transpose_B, kL0Size=kL0Size,
+        M,
+        N,
+        K,
+        block_M,
+        block_N,
+        K_L1,
+        transpose_A=transpose_A,
+        transpose_B=transpose_B,
+        kL0Size=kL0Size,
     )
     kernel = _compile(program, "ascendc")
 

--- a/testing/python/language/test_tilelang_ascend_language_gemm_v0.py
+++ b/testing/python/language/test_tilelang_ascend_language_gemm_v0.py
@@ -201,5 +201,124 @@ def test_gemm_v0_invalid_kL0Size_exceeds_mmad_limit(capfd):
     assert "4095" in captured.err
 
 
+# =============================================================================
+# Regression: int8 gemm_v0 with kL0split > 1 (issue #1395)
+# -----------------------------------------------------------------------------
+# gemm_v0 in src/tl_templates/ascend/common.h previously hardcoded ``16`` in
+# the L1->L0 K-tile offset for the transpose_A and non-transpose_B branches.
+# ``16`` equals ``ELE_NUM_PER_C0`` only for half (32B/sizeof(half)=16); for
+# int8 it must be 32, so once kL0split > 1 (K_L1 > kL0Size) the second K-tile
+# read a wrong offset and produced garbage. K_L1 <= kL0Size (kL0split == 1)
+# masked the bug because the offset was always 0.
+#
+# These cases target the two fixed branches on the ascendc backend (PTO uses a
+# separate, dtype-aware offset path and is unaffected):
+#   * transpose_A=True  -> A[kL0Idx * ELE_NUM_PER_C0 * kL0Size]
+#   * transpose_B=False -> B[... + kL0Idx * ELE_NUM_PER_C0 * kL0Size]
+# =============================================================================
+def _gemm_v0_int8_kernel(M, N, K, block_M, block_N, K_L1, transpose_A=False, transpose_B=False, kL0Size=128):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    a_gm_shape = (K, M) if transpose_A else (M, K)
+    b_gm_shape = (N, K) if transpose_B else (K, N)
+    a_l1_shape = (K_L1, block_M) if transpose_A else (block_M, K_L1)
+    b_l1_shape = (block_N, K_L1) if transpose_B else (K_L1, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor(a_gm_shape, "int8"),
+        B: T.Tensor(b_gm_shape, "int8"),
+        C: T.Tensor((M, N), "int32"),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+
+            A_L1 = T.alloc_L1(a_l1_shape, "int8")
+            B_L1 = T.alloc_L1(b_l1_shape, "int8")
+            C_L0 = T.alloc_L0C((block_M, block_N), "int32")
+
+            with T.Scope("C"):
+                loop_k = T.ceildiv(K, K_L1)
+                for k in T.serial(loop_k):
+                    if transpose_A:
+                        T.copy(A[k * K_L1, bx * block_M], A_L1)
+                    else:
+                        T.copy(A[bx * block_M, k * K_L1], A_L1)
+                    if transpose_B:
+                        T.copy(B[by * block_N, k * K_L1], B_L1)
+                    else:
+                        T.copy(B[k * K_L1, by * block_N], B_L1)
+
+                    T.barrier_all()
+                    T.gemm_v0(
+                        A_L1, B_L1, C_L0,
+                        transpose_A=transpose_A, transpose_B=transpose_B,
+                        init=(k == 0), kL0Size=kL0Size,
+                    )
+                    T.barrier_all()
+
+                # NOTE: use T.copy (not T.Parallel element-wise store) for the
+                # int32 L0C -> GM write: the Parallel path hits an unrelated
+                # codegen InternalError on int32 GM stores, out of scope here.
+                T.copy(C_L0, C[bx * block_M, by * block_N])
+
+    return main
+
+
+def _run_int8_kl0split_case(transpose_A, transpose_B, kL0Size, K_L1):
+    # int8 fractal needs M/N >= 16 and K >= 32. K_L1 > kL0Size forces kL0split
+    # >= 2, which is the trigger condition for issue #1395.
+    M, N, K = 256, 256, 512
+    block_M, block_N = 128, 128
+
+    program = _gemm_v0_int8_kernel(
+        M, N, K, block_M, block_N, K_L1,
+        transpose_A=transpose_A, transpose_B=transpose_B, kL0Size=kL0Size,
+    )
+    kernel = _compile(program, "ascendc")
+
+    a_gm_shape = (K, M) if transpose_A else (M, K)
+    b_gm_shape = (N, K) if transpose_B else (K, N)
+    torch.manual_seed(0)
+    a = torch.randint(-5, 6, a_gm_shape, dtype=torch.int8, device="npu")
+    b = torch.randint(-5, 6, b_gm_shape, dtype=torch.int8, device="npu")
+    c = torch.zeros(M, N, dtype=torch.int32, device="npu")
+
+    torch.npu.synchronize()
+    kernel(a, b, c)
+    torch.npu.synchronize()
+
+    # int32 matmul is unsupported on NPU; compute the reference on CPU.
+    a_ref = a.cpu().T if transpose_A else a.cpu()
+    b_ref = b.cpu().T if transpose_B else b.cpu()
+    ref_c = a_ref.to(torch.int32) @ b_ref.to(torch.int32)
+
+    # int8 -> int32 matmul is exact; assert a tight tolerance to catch any
+    # offset-misalignment regression (the original bug gave max diff ~1649).
+    torch.testing.assert_close(c.cpu(), ref_c, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="gemm_v0 correctness requires an Ascend NPU runtime",
+)
+@pytest.mark.parametrize("transpose_A,transpose_B", [(True, False), (False, False)])
+def test_gemm_v0_int8_kl0split_gt1(transpose_A, transpose_B):
+    # K_L1=256, kL0Size=128 -> kL0split=2: triggers the offset bug pre-fix.
+    _run_int8_kl0split_case(transpose_A, transpose_B, kL0Size=128, K_L1=256)
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="gemm_v0 correctness requires an Ascend NPU runtime",
+)
+@pytest.mark.parametrize("transpose_A,transpose_B", [(True, False), (False, False)])
+def test_gemm_v0_int8_kl0split_eq1(transpose_A, transpose_B):
+    # K_L1 == kL0Size -> kL0split=1: the masked case, must remain correct.
+    _run_int8_kl0split_case(transpose_A, transpose_B, kL0Size=128, K_L1=128)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-n", "8"])


### PR DESCRIPTION
Resolve Issue: #1395 

## 一、问题背景

### 现象

在 AscendC 后端使用 `T.gemm_v0` 做 int8 矩阵乘（`int8 × int8 → int32`）时，当 K 轴 L1 tile 大小 `K_L1` 大于 L0 tile 大小 `kL0Size`（默认 128），即 `kL0split > 1` 时，输出结果错误（max diff ≈ 1649）。当 `K_L1 <= kL0Size`（`kL0split == 1`）时结果正确，bug 被掩盖。

复现脚本（来自 issue）：

```python
# K_L1=256, kL0Size=128(默认) -> kL0split=2, 触发 bug
c = matmul(M, N, K, 128, 256, 256, "int8", "int32")(a, b)
# 修复前: Max diff: 1649
# 修复后: Max diff: 0
```

### 根因定位

`src/tl_templates/ascend/common.h` 的 `gemm_v0` 函数在 L1→L0 的 K-tile 偏移计算中**硬编码了 `16`**：

```cpp
// transpose_A 分支 (原 line 1151)
A[kL0Idx * 16 * kL0Size]

// !transpose_B 分支 (原 line 1155)
B[bNOffset + kL0Idx * 16 * kL0Size]
```

这里的 `16` 实际上是 fractal 布局（zN/zZ/nZ）的 **C0 块元素数** `ELE_NUM_PER_C0`。经核对 catlass 布局定义（`3rdparty/catlass/include/catlass/catlass.hpp` + `tla/layout.hpp`）：

- `BYTE_PER_C0 = 32`（C0 块固定 32 字节）
- `ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(T1)`

| dtype | sizeof | ELE_NUM_PER_C0 | 硬编码 16 是否正确 |
|-------|--------|----------------|------------------|
| half / bfloat16 | 2 | 16 | ✅ 恰好相等 |
| **int8 / uint8** | **1** | **32** | ❌ 差 2 倍 |
| float | 4 | 8 | ❌（此路径未测过 float） |

由于该偏移用于在 L1 的 fractal 布局中定位第 `kL0Idx` 个 K-tile 的起始位置，`kL0split == 1` 时 `kL0Idx` 恒为 0、偏移为 0，bug 被掩盖；一旦 `kL0split > 1`，第 2 个及以后的 K-tile 会读到**错误的 L1 偏移**（int8 下偏移只有正确值的一半），导致取到错误数据。

### 为什么这个 bug 一直没被发现

现有 `gemm_v0` 测试套件的 dtype 全部是 `float16` / `bfloat16`（`ELE_NUM_PER_C0` 恰好为 16），硬编码的 `16` 与正确值完全一致，bug 被测试矩阵的 dtype 选择意外掩盖。这也是 issue 报告者指出"half unaffected"的原因。

## 二、修复方案

### 改动

将硬编码的 `16` 替换为 dtype 感知的常量 `ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(T1)`：

```cpp
// 新增 dtype 感知常量（gemm_v0 顶部）
constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(T1);

// transpose_A 分支
A[kL0Idx * ELE_NUM_PER_C0 * kL0Size]

// !transpose_B 分支
B[bNOffset + kL0Idx * ELE_NUM_PER_C0 * kL0Size]
```

`BYTE_PER_C0` 来自 catlass（`namespace Catlass`，已在文件顶部 `using namespace Catless;` 引入），与 fractal 布局定义中使用的同一个常量，保证一致性。

### 为什么这样修复

1. **直接对齐根因**：硬编码值本就应该是 `ELE_NUM_PER_C0`，catlass 内部所有 fractal 布局代码（`tla/layout.hpp`、`copy_l1_to_l0a/b.hpp` 等）都用 `BYTE_PER_C0 / sizeof(Element)` 计算，此处属于遗漏。
2. **dtype 无关**：`ELE_NUM_PER_C0` 随 `T1` 自动取正确值（half=16, int8=32, float=8），一次性修复所有 dtype。
3. **half 行为不变**：half 的 `ELE_NUM_PER_C0` 仍为 16，与原硬编码值完全一致，对现有所有 half/bf16 调用方**零行为变化**，无回归风险。
4. **最小改动**：仅替换 2 处硬编码 + 新增 1 行常量定义，不触碰任何流水线/同步/N-tiling 逻辑。

### 为什么只改 AscendC，不改 PTO

PTO 后端（`src/tl_templates/pto/common.h`）的 `gemm_v0` 使用**完全不同的偏移机制**：

```cpp
// PTO: 逻辑元素索引 + dtype 感知的 TEXTRACT
copy_l1_to_l0a<T1, M, CurrentK, M, K, false>(l0a, A, 0, kL0Idx * kL0Size);
// 内部: pto::TEXTRACT(l0a, A, indexRow, indexCol) —— 由 TileMatL1<T1> 按 dtype 寻址
```

PTO 传入的是**逻辑元素索引** `kL0Idx * kL0Size`，fractal 字节寻址由带类型的 `TileMatL1<T1>` + `TEXTRACT` 内部自动处理，不存在硬编码常数。实测 PTO 后端 int8 + kL0split=2 在修复前就已正确（max diff = 0），无需改动。

## 三、测试验证

### 1. 新增回归测试

在 `testing/python/language/test_tilelang_ascend_language_gemm_v0.py` 新增 4 个 int8 测试用例，覆盖两个修复分支 × 两种 kL0split 状态：

| 测试 | transpose 组合 | kL0split | 覆盖分支 | 预期 |
|------|---------------|----------|---------|------|
| `test_gemm_v0_int8_kl0split_gt1[True-False]` | transpose_A=True | 2 | line 1156（A 偏移） | bug 触发场景 |
| `test_gemm_v0_int8_kl0split_gt1[False-False]` | transpose_B=False | 2 | line 1160（B 偏移） | bug 触发场景 |
| `test_gemm_v0_int8_kl0split_eq1[True-False]` | transpose_A=True | 1 | — | bug 掩盖基线 |
| `test_gemm_v0_int8_kl0split_eq1[False-False]` | transpose_B=False | 1 | — | bug 掩盖基线 |

- dtype: `int8 × int8 → int32`，`block_M=128, block_N=128, K_L1=256, kL0Size=128`
- 容差: `rtol=0, atol=0`（int8→int32 matmul 精确可复现）
- reference 在 CPU 计算（NPU `aclnnMatmul` 不支持 int32）

### 2. 测试有效性对照实验

通过 `git stash` 回退修复，验证新增测试能捕获 bug：

| 用例 | 修复前 | 修复后 |
|------|--------|--------|
| `int8_kl0split_gt1[True-False]` | ❌ FAILED（mismatch 99.8%, max diff 764） | ✅ PASSED |
| `int8_kl0split_gt1[False-False]` | ❌ FAILED | ✅ PASSED |
| `int8_kl0split_eq1[True-False]` | ✅ PASSED | ✅ PASSED |
| `int8_kl0split_eq1[False-False]` | ✅ PASSED | ✅ PASSED |

新增测试**精确区分了 bug 触发（kL0split>1）与掩盖（kL0split=1）条件**，能有效防止未来回归。

### 3. 现有测试回归确认（修复后全部通过）

| 测试文件 | 用例数 | 结果 | 关键覆盖 |
|---------|--------|------|---------|
| `test_tilelang_ascend_language_gemm_v0.py` | 30（原 26 + 新 4） | ✅ 全过 | ascendc+pto × precision/transpose/default |
| `test_tilelang_ascend_language_gemm_v0_n_tiling.py` | 6 | ✅ 全过 | 含 `(64,512,256)` kL0split=2+nL0split=4（命中修复分支） |
| `test_tilelang_ascend_language_l1_to_l0.py`（gemm_v0 部分） | 32 | ✅ 全过 | explicit+implicit gemm_v0，transpose_B True/False |
| `examples/deepseek_v4/int8_gemm.py` | 1 | ✅ 通过 | int8，transpose_B=True + kL0split=1（未触发，回归确认） |

### 4. PTO 后端交叉验证

在 PTO 后端跑相同 int8 + kL0split=2 用例（未改 PTO 代码）：

| 后端 | int8 K_L1=256 (kL0split=2) | int8 K_L1=128 | half K_L1=256 |
|------|------|------|------|
| AscendC 修复前 | Max diff: **1649** ❌ | 0 | 0.00026 |
| AscendC 修复后 | Max diff: **0** ✅ | 0 | 0.00026 |
| PTO（未改） | Max diff: **0** ✅ | 0 | 0.00026 |

确认 PTO 后端无此 bug，修复只需作用于 AscendC。

## 四、改动文件清单

| 文件 | 改动 | 说明 |
|------|------|------|
| `src/tl_templates/ascend/common.h` | +8 −3 | 新增 `ELE_NUM_PER_C0` 常量，替换 2 处硬编码 `16`，更新注释 |
| `testing/python/language/test_tilelang_ascend_language_gemm_v0.py` | +119 | 新增 int8 回归测试 4 例 |