### PR TITLE
[Feat] Add MTGR ragged segment attention example

### DIFF
--- a/examples/bench_test.sh
+++ b/examples/bench_test.sh
@@ -159,6 +159,8 @@ collect_test_scripts() {
         -not -name "sfa_golden.py" \
         -not -name "utils.py" \
         -not -path "*/bench_sfa/*" \
+        -not -path "*/generative_recommendation/golden.py" \
+        -not -path "*/generative_recommendation/testcase.py" \
         | sort)
     for f in $py_files; do scripts+=("$f"); done
     

--- a/examples/generative_recommendation/golden.py
+++ b/examples/generative_recommendation/golden.py
@@ -1,0 +1,201 @@
+import torch
+
+
+def _prepare_kv_and_mask(
+    query_snd,
+    key_snd,
+    value_snd,
+    segment_offsets_i32,
+    segment_rules_i32,
+    q_seq_starts_i32,
+    matched_prefix_lens_i32,
+    key_cache,
+    value_cache,
+    block_table_i32,
+    block_size,
+):
+    query_snd = query_snd.cpu()
+    key_snd = key_snd.cpu()
+    value_snd = value_snd.cpu()
+    segment_offsets_i32 = segment_offsets_i32.cpu()
+    segment_rules_i32 = segment_rules_i32.cpu()
+    q_seq_starts_i32 = q_seq_starts_i32.cpu()
+    matched_prefix_lens_i32 = matched_prefix_lens_i32.cpu()
+    key_cache = key_cache.cpu()
+    value_cache = value_cache.cpu()
+    block_table_i32 = block_table_i32.cpu()
+
+    B = segment_offsets_i32.size(0)
+    H = query_snd.size(1)
+    D = query_snd.size(2)
+    kv_heads = key_snd.size(1)
+    kv_group = H // kv_heads
+
+    q_starts = q_seq_starts_i32.tolist()
+    matched_prefix_list = matched_prefix_lens_i32.tolist()
+    q_lens = [q_starts[b + 1] - q_starts[b] for b in range(B)]
+
+    per_batch = []
+    for b in range(B):
+        q_start = q_starts[b]
+        q_len = q_lens[b]
+        q_b = query_snd[q_start : q_start + q_len]
+
+        prefix_len = matched_prefix_list[b]
+
+        if prefix_len > 0:
+            num_prefix_blocks = (prefix_len + block_size - 1) // block_size
+            phys_blocks = block_table_i32[b, :num_prefix_blocks]
+            k_prefix_b = key_cache[phys_blocks].reshape(-1, kv_heads, D)[:prefix_len]
+            v_prefix_b = value_cache[phys_blocks].reshape(-1, kv_heads, D)[:prefix_len]
+
+        k_live_b = key_snd[q_start : q_start + q_len]
+        v_live_b = value_snd[q_start : q_start + q_len]
+
+        if prefix_len > 0:
+            k_full_b = torch.cat([k_prefix_b, k_live_b], dim=0)
+            v_full_b = torch.cat([v_prefix_b, v_live_b], dim=0)
+        else:
+            k_full_b = k_live_b
+            v_full_b = v_live_b
+
+        if kv_group > 1:
+            k_full_b = k_full_b.repeat_interleave(kv_group, dim=1)
+            v_full_b = v_full_b.repeat_interleave(kv_group, dim=1)
+
+        total_kv_len_b = prefix_len + q_len
+        offsets = segment_offsets_i32[b].tolist()
+        rules = segment_rules_i32.tolist()
+
+        q_abs_positions = torch.arange(prefix_len, total_kv_len_b)
+        k_abs_positions = torch.arange(total_kv_len_b)
+
+        offsets_tensor = torch.tensor(offsets, dtype=torch.int32)
+        seg_ids = torch.searchsorted(offsets_tensor[1:], q_abs_positions, right=True)
+
+        full_mask = torch.zeros(q_len, total_kv_len_b, dtype=torch.float32)
+
+        for seg_id_val in range(len(rules)):
+            rule = rules[seg_id_val]
+            q_indices = (seg_ids == seg_id_val).nonzero().squeeze(-1)
+            if q_indices.numel() == 0:
+                continue
+
+            q_abs = q_abs_positions[q_indices]
+
+            if rule == 0:
+                causal_mask = k_abs_positions.unsqueeze(0) <= q_abs.unsqueeze(1)
+                full_mask[q_indices] = causal_mask.float()
+            elif rule == 1:
+                end = min(offsets[seg_id_val + 1], total_kv_len_b)
+                full_mask[q_indices, :end] = 1.0
+            elif rule == 2:
+                start = min(offsets[seg_id_val], total_kv_len_b)
+                full_mask[q_indices, :start] = 1.0
+                full_mask[q_indices, q_abs] = 1.0
+
+        per_batch.append(
+            {
+                "q_b": q_b,
+                "k_full_b": k_full_b,
+                "v_full_b": v_full_b,
+                "full_mask": full_mask,
+            }
+        )
+
+    return per_batch, kv_group
+
+
+def golden_attention_float64(
+    query_snd,
+    key_snd,
+    value_snd,
+    segment_offsets_i32,
+    segment_rules_i32,
+    q_seq_starts_i32,
+    matched_prefix_lens_i32,
+    key_cache,
+    value_cache,
+    block_table_i32,
+    block_size,
+    sm_scale,
+):
+    per_batch, kv_group = _prepare_kv_and_mask(
+        query_snd,
+        key_snd,
+        value_snd,
+        segment_offsets_i32,
+        segment_rules_i32,
+        q_seq_starts_i32,
+        matched_prefix_lens_i32,
+        key_cache,
+        value_cache,
+        block_table_i32,
+        block_size,
+    )
+
+    ref_outputs = []
+    for item in per_batch:
+        q = item["q_b"].double()
+        k = item["k_full_b"].double()
+        v = item["v_full_b"].double()
+        full_mask = item["full_mask"]
+
+        scores = torch.einsum("qhd,khd->hqk", q, k) * sm_scale
+        scores = scores.masked_fill(full_mask.unsqueeze(0) == 0.0, float("-inf"))
+        probs = torch.softmax(scores, dim=-1).nan_to_num(0.0)
+        ref_b = torch.einsum("hqk,khd->qhd", probs, v)
+        ref_outputs.append(ref_b)
+
+    return torch.cat(ref_outputs, dim=0)
+
+
+def golden_attention_simulated_kernel(
+    query_snd,
+    key_snd,
+    value_snd,
+    segment_offsets_i32,
+    segment_rules_i32,
+    q_seq_starts_i32,
+    matched_prefix_lens_i32,
+    key_cache,
+    value_cache,
+    block_table_i32,
+    block_size,
+    sm_scale,
+):
+    per_batch, kv_group = _prepare_kv_and_mask(
+        query_snd,
+        key_snd,
+        value_snd,
+        segment_offsets_i32,
+        segment_rules_i32,
+        q_seq_starts_i32,
+        matched_prefix_lens_i32,
+        key_cache,
+        value_cache,
+        block_table_i32,
+        block_size,
+    )
+
+    ref_outputs = []
+    for item in per_batch:
+        q = item["q_b"].to(torch.bfloat16)
+        k = item["k_full_b"].to(torch.bfloat16)
+        v = item["v_full_b"].to(torch.bfloat16)
+        full_mask = item["full_mask"]
+
+        S = torch.einsum("qhd,khd->hqk", q, k)
+        S = (S * sm_scale).to(torch.bfloat16)
+        S = S.masked_fill(full_mask.unsqueeze(0) == 0.0, float("-inf"))
+
+        m = torch.max(S, dim=-1, keepdim=True).values
+        P = torch.exp((S - m).float()).to(torch.bfloat16).nan_to_num(0.0)
+
+        O = torch.einsum("hqk,khd->qhd", P, v).to(torch.bfloat16)
+
+        sumexp = torch.sum(P.float(), dim=-1, keepdim=True).permute(1, 0, 2)
+        out = (O.float() / sumexp.clamp(min=1.0)).to(torch.bfloat16)
+        ref_outputs.append(out)
+
+    return torch.cat(ref_outputs, dim=0)

--- a/examples/generative_recommendation/mtgr_ragged_segment_attention.py
+++ b/examples/generative_recommendation/mtgr_ragged_segment_attention.py
@@ -1,0 +1,792 @@
+import torch
+import tilelang
+import tilelang.language as T
+from tilelang.intrinsics import make_zn_layout, make_nz_layout
+from golden import golden_attention_simulated_kernel
+from testcase import prepare_data
+
+
+# ---------------------------------------------------------------------------
+# 常量与优化 Pass 配置
+# ---------------------------------------------------------------------------
+NEG_INF = -(2.0**30)
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC_VS: True,
+}
+
+
+@tilelang.jit(
+    pass_configs=PASS_CONFIGS,
+)
+def mtgr_ragged_segment_attention_kernel(
+    heads,
+    dim,
+    kv_group=1,
+    sm_scale=None,
+    block_M=128,
+    block_N=128,
+    core_num=24,
+    num_stages=14,
+    cross_interval=2,
+    rule1_seg_idx=1,
+):
+    sm_scale = (1.0 / dim) ** 0.5 if sm_scale is None else sm_scale
+    dtype = "bfloat16"
+    accum_dtype = "float32"
+
+    batch = T.symbolic("batch")
+    total_q = T.symbolic("total_q")
+    num_blocks = T.symbolic("num_blocks")
+    max_blocks = T.symbolic("max_blocks")
+    max_segs = T.symbolic("max_segs")
+
+    kv_heads = heads // kv_group
+    half_M = block_M // 2
+    sub_M = half_M // 2
+
+    # 跨核信号与单核内信号定义
+    SEM_WS1_C2V = 0
+    SEM_WS1_V2C = 1
+    SEM_WS2_V2C = 2
+    SEM_WS2_C2V = 3
+    SEM_WS3_C2V = 4
+    SEM_WS3_V2C = 5
+
+    SIG_K_L1 = 0
+    SIG_P_L1 = 1
+    SIG_V_L1 = 2
+    SIG_L0AB = 3
+    SIG_L0C = 5
+    SIG_Q_L1 = 7
+
+    SIG_IO_UB = 0
+    SIG_S_HALF = 1
+    SIG_O_READY = 3
+
+    @T.prim_func
+    def main(
+        Q: T.Tensor([total_q, heads, dim], dtype),
+        K: T.Tensor([total_q, kv_heads, dim], dtype),
+        V: T.Tensor([total_q, kv_heads, dim], dtype),
+        Output: T.Tensor([total_q, heads, dim], dtype),
+        q_seq_starts: T.Tensor([batch + 1], "int32"),
+        segment_offsets: T.Tensor([batch, max_segs + 1], "int32"),
+        segment_rules: T.Tensor([max_segs], "int32"),
+        workspace_1: T.Tensor([core_num, num_stages, block_M, block_N], dtype),
+        workspace_2: T.Tensor([core_num, num_stages, block_M, block_N], dtype),
+        workspace_3: T.Tensor([core_num, num_stages, block_M, dim], dtype),
+        key_cache: T.Tensor([num_blocks, block_N, kv_heads, dim], dtype),
+        value_cache: T.Tensor([num_blocks, block_N, kv_heads, dim], dtype),
+        block_table: T.Tensor([batch, max_blocks], "int32"),
+        prefix_lens: T.Tensor([batch], "int32"),
+        bin_iters: T.int32,
+    ):
+        with T.Kernel(core_num, is_npu=True) as (cid, vid):
+            q_l1 = T.alloc_L1([block_M, dim], dtype)
+            k_l1 = T.alloc_L1([block_N, dim], dtype)
+            v_l1 = T.alloc_L1([block_N, dim], dtype)
+            p_l1 = T.alloc_L1([block_M, block_N], dtype)
+
+            T.annotate_layout(
+                {
+                    q_l1: make_zn_layout(q_l1),
+                    k_l1: make_nz_layout(k_l1),
+                    p_l1: make_zn_layout(p_l1),
+                    v_l1: make_zn_layout(v_l1),
+                }
+            )
+
+            l0a_s = T.alloc_L0A([2, block_M, dim], dtype)
+            l0b_s = T.alloc_L0B([2, dim, block_N], dtype)
+            l0c_s = T.alloc_L0C([2, block_M, block_N], accum_dtype)
+
+            l0a_o = T.alloc_L0A([2, block_M, block_N], dtype)
+            l0b_o = T.alloc_L0B([2, block_N, dim], dtype)
+            l0c_o_0 = T.alloc_L0C([block_M, dim], accum_dtype)
+            l0c_o_1 = T.alloc_L0C([block_M, dim], accum_dtype)
+
+            acc_o = T.alloc_ub([half_M, dim], accum_dtype)
+            r_factors = T.alloc_ub([num_stages, half_M, 1], accum_dtype)
+            sumexp_is = T.alloc_ub([num_stages, half_M, 1], accum_dtype)
+            sumexp = T.alloc_ub([half_M, 1], accum_dtype)
+            neg_sm = T.alloc_ub([2, half_M, 1], accum_dtype)
+
+            io_buf = T.alloc_ub([half_M, block_N], dtype)
+            acc_s_half = T.alloc_ub([half_M, block_N], dtype)
+            work_ub = T.alloc_ub([half_M, block_N], accum_dtype)
+            buf_2d = T.alloc_ub([half_M, block_N], accum_dtype)
+
+            bcast_buf = T.alloc_ub([half_M, dim], accum_dtype)
+            o_io_buf = T.alloc_ub([half_M, dim], dtype)
+            o_work_buf = T.alloc_ub([half_M, dim], accum_dtype)
+            o_acc_half = T.alloc_ub([half_M, dim], dtype)
+
+            row_rule_buf = T.alloc_ub([half_M], "int32")
+            row_seg_start_buf = T.alloc_ub([half_M], "int32")
+            row_seg_end_buf = T.alloc_ub([half_M], "int32")
+
+            T.annotate_address(
+                {
+                    l0a_s: 0,
+                    l0a_o: 0,
+                    l0b_s: 0,
+                    l0b_o: 0,
+                    l0c_s: 0,
+                    l0c_o_0: 0,
+                    l0c_o_1: block_M * block_N * 4,
+                    acc_o: 0,
+                    r_factors: half_M * dim * 4,
+                    sumexp_is: half_M * dim * 4 + num_stages * half_M * 4,
+                    sumexp: half_M * dim * 4 + num_stages * half_M * 4 * 2,
+                    neg_sm: half_M * dim * 4 + num_stages * half_M * 4 * 2 + half_M * 4,
+                    io_buf: half_M * dim * 4 + num_stages * half_M * 4 * 2 + half_M * 12,
+                    o_io_buf: half_M * dim * 4 + num_stages * half_M * 4 * 2 + half_M * 12,
+                    acc_s_half: half_M * dim * 4 + num_stages * half_M * 4 * 2 + half_M * 12 + half_M * block_N * 2,
+                    o_acc_half: half_M * dim * 4 + num_stages * half_M * 4 * 2 + half_M * 12 + half_M * block_N * 2,
+                    work_ub: half_M * dim * 4 + num_stages * half_M * 4 * 2 + half_M * 12 + half_M * block_N * 4,
+                    o_work_buf: half_M * dim * 4 + num_stages * half_M * 4 * 2 + half_M * 12 + half_M * block_N * 4,
+                    buf_2d: half_M * dim * 4 + num_stages * half_M * 4 * 2 + half_M * 12 + half_M * block_N * 8,
+                    bcast_buf: half_M * dim * 4 + num_stages * half_M * 4 * 2 + half_M * 12 + half_M * block_N * 8,
+                    row_rule_buf: half_M * dim * 4
+                    + num_stages * half_M * 4 * 2
+                    + half_M * 12
+                    + half_M * block_N * 8
+                    + half_M * block_N * 4,
+                    row_seg_start_buf: half_M * dim * 4
+                    + num_stages * half_M * 4 * 2
+                    + half_M * 12
+                    + half_M * block_N * 8
+                    + half_M * block_N * 4
+                    + half_M * 4,
+                    row_seg_end_buf: half_M * dim * 4
+                    + num_stages * half_M * 4 * 2
+                    + half_M * 12
+                    + half_M * block_N * 8
+                    + half_M * block_N * 4
+                    + half_M * 4 * 2,
+                }
+            )
+
+            b_i = T.alloc_var("int32", init=0)
+            s_local = T.alloc_var("int32", init=0)
+            kv_start = T.alloc_var("int32", init=0)
+            kv_size = T.alloc_var("int32", init=0)
+            cum_tiles = T.alloc_var("int32", init=0)
+            num_tiles_b = T.alloc_var("int32", init=0)
+            total_seq_tiles = T.alloc_var("int32", init=0)
+            total_seq_len_b = T.alloc_var("int32", init=0)
+            k_upper_bound = T.alloc_var("int32", init=0)
+            num_k_tiles = T.alloc_var("int32", init=0)
+            seg_id = T.alloc_var("int32", init=0)
+            last_seg_start = T.alloc_var("int32", init=0)
+            gap_k_start = T.alloc_var("int32", init=0)
+            gap_k_end = T.alloc_var("int32", init=0)
+            gap_size = T.alloc_var("int32", init=0)
+            num_effective_k = T.alloc_var("int32", init=0)
+
+            _lo = T.alloc_var("int32", init=0)
+            _hi = T.alloc_var("int32", init=0)
+            _mid = T.alloc_var("int32", init=0)
+
+            total_seq_tiles = 0
+            for _b in T.serial(batch):
+                _total_seq_len = segment_offsets[_b, max_segs]
+                total_seq_tiles = total_seq_tiles + T.ceildiv(_total_seq_len, block_M)
+            total_tasks = total_seq_tiles * heads
+            my_iters = T.if_then_else(
+                cid < total_tasks,
+                T.ceildiv(total_tasks - cid, core_num),
+                0,
+            )
+
+            # =========================================================================
+            # Scope C: Cube 核心 (负责张量搬运与矩阵乘)
+            # =========================================================================
+            with T.Scope("C"):
+                T.set_cross_flag("MTE2", SEM_WS2_C2V)
+                T.set_flag("MTE1", "MTE2", SIG_K_L1)
+                T.set_flag("MTE1", "MTE2", SIG_P_L1)
+                T.set_flag("MTE1", "MTE2", SIG_V_L1)
+                T.set_flag("M", "MTE1", SIG_L0AB)
+                T.set_flag("M", "MTE1", SIG_L0AB + 1)
+                T.set_flag("FIX", "M", SIG_L0C)
+                T.set_flag("FIX", "M", SIG_L0C + 1)
+
+                for core_index in T.serial(my_iters):
+                    pid = cid + core_index * core_num
+                    tile_id = pid // heads
+                    h_i = pid % heads
+                    h_kv = h_i // kv_group
+
+                    cum_tiles = 0
+                    b_i = 0
+                    s_local = 0
+                    for _b in T.serial(batch):
+                        _total_seq_len = segment_offsets[_b, max_segs]
+                        num_tiles_b = T.ceildiv(_total_seq_len, block_M)
+                        _is_this = (tile_id >= cum_tiles) & (tile_id < cum_tiles + num_tiles_b)
+                        b_i = T.if_then_else(_is_this, _b, b_i)
+                        s_local = T.if_then_else(_is_this, tile_id - cum_tiles, s_local)
+                        cum_tiles = cum_tiles + num_tiles_b
+
+                    total_seq_len_b = segment_offsets[b_i, max_segs]
+                    q_start = s_local * block_M
+                    q_end = T.if_then_else(q_start + block_M < total_seq_len_b, q_start + block_M, total_seq_len_b)
+
+                    prefix_len_b = prefix_lens[b_i]
+                    q_start_live = T.if_then_else(q_start >= prefix_len_b, q_start, prefix_len_b)
+                    q_tile_size_live = q_end - q_start_live
+                    q_tile_size_live = T.if_then_else(q_tile_size_live > 0, q_tile_size_live, 0)
+                    q_packed_start = q_seq_starts[b_i] + q_start_live - prefix_len_b
+
+                    _rule1_start = segment_offsets[b_i, rule1_seg_idx]
+                    _rule1_end = segment_offsets[b_i, rule1_seg_idx + 1]
+                    _overlaps = (_rule1_end > q_start) & (_rule1_start < q_end)
+                    k_upper_bound = T.if_then_else(_overlaps & (_rule1_end > q_end), _rule1_end, q_end)
+                    num_k_tiles = T.ceildiv(k_upper_bound, block_M)
+
+                    last_seg_start = segment_offsets[b_i, max_segs - 1]
+                    gap_k_start = T.ceildiv(last_seg_start, block_M)
+                    gap_k_end = q_start // block_M
+                    gap_size = T.if_then_else((q_start >= last_seg_start) & (gap_k_end > gap_k_start), gap_k_end - gap_k_start, 0)
+                    num_effective_k = num_k_tiles - gap_size
+
+                    # 载入 Q
+                    T.copy(Q[q_packed_start : q_packed_start + q_tile_size_live, h_i, :], q_l1[:, :])
+                    T.set_flag("MTE2", "MTE1", SIG_Q_L1)
+                    T.wait_flag("MTE2", "MTE1", SIG_Q_L1)
+                    num_outer = T.ceildiv(num_effective_k, num_stages)
+
+                    for k_outer in T.serial(num_outer):
+                        _remaining = num_effective_k - k_outer * num_stages
+                        batch_iters = T.if_then_else(_remaining < num_stages, _remaining, num_stages)
+
+                        # ---------------------------------
+                        # GEMM1: S = Q * K^T (写入 workspace_1)
+                        # ---------------------------------
+                        T.wait_cross_flag(SEM_WS1_V2C)
+                        for i in T.serial(batch_iters):
+                            side = i % 2
+                            compact_k_idx = k_outer * num_stages + i
+                            k_idx = T.if_then_else(
+                                (q_start >= last_seg_start) & (compact_k_idx >= gap_k_start) & (gap_size > 0),
+                                compact_k_idx + gap_size,
+                                compact_k_idx,
+                            )
+                            kv_start = k_idx * block_M
+                            kv_size = T.if_then_else(kv_start + block_M < k_upper_bound, block_M, k_upper_bound - kv_start)
+
+                            T.wait_flag("MTE1", "MTE2", SIG_K_L1)
+                            if kv_start < prefix_len_b:
+                                cache_block_idx = kv_start // block_N
+                                physical_block = block_table[b_i, cache_block_idx]
+                                block_offset_start = kv_start % block_N
+                                T.copy(
+                                    key_cache[physical_block, block_offset_start : block_offset_start + kv_size, h_kv, :],
+                                    k_l1[:, :],
+                                )
+                            else:
+                                kv_packed_start = q_seq_starts[b_i] + kv_start - prefix_len_b
+                                T.copy(
+                                    K[kv_packed_start : kv_packed_start + kv_size, h_kv, :],
+                                    k_l1[:, :],
+                                )
+                            T.set_flag("MTE2", "MTE1", SIG_K_L1)
+
+                            T.wait_flag("M", "MTE1", SIG_L0AB + side)
+                            if i < 2:
+                                T.copy(q_l1, l0a_s[side, :, :])
+
+                            T.wait_flag("MTE2", "MTE1", SIG_K_L1)
+                            T.copy(k_l1, l0b_s[side, :, :], transpose=True)
+                            T.set_flag("MTE1", "MTE2", SIG_K_L1)
+                            T.set_flag("MTE1", "M", SIG_L0AB + side)
+
+                            T.wait_flag("MTE1", "M", SIG_L0AB + side)
+                            T.wait_flag("FIX", "M", SIG_L0C + side)
+                            T.mma(l0a_s[side, :, :], l0b_s[side, :, :], l0c_s[side, :, :], init=True)
+                            T.set_flag("M", "MTE1", SIG_L0AB + side)
+                            T.set_flag("M", "FIX", SIG_L0C + side)
+
+                            T.wait_flag("M", "FIX", SIG_L0C + side)
+                            T.copy(l0c_s[side, :, :], workspace_1[cid, i, :, :])
+                            T.set_flag("FIX", "M", SIG_L0C + side)
+
+                            if (i + 1) % cross_interval == 0 or i == batch_iters - 1:
+                                T.set_cross_flag("FIX", SEM_WS1_C2V)
+
+                        # ---------------------------------
+                        # GEMM2: O = P * V (写入 workspace_3)
+                        # ---------------------------------
+                        T.wait_cross_flag(SEM_WS3_V2C)
+                        for i in T.serial(batch_iters):
+                            side = i % 2
+                            compact_k_idx = k_outer * num_stages + i
+                            k_idx = T.if_then_else(
+                                (q_start >= last_seg_start) & (compact_k_idx >= gap_k_start) & (gap_size > 0),
+                                compact_k_idx + gap_size,
+                                compact_k_idx,
+                            )
+                            kv_start = k_idx * block_M
+                            kv_size = T.if_then_else(kv_start + block_M < k_upper_bound, block_M, k_upper_bound - kv_start)
+
+                            T.wait_flag("MTE1", "MTE2", SIG_V_L1)
+                            if kv_start < prefix_len_b:
+                                cache_block_idx = kv_start // block_N
+                                physical_block = block_table[b_i, cache_block_idx]
+                                block_offset_start = kv_start % block_N
+                                T.copy(
+                                    value_cache[physical_block, block_offset_start : block_offset_start + kv_size, h_kv, :],
+                                    v_l1[:, :],
+                                )
+                            else:
+                                kv_packed_start = q_seq_starts[b_i] + kv_start - prefix_len_b
+                                T.copy(
+                                    V[kv_packed_start : kv_packed_start + kv_size, h_kv, :],
+                                    v_l1[:, :],
+                                )
+                            T.set_flag("MTE2", "MTE1", SIG_V_L1)
+
+                            T.wait_flag("MTE1", "MTE2", SIG_P_L1)
+                            if i % cross_interval == 0:
+                                T.wait_cross_flag(SEM_WS2_V2C)
+                            T.copy(workspace_2[cid, i, :, :], p_l1)
+                            T.set_flag("MTE2", "MTE1", SIG_P_L1)
+
+                            T.wait_flag("MTE2", "MTE1", SIG_V_L1)
+                            T.wait_flag("M", "MTE1", SIG_L0AB + side)
+                            T.copy(v_l1, l0b_o[side, :, :])
+                            T.set_flag("MTE1", "MTE2", SIG_V_L1)
+
+                            T.wait_flag("MTE2", "MTE1", SIG_P_L1)
+                            T.copy(p_l1, l0a_o[side, :, :])
+                            T.set_flag("MTE1", "MTE2", SIG_P_L1)
+                            T.set_flag("MTE1", "M", SIG_L0AB + side)
+
+                            T.wait_flag("MTE1", "M", SIG_L0AB + side)
+                            T.wait_flag("FIX", "M", SIG_L0C + side)
+                            if side == 0:
+                                T.mma(l0a_o[side, :, :], l0b_o[side, :, :], l0c_o_0[:, :], init=True)
+                            else:
+                                T.mma(l0a_o[side, :, :], l0b_o[side, :, :], l0c_o_1[:, :], init=True)
+                            T.set_flag("M", "MTE1", SIG_L0AB + side)
+                            T.set_flag("M", "FIX", SIG_L0C + side)
+
+                            T.wait_flag("M", "FIX", SIG_L0C + side)
+                            if side == 0:
+                                T.copy(l0c_o_0[:, :], workspace_3[cid, i, :, :])
+                            else:
+                                T.copy(l0c_o_1[:, :], workspace_3[cid, i, :, :])
+                            T.set_flag("FIX", "M", SIG_L0C + side)
+
+                            if (i + 1) % cross_interval == 0 or i == batch_iters - 1:
+                                T.set_cross_flag("FIX", SEM_WS3_C2V)
+                        T.set_cross_flag("MTE2", SEM_WS2_C2V)
+
+                # 回收初始化的 Signal
+                T.wait_flag("MTE1", "MTE2", SIG_K_L1)
+                T.wait_flag("MTE1", "MTE2", SIG_P_L1)
+                T.wait_flag("MTE1", "MTE2", SIG_V_L1)
+                T.wait_flag("M", "MTE1", SIG_L0AB)
+                T.wait_flag("M", "MTE1", SIG_L0AB + 1)
+                T.wait_flag("FIX", "M", SIG_L0C)
+                T.wait_flag("FIX", "M", SIG_L0C + 1)
+
+            # =========================================================================
+            # Scope V: Vector 核心 (负责生成 Mask、Softmax 和累加降级)
+            # =========================================================================
+            with T.Scope("V"):
+                T.set_cross_flag("MTE2", SEM_WS1_V2C)
+                T.set_cross_flag("MTE2", SEM_WS3_V2C)
+                T.set_flag("V", "MTE2", SIG_IO_UB)
+                T.set_flag("MTE3", "V", SIG_S_HALF)
+
+                for core_index in T.serial(my_iters):
+                    pid = cid + core_index * core_num
+                    tile_id = pid // heads
+                    h_i = pid % heads
+                    h_kv = h_i // kv_group
+
+                    cum_tiles = 0
+                    b_i = 0
+                    s_local = 0
+                    for _b in T.serial(batch):
+                        _total_seq_len = segment_offsets[_b, max_segs]
+                        num_tiles_b = T.ceildiv(_total_seq_len, block_M)
+                        _is_this = (tile_id >= cum_tiles) & (tile_id < cum_tiles + num_tiles_b)
+                        b_i = T.if_then_else(_is_this, _b, b_i)
+                        s_local = T.if_then_else(_is_this, tile_id - cum_tiles, s_local)
+                        cum_tiles = cum_tiles + num_tiles_b
+
+                    total_seq_len_b = segment_offsets[b_i, max_segs]
+                    q_start = s_local * block_M
+                    q_end = T.if_then_else(q_start + block_M < total_seq_len_b, q_start + block_M, total_seq_len_b)
+
+                    prefix_len_b = prefix_lens[b_i]
+                    q_start_live = T.if_then_else(q_start >= prefix_len_b, q_start, prefix_len_b)
+                    q_tile_size_live = q_end - q_start_live
+                    q_tile_size_live = T.if_then_else(q_tile_size_live > 0, q_tile_size_live, 0)
+                    q_packed_start = q_seq_starts[b_i] + q_start_live - prefix_len_b
+
+                    _rule1_start = segment_offsets[b_i, rule1_seg_idx]
+                    _rule1_end = segment_offsets[b_i, rule1_seg_idx + 1]
+                    _overlaps = (_rule1_end > q_start) & (_rule1_start < q_end)
+                    k_upper_bound = T.if_then_else(_overlaps & (_rule1_end > q_end), _rule1_end, q_end)
+                    num_k_tiles = T.ceildiv(k_upper_bound, block_M)
+
+                    last_seg_start = segment_offsets[b_i, max_segs - 1]
+                    gap_k_start = T.ceildiv(last_seg_start, block_M)
+                    gap_k_end = q_start // block_M
+                    gap_size = T.if_then_else((q_start >= last_seg_start) & (gap_k_end > gap_k_start), gap_k_end - gap_k_start, 0)
+                    num_effective_k = num_k_tiles - gap_size
+
+                    for row in T.serial(half_M):
+                        row_abs_pos = q_start + vid * half_M + row
+
+                        _lo = 0
+                        _hi = max_segs
+                        for _bi in T.serial(bin_iters):
+                            _mid = (_lo + _hi) // 2
+                            _active = _lo < _hi
+                            _le = segment_offsets[b_i, _mid] <= row_abs_pos
+                            _gt = segment_offsets[b_i, _mid] > row_abs_pos
+                            _lo = T.if_then_else(_active & _le, _mid + 1, _lo)
+                            _hi = T.if_then_else(_active & _gt, _mid, _hi)
+                        seg_id = _lo - 1
+
+                        row_rule_buf[row] = segment_rules[seg_id]
+                        row_seg_start_buf[row] = segment_offsets[b_i, seg_id]
+                        row_seg_end_buf[row] = segment_offsets[b_i, seg_id + 1]
+
+                    T.tile.fill(acc_o, 0.0)
+                    T.tile.fill(sumexp, 0.0)
+                    T.tile.fill(neg_sm, 2**30)
+
+                    num_outer = T.ceildiv(num_effective_k, num_stages)
+                    for k_outer in T.serial(num_outer):
+                        _remaining = num_effective_k - k_outer * num_stages
+                        batch_iters = T.if_then_else(_remaining < num_stages, _remaining, num_stages)
+
+                        # --- Softmax Batch 处理 ---
+                        T.wait_cross_flag(SEM_WS2_C2V)
+                        for i in T.serial(batch_iters):
+                            cur = i % 2
+                            prv = 1 - cur
+
+                            compact_k_idx = k_outer * num_stages + i
+                            k_idx = T.if_then_else(
+                                (q_start >= last_seg_start) & (compact_k_idx >= gap_k_start) & (gap_size > 0),
+                                compact_k_idx + gap_size,
+                                compact_k_idx,
+                            )
+                            kv_start = k_idx * block_M
+                            kv_size = T.if_then_else(kv_start + block_M < k_upper_bound, block_M, k_upper_bound - kv_start)
+
+                            # 【核心优化】计算掩盖 (Hiding Computation)：在等 Cube 前利用算力资源提前生成 MASK
+                            _vid_first_rule = row_rule_buf[0]
+                            _vid_first_seg_start = row_seg_start_buf[0]
+                            _vid_first_seg_end = row_seg_end_buf[0]
+                            _first_row_pos = q_start + vid * half_M
+
+                            _is_full_kv = kv_size == block_M
+
+                            # 基于“可见性单调递增”原理：首行完全可见，则全块必然完全可见
+                            _r0_valid = (_vid_first_rule == 0) & (_first_row_pos + 1 >= kv_start + kv_size)
+                            _r1_valid = (_vid_first_rule == 1) & (kv_start + kv_size <= _vid_first_seg_end)
+                            _r2_valid = (_vid_first_rule == 2) & (kv_start + kv_size <= _vid_first_seg_start)
+
+                            _all_valid = T.if_then_else(
+                                _is_full_kv & _r0_valid,
+                                1,
+                                T.if_then_else(_is_full_kv & _r1_valid, 1, T.if_then_else(_is_full_kv & _r2_valid, 1, 0)),
+                            )
+                            if _all_valid == 1:
+                                T.tile.fill(buf_2d, 0.0)
+                            else:
+                                T.tile.fill(buf_2d, NEG_INF)
+                                for row in T.serial(half_M):
+                                    row_abs_pos = q_start + vid * half_M + row
+
+                                    _row_rule = row_rule_buf[row]
+                                    _row_seg_start = row_seg_start_buf[row]
+                                    _row_seg_end = row_seg_end_buf[row]
+
+                                    if _row_rule == 0:
+                                        raw_len = row_abs_pos - kv_start + 1
+                                        fill_len = T.if_then_else(raw_len < kv_size, raw_len, kv_size)
+                                        if fill_len > 0:
+                                            T.tile.fill(buf_2d[row, 0:fill_len], 0.0)
+                                    elif _row_rule == 1:
+                                        raw_len = _row_seg_end - kv_start
+                                        fill_len = T.if_then_else(raw_len < kv_size, raw_len, kv_size)
+                                        if fill_len > 0:
+                                            T.tile.fill(buf_2d[row, 0:fill_len], 0.0)
+                                    elif _row_rule == 2:
+                                        raw_len = _row_seg_start - kv_start
+                                        fill_len = T.if_then_else(raw_len < kv_size, raw_len, kv_size)
+                                        if fill_len > 0:
+                                            T.tile.fill(buf_2d[row, 0:fill_len], 0.0)
+                                        diag_col = row_abs_pos - kv_start
+                                        if (diag_col >= 0) & (diag_col < kv_size):
+                                            buf_2d[row, diag_col] = 0.0
+
+                            T.wait_flag("V", "MTE2", SIG_IO_UB)
+                            if i % cross_interval == 0:
+                                T.wait_cross_flag(SEM_WS1_C2V)
+
+                            T.copy(workspace_1[cid, i, vid * half_M : vid * half_M + half_M, :], io_buf)
+                            T.set_flag("MTE2", "V", SIG_IO_UB)
+
+                            T.wait_flag("MTE2", "V", SIG_IO_UB)
+                            T.copy(io_buf, work_ub)
+                            T.set_flag("V", "MTE2", SIG_IO_UB)
+
+                            # 施加 Mask 到矩阵 S
+                            T.tile.add(work_ub, work_ub, buf_2d)
+                            T.reduce_max(work_ub, neg_sm[cur, :, :], dim=-1)
+                            T.tile.mul(neg_sm[cur, :, :], neg_sm[cur, :, :], -sm_scale)
+                            T.tile.min(neg_sm[cur, :, :], neg_sm[cur, :, :], neg_sm[prv, :, :])
+                            T.tile.broadcast(buf_2d, neg_sm[cur, :, :])
+                            T.tile.axpy(buf_2d, work_ub, sm_scale)
+                            T.tile.exp(work_ub, buf_2d)
+
+                            T.wait_flag("MTE3", "V", SIG_S_HALF)
+                            T.copy(work_ub, acc_s_half)
+                            T.set_flag("V", "MTE3", SIG_S_HALF)
+
+                            T.wait_flag("V", "MTE3", SIG_S_HALF)
+                            T.copy(acc_s_half, workspace_2[cid, i, vid * half_M : vid * half_M + half_M, :])
+                            T.set_flag("MTE3", "V", SIG_S_HALF)
+
+                            if (i + 1) % cross_interval == 0 or i == batch_iters - 1:
+                                T.set_cross_flag("MTE3", SEM_WS2_V2C)
+
+                            T.reduce_sum(work_ub, sumexp_is[i, :, :], dim=-1)
+                            T.tile.sub(r_factors[i, :, :], neg_sm[cur, :, :], neg_sm[prv, :, :])
+                        T.set_cross_flag("MTE2", SEM_WS1_V2C)
+
+                        # --- O 累加 Batch ---
+                        for i in T.serial(batch_iters):
+                            T.tile.exp(r_factors[i, :, :], r_factors[i, :, :])
+                            T.tile.mul(sumexp, sumexp, r_factors[i, :, :])
+                            T.tile.add(sumexp, sumexp, sumexp_is[i, :, :])
+                            T.tile.broadcast(bcast_buf, r_factors[i, :, :])
+                            T.tile.mul(acc_o, acc_o, bcast_buf)
+
+                            T.wait_flag("V", "MTE2", SIG_IO_UB)
+                            if i % cross_interval == 0:
+                                T.wait_cross_flag(SEM_WS3_C2V)
+                            T.copy(workspace_3[cid, i, vid * half_M : vid * half_M + half_M, :], o_io_buf)
+                            T.set_flag("MTE2", "V", SIG_IO_UB)
+
+                            T.wait_flag("MTE2", "V", SIG_IO_UB)
+                            T.copy(o_io_buf, o_work_buf)
+                            T.set_flag("V", "MTE2", SIG_IO_UB)
+                            T.tile.add(acc_o, acc_o, o_work_buf)
+
+                        T.set_cross_flag("MTE2", SEM_WS3_V2C)
+
+                    for sub in T.serial(2):
+                        row_start = sub * sub_M
+                        T.tile.max(sumexp[row_start : row_start + sub_M, :], sumexp[row_start : row_start + sub_M, :], 1.0)
+                        T.tile.broadcast(bcast_buf[row_start : row_start + sub_M, :], sumexp[row_start : row_start + sub_M, :])
+                        T.tile.div(
+                            acc_o[row_start : row_start + sub_M, :],
+                            acc_o[row_start : row_start + sub_M, :],
+                            bcast_buf[row_start : row_start + sub_M, :],
+                        )
+                        T.copy(
+                            acc_o[row_start : row_start + sub_M, :],
+                            o_acc_half[row_start : row_start + sub_M, :],
+                        )
+                        T.set_flag("V", "MTE3", SIG_O_READY + sub)
+
+                        T.wait_flag("V", "MTE3", SIG_O_READY + sub)
+                        valid_rows_sub = T.if_then_else(
+                            q_tile_size_live >= vid * half_M + row_start + sub_M,
+                            sub_M,
+                            T.if_then_else(
+                                q_tile_size_live > vid * half_M + row_start,
+                                q_tile_size_live - vid * half_M - row_start,
+                                0,
+                            ),
+                        )
+                        h_i_out = (cid + core_index * core_num) % heads
+                        output_packed_start = q_packed_start + vid * half_M + row_start
+
+                        if valid_rows_sub > 0:
+                            T.copy(
+                                o_acc_half[row_start : row_start + valid_rows_sub, :],
+                                Output[
+                                    output_packed_start : output_packed_start + valid_rows_sub,
+                                    h_i_out,
+                                    :,
+                                ],
+                            )
+
+                T.wait_flag("V", "MTE2", SIG_IO_UB)
+                T.wait_flag("MTE3", "V", SIG_S_HALF)
+
+    return main
+
+
+# ---------------------------------------------------------------------------
+# Host 端 Wrapper（集成动态长度推导与 Workspace 分配）
+# ---------------------------------------------------------------------------
+def mtgr_ragged_segment_attention(
+    query,
+    key,
+    value,
+    segment_offsets_i32,
+    segment_rules_i32,
+    q_seq_starts_i32,
+    matched_prefix_lens_i32,
+    match_mode,
+    key_cache,
+    value_cache,
+    block_table_i32,
+    block_size,
+    max_request_len,
+    sm_scale,
+    output_snd,
+    block_M=128,
+    core_num=24,
+    num_stages=14,
+    kv_group=1,
+    cross_interval=2,
+):
+    assert block_size == 128, f"block_size must be 128, got {block_size}"
+    block_N = block_size
+
+    B = segment_offsets_i32.size(0)
+    H = query.size(1)
+    D = query.size(2)
+    max_segs = segment_offsets_i32.size(1) - 1
+
+    assert segment_offsets_i32.size(1) == max_segs + 1, (
+        f"segment_offsets_i32 shape {segment_offsets_i32.shape} != [batch={B}, max_segs+1={max_segs + 1}]"
+    )
+    assert segment_rules_i32.size(0) == max_segs, f"segment_rules_i32 shape {segment_rules_i32.shape} != [max_segs={max_segs}]"
+
+    ws1 = torch.empty((core_num, num_stages, block_M, block_N), dtype=torch.bfloat16, device=query.device)
+    ws2 = torch.empty((core_num, num_stages, block_M, block_N), dtype=torch.bfloat16, device=query.device)
+    ws3 = torch.zeros((core_num, num_stages, block_M, D), dtype=torch.bfloat16, device=query.device)
+
+    bin_iters = max_segs.bit_length()
+
+    func = mtgr_ragged_segment_attention_kernel(
+        heads=H,
+        dim=D,
+        kv_group=kv_group,
+        sm_scale=sm_scale,
+        block_M=block_M,
+        block_N=block_N,
+        core_num=core_num,
+        num_stages=num_stages,
+        cross_interval=cross_interval,
+    )
+
+    func(
+        query,
+        key,
+        value,
+        output_snd,
+        q_seq_starts_i32,
+        segment_offsets_i32,
+        segment_rules_i32,
+        ws1,
+        ws2,
+        ws3,
+        key_cache,
+        value_cache,
+        block_table_i32,
+        matched_prefix_lens_i32,
+        bin_iters,
+    )
+
+    torch.npu.synchronize()
+    return output_snd
+
+
+def test(config, block_M=128, core_num=24, num_stages=14, cross_interval=2):
+    tilelang.disable_cache()
+    tilelang.cache.clear_cache()
+    data = prepare_data(config)
+
+    torch.npu.synchronize()
+    print("init successful!")
+
+    q_seq_starts = data["q_seq_starts_i32"].tolist()
+    max_request_len = max(q_seq_starts[b + 1] - q_seq_starts[b] for b in range(len(q_seq_starts) - 1))
+    prefix_lens = data["matched_prefix_lens_i32"].tolist()
+    if all(p == 0 for p in prefix_lens):
+        match_mode = 0
+    elif all(p > 0 for p in prefix_lens):
+        match_mode = 1
+    else:
+        match_mode = 2
+
+    output_snd = torch.empty_like(data["query_snd"].npu())
+    output_snd = mtgr_ragged_segment_attention(
+        data["query_snd"].npu(),
+        data["key_snd"].npu(),
+        data["value_snd"].npu(),
+        data["segment_offsets_i32"].npu(),
+        data["segment_rules_i32"].npu(),
+        data["q_seq_starts_i32"].npu(),
+        data["matched_prefix_lens_i32"].npu(),
+        match_mode,
+        data["key_cache"].npu(),
+        data["value_cache"].npu(),
+        data["block_table_tensor"].npu(),
+        data["block_size"],
+        max_request_len,
+        data["sm_scale"],
+        output_snd,
+        block_M=block_M,
+        core_num=core_num,
+        kv_group=data["kv_group"],
+        num_stages=num_stages,
+        cross_interval=cross_interval,
+    )
+
+    torch.npu.synchronize()
+
+    ref_output = golden_attention_simulated_kernel(
+        data["query_snd"],
+        data["key_snd"],
+        data["value_snd"],
+        data["segment_offsets_i32"],
+        data["segment_rules_i32"],
+        data["q_seq_starts_i32"],
+        data["matched_prefix_lens_i32"],
+        data["key_cache"],
+        data["value_cache"],
+        data["block_table_tensor"],
+        data["block_size"],
+        data["sm_scale"],
+    ).to(torch.bfloat16)
+
+    torch.npu.synchronize()
+    torch.testing.assert_close(ref_output.cpu(), output_snd.cpu(), rtol=1e-2, atol=1e-2)
+    print("Kernel Output Match!")
+
+
+if __name__ == "__main__":
+    test_configs = [
+        {
+            "H": 8,
+            "D": 128,
+            "seg_lengths": [[1600, 8] + [5] * 1 + [1200]],
+            "rules": [0, 1] + [2] * 1 + [2],
+            "matched_prefix_arr": [0],
+        },
+    ]
+
+    for config in test_configs:
+        test(config)

--- a/examples/generative_recommendation/testcase.py
+++ b/examples/generative_recommendation/testcase.py
@@ -1,0 +1,487 @@
+import math
+import random
+import torch
+
+
+def prepare_data(config, seed=0):
+    H = config["H"]
+    D = config["D"]
+    seg_lengths = config["seg_lengths"]
+    rules = config["rules"]
+    matched_prefix_arr = config["matched_prefix_arr"]
+    kv_group = config.get("kv_group", 1)
+    block_N = config.get("block_N", 128)
+    block_size = block_N
+
+    B = len(seg_lengths)
+    kv_heads = H // kv_group
+
+    for b_idx, plen in enumerate(matched_prefix_arr):
+        if plen % block_N != 0:
+            raise ValueError(f"matched_prefix_arr[{b_idx}] = {plen} is not a multiple of block_N={block_N}")
+
+    S_logical_list = [sum(sl) for sl in seg_lengths]
+
+    offsets_list = []
+    for sl in seg_lengths:
+        off = [0]
+        for s in sl:
+            off.append(off[-1] + s)
+        offsets_list.append(off)
+
+    actual_q_len_arr = [S_logical_list[b] - matched_prefix_arr[b] for b in range(B)]
+
+    q_seq_starts_arr = [0]
+    for b in range(1, B):
+        q_seq_starts_arr.append(q_seq_starts_arr[b - 1] + actual_q_len_arr[b - 1])
+    q_seq_starts_arr.append(q_seq_starts_arr[B - 1] + actual_q_len_arr[B - 1])
+
+    torch.manual_seed(seed)
+
+    q_list, k_list_full, v_list_full, k_list_live, v_list_live = [], [], [], [], []
+    for b in range(B):
+        q_b = torch.randn(actual_q_len_arr[b], H, D, dtype=torch.float32, device="cpu").to(torch.bfloat16)
+        k_b_full = torch.randn(S_logical_list[b], kv_heads, D, dtype=torch.float32, device="cpu").to(torch.bfloat16)
+        v_b_full = torch.randn(S_logical_list[b], kv_heads, D, dtype=torch.float32, device="cpu").to(torch.bfloat16)
+        q_list.append(q_b)
+        k_list_full.append(k_b_full)
+        v_list_full.append(v_b_full)
+        prefix_len = matched_prefix_arr[b]
+        k_list_live.append(k_b_full[prefix_len:])
+        v_list_live.append(v_b_full[prefix_len:])
+
+    query_snd = torch.cat(q_list, dim=0)
+    key_snd = torch.cat(k_list_live, dim=0)
+    value_snd = torch.cat(v_list_live, dim=0)
+
+    num_cache_blocks = max(1, sum((matched_prefix_arr[b] + block_size - 1) // block_size for b in range(B)))
+    key_cache = torch.zeros(num_cache_blocks, block_size, kv_heads, D, dtype=torch.bfloat16, device="cpu")
+    value_cache = torch.zeros(num_cache_blocks, block_size, kv_heads, D, dtype=torch.bfloat16, device="cpu")
+
+    block_table_arr = []
+    physical_block_offset = 0
+    for b in range(B):
+        prefix_len = matched_prefix_arr[b]
+        num_logical_blocks = (S_logical_list[b] + block_size - 1) // block_size
+        bt_row = []
+        for lb in range(num_logical_blocks):
+            if lb < (prefix_len + block_size - 1) // block_size:
+                bt_row.append(physical_block_offset + lb)
+            else:
+                bt_row.append(0)
+        block_table_arr.append(bt_row)
+        physical_block_offset += (prefix_len + block_size - 1) // block_size
+
+    for b in range(B):
+        prefix_len = matched_prefix_arr[b]
+        if prefix_len > 0:
+            for p in range(prefix_len):
+                block_idx = p // block_size
+                block_offset = p % block_size
+                physical_block = block_table_arr[b][block_idx]
+                key_cache[physical_block, block_offset, :, :] = k_list_full[b][p, :, :]
+                value_cache[physical_block, block_offset, :, :] = v_list_full[b][p, :, :]
+
+    max_blocks_per_request = max(1, max(len(bt) for bt in block_table_arr))
+    block_table_tensor = torch.zeros(B, max_blocks_per_request, dtype=torch.int32, device="cpu")
+    for b in range(B):
+        for lb in range(len(block_table_arr[b])):
+            block_table_tensor[b, lb] = block_table_arr[b][lb]
+
+    segment_offsets_i32 = torch.tensor(offsets_list, dtype=torch.int32, device="cpu")
+    segment_rules_i32 = torch.tensor(rules, dtype=torch.int32, device="cpu")
+    q_seq_starts_i32 = torch.tensor(q_seq_starts_arr, dtype=torch.int32, device="cpu")
+    matched_prefix_lens_i32 = torch.tensor(matched_prefix_arr, dtype=torch.int32, device="cpu")
+
+    sm_scale = 1.0 / math.sqrt(D)
+
+    return dict(
+        query_snd=query_snd,
+        key_snd=key_snd,
+        value_snd=value_snd,
+        segment_offsets_i32=segment_offsets_i32,
+        segment_rules_i32=segment_rules_i32,
+        q_seq_starts_i32=q_seq_starts_i32,
+        matched_prefix_lens_i32=matched_prefix_lens_i32,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        block_table_tensor=block_table_tensor,
+        num_cache_blocks=num_cache_blocks,
+        sm_scale=sm_scale,
+        H=H,
+        D=D,
+        kv_group=kv_group,
+        block_size=block_size,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pattern helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pattern(seg_lengths, rules=None, matched_prefix_arr=None):
+    n = len(seg_lengths[0])
+    if rules is None:
+        rules = [0, 1] + [2] * (n - 2)
+    if matched_prefix_arr is None:
+        matched_prefix_arr = [0] * len(seg_lengths)
+    return {
+        "seg_lengths": seg_lengths,
+        "rules": rules,
+        "matched_prefix_arr": matched_prefix_arr,
+    }
+
+
+def _gen_uniform(num_seg, seg_len, B, prefix=1600, suffix=1200, matched_prefix=0):
+    sl = [prefix, 8] + [seg_len] * num_seg + [suffix]
+    return _make_pattern([sl] * B, matched_prefix_arr=[matched_prefix] * B)
+
+
+_PREFIX_POOL = [1600, 2000, 2400, 3200]
+_SUFFIX_POOL = [1024, 1200, 1800, 2048]
+
+
+def _gen_random_ps(num_seg, seg_len, B, rng):
+    return _gen_uniform(
+        num_seg,
+        seg_len,
+        B,
+        prefix=rng.choice(_PREFIX_POOL),
+        suffix=rng.choice(_SUFFIX_POOL),
+    )
+
+
+_SEG_NUM_MU = math.log(50)
+_SEG_NUM_SIGMA = 1.4
+_MAX_CORE_LEN = 32768
+
+
+def _sample_seg_num(rng):
+    x = rng.lognormvariate(_SEG_NUM_MU, _SEG_NUM_SIGMA)
+    n = min(max(int(round(x)), 1), 1024)
+    if n * 50 > _MAX_CORE_LEN:
+        n = _MAX_CORE_LEN // 50
+    return n
+
+
+def _sample_seg_len(rng):
+    r = rng.random()
+    if r < 0.90:
+        return rng.randint(5, 15)
+    elif r < 0.95:
+        return rng.randint(2, 4)
+    else:
+        return rng.randint(16, 50)
+
+
+# ---------------------------------------------------------------------------
+# Pattern generators
+# ---------------------------------------------------------------------------
+
+_base_patterns = [
+    # 4-seg, rules [0, 1, 2, 2]
+    _make_pattern([[1600, 8, 200, 1200]], [0, 1, 2, 2]),
+    _make_pattern([[1600, 8, 200, 1200], [1700, 8, 300, 1024]], [0, 1, 2, 2]),
+    _make_pattern(
+        [
+            [1600, 8, 200, 1200],
+            [1700, 8, 300, 1024],
+            [1680, 8, 200, 1280],
+            [2000, 8, 700, 2048],
+        ],
+        [0, 1, 2, 2],
+    ),
+    _make_pattern(
+        [
+            [2200, 8, 200, 1024],
+            [1700, 8, 100, 1100],
+            [2440, 8, 200, 2048],
+            [1600, 8, 600, 1900],
+            [3300, 8, 200, 1300],
+            [1700, 8, 300, 2100],
+            [1780, 8, 700, 1200],
+            [2048, 8, 500, 1800],
+        ],
+        [0, 1, 2, 2],
+    ),
+    # various seg counts, rules auto-derived as [0, 1, 2, ..., 2]
+    _make_pattern([[1600, 8, 10, 1200]]),
+    _make_pattern([[1600, 8, 8, 12, 1200], [1700, 8, 6, 15, 1024]]),
+    _make_pattern(
+        [
+            [1600, 8, 5, 6, 7, 8, 1200],
+            [1700, 8, 10, 12, 13, 15, 1024],
+            [1680, 8, 10, 12, 13, 15, 1280],
+            [2000, 8, 13, 14, 15, 15, 2048],
+        ]
+    ),
+    _make_pattern(
+        [
+            [2200, 8, 5, 5, 5, 5, 5, 5, 5, 5, 1024],
+            [1700, 8, 5, 5, 5, 5, 5, 5, 5, 10, 1100],
+            [2440, 8, 5, 5, 5, 5, 5, 5, 5, 12, 2048],
+            [1600, 8, 5, 15, 5, 5, 5, 5, 5, 5, 1900],
+            [3300, 8, 5, 10, 10, 5, 5, 5, 5, 5, 1300],
+            [1700, 8, 15, 15, 5, 5, 5, 5, 5, 5, 2100],
+            [1780, 8, 15, 15, 15, 5, 5, 5, 5, 5, 1200],
+            [2048, 8, 15, 15, 15, 15, 5, 5, 5, 5, 1800],
+        ]
+    ),
+]
+
+
+def _generate_multi_seg():
+    cases = [1, 2, 4, 7, 8, 15, 16, 25, 32, 43, 63, 64, 85, 119, 128, 143, 256, 512, 1024]
+    return [_gen_uniform(ns, 5, 1) for ns in cases]
+
+
+def _generate_big_seg():
+    cases = [4, 8, 16, 32, 64, 128, 256, 512]
+    return [_gen_uniform(1, sl, 1) for sl in cases]
+
+
+def _generate_multi_seg_patterns():
+    rng = random.Random(42)
+    cases = [
+        (64, 16, 4),
+        (64, 16, 2),
+        (64, 16, 1),
+        (128, 16, 2),
+        (128, 16, 1),
+        (256, 16, 1),
+        (512, 16, 1),
+        (64, 32, 2),
+        (64, 64, 2),
+        (64, 64, 1),
+        (64, 128, 1),
+        (128, 32, 2),
+        (128, 32, 1),
+        (128, 64, 1),
+        (256, 32, 1),
+    ]
+    return [_gen_random_ps(ns, sl, b, rng) for ns, sl, b in cases]
+
+
+def _generate_constraint_patterns():
+    rng = random.Random(123)
+    cases = [
+        (32, 5, 4),
+        (32, 5, 2),
+        (32, 5, 1),
+        (32, 7, 2),
+        (32, 7, 1),
+        (32, 10, 2),
+        (32, 10, 1),
+        (32, 12, 1),
+        (32, 15, 1),
+        (50, 5, 2),
+        (50, 5, 1),
+        (50, 7, 1),
+        (50, 10, 1),
+        (50, 12, 1),
+        (50, 15, 1),
+        (64, 5, 1),
+        (64, 7, 1),
+        (64, 10, 1),
+        (64, 12, 1),
+        (64, 15, 1),
+    ]
+    return [_gen_random_ps(ns, sl, b, rng) for ns, sl, b in cases]
+
+
+def _generate_prefix_patterns():
+    cases = [(ns, 5, 1, pl) for ns in [1, 4, 8, 16, 32] for pl in [128, 256, 512, 1024]] + [
+        (4, 5, 2, 128),
+        (4, 5, 2, 512),
+        (8, 5, 4, 256),
+        (8, 5, 4, 1024),
+    ]
+    return [_gen_uniform(ns, sl, b, matched_prefix=pl) for ns, sl, b, pl in cases]
+
+
+def _generate_sampled_patterns():
+    rng = random.Random(777)
+    patterns = []
+    B_choices = [1, 2, 4, 8]
+    for _ in range(50):
+        B = rng.choice(B_choices)
+        num_seg = _sample_seg_num(rng)
+        seg_lengths_all = []
+        for _ in range(B):
+            prefix = rng.choice(_PREFIX_POOL)
+            suffix = rng.choice(_SUFFIX_POOL)
+            seg_lens = [_sample_seg_len(rng) for _ in range(num_seg)]
+            seg_lengths_all.append([prefix, 8] + seg_lens + [suffix])
+        rules = [0, 1] + [2] * (len(seg_lengths_all[0]) - 2)
+        patterns.append(_make_pattern(seg_lengths_all, rules=rules))
+    return patterns
+
+
+# ---------------------------------------------------------------------------
+# Assemble test configs
+# ---------------------------------------------------------------------------
+
+case = []
+case.extend(_base_patterns)
+case.extend(_generate_multi_seg())
+case.extend(_generate_big_seg())
+case.extend(_generate_multi_seg_patterns())
+case.extend(_generate_constraint_patterns())
+case.extend(_generate_prefix_patterns())
+case.extend(_generate_sampled_patterns())
+
+_D_values = [128, 64, 32]
+
+test_configs = [{"H": 8, "D": d, **pattern} for d in _D_values for pattern in case]
+
+# ---------------------------------------------------------------------------
+# GQA test configs (kv_group > 1)
+# ---------------------------------------------------------------------------
+
+_gqa_patterns = [
+    # P0: 基础单 batch 4-seg
+    _make_pattern([[1600, 8, 200, 1200]], [0, 1, 2, 2]),
+    # P1: 多 batch(4) 4-seg
+    _make_pattern(
+        [
+            [1600, 8, 200, 1200],
+            [1700, 8, 300, 1024],
+            [1680, 8, 200, 1280],
+            [2000, 8, 700, 2048],
+        ],
+        [0, 1, 2, 2],
+    ),
+    # P2: prefix + paged cache
+    _make_pattern([[1600, 8, 200, 1200]], [0, 1, 2, 2], matched_prefix_arr=[512]),
+    # P3: 多 segment(16 段)
+    _make_pattern([[1600, 8] + [5] * 16 + [1200]]),
+    # P4: 多 batch 多 seg
+    _make_pattern([[1600, 8, 10, 12, 1200], [1700, 8, 6, 15, 1024]]),
+]
+
+_gqa_kv_groups = [2, 4, 8]
+_gqa_D_values = [128, 64]
+
+test_configs += [{"H": 8, "D": d, "kv_group": kg, **p} for d in _gqa_D_values for kg in _gqa_kv_groups for p in _gqa_patterns]
+
+# ---------------------------------------------------------------------------
+# Per-case test flags
+# ---------------------------------------------------------------------------
+# multi_seed: accuracy 模式下是否跑多种子（CPU golden 开销大，每类仅 1-2 条）
+# perf_test:  compare 模式下是否跑性能测试
+#
+# 索引布局（共 462 条）：
+#   D=128:  idx 0-143   (144 条 MHA) + idx 432-446 (15 条 GQA)
+#   D=64:   idx 144-287 (144 条 MHA) + idx 447-461 (15 条 GQA)
+#   D=32:   idx 288-431 (144 条 MHA, 无 GQA)
+#
+# 各类别边界（在每个 D 内）：
+#   base:                 0-7
+#   multi_seg:            8-26
+#   big_seg:              27-34
+#   multi_seg_patterns:   35-49
+#   constraint:           50-69
+#   prefix:               70-93
+#   sampled:              94-143
+
+_multi_seed_indices = {
+    # D=128
+    0,
+    3,  # base: 单batch基础 + 多batch(8)
+    14,  # multi_seg: segs=19
+    30,  # big_seg: seg_len=64
+    37,  # multi_seg_patterns: B=1, segs=67
+    52,  # constraint: B=1, segs=35
+    72,  # prefix: pf=512, segs=4
+    98,  # sampled: B=1, segs=51
+    437,
+    442,  # GQA4 + GQA8(MQA)
+    # D=64
+    144,  # base: 单batch基础
+    216,  # prefix: pf=512, segs=4
+    # D=32
+    288,  # base: 单batch基础
+    360,  # prefix: pf=512, segs=4
+}
+
+_perf_test_indices = {
+    # === D=128 (33 条) ===
+    # base: B=1/2/4/8
+    0,
+    1,
+    2,
+    3,
+    # multi_seg: segs=4/19/66/131/1027
+    8,
+    14,
+    18,
+    22,
+    26,
+    # big_seg: seg_len=4/64/512
+    27,
+    30,
+    34,
+    # multi_seg_patterns: B=4/B=1/B=2
+    35,
+    37,
+    42,
+    # constraint: 不同约束组合
+    50,
+    52,
+    58,
+    # prefix: pf=128/512/1024 + B=2
+    70,
+    72,
+    73,
+    90,
+    # sampled: 随机场景采样
+    94,
+    96,
+    98,
+    103,
+    114,
+    118,
+    # GQA: GQA2(B=1/B=4) + GQA4 + GQA8(B=1/pf=512)
+    432,
+    433,
+    437,
+    442,
+    444,
+    # === D=64 (15 条) ===
+    144,
+    147,
+    152,
+    162,
+    170,
+    171,
+    178,
+    181,
+    196,
+    216,
+    217,
+    240,
+    247,
+    262,
+    452,
+    # === D=32 (15 条) ===
+    288,
+    291,
+    296,
+    306,
+    314,
+    315,
+    322,
+    325,
+    340,
+    360,
+    361,
+    384,
+    391,
+    402,
+    406,
+}
+
+for _idx in range(len(test_configs)):
+    test_configs[_idx]["multi_seed"] = _idx in _multi_seed_indices
+    test_configs[_idx]["perf_test"] = _idx in _perf_test_indices


### PR DESCRIPTION
## 功能
- 将逻辑序列划分为多段，每段采用不同掩码规则（Causal / Full / Diagonal）
- 支持 ragged batch（TND packed 布局）与前缀缓存匹配
- 采用 Online Safe Softmax 在线迭代算法

## 实现
- Expert 模式，Cube/Vector 双核协作流水线（workspace 核间交换）
- 关键优化：掩盖计算、可见性单调递增快速路径、双缓冲 L0A/L0B/L0C、跨核同步聚合、手动地址规划
- 目标硬件：昇腾 NPU 910_9382（24 核），bfloat16 计算（float32 累加）

## 精度
- 462 用例全部通过，累计 11,480 次运行 0 失败（通过率 100%）
- 精度标准：atol=1e-2, rtol=1e-2

## 性能
- 对比基线：CANN FusedInferAttentionScore + Mask 两算子串联
- Kernel 平均加速 1.80x（最高 2.48x），56/63 用例 ≥ 1.5x

## 改动
- Add mtgr_ragged_segment_attention.py: MTGR ragged segment attention kernel implementation
- Add golden.py: golden reference implementation for correctness verification
- Add testcase.py: data preparation utilities for the kernel