### PR TITLE
[Ascend] Support guarded axis-0 tail reductions in AscendC/PTO

### DIFF
--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -2285,7 +2285,7 @@ void CodeGenTileLangAscend::TailReduceOpCodegen(const CallNode *op) {
   std::string dtype = getType(GetAccessPtrDtype(op->args[1].as<CallNode>()));
   std::string out = PrintBufferOffset(op->args[1].as<CallNode>());
   std::string src = PrintBufferOffset(op->args[2].as<CallNode>());
-  std::string tmp = PrintBufferOffset(op->args[3].as<CallNode>(), false);
+  std::string tmp = PrintBufferOffset(op->args[3].as<CallNode>());
   // Bind valid-region expressions first (see TailUnaryOpCodegen).
   std::string dim_str = PrintExpr(op->args[4]);
   std::string vrow = PrintExpr(op->args[5]);

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -875,14 +875,16 @@ void CodeGenTileLangAscendPto::VisitExpr_(const CallNode *op,
     BinaryVecOpsCodegen(op, "TMINS");
 
     // --- tail-aware vector ops (AscendTailMaskPropagation) ---
-    // Only unary / binary / scalar are rewritten; reduce / broadcast / compare
-    // / select stay on the full-tile path (gap filled with pad_value).
+    // Broadcast / compare / select stay on the full-tile path (gap filled with
+    // pad_value).
   } else if (op->op.same_as(tl::ascend_tail_unary())) {
     TailUnaryOpCodegen(op);
   } else if (op->op.same_as(tl::ascend_tail_binary())) {
     TailBinaryOpCodegen(op);
   } else if (op->op.same_as(tl::ascend_tail_scalar())) {
     TailScalarOpCodegen(op);
+  } else if (op->op.same_as(tl::ascend_tail_reduce())) {
+    TailReduceOpCodegen(op);
 
     // --- sync / barrier ---
   } else if (op->op.same_as(tl::ascend_sync_all())) {
@@ -2773,6 +2775,67 @@ void CodeGenTileLangAscendPto::TailScalarOpCodegen(const CallNode *op) {
                << ");\n";
 }
 
+void CodeGenTileLangAscendPto::TailReduceOpCodegen(const CallNode *op) {
+  // args: kind(0) out(1) src(2) tmp(3) dim(4) validRow(5) validCol(6)
+  //       physCol(7) clear(8)
+  ICHECK_EQ(op->args.size(), 9U) << "tail_reduce expects 9 arguments";
+  const auto *kind_imm = op->args[0].as<StringImmNode>();
+  ICHECK(kind_imm) << "tail_reduce: kind must be a string";
+  ICHECK(is_zero(op->args[4]))
+      << "PTO tail_reduce supports only column-wise (axis 0) reduction";
+  ICHECK(!is_zero(op->args[8])) << "PTO tail_reduce supports only clear=true";
+
+  ReduceKind kind = ReduceKind::SUM;
+  if (kind_imm->value == "reduce_sum") {
+    kind = ReduceKind::SUM;
+  } else if (kind_imm->value == "reduce_max") {
+    kind = ReduceKind::MAX;
+  } else if (kind_imm->value == "reduce_min") {
+    kind = ReduceKind::MIN;
+  } else {
+    LOG(FATAL) << "Unsupported PTO tail_reduce kind: " << kind_imm->value;
+  }
+
+  // Bind runtime valid-region expressions before emitting any tile views.
+  std::string valid_row = PrintExpr(op->args[5]);
+  std::string valid_col = PrintExpr(op->args[6]);
+  ShapeInfo dst_info = GetSliceInfo(op->args[1].as<CallNode>());
+  ShapeInfo src_info = GetSliceInfo(op->args[2].as<CallNode>());
+  ShapeInfo tmp_info = GetSliceInfo(op->args[3].as<CallNode>());
+  ICHECK_EQ(dst_info.type, src_info.type)
+      << "PTO tail_reduce input and output dtypes must match";
+  ICHECK_GT(src_info.row, 0);
+  ICHECK_GT(src_info.col, 0);
+
+  // The destination access may be a [1, N] slice of a larger allocation.
+  // Normalize its tile view to the axis-0 reduce result shape while preserving
+  // the slice address and offset computed by GetSliceInfo.
+  ShapeInfo reduce_dst_info = dst_info;
+  reduce_dst_info.row = 1;
+  reduce_dst_info.col = src_info.col;
+  reduce_dst_info.slice_row = 1;
+  reduce_dst_info.slice_col = src_info.col;
+  reduce_dst_info.slice_valid_row = 1;
+  reduce_dst_info.slice_valid_col = src_info.col;
+  reduce_dst_info.extent = src_info.col;
+  reduce_dst_info.is_slice = true;
+
+  std::string dst = CreateUbVariableDynamic(reduce_dst_info, "1", valid_col);
+  std::string src = CreateUbVariableDynamic(src_info, valid_row, valid_col);
+  std::string op_name = GetReduceOpName(kind, ReduceDirection::COL);
+
+  std::string tmp;
+  if (kind == ReduceKind::SUM) {
+    tmp = ResolveColReduceTmpName(reduce_dst_info, src_info, tmp_info);
+  }
+
+  this->PrintIndent();
+  this->stream << op_name << "(" << dst << ", " << src;
+  if (kind == ReduceKind::SUM)
+    this->stream << ", " << tmp << ", false";
+  this->stream << ");\n";
+}
+
 void CodeGenTileLangAscendPto::ScalarOpCodegen(const CallNode *op,
                                                const std::string &op_name) {
   ShapeInfo src_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
@@ -3131,24 +3194,9 @@ void CodeGenTileLangAscendPto::CodegenColReduce(const ReduceOpInfo &op_info,
     CreateUbVariableND(src_name, src);
   }
 
-  // TCOLSUM: src.dtyp == dst.dtyp == tmp.dtype
   std::string temp_name = tmp.ub_name;
   if (op_info.kind == ReduceKind::SUM) {
-    ICHECK(dst.type == src.type)
-        << "Reduce_sum input dtype must be consistent with the output "
-           "dtype.";
-    if (dst.type != tmp.type) {
-      temp_name = GetTempVarName(temp_name);
-
-      int tmp_col =
-          tmp.row * tmp.col * GetTypeLen(tmp.type) / GetTypeLen(dst.type);
-      tmp_col = GetValidShape(tmp_col, dst.type);
-      ShapeInfo tmp_cast =
-          ShapeInfo{1,          tmp_col,  1,           tmp_col,
-                    1,          tmp_col,  tmp.extent,  tmp.first_addr,
-                    tmp.offset, dst.type, tmp.ub_name, false};
-      CreateUbVariableND(temp_name, tmp_cast);
-    }
+    temp_name = ResolveColReduceTmpName(dst, src, tmp);
   }
 
   this->PrintIndent();
@@ -3159,6 +3207,26 @@ void CodeGenTileLangAscendPto::CodegenColReduce(const ReduceOpInfo &op_info,
   }
 
   this->stream << ");\n";
+}
+
+std::string CodeGenTileLangAscendPto::ResolveColReduceTmpName(
+    const ShapeInfo &dst, const ShapeInfo &src, const ShapeInfo &tmp) {
+  // TCOLSUM requires src, dst and tmp to expose the same element type. The
+  // injected scratch buffer is commonly byte-typed, so bind an aligned typed
+  // view over the same storage when needed.
+  ICHECK_EQ(dst.type, src.type)
+      << "Reduce_sum input dtype must be consistent with the output dtype.";
+  if (dst.type == tmp.type)
+    return tmp.ub_name;
+
+  std::string temp_name = GetTempVarName(tmp.ub_name);
+  int tmp_col = tmp.row * tmp.col * GetTypeLen(tmp.type) / GetTypeLen(dst.type);
+  tmp_col = GetValidShape(tmp_col, dst.type);
+  ShapeInfo tmp_cast = ShapeInfo{
+      1,          tmp_col,        1,          tmp_col,  1,           tmp_col,
+      tmp.extent, tmp.first_addr, tmp.offset, dst.type, tmp.ub_name, false};
+  CreateUbVariableND(temp_name, tmp_cast);
+  return temp_name;
 }
 
 void CodeGenTileLangAscendPto::ReduceOpCodegen(const CallNode *op) {

--- a/src/target/codegen_ascend_pto.h
+++ b/src/target/codegen_ascend_pto.h
@@ -126,14 +126,16 @@ private:
   void BinaryVecOpsCodegen(const CallNode *op, const std::string &op_name);
 
   // Tail-aware vector ops produced by AscendTailMaskPropagation. The pass
-  // rewrites unary / binary / scalar ops on tail UB tiles to these internal
-  // ops carrying the runtime valid rectangle; reduce / broadcast / compare /
-  // select are NOT rewritten (hybrid scheme) so only these three are needed.
+  // rewrites supported ops on tail UB tiles to these internal ops carrying the
+  // runtime valid rectangle. Broadcast / compare / select stay on the hybrid
+  // full-tile path.
   void TailUnaryOpCodegen(const CallNode *op);
 
   void TailBinaryOpCodegen(const CallNode *op);
 
   void TailScalarOpCodegen(const CallNode *op);
+
+  void TailReduceOpCodegen(const CallNode *op);
 
   void CallExternCodegen(const CallNode *op);
 
@@ -263,6 +265,9 @@ private:
 
   ReduceOpInfo ParseReduceOpInfo(const std::string &op_name);
   std::string GetReduceOpName(ReduceKind kind, ReduceDirection direction);
+  std::string ResolveColReduceTmpName(const ShapeInfo &dst,
+                                      const ShapeInfo &src,
+                                      const ShapeInfo &tmp);
   void CodegenRowReduce(const ReduceOpInfo &op_info, const ShapeInfo &dst,
                         const ShapeInfo &src, const ShapeInfo &tmp);
   void CodegenColReduce(const ReduceOpInfo &op_info, const ShapeInfo &dst,

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -912,23 +912,13 @@ CATLASS_DEVICE void tail_reduce_sum(LocalTensor<T> out, LocalTensor<T> src,
   // path: every row writes one scalar to contiguous out[r].  The native
   // Pattern-AR path is intentionally not used here because its runtime-shape
   // output layout has not yet been validated for tail blocks.
-  // clear == false is handled by backing up the old result and merging.
-  constexpr uint32_t kTailMaxRows = 256;
-  T backup[kTailMaxRows];
-  bool merge = (!clear) && (validRow <= kTailMaxRows);
-  if (merge) {
-    for (uint32_t r = 0; r < validRow; ++r)
-      backup[r] = out.GetValue(r);
-  }
   for (uint32_t r = 0; r < validRow; ++r) {
     T acc = static_cast<T>(0);
     for (uint32_t c = 0; c < validCol; ++c)
       acc = static_cast<T>(acc + src.GetValue(r * physCol + c));
+    if (!clear)
+      acc = static_cast<T>(out.GetValue(r) + acc);
     out.SetValue(r, acc);
-  }
-  if (merge) {
-    for (uint32_t r = 0; r < validRow; ++r)
-      out.SetValue(r, static_cast<T>(out.GetValue(r) + backup[r]));
   }
 }
 
@@ -951,33 +941,18 @@ CATLASS_DEVICE void tail_reduce_max(LocalTensor<T> out, LocalTensor<T> src,
     }
     return;
   }
-  // dim == -1: reduce each row over its valid columns (Pattern-AR).
-  constexpr uint32_t kTailMaxRows = 256;
-  T backup[kTailMaxRows];
-  bool merge = (!clear) && (validRow <= kTailMaxRows);
-  if (merge) {
-    for (uint32_t r = 0; r < validRow; ++r)
-      backup[r] = out.GetValue(r);
-  }
-  if (validCol == physCol) {
-    uint32_t shape[2] = {validRow, validCol};
-    AscendC::ReduceMax<T, AscendC::Pattern::Reduce::AR>(out, src, tmp, shape,
-                                                        true);
-  } else {
-    // validCol != physCol (tail columns): scalar fallback (see
-    // tail_reduce_sum).
-    for (uint32_t r = 0; r < validRow; ++r) {
-      T acc = src.GetValue(r * physCol);
-      for (uint32_t c = 1; c < validCol; ++c) {
-        T v = src.GetValue(r * physCol + c);
-        acc = reduce_scalar_max_safe(acc, v);
-      }
-      out.SetValue(r, acc);
+  // dim == -1: reduce each row over its valid columns with an explicit
+  // contiguous out[r] layout.
+  (void)tmp;
+  for (uint32_t r = 0; r < validRow; ++r) {
+    T acc = src.GetValue(r * physCol);
+    for (uint32_t c = 1; c < validCol; ++c) {
+      T v = src.GetValue(r * physCol + c);
+      acc = reduce_scalar_max_safe(acc, v);
     }
-  }
-  if (merge) {
-    for (uint32_t r = 0; r < validRow; ++r)
-      out.SetValue(r, reduce_scalar_max_safe(out.GetValue(r), backup[r]));
+    if (!clear)
+      acc = reduce_scalar_max_safe(out.GetValue(r), acc);
+    out.SetValue(r, acc);
   }
 }
 
@@ -1000,33 +975,18 @@ CATLASS_DEVICE void tail_reduce_min(LocalTensor<T> out, LocalTensor<T> src,
     }
     return;
   }
-  // dim == -1: reduce each row over its valid columns (Pattern-AR).
-  constexpr uint32_t kTailMaxRows = 256;
-  T backup[kTailMaxRows];
-  bool merge = (!clear) && (validRow <= kTailMaxRows);
-  if (merge) {
-    for (uint32_t r = 0; r < validRow; ++r)
-      backup[r] = out.GetValue(r);
-  }
-  if (validCol == physCol) {
-    uint32_t shape[2] = {validRow, validCol};
-    AscendC::ReduceMin<T, AscendC::Pattern::Reduce::AR>(out, src, tmp, shape,
-                                                        true);
-  } else {
-    // validCol != physCol (tail columns): scalar fallback (see
-    // tail_reduce_sum).
-    for (uint32_t r = 0; r < validRow; ++r) {
-      T acc = src.GetValue(r * physCol);
-      for (uint32_t c = 1; c < validCol; ++c) {
-        T v = src.GetValue(r * physCol + c);
-        acc = reduce_scalar_min_safe(acc, v);
-      }
-      out.SetValue(r, acc);
+  // dim == -1: reduce each row over its valid columns with an explicit
+  // contiguous out[r] layout.
+  (void)tmp;
+  for (uint32_t r = 0; r < validRow; ++r) {
+    T acc = src.GetValue(r * physCol);
+    for (uint32_t c = 1; c < validCol; ++c) {
+      T v = src.GetValue(r * physCol + c);
+      acc = reduce_scalar_min_safe(acc, v);
     }
-  }
-  if (merge) {
-    for (uint32_t r = 0; r < validRow; ++r)
-      out.SetValue(r, reduce_scalar_min_safe(out.GetValue(r), backup[r]));
+    if (!clear)
+      acc = reduce_scalar_min_safe(out.GetValue(r), acc);
+    out.SetValue(r, acc);
   }
 }
 

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -911,7 +911,9 @@ CATLASS_DEVICE void tail_reduce_sum(LocalTensor<T> out, LocalTensor<T> src,
   // Keep a single explicit layout contract for the first enabled tail-reduce
   // path: every row writes one scalar to contiguous out[r].  The native
   // Pattern-AR path is intentionally not used here because its runtime-shape
-  // output layout has not yet been validated for tail blocks.
+  // output layout has not yet been validated for tail blocks. This GetValue /
+  // SetValue fallback runs on the scalar unit and is intentionally correctness
+  // first; replace it with a vector reduction once that layout is validated.
   for (uint32_t r = 0; r < validRow; ++r) {
     T acc = static_cast<T>(0);
     for (uint32_t c = 0; c < validCol; ++c)
@@ -941,8 +943,8 @@ CATLASS_DEVICE void tail_reduce_max(LocalTensor<T> out, LocalTensor<T> src,
     }
     return;
   }
-  // dim == -1: reduce each row over its valid columns with an explicit
-  // contiguous out[r] layout.
+  // dim == -1: correctness-first scalar fallback with an explicit contiguous
+  // out[r] layout. It is slower than a vector reduction; see tail_reduce_sum.
   (void)tmp;
   for (uint32_t r = 0; r < validRow; ++r) {
     T acc = src.GetValue(r * physCol);
@@ -975,8 +977,8 @@ CATLASS_DEVICE void tail_reduce_min(LocalTensor<T> out, LocalTensor<T> src,
     }
     return;
   }
-  // dim == -1: reduce each row over its valid columns with an explicit
-  // contiguous out[r] layout.
+  // dim == -1: correctness-first scalar fallback with an explicit contiguous
+  // out[r] layout. It is slower than a vector reduction; see tail_reduce_sum.
   (void)tmp;
   for (uint32_t r = 0; r < validRow; ++r) {
     T acc = src.GetValue(r * physCol);

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -885,42 +885,25 @@ CATLASS_DEVICE void tail_scalar(TailVecScalarOp op, LocalTensor<T> dst,
 }
 
 // ---- reduce ----
-// dim == -1 : reduce each row over its valid columns -> out[0..validRow).
-// dim == 0  : reduce down the valid rows           -> out[0..validCol).
+// The propagation pass emits this helper only for axis 0/-2: reduce down the
+// valid rows into out[0..validCol). `tmp`, `dim`, and `clear` stay in the ABI
+// shared with the native reduce call; this validated contract does not consume
+// tmp and always arrives normalized as dim == 0, clear == true.
 template <typename T>
 CATLASS_DEVICE void tail_reduce_sum(LocalTensor<T> out, LocalTensor<T> src,
                                     LocalTensor<uint8_t> tmp, int dim,
                                     uint32_t validRow, uint32_t validCol,
                                     uint32_t physCol, bool clear) {
   (void)tmp;
+  (void)dim;
+  (void)clear;
   if (validRow == 0 || validCol == 0)
     return;
-  if (dim == 0) {
-    uint32_t r0 = 0;
-    if (clear) {
-      AscendC::Adds(out, src, static_cast<T>(0),
-                    static_cast<int32_t>(validCol));
-      r0 = 1;
-    }
-    for (uint32_t r = r0; r < validRow; ++r) {
-      AscendC::Add(out, out, src[r * physCol], static_cast<int32_t>(validCol));
-    }
-    return;
-  }
-  // dim == -1: reduce each row over its valid columns -> out[0..validRow).
-  // Keep a single explicit layout contract for the first enabled tail-reduce
-  // path: every row writes one scalar to contiguous out[r].  The native
-  // Pattern-AR path is intentionally not used here because its runtime-shape
-  // output layout has not yet been validated for tail blocks. This GetValue /
-  // SetValue fallback runs on the scalar unit and is intentionally correctness
-  // first; replace it with a vector reduction once that layout is validated.
-  for (uint32_t r = 0; r < validRow; ++r) {
-    T acc = static_cast<T>(0);
-    for (uint32_t c = 0; c < validCol; ++c)
-      acc = static_cast<T>(acc + src.GetValue(r * physCol + c));
-    if (!clear)
-      acc = static_cast<T>(out.GetValue(r) + acc);
-    out.SetValue(r, acc);
+  // Multiplication by one preserves signed zero while initializing the first
+  // row; Adds(..., 0) may canonicalize -0.0 on device.
+  AscendC::Muls(out, src, static_cast<T>(1), static_cast<int32_t>(validCol));
+  for (uint32_t r = 1; r < validRow; ++r) {
+    AscendC::Add(out, out, src[r * physCol], static_cast<int32_t>(validCol));
   }
 }
 
@@ -929,32 +912,14 @@ CATLASS_DEVICE void tail_reduce_max(LocalTensor<T> out, LocalTensor<T> src,
                                     LocalTensor<uint8_t> tmp, int dim,
                                     uint32_t validRow, uint32_t validCol,
                                     uint32_t physCol, bool clear) {
+  (void)tmp;
+  (void)dim;
+  (void)clear;
   if (validRow == 0 || validCol == 0)
     return;
-  if (dim == 0) {
-    uint32_t r0 = 0;
-    if (clear) {
-      AscendC::Adds(out, src, static_cast<T>(0),
-                    static_cast<int32_t>(validCol));
-      r0 = 1;
-    }
-    for (uint32_t r = r0; r < validRow; ++r) {
-      AscendC::Max(out, out, src[r * physCol], static_cast<int32_t>(validCol));
-    }
-    return;
-  }
-  // dim == -1: correctness-first scalar fallback with an explicit contiguous
-  // out[r] layout. It is slower than a vector reduction; see tail_reduce_sum.
-  (void)tmp;
-  for (uint32_t r = 0; r < validRow; ++r) {
-    T acc = src.GetValue(r * physCol);
-    for (uint32_t c = 1; c < validCol; ++c) {
-      T v = src.GetValue(r * physCol + c);
-      acc = reduce_scalar_max_safe(acc, v);
-    }
-    if (!clear)
-      acc = reduce_scalar_max_safe(out.GetValue(r), acc);
-    out.SetValue(r, acc);
+  AscendC::Muls(out, src, static_cast<T>(1), static_cast<int32_t>(validCol));
+  for (uint32_t r = 1; r < validRow; ++r) {
+    AscendC::Max(out, out, src[r * physCol], static_cast<int32_t>(validCol));
   }
 }
 
@@ -963,32 +928,14 @@ CATLASS_DEVICE void tail_reduce_min(LocalTensor<T> out, LocalTensor<T> src,
                                     LocalTensor<uint8_t> tmp, int dim,
                                     uint32_t validRow, uint32_t validCol,
                                     uint32_t physCol, bool clear) {
+  (void)tmp;
+  (void)dim;
+  (void)clear;
   if (validRow == 0 || validCol == 0)
     return;
-  if (dim == 0) {
-    uint32_t r0 = 0;
-    if (clear) {
-      AscendC::Adds(out, src, static_cast<T>(0),
-                    static_cast<int32_t>(validCol));
-      r0 = 1;
-    }
-    for (uint32_t r = r0; r < validRow; ++r) {
-      AscendC::Min(out, out, src[r * physCol], static_cast<int32_t>(validCol));
-    }
-    return;
-  }
-  // dim == -1: correctness-first scalar fallback with an explicit contiguous
-  // out[r] layout. It is slower than a vector reduction; see tail_reduce_sum.
-  (void)tmp;
-  for (uint32_t r = 0; r < validRow; ++r) {
-    T acc = src.GetValue(r * physCol);
-    for (uint32_t c = 1; c < validCol; ++c) {
-      T v = src.GetValue(r * physCol + c);
-      acc = reduce_scalar_min_safe(acc, v);
-    }
-    if (!clear)
-      acc = reduce_scalar_min_safe(out.GetValue(r), acc);
-    out.SetValue(r, acc);
+  AscendC::Muls(out, src, static_cast<T>(1), static_cast<int32_t>(validCol));
+  for (uint32_t r = 1; r < validRow; ++r) {
+    AscendC::Min(out, out, src[r * physCol], static_cast<int32_t>(validCol));
   }
 }
 

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -892,6 +892,7 @@ CATLASS_DEVICE void tail_reduce_sum(LocalTensor<T> out, LocalTensor<T> src,
                                     LocalTensor<uint8_t> tmp, int dim,
                                     uint32_t validRow, uint32_t validCol,
                                     uint32_t physCol, bool clear) {
+  (void)tmp;
   if (validRow == 0 || validCol == 0)
     return;
   if (dim == 0) {
@@ -907,8 +908,10 @@ CATLASS_DEVICE void tail_reduce_sum(LocalTensor<T> out, LocalTensor<T> src,
     return;
   }
   // dim == -1: reduce each row over its valid columns -> out[0..validRow).
-  // Use the proven Pattern-AR reduce: one contiguous block reduce when
-  // validCol == physCol, otherwise per-row (each row is contiguous internally).
+  // Keep a single explicit layout contract for the first enabled tail-reduce
+  // path: every row writes one scalar to contiguous out[r].  The native
+  // Pattern-AR path is intentionally not used here because its runtime-shape
+  // output layout has not yet been validated for tail blocks.
   // clear == false is handled by backing up the old result and merging.
   constexpr uint32_t kTailMaxRows = 256;
   T backup[kTailMaxRows];
@@ -917,21 +920,11 @@ CATLASS_DEVICE void tail_reduce_sum(LocalTensor<T> out, LocalTensor<T> src,
     for (uint32_t r = 0; r < validRow; ++r)
       backup[r] = out.GetValue(r);
   }
-  if (validCol == physCol) {
-    uint32_t shape[2] = {validRow, validCol};
-    AscendC::ReduceSum<T, AscendC::Pattern::Reduce::AR>(out, src, tmp, shape,
-                                                        true);
-  } else {
-    // validCol != physCol (tail columns): AR-pattern ReduceSum with a sub-tile
-    // shape {1, validCol} triggers aicore exceptions on some tiles, so fall
-    // back to explicit scalar accumulation (always correct; tail validCol is
-    // small so the cost is bounded). merge (clear==false) handled below.
-    for (uint32_t r = 0; r < validRow; ++r) {
-      T acc = static_cast<T>(0);
-      for (uint32_t c = 0; c < validCol; ++c)
-        acc = static_cast<T>(acc + src.GetValue(r * physCol + c));
-      out.SetValue(r, acc);
-    }
+  for (uint32_t r = 0; r < validRow; ++r) {
+    T acc = static_cast<T>(0);
+    for (uint32_t c = 0; c < validCol; ++c)
+      acc = static_cast<T>(acc + src.GetValue(r * physCol + c));
+    out.SetValue(r, acc);
   }
   if (merge) {
     for (uint32_t r = 0; r < validRow; ++r)

--- a/src/transform/ascend_tail_mask_propagation.cc
+++ b/src/transform/ascend_tail_mask_propagation.cc
@@ -151,6 +151,8 @@ private:
   std::unordered_set<const VarNode *> active_loop_vars_;
 
   bool HasOutOfScopeLoopVar(const PrimExpr &e) const {
+    if (!e.defined())
+      return false;
     bool found = false;
     PostOrderVisit(e, [&](const ObjectRef &n) {
       if (const auto *v = n.as<VarNode>()) {
@@ -505,17 +507,30 @@ private:
   }
 
   static int ParseReduceDim(const std::string &tag) {
-    // tag like "reduce_sum<float, 16, 32, -1>"; dim is the last template field.
+    // tag like "reduce_sum<float, 16, 32, -1>"; dim is the fourth template
+    // field. Parse it from the known row/column fields instead of assuming it
+    // remains the final field if the tag gains more metadata later.
     size_t lt = tag.find('<');
     size_t gt = tag.rfind('>');
     if (lt == std::string::npos || gt == std::string::npos || gt <= lt)
       return 2;
     std::string inner = tag.substr(lt + 1, gt - lt - 1);
-    size_t comma = inner.rfind(',');
-    std::string dim_str =
-        comma == std::string::npos ? inner : inner.substr(comma + 1);
+    size_t dtype_end = inner.find(',');
+    if (dtype_end == std::string::npos)
+      return 2;
+    size_t row_end = inner.find(',', dtype_end + 1);
+    if (row_end == std::string::npos)
+      return 2;
+    size_t col_end = inner.find(',', row_end + 1);
+    if (col_end == std::string::npos)
+      return 2;
+    size_t dim_end = inner.find(',', col_end + 1);
+    std::string dim_str = inner.substr(col_end + 1, dim_end - (col_end + 1));
     try {
-      return std::stoi(dim_str);
+      size_t parsed = 0;
+      int dim = std::stoi(dim_str, &parsed);
+      return dim_str.find_first_not_of(" \t", parsed) == std::string::npos ? dim
+                                                                           : 2;
     } catch (...) {
       return 2;
     }

--- a/src/transform/ascend_tail_mask_propagation.cc
+++ b/src/transform/ascend_tail_mask_propagation.cc
@@ -406,7 +406,21 @@ private:
     // The valid_row/valid_col must also not reference loop vars that have
     // already gone out of scope (e.g. a copy seeded inside `for by` whose
     // valid_col = f(by), but the reduce runs outside the loop).
-    bool ok = rewrite_reduce_ && CleanTail(PtrExtent(call->args[2]), in) &&
+    // Batch 1.1 deliberately enables only the smallest validated reduce
+    // contract: reduce_sum over the last axis with clear=true and a contiguous
+    // output vector.  Other kinds, axes and accumulation semantics keep using
+    // the established full-tile + pad path until they have dedicated tests.
+    DataType src_dtype = PtrDtype(call->args[2]);
+    PrimExpr out_extent = PtrExtent(call->args[1]);
+    bool supported_contract =
+        call->args.size() == 5 && kind == "reduce_sum" &&
+        (raw_dim == 1 || raw_dim == -1) && is_one(call->args[4]) &&
+        src_dtype == DataType::Float(32) &&
+        PtrDtype(call->args[1]) == src_dtype && out_extent.defined() &&
+        in.physical_row.defined() &&
+        analyzer_->CanProveEqual(out_extent, in.physical_row);
+    bool ok = rewrite_reduce_ && supported_contract &&
+              CleanTail(PtrExtent(call->args[2]), in) &&
               SupportedTailDtype(PtrDtype(call->args[2])) &&
               !HasOutOfScopeLoopVar(in.valid_row) &&
               !HasOutOfScopeLoopVar(in.valid_col) && !IsBroadcastScalarMask(in);
@@ -494,7 +508,7 @@ private:
     size_t lt = tag.find('<');
     size_t gt = tag.rfind('>');
     if (lt == std::string::npos || gt == std::string::npos || gt <= lt)
-      return -1;
+      return 2;
     std::string inner = tag.substr(lt + 1, gt - lt - 1);
     size_t comma = inner.rfind(',');
     std::string dim_str =
@@ -502,7 +516,7 @@ private:
     try {
       return std::stoi(dim_str);
     } catch (...) {
-      return -1;
+      return 2;
     }
   }
 };

--- a/src/transform/ascend_tail_mask_propagation.cc
+++ b/src/transform/ascend_tail_mask_propagation.cc
@@ -409,7 +409,9 @@ private:
     // already gone out of scope (e.g. a copy seeded inside `for by` whose
     // valid_col = f(by), but the reduce runs outside the loop).
     // Enable the contracts whose output layout is explicit and validated:
-    // float32 sum/max/min, clear=true, reducing either axis of a 2D tile.
+    // float32 sum/max/min, clear=true, reducing rows (axis 0/-2) of a 2D tile.
+    // The scalar last-axis fallback is not device-reliable for a full 32-row
+    // tile, so keep that contract on the established native path.
     // Accumulating reductions and lower-precision accumulation keep using the
     // established full-tile + pad path until their backend semantics are
     // validated independently.
@@ -417,8 +419,7 @@ private:
     PrimExpr out_extent = PtrExtent(call->args[1]);
     bool supported_kind =
         kind == "reduce_sum" || kind == "reduce_max" || kind == "reduce_min";
-    bool supported_dim =
-        raw_dim == 0 || raw_dim == -2 || raw_dim == 1 || raw_dim == -1;
+    bool supported_dim = raw_dim == 0 || raw_dim == -2;
     PrimExpr expected_out_extent =
         (raw_dim == 0 || raw_dim == -2) ? in.physical_col : in.physical_row;
     bool supported_contract =

--- a/src/transform/ascend_tail_mask_propagation.cc
+++ b/src/transform/ascend_tail_mask_propagation.cc
@@ -135,8 +135,8 @@ public:
 private:
   // Per UB data Var -> current valid region. Absent => full (untracked).
   std::unordered_map<const VarNode *, TailMaskInfo> state_;
-  // Whether reduce ops may be rewritten to tail_reduce. Disabled for the PTO
-  // backend, whose reduce codegen handles valid shapes natively.
+  // Whether reduce ops may be rewritten to tail_reduce. The caller enables
+  // this only for backends with a dedicated tail-reduce lowering.
   bool rewrite_reduce_ = true;
 
   // --- loop-variable scope tracking ---------------------------------------
@@ -399,8 +399,9 @@ private:
     TailMaskInfo in = GetMask(GetPtrVar(call->args[2]));
 
     // Reduce is rewritten to a valid-region tail_reduce (which needs no pad)
-    // only on the AscendC backend, for a clean 2D float tile. On PTO, or for
-    // 3D / int tiles, it stays the native reduce over the pad-filled tile.
+    // only for a clean 2D float tile on a backend that supports the internal
+    // op. Unsupported contracts stay on the native reduce over the pad-filled
+    // tile.
     // The valid_row/valid_col must also not reference loop vars that have
     // already gone out of scope (e.g. a copy seeded inside `for by` whose
     // valid_col = f(by), but the reduce runs outside the loop).

--- a/src/transform/ascend_tail_mask_propagation.cc
+++ b/src/transform/ascend_tail_mask_propagation.cc
@@ -395,10 +395,6 @@ private:
     std::string reduce_tag = name->value; // e.g. reduce_sum<...>
     std::string kind = reduce_tag.substr(0, reduce_tag.find('<')); // reduce_sum
     int raw_dim = ParseReduceDim(reduce_tag);
-    // Normalize to 0 (reduce rows) or -1 (reduce last axis). For 2D tiles
-    // axis 0/-2 reduce rows and axis 1/-1 reduce columns.
-    int dim = (raw_dim == 0 || raw_dim == -2) ? 0 : -1;
-
     const VarNode *out_v = GetPtrVar(call->args[1]);
     TailMaskInfo in = GetMask(GetPtrVar(call->args[2]));
 
@@ -420,8 +416,7 @@ private:
     bool supported_kind =
         kind == "reduce_sum" || kind == "reduce_max" || kind == "reduce_min";
     bool supported_dim = raw_dim == 0 || raw_dim == -2;
-    PrimExpr expected_out_extent =
-        (raw_dim == 0 || raw_dim == -2) ? in.physical_col : in.physical_row;
+    PrimExpr expected_out_extent = in.physical_col;
     bool supported_contract =
         call->args.size() == 5 && supported_kind && supported_dim &&
         is_one(call->args[4]) && src_dtype == DataType::Float(32) &&
@@ -438,13 +433,8 @@ private:
     // Output rectangle for downstream propagation (only when rewriting).
     TailMaskInfo out;
     if (ok) {
-      if (dim == 0) {
-        PrimExpr one = IntImm(DataType::Int(32), 1);
-        out = MakeCopyMask(one, in.valid_col, one, in.physical_col, analyzer_);
-      } else { // dim == -1 (reduce last axis) -> column vector
-        PrimExpr one = IntImm(DataType::Int(32), 1);
-        out = MakeCopyMask(in.valid_row, one, in.physical_row, one, analyzer_);
-      }
+      PrimExpr one = IntImm(DataType::Int(32), 1);
+      out = MakeCopyMask(one, in.valid_col, one, in.physical_col, analyzer_);
     }
     if (out_v != nullptr)
       state_[out_v] = out;
@@ -458,7 +448,7 @@ private:
                          call->args[1],
                          call->args[2],
                          call->args[3],
-                         IntImm(DataType::Int(32), dim),
+                         IntImm(DataType::Int(32), 0),
                          in.valid_row,
                          in.valid_col,
                          in.physical_col,

--- a/src/transform/ascend_tail_mask_propagation.cc
+++ b/src/transform/ascend_tail_mask_propagation.cc
@@ -18,10 +18,10 @@
  * valid_row/valid_col/physical_col) so the codegen emits a tl::ascend::tail_*
  * helper that computes only over the valid region.
  *
- * Batch 1 rewrites: unary / binary / scalar(immediate) / reduce.
- * Batch 1 propagates-but-does-not-rewrite: cast / broadcast / copy_ub_to_ub
- * (they are per-lane or shape-only, so the full-tile path stays numerically
- * correct; the mask still flows through to a downstream reduce).
+ * Rewrites: unary / binary / scalar(immediate), plus a conservative allow-list
+ * of 2D reduce contracts. Propagates-but-does-not-rewrite: cast / broadcast /
+ * copy_ub_to_ub (they are per-lane or shape-only, so the full-tile path stays
+ * numerically correct; the mask still flows through to a downstream reduce).
  */
 
 #include "arith/ir_mutator_with_analyzer.h"
@@ -406,19 +406,26 @@ private:
     // The valid_row/valid_col must also not reference loop vars that have
     // already gone out of scope (e.g. a copy seeded inside `for by` whose
     // valid_col = f(by), but the reduce runs outside the loop).
-    // Batch 1.1 deliberately enables only the smallest validated reduce
-    // contract: reduce_sum over the last axis with clear=true and a contiguous
-    // output vector.  Other kinds, axes and accumulation semantics keep using
-    // the established full-tile + pad path until they have dedicated tests.
+    // Enable the contracts whose output layout is explicit and validated:
+    // float32 sum/max/min, clear=true, reducing either axis of a 2D tile.
+    // Accumulating reductions and lower-precision accumulation keep using the
+    // established full-tile + pad path until their backend semantics are
+    // validated independently.
     DataType src_dtype = PtrDtype(call->args[2]);
     PrimExpr out_extent = PtrExtent(call->args[1]);
+    bool supported_kind =
+        kind == "reduce_sum" || kind == "reduce_max" || kind == "reduce_min";
+    bool supported_dim =
+        raw_dim == 0 || raw_dim == -2 || raw_dim == 1 || raw_dim == -1;
+    PrimExpr expected_out_extent =
+        (raw_dim == 0 || raw_dim == -2) ? in.physical_col : in.physical_row;
     bool supported_contract =
-        call->args.size() == 5 && kind == "reduce_sum" &&
-        (raw_dim == 1 || raw_dim == -1) && is_one(call->args[4]) &&
-        src_dtype == DataType::Float(32) &&
+        call->args.size() == 5 && supported_kind && supported_dim &&
+        is_one(call->args[4]) && src_dtype == DataType::Float(32) &&
         PtrDtype(call->args[1]) == src_dtype && out_extent.defined() &&
-        in.physical_row.defined() &&
-        analyzer_->CanProveEqual(out_extent, in.physical_row);
+        expected_out_extent.defined() &&
+        analyzer_->CanProveEqual(out_extent, expected_out_extent) &&
+        ReduceShapeMatchesPhysical(reduce_tag, in);
     bool ok = rewrite_reduce_ && supported_contract &&
               CleanTail(PtrExtent(call->args[2]), in) &&
               SupportedTailDtype(PtrDtype(call->args[2])) &&
@@ -428,19 +435,13 @@ private:
     // Output rectangle for downstream propagation (only when rewriting).
     TailMaskInfo out;
     if (ok) {
-      out.kind = TailMaskKind::kTail;
       if (dim == 0) {
-        out.valid_row = IntImm(DataType::Int(32), 1);
-        out.valid_col = in.valid_col;
-        out.physical_row = IntImm(DataType::Int(32), 1);
-        out.physical_col = in.physical_col;
+        PrimExpr one = IntImm(DataType::Int(32), 1);
+        out = MakeCopyMask(one, in.valid_col, one, in.physical_col, analyzer_);
       } else { // dim == -1 (reduce last axis) -> column vector
-        out.valid_row = in.valid_row;
-        out.valid_col = IntImm(DataType::Int(32), 1);
-        out.physical_row = in.physical_row;
-        out.physical_col = IntImm(DataType::Int(32), 1);
+        PrimExpr one = IntImm(DataType::Int(32), 1);
+        out = MakeCopyMask(in.valid_row, one, in.physical_row, one, analyzer_);
       }
-      out.storage_col = out.physical_col;
     }
     if (out_v != nullptr)
       state_[out_v] = out;
@@ -517,6 +518,46 @@ private:
       return std::stoi(dim_str);
     } catch (...) {
       return 2;
+    }
+  }
+
+  bool ReduceShapeMatchesPhysical(const std::string &tag,
+                                  const TailMaskInfo &in) {
+    if (!in.physical_row.defined() || !in.physical_col.defined())
+      return false;
+    size_t lt = tag.find('<');
+    size_t gt = tag.rfind('>');
+    if (lt == std::string::npos || gt == std::string::npos || gt <= lt)
+      return false;
+    std::string inner = tag.substr(lt + 1, gt - lt - 1);
+    size_t dtype_end = inner.find(',');
+    if (dtype_end == std::string::npos)
+      return false;
+    size_t row_end = inner.find(',', dtype_end + 1);
+    if (row_end == std::string::npos)
+      return false;
+    size_t col_end = inner.find(',', row_end + 1);
+    if (col_end == std::string::npos)
+      return false;
+    try {
+      auto parse_int = [](const std::string &token, int *value) {
+        size_t parsed = 0;
+        *value = std::stoi(token, &parsed);
+        return token.find_first_not_of(" \t", parsed) == std::string::npos;
+      };
+      int row = 0;
+      int col = 0;
+      if (!parse_int(inner.substr(dtype_end + 1, row_end - dtype_end - 1),
+                     &row) ||
+          !parse_int(inner.substr(row_end + 1, col_end - row_end - 1), &col))
+        return false;
+      return row > 0 && col > 0 &&
+             analyzer_->CanProveEqual(in.physical_row, row) &&
+             analyzer_->CanProveEqual(in.physical_col, col);
+    } catch (...) {
+      // Dynamic or otherwise unparseable explicit real_shape stays on the
+      // established native reduce path.
+      return false;
     }
   }
 };

--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -345,13 +345,18 @@ def test_reduce_max_tail(rows_valid, rows_phys, cols, dtype, target, tail_mask):
 
 
 # =============================================================================
-# Group 2d - AscendC last-axis tail reduce_sum   [risk: high]
-# Version 1 intentionally covers only sum, dim=-1 and clear=true. Each N tile
-# produces one partial row sum, so the output shape is [M, ceildiv(N, block_N)].
+# Group 2d - AscendC 2D tail reductions   [risk: high]
+# Covers sum/max/min with clear=true on both axes. Each tile writes one partial
+# reduction, so different blocks never race on the output.
 # =============================================================================
-def reduce_sum_last_axis_tail(M, N, block_M, block_N, dtype="float"):
+def reduce_last_axis_tail(M, N, block_M, block_N, kind, dtype="float"):
     m_num = T.ceildiv(M, block_M)
     n_num = T.ceildiv(N, block_N)
+    reduce_fn = {
+        "sum": T.reduce_sum,
+        "max": T.reduce_max,
+        "min": T.reduce_min,
+    }[kind]
 
     @T.prim_func
     def main(
@@ -365,15 +370,16 @@ def reduce_sum_last_axis_tail(M, N, block_M, block_N, dtype="float"):
             out_ub = T.alloc_ub((block_M, 1), dtype)
 
             T.copy(Input[bx * block_M, by * block_N], in_ub)
-            T.reduce_sum(in_ub, out_ub, dim=-1, clear=True)
+            reduce_fn(in_ub, out_ub, dim=-1, clear=True)
             T.copy(out_ub, Output[bx * block_M, by])
 
     return main
 
 
-def test_reduce_sum_last_axis_tail_ascendc():
+@pytest.mark.parametrize("kind", ["sum", "max", "min"])
+def test_reduce_last_axis_tail_ascendc(kind):
     M, N, block_M, block_N = 34, 130, 32, 32
-    func = reduce_sum_last_axis_tail(M, N, block_M, block_N)
+    func = reduce_last_axis_tail(M, N, block_M, block_N, kind)
     func = tilelang.compile(
         func, out_idx=[-1], pass_configs=_vec_configs(tail_mask=True), target="ascendc"
     )
@@ -385,7 +391,57 @@ def test_reduce_sum_last_axis_tail_ascendc():
     n_num = (N + block_N - 1) // block_N
     ref = torch.empty((M, n_num), dtype=torch.float32, device=a.device)
     for by in range(n_num):
-        ref[:, by] = a[:, by * block_N : min((by + 1) * block_N, N)].sum(dim=-1)
+        tile = a[:, by * block_N : min((by + 1) * block_N, N)]
+        reduced = getattr(tile, kind)(dim=-1)
+        ref[:, by] = reduced if kind == "sum" else reduced.values
+    torch.testing.assert_close(out, ref, rtol=1e-4, atol=1e-4)
+
+
+def reduce_axis0_tail(M, N, block_M, block_N, kind, dtype="float"):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+    reduce_fn = {
+        "sum": T.reduce_sum,
+        "max": T.reduce_max,
+        "min": T.reduce_min,
+    }[kind]
+
+    @T.prim_func
+    def main(
+        Input: T.Tensor((M, N), dtype),  # type: ignore
+        Output: T.Tensor((m_num, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            in_ub = T.alloc_ub((block_M, block_N), dtype)
+            out_ub = T.alloc_ub((1, block_N), dtype)
+
+            T.copy(Input[bx * block_M, by * block_N], in_ub)
+            reduce_fn(in_ub, out_ub, dim=0, clear=True)
+            T.copy(out_ub, Output[bx, by * block_N])
+
+    return main
+
+
+@pytest.mark.parametrize("kind", ["sum", "max", "min"])
+def test_reduce_axis0_tail_ascendc(kind):
+    M, N, block_M, block_N = 34, 130, 32, 32
+    func = reduce_axis0_tail(M, N, block_M, block_N, kind)
+    func = tilelang.compile(
+        func, out_idx=[-1], pass_configs=_vec_configs(tail_mask=True), target="ascendc"
+    )
+
+    torch.manual_seed(0)
+    a = torch.randn(M, N, dtype=torch.float32).npu()
+    out = func(a)
+
+    m_num = (M + block_M - 1) // block_M
+    ref = torch.empty((m_num, N), dtype=torch.float32, device=a.device)
+    for bx in range(m_num):
+        tile = a[bx * block_M : min((bx + 1) * block_M, M), :]
+        reduced = getattr(tile, kind)(dim=0)
+        ref[bx, :] = reduced if kind == "sum" else reduced.values
     torch.testing.assert_close(out, ref, rtol=1e-4, atol=1e-4)
 
 

--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -60,13 +60,20 @@ CUBE_PASS_CONFIGS = {
     tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
 }
 
-# VECTOR: mirrors the elementwise suite's config (CV combine is harmless for a
-# pure-vector kernel and matches the existing passing tests).
+# VECTOR: the elementwise suite keeps its established configuration.
 VEC_PASS_CONFIGS = {
     tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
     tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
     tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
     tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+# Tail reduction is a pure-vector kernel. Keep its configuration isolated from
+# CV combine/sync so this suite exercises only the passes required by reduce.
+TAIL_REDUCE_PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_TAIL_MASK: True,
 }
 
 
@@ -334,8 +341,9 @@ reduce_tail_configs = [
 ]
 
 
-# tail_mask=True also asserts that enabling the switch does not disturb the
-# real_shape reduce (reduce is not rewritten while rewrite_reduce=False).
+# For AscendC, reduce rewriting is enabled, but this explicit real_shape does
+# not match the physical tile and therefore stays on the native real_shape
+# path. PTO disables reduce rewriting at the phase level.
 @pytest.mark.parametrize("tail_mask", [False, True])
 @pytest.mark.parametrize("dtype", ["float"])
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
@@ -349,7 +357,7 @@ def test_reduce_max_tail(rows_valid, rows_phys, cols, dtype, target, tail_mask):
 # Covers sum/max/min with clear=true. Each tile writes one partial
 # reduction, so different blocks never race on the output.
 # =============================================================================
-def reduce_axis0_tail(M, N, block_M, block_N, kind, dtype="float"):
+def reduce_axis0_tail(M, N, block_M, block_N, kind, dim=0, dtype="float"):
     m_num = T.ceildiv(M, block_M)
     n_num = T.ceildiv(N, block_N)
     reduce_fn = {
@@ -370,17 +378,29 @@ def reduce_axis0_tail(M, N, block_M, block_N, kind, dtype="float"):
             out_ub = T.alloc_ub((1, block_N), dtype)
 
             T.copy(Input[bx * block_M, by * block_N], in_ub)
-            reduce_fn(in_ub, out_ub, dim=0, clear=True)
+            reduce_fn(in_ub, out_ub, dim=dim, clear=True)
             T.copy(out_ub, Output[bx, by * block_N])
 
     return main
 
 
+reduce_axis0_configs = [
+    (34, 128, 32, 32),  # row tail only
+    (32, 130, 32, 32),  # column tail only
+    (34, 130, 32, 32),  # row and column tails
+    (33, 129, 32, 32),  # one valid row and one valid column in the last tile
+    (7, 13, 32, 32),  # tensor smaller than one physical tile
+    (32, 128, 32, 32),  # exact full tiles
+    (65, 130, 64, 32),  # larger physical row with a one-row tail
+]
+
+
 @pytest.mark.parametrize("kind", ["sum", "max", "min"])
-def test_reduce_axis0_tail_ascendc(kind):
-    M, N, block_M, block_N = 34, 130, 32, 32
-    func = reduce_axis0_tail(M, N, block_M, block_N, kind)
-    func = tilelang.compile(func, out_idx=[-1], pass_configs=_vec_configs(tail_mask=True), target="ascendc")
+@pytest.mark.parametrize("dim", [0, -2])
+@pytest.mark.parametrize("M,N,block_M,block_N", reduce_axis0_configs)
+def test_reduce_axis0_tail_ascendc(M, N, block_M, block_N, kind, dim):
+    func = reduce_axis0_tail(M, N, block_M, block_N, kind, dim=dim)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=TAIL_REDUCE_PASS_CONFIGS, target="ascendc")
 
     torch.manual_seed(0)
     a = torch.randn(M, N, dtype=torch.float32).npu()
@@ -393,6 +413,29 @@ def test_reduce_axis0_tail_ascendc(kind):
         reduced = getattr(tile, kind)(dim=0)
         ref[bx, :] = reduced if kind == "sum" else reduced.values
     torch.testing.assert_close(out, ref, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("kind", ["sum", "max", "min"])
+def test_reduce_axis0_special_values_ascendc(kind):
+    M, N, block_M, block_N = 3, 8, 4, 8
+    func = reduce_axis0_tail(M, N, block_M, block_N, kind)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=TAIL_REDUCE_PASS_CONFIGS, target="ascendc")
+
+    a = torch.tensor(
+        [
+            [0.0, -0.0, float("inf"), float("-inf"), float("nan"), 1.0, -1.0, 3.0],
+            [-0.0, 0.0, 2.0, -2.0, 4.0, float("nan"), -3.0, 3.0],
+            [0.0, -0.0, -5.0, 5.0, -4.0, 2.0, float("nan"), -3.0],
+        ],
+        dtype=torch.float32,
+    ).npu()
+    out = func(a)[0]
+    reduced = getattr(a, kind)(dim=0)
+    ref = reduced if kind == "sum" else reduced.values
+    torch.testing.assert_close(out, ref, rtol=0, atol=0, equal_nan=True)
+
+    finite_zero = (ref == 0) & ~torch.isnan(ref)
+    torch.testing.assert_close(torch.signbit(out[finite_zero]), torch.signbit(ref[finite_zero]))
 
 
 # =============================================================================

--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -126,13 +126,14 @@ def cube_matmul_tail(M, N, K, block_M, block_N, K_L1, dtype="float16", accum_dty
             B_L1 = T.alloc_L1((K_L1, block_N), dtype)
             C_L0 = T.alloc_L0C((block_M, block_N), accum_dtype)
 
-            loop_k = T.ceildiv(K, K_L1)
-            for k in T.serial(loop_k):
-                T.copy(A[bx * block_M, k * K_L1], A_L1)  # gm2l1: M & K tail
-                T.copy(B[k * K_L1, by * block_N], B_L1)  # gm2l1: K & N tail
-                T.gemm_v0(A_L1, B_L1, C_L0, init=(k == 0))
+            with T.Scope("C"):
+                loop_k = T.ceildiv(K, K_L1)
+                for k in T.serial(loop_k):
+                    T.copy(A[bx * block_M, k * K_L1], A_L1)  # gm2l1: M & K tail
+                    T.copy(B[k * K_L1, by * block_N], B_L1)  # gm2l1: K & N tail
+                    T.gemm_v0(A_L1, B_L1, C_L0, init=(k == 0))
 
-            T.copy(C_L0, C[bx * block_M, by * block_N])  # l0c2gm: M & N tail
+                T.copy(C_L0, C[bx * block_M, by * block_N])  # l0c2gm: M & N tail
 
     return main
 
@@ -494,31 +495,33 @@ def cv_matmul_add_tail(M, N, K, block_M, block_N, block_K, dtype="float16", accu
             d_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
             c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
 
-            loop_k = T.ceildiv(K, block_K)
-            for k in T.serial(loop_k):
-                T.copy(A[bx * block_M, k * block_K], A_L1)  # gm2l1: M & K tail
-                T.copy(B[k * block_K, by * block_N], B_L1)  # gm2l1: K & N tail
+            with T.Scope("C"):
+                loop_k = T.ceildiv(K, block_K)
+                for k in T.serial(loop_k):
+                    T.copy(A[bx * block_M, k * block_K], A_L1)  # gm2l1: M & K tail
+                    T.copy(B[k * block_K, by * block_N], B_L1)  # gm2l1: K & N tail
+
+                    T.barrier_all()
+                    if k == 0:
+                        T.gemm_v0(A_L1, B_L1, C_L0, init=True)
+                    else:
+                        T.gemm_v0(A_L1, B_L1, C_L0)
+                    T.barrier_all()
+
+                T.copy(C_L0, C[bx * block_M, by * block_N])  # l0c2gm: M & N tail
+                T.set_cross_flag("FIX", 0)
+
+            with T.Scope("V"):
+                T.wait_cross_flag(0)
+
+                T.copy(C[bx * block_M + vid * block_M // VEC_NUM, by * block_N], c_ub)  # gm2ub tail
+                T.copy(D[bx * block_M + vid * block_M // VEC_NUM, by * block_N], d_ub)
 
                 T.barrier_all()
-                if k == 0:
-                    T.gemm_v0(A_L1, B_L1, C_L0, init=True)
-                else:
-                    T.gemm_v0(A_L1, B_L1, C_L0)
+                T.tile.add(c_ub, c_ub, d_ub)
                 T.barrier_all()
 
-            T.copy(C_L0, C[bx * block_M, by * block_N])  # l0c2gm: M & N tail
-            T.set_cross_flag("FIX", 0)
-
-            T.wait_cross_flag(0)
-
-            T.copy(C[bx * block_M + vid * block_M // VEC_NUM, by * block_N], c_ub)  # gm2ub tail
-            T.copy(D[bx * block_M + vid * block_M // VEC_NUM, by * block_N], d_ub)
-
-            T.barrier_all()
-            T.tile.add(c_ub, c_ub, d_ub)
-            T.barrier_all()
-
-            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])  # ub2gm tail
+                T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])  # ub2gm tail
 
     return main
 

--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -345,6 +345,51 @@ def test_reduce_max_tail(rows_valid, rows_phys, cols, dtype, target, tail_mask):
 
 
 # =============================================================================
+# Group 2d - AscendC last-axis tail reduce_sum   [risk: high]
+# Version 1 intentionally covers only sum, dim=-1 and clear=true. Each N tile
+# produces one partial row sum, so the output shape is [M, ceildiv(N, block_N)].
+# =============================================================================
+def reduce_sum_last_axis_tail(M, N, block_M, block_N, dtype="float"):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+
+    @T.prim_func
+    def main(
+        Input: T.Tensor((M, N), dtype),  # type: ignore
+        Output: T.Tensor((M, n_num), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            in_ub = T.alloc_ub((block_M, block_N), dtype)
+            out_ub = T.alloc_ub((block_M, 1), dtype)
+
+            T.copy(Input[bx * block_M, by * block_N], in_ub)
+            T.reduce_sum(in_ub, out_ub, dim=-1, clear=True)
+            T.copy(out_ub, Output[bx * block_M, by])
+
+    return main
+
+
+def test_reduce_sum_last_axis_tail_ascendc():
+    M, N, block_M, block_N = 34, 130, 32, 32
+    func = reduce_sum_last_axis_tail(M, N, block_M, block_N)
+    func = tilelang.compile(
+        func, out_idx=[-1], pass_configs=_vec_configs(tail_mask=True), target="ascendc"
+    )
+
+    torch.manual_seed(0)
+    a = torch.randn(M, N, dtype=torch.float32).npu()
+    out = func(a)
+
+    n_num = (N + block_N - 1) // block_N
+    ref = torch.empty((M, n_num), dtype=torch.float32, device=a.device)
+    for by in range(n_num):
+        ref[:, by] = a[:, by * block_N : min((by + 1) * block_N, N)].sum(dim=-1)
+    torch.testing.assert_close(out, ref, rtol=1e-4, atol=1e-4)
+
+
+# =============================================================================
 # Group 3 - CV fusion (matmul + add) tail   [risk: medium]
 # Mirrors examples/simple_fusion/matmul_add.py, but the grid uses T.ceildiv with
 # non-divisible M/N. C-scope (cube) tails ride gm2l1/l0c2gm; V-scope (vector,

--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -126,14 +126,13 @@ def cube_matmul_tail(M, N, K, block_M, block_N, K_L1, dtype="float16", accum_dty
             B_L1 = T.alloc_L1((K_L1, block_N), dtype)
             C_L0 = T.alloc_L0C((block_M, block_N), accum_dtype)
 
-            with T.Scope("C"):
-                loop_k = T.ceildiv(K, K_L1)
-                for k in T.serial(loop_k):
-                    T.copy(A[bx * block_M, k * K_L1], A_L1)  # gm2l1: M & K tail
-                    T.copy(B[k * K_L1, by * block_N], B_L1)  # gm2l1: K & N tail
-                    T.gemm_v0(A_L1, B_L1, C_L0, init=(k == 0))
+            loop_k = T.ceildiv(K, K_L1)
+            for k in T.serial(loop_k):
+                T.copy(A[bx * block_M, k * K_L1], A_L1)  # gm2l1: M & K tail
+                T.copy(B[k * K_L1, by * block_N], B_L1)  # gm2l1: K & N tail
+                T.gemm_v0(A_L1, B_L1, C_L0, init=(k == 0))
 
-                T.copy(C_L0, C[bx * block_M, by * block_N])  # l0c2gm: M & N tail
+            T.copy(C_L0, C[bx * block_M, by * block_N])  # l0c2gm: M & N tail
 
     return main
 
@@ -495,33 +494,31 @@ def cv_matmul_add_tail(M, N, K, block_M, block_N, block_K, dtype="float16", accu
             d_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
             c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
 
-            with T.Scope("C"):
-                loop_k = T.ceildiv(K, block_K)
-                for k in T.serial(loop_k):
-                    T.copy(A[bx * block_M, k * block_K], A_L1)  # gm2l1: M & K tail
-                    T.copy(B[k * block_K, by * block_N], B_L1)  # gm2l1: K & N tail
-
-                    T.barrier_all()
-                    if k == 0:
-                        T.gemm_v0(A_L1, B_L1, C_L0, init=True)
-                    else:
-                        T.gemm_v0(A_L1, B_L1, C_L0)
-                    T.barrier_all()
-
-                T.copy(C_L0, C[bx * block_M, by * block_N])  # l0c2gm: M & N tail
-                T.set_cross_flag("FIX", 0)
-
-            with T.Scope("V"):
-                T.wait_cross_flag(0)
-
-                T.copy(C[bx * block_M + vid * block_M // VEC_NUM, by * block_N], c_ub)  # gm2ub tail
-                T.copy(D[bx * block_M + vid * block_M // VEC_NUM, by * block_N], d_ub)
+            loop_k = T.ceildiv(K, block_K)
+            for k in T.serial(loop_k):
+                T.copy(A[bx * block_M, k * block_K], A_L1)  # gm2l1: M & K tail
+                T.copy(B[k * block_K, by * block_N], B_L1)  # gm2l1: K & N tail
 
                 T.barrier_all()
-                T.tile.add(c_ub, c_ub, d_ub)
+                if k == 0:
+                    T.gemm_v0(A_L1, B_L1, C_L0, init=True)
+                else:
+                    T.gemm_v0(A_L1, B_L1, C_L0)
                 T.barrier_all()
 
-                T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])  # ub2gm tail
+            T.copy(C_L0, C[bx * block_M, by * block_N])  # l0c2gm: M & N tail
+            T.set_cross_flag("FIX", 0)
+
+            T.wait_cross_flag(0)
+
+            T.copy(C[bx * block_M + vid * block_M // VEC_NUM, by * block_N], c_ub)  # gm2ub tail
+            T.copy(D[bx * block_M + vid * block_M // VEC_NUM, by * block_N], d_ub)
+
+            T.barrier_all()
+            T.tile.add(c_ub, c_ub, d_ub)
+            T.barrier_all()
+
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])  # ub2gm tail
 
     return main
 

--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -406,9 +406,7 @@ REDUCE_TAIL_AXIS0_DIMS = (0, -2)
 @pytest.mark.parametrize("M,N,block_M,block_N", reduce_axis0_configs)
 def test_reduce_axis0_tail(M, N, block_M, block_N, target, kind, dim):
     func = reduce_axis0_tail(M, N, block_M, block_N, kind, dim=dim)
-    func = tilelang.compile(
-        func, out_idx=[-1], pass_configs=TAIL_REDUCE_PASS_CONFIGS, target=target
-    )
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=TAIL_REDUCE_PASS_CONFIGS, target=target)
 
     torch.manual_seed(0)
     a = torch.randn(M, N, dtype=torch.float32).npu()
@@ -429,9 +427,7 @@ def test_reduce_axis0_tail_does_not_consume_zero_padding(target, kind, sign):
     """Guard max/min against treating the zero-filled physical tail as data."""
     M, N, block_M, block_N = 3, 8, 4, 8
     func = reduce_axis0_tail(M, N, block_M, block_N, kind)
-    func = tilelang.compile(
-        func, out_idx=[-1], pass_configs=TAIL_REDUCE_PASS_CONFIGS, target=target
-    )
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=TAIL_REDUCE_PASS_CONFIGS, target=target)
 
     base = torch.arange(1, M * N + 1, dtype=torch.float32).reshape(M, N)
     a = (base * sign).npu()
@@ -449,9 +445,7 @@ def test_reduce_axis0_tail_does_not_consume_zero_padding(target, kind, sign):
 def test_reduce_axis0_special_values_ascendc(kind):
     M, N, block_M, block_N = 3, 8, 4, 8
     func = reduce_axis0_tail(M, N, block_M, block_N, kind)
-    func = tilelang.compile(
-        func, out_idx=[-1], pass_configs=TAIL_REDUCE_PASS_CONFIGS, target="ascendc"
-    )
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=TAIL_REDUCE_PASS_CONFIGS, target="ascendc")
 
     a = torch.tensor(
         [

--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -371,7 +371,13 @@ def reduce_last_axis_tail(M, N, block_M, block_N, kind, dtype="float"):
 
             T.copy(Input[bx * block_M, by * block_N], in_ub)
             reduce_fn(in_ub, out_ub, dim=-1, clear=True)
-            T.copy(out_ub, Output[bx * block_M, by])
+            T.copy(
+                out_ub,
+                Output[
+                    bx * block_M : (bx + 1) * block_M,
+                    by : by + 1,
+                ],
+            )
 
     return main
 

--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -380,9 +380,7 @@ def reduce_last_axis_tail(M, N, block_M, block_N, kind, dtype="float"):
 def test_reduce_last_axis_tail_ascendc(kind):
     M, N, block_M, block_N = 34, 130, 32, 32
     func = reduce_last_axis_tail(M, N, block_M, block_N, kind)
-    func = tilelang.compile(
-        func, out_idx=[-1], pass_configs=_vec_configs(tail_mask=True), target="ascendc"
-    )
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=_vec_configs(tail_mask=True), target="ascendc")
 
     torch.manual_seed(0)
     a = torch.randn(M, N, dtype=torch.float32).npu()
@@ -428,9 +426,7 @@ def reduce_axis0_tail(M, N, block_M, block_N, kind, dtype="float"):
 def test_reduce_axis0_tail_ascendc(kind):
     M, N, block_M, block_N = 34, 130, 32, 32
     func = reduce_axis0_tail(M, N, block_M, block_N, kind)
-    func = tilelang.compile(
-        func, out_idx=[-1], pass_configs=_vec_configs(tail_mask=True), target="ascendc"
-    )
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=_vec_configs(tail_mask=True), target="ascendc")
 
     torch.manual_seed(0)
     a = torch.randn(M, N, dtype=torch.float32).npu()

--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -42,11 +42,13 @@ mechanism: the PTO backend emits ``PadValue::Null`` for sliced loads
       (ub2gm re-clamps the store) -> pad_value is irrelevant, default 0 is fine.
     * CUBE gemm K-tail           : the L1 tail is implicitly 0, and 0 * B = 0,
       so the matmul stays correct.
-    * reduce                     : the tail WOULD corrupt the result, so the
-      reduce must be told its logical valid extent via ``real_shape=[rows, cols]``
-      (reduce_ascend.py) and never reads the tail at all. Relying on a -inf
-      pad instead produces inf/nan on NPU (verified) because PTO does not pad
-      sliced loads. ``test_reduce_max_tail`` guards the ``real_shape`` path.
+    * reduce                     : native fallback reductions must be told their
+      logical valid extent via ``real_shape=[rows, cols]`` (reduce_ascend.py).
+      With ``TL_ASCEND_TAIL_MASK``, the guarded axis-0 float32 contract instead
+      carries the runtime valid rectangle into backend-native reduction code.
+      Relying on a -inf pad produces inf/nan on NPU (verified) because PTO does
+      not pad sliced loads. ``test_reduce_max_tail`` guards the real_shape
+      fallback; Group 2d guards the valid-region rewrite.
 
 NOTE: these cases execute on real NPU hardware (``.npu()``); they cannot run in a
 CPU-only environment. Risk levels are annotated per group so unsupported
@@ -341,9 +343,8 @@ reduce_tail_configs = [
 ]
 
 
-# For AscendC, reduce rewriting is enabled, but this explicit real_shape does
-# not match the physical tile and therefore stays on the native real_shape
-# path. PTO disables reduce rewriting at the phase level.
+# With tail-mask enabled, this explicit real_shape does not match the physical
+# tile and therefore stays on the native real_shape path on both backends.
 @pytest.mark.parametrize("tail_mask", [False, True])
 @pytest.mark.parametrize("dtype", ["float"])
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
@@ -353,7 +354,7 @@ def test_reduce_max_tail(rows_valid, rows_phys, cols, dtype, target, tail_mask):
 
 
 # =============================================================================
-# Group 2d - AscendC axis-0 tail reductions   [risk: high]
+# Group 2d - AscendC/PTO axis-0 tail reductions   [risk: high]
 # Covers sum/max/min with clear=true. Each tile writes one partial
 # reduction, so different blocks never race on the output.
 # =============================================================================
@@ -394,13 +395,20 @@ reduce_axis0_configs = [
     (65, 130, 64, 32),  # larger physical row with a one-row tail
 ]
 
+REDUCE_TAIL_TARGETS = ("ascendc", "pto")
+REDUCE_TAIL_KINDS = ("sum", "max", "min")
+REDUCE_TAIL_AXIS0_DIMS = (0, -2)
 
-@pytest.mark.parametrize("kind", ["sum", "max", "min"])
-@pytest.mark.parametrize("dim", [0, -2])
+
+@pytest.mark.parametrize("kind", REDUCE_TAIL_KINDS)
+@pytest.mark.parametrize("dim", REDUCE_TAIL_AXIS0_DIMS)
+@pytest.mark.parametrize("target", REDUCE_TAIL_TARGETS)
 @pytest.mark.parametrize("M,N,block_M,block_N", reduce_axis0_configs)
-def test_reduce_axis0_tail_ascendc(M, N, block_M, block_N, kind, dim):
+def test_reduce_axis0_tail(M, N, block_M, block_N, target, kind, dim):
     func = reduce_axis0_tail(M, N, block_M, block_N, kind, dim=dim)
-    func = tilelang.compile(func, out_idx=[-1], pass_configs=TAIL_REDUCE_PASS_CONFIGS, target="ascendc")
+    func = tilelang.compile(
+        func, out_idx=[-1], pass_configs=TAIL_REDUCE_PASS_CONFIGS, target=target
+    )
 
     torch.manual_seed(0)
     a = torch.randn(M, N, dtype=torch.float32).npu()
@@ -415,11 +423,35 @@ def test_reduce_axis0_tail_ascendc(M, N, block_M, block_N, kind, dim):
     torch.testing.assert_close(out, ref, rtol=1e-4, atol=1e-4)
 
 
+@pytest.mark.parametrize(("kind", "sign"), [("max", -1.0), ("min", 1.0)])
+@pytest.mark.parametrize("target", REDUCE_TAIL_TARGETS)
+def test_reduce_axis0_tail_does_not_consume_zero_padding(target, kind, sign):
+    """Guard max/min against treating the zero-filled physical tail as data."""
+    M, N, block_M, block_N = 3, 8, 4, 8
+    func = reduce_axis0_tail(M, N, block_M, block_N, kind)
+    func = tilelang.compile(
+        func, out_idx=[-1], pass_configs=TAIL_REDUCE_PASS_CONFIGS, target=target
+    )
+
+    base = torch.arange(1, M * N + 1, dtype=torch.float32).reshape(M, N)
+    a = (base * sign).npu()
+    out = func(a)[0]
+    reduced = getattr(a, kind)(dim=0)
+    ref = reduced.values
+    torch.testing.assert_close(out, ref, rtol=0, atol=0)
+
+
+# NaN propagation and signed-zero tie-breaking are backend-instruction
+# semantics rather than part of the shared valid-region contract. Keep this
+# exact-bit regression scoped to the AscendC helper until PTO documents and
+# validates an equivalent guarantee on hardware.
 @pytest.mark.parametrize("kind", ["sum", "max", "min"])
 def test_reduce_axis0_special_values_ascendc(kind):
     M, N, block_M, block_N = 3, 8, 4, 8
     func = reduce_axis0_tail(M, N, block_M, block_N, kind)
-    func = tilelang.compile(func, out_idx=[-1], pass_configs=TAIL_REDUCE_PASS_CONFIGS, target="ascendc")
+    func = tilelang.compile(
+        func, out_idx=[-1], pass_configs=TAIL_REDUCE_PASS_CONFIGS, target="ascendc"
+    )
 
     a = torch.tensor(
         [

--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -70,11 +70,11 @@ VEC_PASS_CONFIGS = {
     tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
 }
 
-# Tail reduction is a pure-vector kernel. Keep its configuration isolated from
-# CV combine/sync so this suite exercises only the passes required by reduce.
+# Tail reduction is a pure-vector kernel. Reuse the established vector pass
+# configuration so PTO mixed-target compilation scopes vector intrinsics to
+# the vector branch.
 TAIL_REDUCE_PASS_CONFIGS = {
-    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
-    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    **VEC_PASS_CONFIGS,
     tilelang.PassConfigKey.TL_ASCEND_TAIL_MASK: True,
 }
 

--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -345,62 +345,10 @@ def test_reduce_max_tail(rows_valid, rows_phys, cols, dtype, target, tail_mask):
 
 
 # =============================================================================
-# Group 2d - AscendC 2D tail reductions   [risk: high]
-# Covers sum/max/min with clear=true on both axes. Each tile writes one partial
+# Group 2d - AscendC axis-0 tail reductions   [risk: high]
+# Covers sum/max/min with clear=true. Each tile writes one partial
 # reduction, so different blocks never race on the output.
 # =============================================================================
-def reduce_last_axis_tail(M, N, block_M, block_N, kind, dtype="float"):
-    m_num = T.ceildiv(M, block_M)
-    n_num = T.ceildiv(N, block_N)
-    reduce_fn = {
-        "sum": T.reduce_sum,
-        "max": T.reduce_max,
-        "min": T.reduce_min,
-    }[kind]
-
-    @T.prim_func
-    def main(
-        Input: T.Tensor((M, N), dtype),  # type: ignore
-        Output: T.Tensor((M, n_num), dtype),  # type: ignore
-    ):
-        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
-            bx = cid // n_num
-            by = cid % n_num
-            in_ub = T.alloc_ub((block_M, block_N), dtype)
-            out_ub = T.alloc_ub((block_M, 1), dtype)
-
-            T.copy(Input[bx * block_M, by * block_N], in_ub)
-            reduce_fn(in_ub, out_ub, dim=-1, clear=True)
-            T.copy(
-                out_ub,
-                Output[
-                    bx * block_M : (bx + 1) * block_M,
-                    by : by + 1,
-                ],
-            )
-
-    return main
-
-
-@pytest.mark.parametrize("kind", ["sum", "max", "min"])
-def test_reduce_last_axis_tail_ascendc(kind):
-    M, N, block_M, block_N = 34, 130, 32, 32
-    func = reduce_last_axis_tail(M, N, block_M, block_N, kind)
-    func = tilelang.compile(func, out_idx=[-1], pass_configs=_vec_configs(tail_mask=True), target="ascendc")
-
-    torch.manual_seed(0)
-    a = torch.randn(M, N, dtype=torch.float32).npu()
-    out = func(a)
-
-    n_num = (N + block_N - 1) // block_N
-    ref = torch.empty((M, n_num), dtype=torch.float32, device=a.device)
-    for by in range(n_num):
-        tile = a[:, by * block_N : min((by + 1) * block_N, N)]
-        reduced = getattr(tile, kind)(dim=-1)
-        ref[:, by] = reduced if kind == "sum" else reduced.values
-    torch.testing.assert_close(out, ref, rtol=1e-4, atol=1e-4)
-
-
 def reduce_axis0_tail(M, N, block_M, block_N, kind, dtype="float"):
     m_num = T.ceildiv(M, block_M)
     n_num = T.ceildiv(N, block_N)

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -447,6 +447,7 @@ def test_unsupported_tail_reduce_contracts_fall_back(target, kind, dtype, clear,
     assert _no_tail_marker(target) not in src, src
     assert _native_reduce_marker(kind, target=target, dtype=dtype, clear=clear, dim=0) in src, src
 
+
 @pytest.mark.parametrize(
     ("kind", "merge_marker"),
     [("sum", "TADD("), ("max", "TMAX("), ("min", "TMIN(")],

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -56,9 +56,14 @@ def _tail_add(M, N, block_M, block_N, dtype="float"):
     return main
 
 
-def _tail_reduce(M, N, block_M, block_N, dtype="float"):
+def _tail_reduce(M, N, block_M, block_N, dtype="float", kind="sum", clear=True):
     m_num = T.ceildiv(M, block_M)
     n_num = T.ceildiv(N, block_N)
+    reduce_fn = {
+        "sum": T.reduce_sum,
+        "max": T.reduce_max,
+        "min": T.reduce_min,
+    }[kind]
 
     @T.prim_func
     def main(
@@ -71,8 +76,29 @@ def _tail_reduce(M, N, block_M, block_N, dtype="float"):
             a_ub = T.alloc_ub((block_M, block_N), dtype)
             r_ub = T.alloc_ub((block_M, 1), dtype)
             T.copy(A[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N], a_ub)
-            T.reduce_sum(a_ub, r_ub, dim=-1)
+            reduce_fn(a_ub, r_ub, dim=-1, clear=clear)
             T.copy(r_ub, B[bx * block_M : (bx + 1) * block_M, by : by + 1])
+
+    return main
+
+
+def _tail_reduce_axis0(M, N, block_M, block_N, dtype="float"):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((m_num, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+            r_ub = T.alloc_ub((1, block_N), dtype)
+            T.copy(A[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N], a_ub)
+            T.reduce_sum(a_ub, r_ub, dim=0)
+            T.copy(r_ub, B[bx : bx + 1, by * block_N : (by + 1) * block_N])
 
     return main
 
@@ -162,13 +188,36 @@ def test_tail_scalar_emits_tail_helper(target):
     assert _emit_marker(target, "scalar") in src, src
 
 
-@pytest.mark.parametrize("target", ["ascendc", "pto"])
-def test_tail_reduce_not_rewritten(target):
-    # reduce is currently NOT rewritten to a tail variant (rewrite_reduce=False):
-    # it stays on the full-tile + pad_value/real_shape path, so neither backend
-    # emits its tail marker for a reduce-only kernel.
-    src = _source(_tail_reduce(34, 130, 32, 32, "float"), target=target)
-    assert _no_tail_marker(target) not in src, src
+def test_tail_reduce_sum_last_axis_emits_ascendc_helper():
+    src = _source(_tail_reduce(34, 130, 32, 32, "float"), target="ascendc")
+    assert "tl::ascend::tail_reduce_sum" in src, src
+
+
+def test_tail_reduce_sum_not_rewritten_for_pto():
+    src = _source(_tail_reduce(34, 130, 32, 32, "float"), target="pto")
+    assert _no_tail_marker("pto") not in src, src
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        _tail_reduce(34, 130, 32, 32, "float", kind="max"),
+        _tail_reduce(34, 130, 32, 32, "float", clear=False),
+        _tail_reduce_axis0(34, 130, 32, 32, "float"),
+        _tail_reduce(34, 130, 32, 32, "float16"),
+    ],
+    ids=["reduce_max", "reduce_sum_clear_false", "reduce_sum_axis0", "float16"],
+)
+def test_unsupported_tail_reduce_contracts_fall_back(func):
+    src = _source(func, target="ascendc")
+    assert "tl::ascend::tail_reduce" not in src, src
+
+
+def test_tail_reduce_flag_off_emits_no_tail_helper():
+    src = _source(
+        _tail_reduce(34, 130, 32, 32, "float"), target="ascendc", tail_mask=False
+    )
+    assert "tl::ascend::tail_reduce" not in src, src
 
 
 @pytest.mark.parametrize("target", ["ascendc", "pto"])

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -445,11 +445,7 @@ def test_unsupported_tail_reduce_contracts_fall_back(target, kind, dtype, clear,
     )
     src = _source(func, target=target)
     assert _no_tail_marker(target) not in src, src
-    assert (
-        _native_reduce_marker(kind, target=target, dtype=dtype, clear=clear, dim=0)
-        in src
-    ), src
-
+    assert (_native_reduce_marker(kind, target=target, dtype=dtype, clear=clear, dim=0) in src), src
 
 @pytest.mark.parametrize(
     ("kind", "merge_marker"),

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -6,8 +6,9 @@ with the Ascend codegen. They verify that:
 
   * a kernel with a real tail (M and/or N not divisible by the block) emits the
     internal ``tl::ascend::tail_*`` helpers, and
-  * the removed ``pad_value`` path (the UB gap-fill ``Duplicate``) is gone, i.e.
-    ``T.copy`` no longer carries a pad argument.
+  * guarded reduction contracts either emit the axis-0 tail helper or retain
+    the native reduce path. The hybrid ``pad_value`` fallback remains available
+    for unsupported full-tile readers.
 """
 
 import pytest
@@ -16,10 +17,8 @@ import tilelang
 import tilelang.language as T
 
 pass_configs = {
-    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
     tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
     tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
-    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
     # Enable the opt-in tail-block scheme (default off) so the tail_* helpers
     # are actually emitted for these tests.
     tilelang.PassConfigKey.TL_ASCEND_TAIL_MASK: True,
@@ -82,33 +81,6 @@ def _tail_reduce(M, N, block_M, block_N, dtype="float", kind="sum", clear=True):
     return main
 
 
-def _tail_reduce_real_shape(M, N, block_M, block_N, dtype="float"):
-    m_num = T.ceildiv(M, block_M)
-    n_num = T.ceildiv(N, block_N)
-
-    @T.prim_func
-    def main(
-        A: T.Tensor((M, N), dtype),
-        B: T.Tensor((m_num * n_num, block_M), dtype),
-    ):
-        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
-            bx = cid // n_num
-            by = cid % n_num
-            a_ub = T.alloc_ub((block_M, block_N), dtype)
-            r_ub = T.alloc_ub((block_M,), dtype)
-            T.copy(
-                A[
-                    bx * block_M : (bx + 1) * block_M,
-                    by * block_N : (by + 1) * block_N,
-                ],
-                a_ub,
-            )
-            T.reduce_sum(a_ub, r_ub, dim=-1, real_shape=[block_M, block_N - 1])
-            T.copy(r_ub, B[cid, :])
-
-    return main
-
-
 def _tail_reduce_then_unary(M, N, block_M, block_N, dtype="float"):
     m_num = T.ceildiv(M, block_M)
     n_num = T.ceildiv(N, block_N)
@@ -138,7 +110,18 @@ def _tail_reduce_then_unary(M, N, block_M, block_N, dtype="float"):
     return main
 
 
-def _tail_reduce_axis0(M, N, block_M, block_N, dtype="float", kind="sum"):
+def _tail_reduce_axis0(
+    M,
+    N,
+    block_M,
+    block_N,
+    dtype="float",
+    kind="sum",
+    dim=0,
+    clear=True,
+    real_shape=None,
+    output_cols=None,
+):
     m_num = T.ceildiv(M, block_M)
     n_num = T.ceildiv(N, block_N)
 
@@ -147,6 +130,8 @@ def _tail_reduce_axis0(M, N, block_M, block_N, dtype="float", kind="sum"):
         "max": T.reduce_max,
         "min": T.reduce_min,
     }[kind]
+
+    output_cols = block_N if output_cols is None else output_cols
 
     @T.prim_func
     def main(
@@ -157,10 +142,33 @@ def _tail_reduce_axis0(M, N, block_M, block_N, dtype="float", kind="sum"):
             bx = cid // n_num
             by = cid % n_num
             a_ub = T.alloc_ub((block_M, block_N), dtype)
-            r_ub = T.alloc_ub((1, block_N), dtype)
+            r_ub = T.alloc_ub((1, output_cols), dtype)
             T.copy(A[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N], a_ub)
-            reduce_fn(a_ub, r_ub, dim=0)
-            T.copy(r_ub, B[bx : bx + 1, by * block_N : (by + 1) * block_N])
+            if real_shape is None:
+                reduce_fn(a_ub, r_ub, dim=dim, clear=clear)
+            else:
+                reduce_fn(a_ub, r_ub, dim=dim, clear=clear, real_shape=real_shape)
+            T.copy(r_ub, B[bx : bx + 1, by * block_N : by * block_N + output_cols])
+
+    return main
+
+
+def _tail_reduce_axis0_then_unary(M, N, block_M, block_N, dtype="float"):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), B: T.Tensor((m_num, N), dtype)):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+            r_ub = T.alloc_ub((1, block_N), dtype)
+            o_ub = T.alloc_ub((1, block_N), dtype)
+            T.copy(A[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N], a_ub)
+            T.reduce_sum(a_ub, r_ub, dim=0, clear=True)
+            T.tile.exp(o_ub, r_ub)
+            T.copy(o_ub, B[bx : bx + 1, by * block_N : (by + 1) * block_N])
 
     return main
 
@@ -231,6 +239,10 @@ def _no_tail_marker(target):
     return "tl::ascend::tail_" if target == "ascendc" else "pto::DYNAMIC"
 
 
+def _native_reduce_marker(kind):
+    return f"reduce_{kind}<"
+
+
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
 def test_tail_add_emits_tail_helper(target):
     # 34x130 with 32x32 blocks => tail in both M and N.
@@ -251,8 +263,9 @@ def test_tail_scalar_emits_tail_helper(target):
 
 
 @pytest.mark.parametrize("kind", ["sum", "max", "min"])
-def test_tail_reduce_float32_axis0_emits_ascendc_helper(kind):
-    func = _tail_reduce_axis0(34, 130, 32, 32, "float", kind=kind)
+@pytest.mark.parametrize("dim", [0, -2])
+def test_tail_reduce_float32_axis0_emits_ascendc_helper(kind, dim):
+    func = _tail_reduce_axis0(34, 130, 32, 32, "float", kind=kind, dim=dim)
     src = _source(func, target="ascendc")
     assert f"tl::ascend::tail_reduce_{kind}" in src, src
 
@@ -261,18 +274,27 @@ def test_tail_reduce_float32_axis0_emits_ascendc_helper(kind):
 def test_tail_reduce_float32_last_axis_uses_native_path(kind):
     src = _source(_tail_reduce(34, 130, 32, 32, "float", kind=kind), target="ascendc")
     assert "tl::ascend::tail_reduce" not in src, src
+    assert _native_reduce_marker(kind) in src, src
+
+
+def test_tail_reduce_axis0_propagates_column_tail_to_unary():
+    src = _source(_tail_reduce_axis0_then_unary(34, 130, 32, 32), target="ascendc")
+    assert "tl::ascend::tail_reduce_sum" in src, src
+    assert "tl::ascend::tail_unary" in src, src
 
 
 def test_native_last_axis_reduce_clears_downstream_tail_state():
     src = _source(_tail_reduce_then_unary(34, 130, 32, 32), target="ascendc")
     assert "tl::ascend::tail_reduce" not in src, src
     assert "tl::ascend::tail_unary" not in src, src
+    assert _native_reduce_marker("sum") in src, src
 
 
 def test_native_last_axis_reduce_with_column_tail_stays_native():
     src = _source(_tail_reduce_then_unary(32, 130, 32, 32), target="ascendc")
     assert "tl::ascend::tail_reduce" not in src, src
     assert "tl::ascend::tail_unary" not in src, src
+    assert _native_reduce_marker("sum") in src, src
 
 
 def test_unsupported_reduce_clears_downstream_tail_state():
@@ -282,30 +304,38 @@ def test_unsupported_reduce_clears_downstream_tail_state():
     )
     assert "tl::ascend::tail_reduce" not in src, src
     assert "tl::ascend::tail_unary" not in src, src
+    assert _native_reduce_marker("sum") in src, src
 
 
 def test_tail_reduce_sum_not_rewritten_for_pto():
-    src = _source(_tail_reduce(34, 130, 32, 32, "float"), target="pto")
+    src = _source(_tail_reduce_axis0(34, 130, 32, 32), target="pto")
     assert _no_tail_marker("pto") not in src, src
+    assert _native_reduce_marker("sum") in src, src
 
 
 @pytest.mark.parametrize(
     "func",
     [
-        _tail_reduce(34, 130, 32, 32, "float", clear=False),
-        _tail_reduce(34, 130, 32, 32, "float16"),
-        _tail_reduce_real_shape(34, 130, 32, 32, "float"),
+        _tail_reduce_axis0(34, 130, 32, 32, clear=False),
+        _tail_reduce_axis0(34, 130, 32, 32, dtype="float16"),
+        _tail_reduce_axis0(34, 130, 32, 32, real_shape=[31, 32]),
+        _tail_reduce_axis0(34, 130, 32, 32, output_cols=31),
     ],
-    ids=["reduce_sum_clear_false", "float16", "explicit_real_shape"],
+    ids=["clear_false", "float16", "real_shape_mismatch", "output_extent_mismatch"],
 )
 def test_unsupported_tail_reduce_contracts_fall_back(func):
     src = _source(func, target="ascendc")
     assert "tl::ascend::tail_reduce" not in src, src
+    assert _native_reduce_marker("sum") in src, src
 
 
 def test_tail_reduce_flag_off_emits_no_tail_helper():
-    src = _source(_tail_reduce(34, 130, 32, 32, "float"), target="ascendc", tail_mask=False)
-    assert "tl::ascend::tail_reduce" not in src, src
+    func = _tail_reduce_axis0(34, 130, 32, 32)
+    src_on = _source(func, target="ascendc", tail_mask=True)
+    src_off = _source(func, target="ascendc", tail_mask=False)
+    assert "tl::ascend::tail_reduce_sum" in src_on, src_on
+    assert "tl::ascend::tail_reduce" not in src_off, src_off
+    assert _native_reduce_marker("sum") in src_off, src_off
 
 
 @pytest.mark.parametrize("target", ["ascendc", "pto"])

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -15,6 +15,8 @@ import pytest
 
 import tilelang
 import tilelang.language as T
+from tilelang import tvm
+from tilelang.transform.pass_config import process_default_pass_config
 
 pass_configs = {
     tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
@@ -23,12 +25,6 @@ pass_configs = {
     # are actually emitted for these tests.
     tilelang.PassConfigKey.TL_ASCEND_TAIL_MASK: True,
 }
-
-
-@pytest.fixture(scope="session", autouse=True)
-def clear_cache():
-    tilelang.cache.clear_cache()
-    yield
 
 
 def _tail_add(M, N, block_M, block_N, dtype="float"):
@@ -213,9 +209,23 @@ def _tail_scalar(M, N, block_M, block_N, dtype="float"):
 
 
 def _source(func, target="ascendc", tail_mask=True):
-    cfg = {**pass_configs, tilelang.PassConfigKey.TL_ASCEND_TAIL_MASK: tail_mask}
-    compiled = tilelang.compile(func, pass_configs=cfg, target=target)
-    return compiled.get_kernel_source()
+    """Lower a PrimFunc and return generated device source.
+
+    These source-inspection tests intentionally avoid creating a JIT adapter
+    or compiling the generated AscendC/PTO source into a runnable kernel.
+    """
+    cfg = process_default_pass_config(
+        target,
+        {
+            **pass_configs,
+            tilelang.PassConfigKey.TL_ASCEND_TAIL_MASK: tail_mask,
+        },
+    )
+
+    with tvm.transform.PassContext(opt_level=3, config=cfg):
+        artifact = tilelang.lower(func, target=target, platform="auto")
+
+    return artifact.kernel_source
 
 
 # Per-backend "a tail-aware op was emitted" marker. The two backends express the

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -251,22 +251,27 @@ def test_tail_scalar_emits_tail_helper(target):
 
 
 @pytest.mark.parametrize("kind", ["sum", "max", "min"])
-@pytest.mark.parametrize("axis", [-1, 0])
-def test_tail_reduce_float32_emits_ascendc_helper(kind, axis):
-    func = _tail_reduce(34, 130, 32, 32, "float", kind=kind) if axis == -1 else _tail_reduce_axis0(34, 130, 32, 32, "float", kind=kind)
+def test_tail_reduce_float32_axis0_emits_ascendc_helper(kind):
+    func = _tail_reduce_axis0(34, 130, 32, 32, "float", kind=kind)
     src = _source(func, target="ascendc")
     assert f"tl::ascend::tail_reduce_{kind}" in src, src
 
 
-def test_tail_reduce_propagates_non_reduced_axis_tail():
+@pytest.mark.parametrize("kind", ["sum", "max", "min"])
+def test_tail_reduce_float32_last_axis_uses_native_path(kind):
+    src = _source(_tail_reduce(34, 130, 32, 32, "float", kind=kind), target="ascendc")
+    assert "tl::ascend::tail_reduce" not in src, src
+
+
+def test_native_last_axis_reduce_clears_downstream_tail_state():
     src = _source(_tail_reduce_then_unary(34, 130, 32, 32), target="ascendc")
-    assert "tl::ascend::tail_reduce_sum" in src, src
-    assert "tl::ascend::tail_unary" in src, src
+    assert "tl::ascend::tail_reduce" not in src, src
+    assert "tl::ascend::tail_unary" not in src, src
 
 
-def test_tail_reduce_eliminates_reduced_axis_only_tail():
+def test_native_last_axis_reduce_with_column_tail_stays_native():
     src = _source(_tail_reduce_then_unary(32, 130, 32, 32), target="ascendc")
-    assert "tl::ascend::tail_reduce_sum" in src, src
+    assert "tl::ascend::tail_reduce" not in src, src
     assert "tl::ascend::tail_unary" not in src, src
 
 

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -56,7 +56,9 @@ def _tail_add(M, N, block_M, block_N, dtype="float"):
     return main
 
 
-def _tail_reduce(M, N, block_M, block_N, dtype="float", kind="sum", clear=True):
+def _tail_reduce(
+    M, N, block_M, block_N, dtype="float", kind="sum", clear=True
+):
     m_num = T.ceildiv(M, block_M)
     n_num = T.ceildiv(N, block_N)
     reduce_fn = {
@@ -82,9 +84,71 @@ def _tail_reduce(M, N, block_M, block_N, dtype="float", kind="sum", clear=True):
     return main
 
 
-def _tail_reduce_axis0(M, N, block_M, block_N, dtype="float"):
+def _tail_reduce_real_shape(M, N, block_M, block_N, dtype="float"):
     m_num = T.ceildiv(M, block_M)
     n_num = T.ceildiv(N, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((m_num * n_num, block_M), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+            r_ub = T.alloc_ub((block_M,), dtype)
+            T.copy(
+                A[
+                    bx * block_M : (bx + 1) * block_M,
+                    by * block_N : (by + 1) * block_N,
+                ],
+                a_ub,
+            )
+            T.reduce_sum(a_ub, r_ub, dim=-1, real_shape=[block_M, block_N - 1])
+            T.copy(r_ub, B[cid, :])
+
+    return main
+
+
+def _tail_reduce_then_unary(M, N, block_M, block_N, dtype="float"):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, n_num), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+            r_ub = T.alloc_ub((block_M, 1), dtype)
+            o_ub = T.alloc_ub((block_M, 1), dtype)
+            T.copy(
+                A[
+                    bx * block_M : (bx + 1) * block_M,
+                    by * block_N : (by + 1) * block_N,
+                ],
+                a_ub,
+            )
+            T.reduce_sum(a_ub, r_ub, dim=-1)
+            T.tile.exp(o_ub, r_ub)
+            T.copy(o_ub, B[bx * block_M : (bx + 1) * block_M, by : by + 1])
+
+    return main
+
+
+def _tail_reduce_axis0(M, N, block_M, block_N, dtype="float", kind="sum"):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+
+    reduce_fn = {
+        "sum": T.reduce_sum,
+        "max": T.reduce_max,
+        "min": T.reduce_min,
+    }[kind]
 
     @T.prim_func
     def main(
@@ -97,7 +161,7 @@ def _tail_reduce_axis0(M, N, block_M, block_N, dtype="float"):
             a_ub = T.alloc_ub((block_M, block_N), dtype)
             r_ub = T.alloc_ub((1, block_N), dtype)
             T.copy(A[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N], a_ub)
-            T.reduce_sum(a_ub, r_ub, dim=0)
+            reduce_fn(a_ub, r_ub, dim=0)
             T.copy(r_ub, B[bx : bx + 1, by * block_N : (by + 1) * block_N])
 
     return main
@@ -188,9 +252,37 @@ def test_tail_scalar_emits_tail_helper(target):
     assert _emit_marker(target, "scalar") in src, src
 
 
-def test_tail_reduce_sum_last_axis_emits_ascendc_helper():
-    src = _source(_tail_reduce(34, 130, 32, 32, "float"), target="ascendc")
+@pytest.mark.parametrize("kind", ["sum", "max", "min"])
+@pytest.mark.parametrize("axis", [-1, 0])
+def test_tail_reduce_float32_emits_ascendc_helper(kind, axis):
+    func = (
+        _tail_reduce(34, 130, 32, 32, "float", kind=kind)
+        if axis == -1
+        else _tail_reduce_axis0(34, 130, 32, 32, "float", kind=kind)
+    )
+    src = _source(func, target="ascendc")
+    assert f"tl::ascend::tail_reduce_{kind}" in src, src
+
+
+def test_tail_reduce_propagates_non_reduced_axis_tail():
+    src = _source(_tail_reduce_then_unary(34, 130, 32, 32), target="ascendc")
     assert "tl::ascend::tail_reduce_sum" in src, src
+    assert "tl::ascend::tail_unary" in src, src
+
+
+def test_tail_reduce_eliminates_reduced_axis_only_tail():
+    src = _source(_tail_reduce_then_unary(32, 130, 32, 32), target="ascendc")
+    assert "tl::ascend::tail_reduce_sum" in src, src
+    assert "tl::ascend::tail_unary" not in src, src
+
+
+def test_unsupported_reduce_clears_downstream_tail_state():
+    src = _source(
+        _tail_reduce_then_unary(34, 130, 32, 32, dtype="float16"),
+        target="ascendc",
+    )
+    assert "tl::ascend::tail_reduce" not in src, src
+    assert "tl::ascend::tail_unary" not in src, src
 
 
 def test_tail_reduce_sum_not_rewritten_for_pto():
@@ -201,12 +293,11 @@ def test_tail_reduce_sum_not_rewritten_for_pto():
 @pytest.mark.parametrize(
     "func",
     [
-        _tail_reduce(34, 130, 32, 32, "float", kind="max"),
         _tail_reduce(34, 130, 32, 32, "float", clear=False),
-        _tail_reduce_axis0(34, 130, 32, 32, "float"),
         _tail_reduce(34, 130, 32, 32, "float16"),
+        _tail_reduce_real_shape(34, 130, 32, 32, "float"),
     ],
-    ids=["reduce_max", "reduce_sum_clear_false", "reduce_sum_axis0", "float16"],
+    ids=["reduce_sum_clear_false", "float16", "explicit_real_shape"],
 )
 def test_unsupported_tail_reduce_contracts_fall_back(func):
     src = _source(func, target="ascendc")

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -246,14 +246,21 @@ def _no_tail_marker(target):
     return "tl::ascend::tail_" if target == "ascendc" else "pto::DYNAMIC"
 
 
-def _native_reduce_marker(kind, *, target="ascendc", dtype="float", clear=True):
+def _native_reduce_marker(kind, *, target="ascendc", dtype="float", clear=True, dim=-1):
     """Return a backend-specific marker for a native reduce path."""
     if target == "pto":
+        direction = {
+            -1: "row",
+            0: "col",
+        }[dim]
         return {
-            "sum": "TADD(",
-            "max": "TMAX(",
-            "min": "TMIN(",
-        }[kind]
+            ("sum", "row"): "TROWSUM(",
+            ("sum", "col"): "TCOLSUM(",
+            ("max", "row"): "TROWMAX(",
+            ("max", "col"): "TCOLMAX(",
+            ("min", "row"): "TROWMIN(",
+            ("min", "col"): "TCOLMIN(",
+        }[(kind, direction)]
 
     # AscendC uses a dedicated helper for clear=true float16 sum reductions.
     if kind == "sum" and dtype == "float16" and clear:
@@ -329,7 +336,7 @@ def test_unsupported_reduce_clears_downstream_tail_state():
 def test_tail_reduce_sum_not_rewritten_for_pto():
     src = _source(_tail_reduce_axis0(34, 130, 32, 32), target="pto")
     assert _no_tail_marker("pto") not in src, src
-    assert _native_reduce_marker("sum", target="pto") in src, src
+    assert _native_reduce_marker("sum", target="pto", dim=0) in src, src
 
 
 @pytest.mark.parametrize(

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -445,7 +445,7 @@ def test_unsupported_tail_reduce_contracts_fall_back(target, kind, dtype, clear,
     )
     src = _source(func, target=target)
     assert _no_tail_marker(target) not in src, src
-    assert (_native_reduce_marker(kind, target=target, dtype=dtype, clear=clear, dim=0) in src), src
+    assert _native_reduce_marker(kind, target=target, dtype=dtype, clear=clear, dim=0) in src, src
 
 @pytest.mark.parametrize(
     ("kind", "merge_marker"),

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -120,7 +120,6 @@ def _tail_reduce_axis0(
     dim=0,
     clear=True,
     real_shape=None,
-    output_cols=None,
 ):
     m_num = T.ceildiv(M, block_M)
     n_num = T.ceildiv(N, block_N)
@@ -131,8 +130,6 @@ def _tail_reduce_axis0(
         "min": T.reduce_min,
     }[kind]
 
-    output_cols = block_N if output_cols is None else output_cols
-
     @T.prim_func
     def main(
         A: T.Tensor((M, N), dtype),
@@ -142,13 +139,13 @@ def _tail_reduce_axis0(
             bx = cid // n_num
             by = cid % n_num
             a_ub = T.alloc_ub((block_M, block_N), dtype)
-            r_ub = T.alloc_ub((1, output_cols), dtype)
+            r_ub = T.alloc_ub((1, block_N), dtype)
             T.copy(A[bx * block_M : (bx + 1) * block_M, by * block_N : (by + 1) * block_N], a_ub)
             if real_shape is None:
                 reduce_fn(a_ub, r_ub, dim=dim, clear=clear)
             else:
                 reduce_fn(a_ub, r_ub, dim=dim, clear=clear, real_shape=real_shape)
-            T.copy(r_ub, B[bx : bx + 1, by * block_N : by * block_N + output_cols])
+            T.copy(r_ub, B[bx : bx + 1, by * block_N : (by + 1) * block_N])
 
     return main
 
@@ -319,9 +316,8 @@ def test_tail_reduce_sum_not_rewritten_for_pto():
         _tail_reduce_axis0(34, 130, 32, 32, clear=False),
         _tail_reduce_axis0(34, 130, 32, 32, dtype="float16"),
         _tail_reduce_axis0(34, 130, 32, 32, real_shape=[31, 32]),
-        _tail_reduce_axis0(34, 130, 32, 32, output_cols=31),
     ],
-    ids=["clear_false", "float16", "real_shape_mismatch", "output_extent_mismatch"],
+    ids=["clear_false", "float16", "real_shape_mismatch"],
 )
 def test_unsupported_tail_reduce_contracts_fall_back(func):
     src = _source(func, target="ascendc")

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -1,4 +1,4 @@
-"""Codegen-level checks for the AscendC vector tail-block scheme.
+"""Codegen-level checks for the Ascend vector tail-block scheme.
 
 These tests only inspect the generated kernel source (host-side codegen), so
 they do not require NPU hardware to *run* the kernel -- only a built tilelang
@@ -25,6 +25,10 @@ pass_configs = {
     # are actually emitted for these tests.
     tilelang.PassConfigKey.TL_ASCEND_TAIL_MASK: True,
 }
+
+TAIL_TARGETS = ("ascendc", "pto")
+TAIL_REDUCE_KINDS = ("sum", "max", "min")
+TAIL_REDUCE_AXIS0_DIMS = (0, -2)
 
 
 def _tail_add(M, N, block_M, block_N, dtype="float"):
@@ -166,6 +170,42 @@ def _tail_reduce_axis0_then_unary(M, N, block_M, block_N, dtype="float"):
     return main
 
 
+def _tail_reduce_axis0_to_output_slice(M, N, block_M, block_N, dtype="float"):
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(N, block_N)
+
+    def output_slice(buffer):
+        return tvm.tir.BufferRegion(
+            buffer,
+            [
+                tvm.ir.Range.from_min_extent(1, 1),
+                tvm.ir.Range.from_min_extent(0, block_N),
+            ],
+        )
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), B: T.Tensor((m_num, N), dtype)):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+            r_ub = T.alloc_ub((2, block_N), dtype)
+            T.copy(
+                A[
+                    bx * block_M : (bx + 1) * block_M,
+                    by * block_N : (by + 1) * block_N,
+                ],
+                a_ub,
+            )
+            T.reduce_sum(a_ub, output_slice(r_ub), dim=0, clear=True)
+            T.copy(
+                output_slice(r_ub),
+                B[bx : bx + 1, by * block_N : (by + 1) * block_N],
+            )
+
+    return main
+
+
 def _tail_unary(M, N, block_M, block_N, dtype="float"):
     m_num = T.ceildiv(M, block_M)
     n_num = T.ceildiv(N, block_N)
@@ -234,9 +274,9 @@ def _source(func, target="ascendc", tail_mask=True):
 #     (the mask/repeat/count ladder written in ascend/common.h).
 #   * pto     -> a ``TileUbDataND<..., pto::DYNAMIC, pto::DYNAMIC>`` dynamic tile.
 #     PTO reuses its native dynamic-tile op macros (TADD/TEXP/TADDS/...), so the
-#     tell-tale is the DYNAMIC valid-shape tile, which is emitted *only* by the
-#     tail unary/binary/scalar codegen (CreateUbVariableDynamic) and nowhere on
-#     the ordinary full-tile path.
+#     tell-tale is the DYNAMIC valid-shape tile, which is emitted by the tail
+#     unary/binary/scalar/reduce codegen (CreateUbVariableDynamic) and nowhere
+#     on the ordinary full-tile path.
 def _emit_marker(target, kind):
     return f"tl::ascend::tail_{kind}" if target == "ascendc" else "pto::DYNAMIC"
 
@@ -250,8 +290,10 @@ def _native_reduce_marker(kind, *, target="ascendc", dtype="float", clear=True, 
     """Return a backend-specific marker for a native reduce path."""
     if target == "pto":
         direction = {
+            -2: "col",
             -1: "row",
             0: "col",
+            1: "row",
         }[dim]
         return {
             ("sum", "row"): "TROWSUM(",
@@ -267,6 +309,18 @@ def _native_reduce_marker(kind, *, target="ascendc", dtype="float", clear=True, 
         return "tl::ascend::reduce_sum_half<"
 
     return f"tl::ascend::reduce_{kind}<"
+
+
+def _assert_tail_reduce_rewritten(src, target, kind):
+    """Check the backend-specific lowering of the shared tail-reduce contract."""
+    if target == "ascendc":
+        assert f"tl::ascend::tail_reduce_{kind}" in src, src
+        return
+
+    assert "pto::DYNAMIC" in src, src
+    assert "TileUbDataND<float, 32, 32, pto::DYNAMIC, pto::DYNAMIC>" in src, src
+    assert "TileUbDataND<float, 1, 32, pto::DYNAMIC, pto::DYNAMIC>" in src, src
+    assert _native_reduce_marker(kind, target="pto", dim=0) in src, src
 
 
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
@@ -288,88 +342,135 @@ def test_tail_scalar_emits_tail_helper(target):
     assert _emit_marker(target, "scalar") in src, src
 
 
-@pytest.mark.parametrize("kind", ["sum", "max", "min"])
-@pytest.mark.parametrize("dim", [0, -2])
-def test_tail_reduce_float32_axis0_emits_ascendc_helper(kind, dim):
+@pytest.mark.parametrize("target", TAIL_TARGETS)
+@pytest.mark.parametrize("kind", TAIL_REDUCE_KINDS)
+@pytest.mark.parametrize("dim", TAIL_REDUCE_AXIS0_DIMS)
+def test_tail_reduce_float32_axis0_emits_backend_path(target, kind, dim):
     func = _tail_reduce_axis0(34, 130, 32, 32, "float", kind=kind, dim=dim)
-    src = _source(func, target="ascendc")
-    assert f"tl::ascend::tail_reduce_{kind}" in src, src
-
-
-@pytest.mark.parametrize("kind", ["sum", "max", "min"])
-def test_tail_reduce_float32_last_axis_uses_native_path(kind):
-    src = _source(_tail_reduce(34, 130, 32, 32, "float", kind=kind), target="ascendc")
-    assert "tl::ascend::tail_reduce" not in src, src
-    assert _native_reduce_marker(kind, target="ascendc", dtype="float") in src, src
-
-
-def test_tail_reduce_axis0_propagates_column_tail_to_unary():
-    src = _source(_tail_reduce_axis0_then_unary(34, 130, 32, 32), target="ascendc")
-    assert "tl::ascend::tail_reduce_sum" in src, src
-    assert "tl::ascend::tail_unary" in src, src
-
-
-def test_native_last_axis_reduce_clears_downstream_tail_state():
-    src = _source(_tail_reduce_then_unary(34, 130, 32, 32), target="ascendc")
-    assert "tl::ascend::tail_reduce" not in src, src
-    assert "tl::ascend::tail_unary" not in src, src
-    assert _native_reduce_marker("sum", target="ascendc", dtype="float") in src, src
-
-
-def test_native_last_axis_reduce_with_column_tail_stays_native():
-    src = _source(_tail_reduce_then_unary(32, 130, 32, 32), target="ascendc")
-    assert "tl::ascend::tail_reduce" not in src, src
-    assert "tl::ascend::tail_unary" not in src, src
-    assert _native_reduce_marker("sum", target="ascendc", dtype="float") in src, src
-
-
-def test_unsupported_reduce_clears_downstream_tail_state():
-    src = _source(
-        _tail_reduce_then_unary(34, 130, 32, 32, dtype="float16"),
-        target="ascendc",
-    )
-    assert "tl::ascend::tail_reduce" not in src, src
-    assert "tl::ascend::tail_unary" not in src, src
-    assert _native_reduce_marker("sum", target="ascendc", dtype="float16") in src, src
-
-
-def test_tail_reduce_sum_not_rewritten_for_pto():
-    src = _source(_tail_reduce_axis0(34, 130, 32, 32), target="pto")
-    assert _no_tail_marker("pto") not in src, src
-    assert _native_reduce_marker("sum", target="pto", dim=0) in src, src
+    src = _source(func, target=target)
+    _assert_tail_reduce_rewritten(src, target, kind)
 
 
 @pytest.mark.parametrize(
-    ("func", "native_marker"),
+    ("M", "N", "rewritten"),
     [
-        (
-            _tail_reduce_axis0(34, 130, 32, 32, clear=False),
-            _native_reduce_marker("sum", target="ascendc", dtype="float", clear=False),
-        ),
-        (
-            _tail_reduce_axis0(34, 130, 32, 32, dtype="float16"),
-            _native_reduce_marker("sum", target="ascendc", dtype="float16"),
-        ),
-        (
-            _tail_reduce_axis0(34, 130, 32, 32, real_shape=[31, 32]),
-            _native_reduce_marker("sum", target="ascendc", dtype="float"),
-        ),
+        (34, 128, True),
+        (32, 130, True),
+        (34, 130, True),
+        (32, 128, False),
+    ],
+    ids=["row_tail", "column_tail", "both_tails", "full_tile"],
+)
+@pytest.mark.parametrize("target", TAIL_TARGETS)
+def test_tail_reduce_sum_rewrites_only_partial_tiles(target, M, N, rewritten):
+    src = _source(_tail_reduce_axis0(M, N, 32, 32), target=target)
+    assert (_emit_marker(target, "reduce_sum") in src) is rewritten, src
+    if rewritten:
+        _assert_tail_reduce_rewritten(src, target, "sum")
+    else:
+        assert _native_reduce_marker("sum", target=target, dim=0) in src, src
+
+
+@pytest.mark.parametrize("target", TAIL_TARGETS)
+def test_tail_reduce_accepts_explicit_matching_real_shape(target):
+    func = _tail_reduce_axis0(34, 130, 32, 32, real_shape=[32, 32])
+    src = _source(func, target=target)
+    _assert_tail_reduce_rewritten(src, target, "sum")
+
+
+@pytest.mark.parametrize("target", TAIL_TARGETS)
+def test_tail_reduce_supports_output_slice(target):
+    src = _source(_tail_reduce_axis0_to_output_slice(34, 130, 32, 32), target=target)
+    _assert_tail_reduce_rewritten(src, target, "sum")
+
+
+@pytest.mark.parametrize("target", TAIL_TARGETS)
+@pytest.mark.parametrize("kind", TAIL_REDUCE_KINDS)
+def test_tail_reduce_float32_last_axis_uses_native_path(target, kind):
+    src = _source(_tail_reduce(34, 130, 32, 32, "float", kind=kind), target=target)
+    assert _no_tail_marker(target) not in src, src
+    assert _native_reduce_marker(kind, target=target, dtype="float", dim=-1) in src, src
+
+
+@pytest.mark.parametrize("target", TAIL_TARGETS)
+def test_tail_reduce_axis0_propagates_column_tail_to_unary(target):
+    src = _source(_tail_reduce_axis0_then_unary(34, 130, 32, 32), target=target)
+    if target == "ascendc":
+        assert "tl::ascend::tail_reduce_sum" in src, src
+        assert "tl::ascend::tail_unary" in src, src
+    else:
+        assert _native_reduce_marker("sum", target="pto", dim=0) in src, src
+        assert "TEXP(" in src, src
+        # Dynamic views are emitted for both the tail reduction and unary op.
+        assert src.count("pto::DYNAMIC") >= 8, src
+
+
+@pytest.mark.parametrize("target", TAIL_TARGETS)
+@pytest.mark.parametrize(
+    ("M", "N", "dtype"),
+    [
+        (34, 130, "float"),
+        (32, 130, "float"),
+        (34, 130, "float16"),
+    ],
+    ids=["both_tails", "column_tail", "unsupported_float16"],
+)
+def test_native_reduce_clears_downstream_tail_state(target, M, N, dtype):
+    src = _source(_tail_reduce_then_unary(M, N, 32, 32, dtype=dtype), target=target)
+    assert _no_tail_marker(target) not in src, src
+    assert _native_reduce_marker("sum", target=target, dtype=dtype, dim=-1) in src, src
+
+
+@pytest.mark.parametrize(
+    ("dtype", "clear", "real_shape"),
+    [
+        ("float", False, None),
+        ("float16", True, None),
+        ("float", True, [31, 32]),
     ],
     ids=["clear_false", "float16", "real_shape_mismatch"],
 )
-def test_unsupported_tail_reduce_contracts_fall_back(func, native_marker):
-    src = _source(func, target="ascendc")
-    assert "tl::ascend::tail_reduce" not in src, src
-    assert native_marker in src, src
+@pytest.mark.parametrize("kind", TAIL_REDUCE_KINDS)
+@pytest.mark.parametrize("target", TAIL_TARGETS)
+def test_unsupported_tail_reduce_contracts_fall_back(target, kind, dtype, clear, real_shape):
+    func = _tail_reduce_axis0(
+        34,
+        130,
+        32,
+        32,
+        dtype=dtype,
+        kind=kind,
+        clear=clear,
+        real_shape=real_shape,
+    )
+    src = _source(func, target=target)
+    assert _no_tail_marker(target) not in src, src
+    assert (
+        _native_reduce_marker(kind, target=target, dtype=dtype, clear=clear, dim=0)
+        in src
+    ), src
 
 
-def test_tail_reduce_flag_off_emits_no_tail_helper():
+@pytest.mark.parametrize(
+    ("kind", "merge_marker"),
+    [("sum", "TADD("), ("max", "TMAX("), ("min", "TMIN(")],
+)
+def test_pto_accumulating_tail_reduce_uses_native_reduce_and_merge(kind, merge_marker):
+    func = _tail_reduce_axis0(34, 130, 32, 32, kind=kind, clear=False)
+    src = _source(func, target="pto")
+    assert _no_tail_marker("pto") not in src, src
+    assert _native_reduce_marker(kind, target="pto", dim=0) in src, src
+    assert merge_marker in src, src
+
+
+@pytest.mark.parametrize("target", TAIL_TARGETS)
+def test_tail_reduce_flag_off_emits_no_tail_helper(target):
     func = _tail_reduce_axis0(34, 130, 32, 32)
-    src_on = _source(func, target="ascendc", tail_mask=True)
-    src_off = _source(func, target="ascendc", tail_mask=False)
-    assert "tl::ascend::tail_reduce_sum" in src_on, src_on
-    assert "tl::ascend::tail_reduce" not in src_off, src_off
-    assert _native_reduce_marker("sum", target="ascendc", dtype="float") in src_off, src_off
+    src_on = _source(func, target=target, tail_mask=True)
+    src_off = _source(func, target=target, tail_mask=False)
+    assert _emit_marker(target, "reduce_sum") in src_on, src_on
+    assert _no_tail_marker(target) not in src_off, src_off
+    assert _native_reduce_marker("sum", target=target, dtype="float", dim=0) in src_off, src_off
 
 
 @pytest.mark.parametrize("target", ["ascendc", "pto"])

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -56,9 +56,7 @@ def _tail_add(M, N, block_M, block_N, dtype="float"):
     return main
 
 
-def _tail_reduce(
-    M, N, block_M, block_N, dtype="float", kind="sum", clear=True
-):
+def _tail_reduce(M, N, block_M, block_N, dtype="float", kind="sum", clear=True):
     m_num = T.ceildiv(M, block_M)
     n_num = T.ceildiv(N, block_N)
     reduce_fn = {
@@ -255,11 +253,7 @@ def test_tail_scalar_emits_tail_helper(target):
 @pytest.mark.parametrize("kind", ["sum", "max", "min"])
 @pytest.mark.parametrize("axis", [-1, 0])
 def test_tail_reduce_float32_emits_ascendc_helper(kind, axis):
-    func = (
-        _tail_reduce(34, 130, 32, 32, "float", kind=kind)
-        if axis == -1
-        else _tail_reduce_axis0(34, 130, 32, 32, "float", kind=kind)
-    )
+    func = _tail_reduce(34, 130, 32, 32, "float", kind=kind) if axis == -1 else _tail_reduce_axis0(34, 130, 32, 32, "float", kind=kind)
     src = _source(func, target="ascendc")
     assert f"tl::ascend::tail_reduce_{kind}" in src, src
 
@@ -305,9 +299,7 @@ def test_unsupported_tail_reduce_contracts_fall_back(func):
 
 
 def test_tail_reduce_flag_off_emits_no_tail_helper():
-    src = _source(
-        _tail_reduce(34, 130, 32, 32, "float"), target="ascendc", tail_mask=False
-    )
+    src = _source(_tail_reduce(34, 130, 32, 32, "float"), target="ascendc", tail_mask=False)
     assert "tl::ascend::tail_reduce" not in src, src
 
 

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -246,8 +246,20 @@ def _no_tail_marker(target):
     return "tl::ascend::tail_" if target == "ascendc" else "pto::DYNAMIC"
 
 
-def _native_reduce_marker(kind):
-    return f"reduce_{kind}<"
+def _native_reduce_marker(kind, *, target="ascendc", dtype="float", clear=True):
+    """Return a backend-specific marker for a native reduce path."""
+    if target == "pto":
+        return {
+            "sum": "TADD(",
+            "max": "TMAX(",
+            "min": "TMIN(",
+        }[kind]
+
+    # AscendC uses a dedicated helper for clear=true float16 sum reductions.
+    if kind == "sum" and dtype == "float16" and clear:
+        return "tl::ascend::reduce_sum_half<"
+
+    return f"tl::ascend::reduce_{kind}<"
 
 
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
@@ -281,7 +293,7 @@ def test_tail_reduce_float32_axis0_emits_ascendc_helper(kind, dim):
 def test_tail_reduce_float32_last_axis_uses_native_path(kind):
     src = _source(_tail_reduce(34, 130, 32, 32, "float", kind=kind), target="ascendc")
     assert "tl::ascend::tail_reduce" not in src, src
-    assert _native_reduce_marker(kind) in src, src
+    assert _native_reduce_marker(kind, target="ascendc", dtype="float") in src, src
 
 
 def test_tail_reduce_axis0_propagates_column_tail_to_unary():
@@ -294,14 +306,14 @@ def test_native_last_axis_reduce_clears_downstream_tail_state():
     src = _source(_tail_reduce_then_unary(34, 130, 32, 32), target="ascendc")
     assert "tl::ascend::tail_reduce" not in src, src
     assert "tl::ascend::tail_unary" not in src, src
-    assert _native_reduce_marker("sum") in src, src
+    assert _native_reduce_marker("sum", target="ascendc", dtype="float") in src, src
 
 
 def test_native_last_axis_reduce_with_column_tail_stays_native():
     src = _source(_tail_reduce_then_unary(32, 130, 32, 32), target="ascendc")
     assert "tl::ascend::tail_reduce" not in src, src
     assert "tl::ascend::tail_unary" not in src, src
-    assert _native_reduce_marker("sum") in src, src
+    assert _native_reduce_marker("sum", target="ascendc", dtype="float") in src, src
 
 
 def test_unsupported_reduce_clears_downstream_tail_state():
@@ -311,28 +323,37 @@ def test_unsupported_reduce_clears_downstream_tail_state():
     )
     assert "tl::ascend::tail_reduce" not in src, src
     assert "tl::ascend::tail_unary" not in src, src
-    assert _native_reduce_marker("sum") in src, src
+    assert _native_reduce_marker("sum", target="ascendc", dtype="float16") in src, src
 
 
 def test_tail_reduce_sum_not_rewritten_for_pto():
     src = _source(_tail_reduce_axis0(34, 130, 32, 32), target="pto")
     assert _no_tail_marker("pto") not in src, src
-    assert _native_reduce_marker("sum") in src, src
+    assert _native_reduce_marker("sum", target="pto") in src, src
 
 
 @pytest.mark.parametrize(
-    "func",
+    ("func", "native_marker"),
     [
-        _tail_reduce_axis0(34, 130, 32, 32, clear=False),
-        _tail_reduce_axis0(34, 130, 32, 32, dtype="float16"),
-        _tail_reduce_axis0(34, 130, 32, 32, real_shape=[31, 32]),
+        (
+            _tail_reduce_axis0(34, 130, 32, 32, clear=False),
+            _native_reduce_marker("sum", target="ascendc", dtype="float", clear=False),
+        ),
+        (
+            _tail_reduce_axis0(34, 130, 32, 32, dtype="float16"),
+            _native_reduce_marker("sum", target="ascendc", dtype="float16"),
+        ),
+        (
+            _tail_reduce_axis0(34, 130, 32, 32, real_shape=[31, 32]),
+            _native_reduce_marker("sum", target="ascendc", dtype="float"),
+        ),
     ],
     ids=["clear_false", "float16", "real_shape_mismatch"],
 )
-def test_unsupported_tail_reduce_contracts_fall_back(func):
+def test_unsupported_tail_reduce_contracts_fall_back(func, native_marker):
     src = _source(func, target="ascendc")
     assert "tl::ascend::tail_reduce" not in src, src
-    assert _native_reduce_marker("sum") in src, src
+    assert native_marker in src, src
 
 
 def test_tail_reduce_flag_off_emits_no_tail_helper():
@@ -341,7 +362,7 @@ def test_tail_reduce_flag_off_emits_no_tail_helper():
     src_off = _source(func, target="ascendc", tail_mask=False)
     assert "tl::ascend::tail_reduce_sum" in src_on, src_on
     assert "tl::ascend::tail_reduce" not in src_off, src_off
-    assert _native_reduce_marker("sum") in src_off, src_off
+    assert _native_reduce_marker("sum", target="ascendc", dtype="float") in src_off, src_off
 
 
 @pytest.mark.parametrize("target", ["ascendc", "pto"])

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -71,11 +71,12 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
     # Propagate UB tail valid-regions and rewrite unary/binary/scalar ops to
     # tail-aware variants (must run before passes that reorder copy/vector ops).
     # The pass self-gates on TL_ASCEND_TAIL_MASK (default off) and is a no-op
-    # otherwise, so non-tail kernels are unaffected. Reduce is NOT rewritten for
-    # now (the tail_reduce ReduceSum<AR> path has an output-layout bug); it stays
-    # on the full-tile + pad_value path, revisited in batch 2 with
-    # compare/select/broadcast tail support.
-    mod = tilelang.transform.AscendTailMaskPropagation(rewrite_reduce=False)(mod)
+    # otherwise, so non-tail kernels are unaffected. Reduce rewrite is enabled
+    # only for the AscendC backend; the pass itself keeps a strict allow-list for
+    # reduce_sum over the last axis. PTO and all other reduce forms stay on the
+    # established full-tile + pad_value path.
+    rewrite_reduce = target.model == "ascendc" or target.model == "auto"
+    mod = tilelang.transform.AscendTailMaskPropagation(rewrite_reduce=rewrite_reduce)(mod)
     # Erase manual workspace allocations for virtual CV copy in Ascend
     mod = tilelang.transform.AscendWorkspaceReduction()(mod)
     # Legalize vectorized loops to ensure they are valid

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -68,13 +68,14 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.CollectBufferShapes()(mod)
     # Lower high-level tile operations to low-level operations
     mod = tilelang.transform.LowerTileOp()(mod)
-    # Propagate UB tail valid-regions and rewrite unary/binary/scalar ops to
-    # tail-aware variants (must run before passes that reorder copy/vector ops).
+    # Propagate UB tail valid-regions and rewrite unary/binary/scalar plus the
+    # allow-listed reduce ops to tail-aware variants (must run before passes
+    # that reorder copy/vector ops).
     # The pass self-gates on TL_ASCEND_TAIL_MASK (default off) and is a no-op
     # otherwise, so non-tail kernels are unaffected. Reduce rewrite is enabled
     # only for the AscendC backend; the pass itself keeps a strict allow-list for
-    # reduce_sum over the last axis. PTO and all other reduce forms stay on the
-    # established full-tile + pad_value path.
+    # float32 sum/max/min over either 2D axis. PTO and all other reduce forms
+    # stay on the established full-tile + pad_value path.
     rewrite_reduce = target.model == "ascendc" or target.model == "auto"
     mod = tilelang.transform.AscendTailMaskPropagation(rewrite_reduce=rewrite_reduce)(mod)
     # Erase manual workspace allocations for virtual CV copy in Ascend

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -74,8 +74,8 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
     # The pass self-gates on TL_ASCEND_TAIL_MASK (default off) and is a no-op
     # otherwise, so non-tail kernels are unaffected. Reduce rewrite is enabled
     # only for the AscendC backend; the pass itself keeps a strict allow-list for
-    # float32 sum/max/min over either 2D axis. PTO and all other reduce forms
-    # stay on the established full-tile + pad_value path.
+    # float32 sum/max/min over axis 0 of a 2D tile. PTO, last-axis reduction, and
+    # all other reduce forms stay on the established full-tile + pad_value path.
     rewrite_reduce = target.model == "ascendc" or target.model == "auto"
     mod = tilelang.transform.AscendTailMaskPropagation(rewrite_reduce=rewrite_reduce)(mod)
     # Erase manual workspace allocations for virtual CV copy in Ascend

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -72,11 +72,12 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
     # allow-listed reduce ops to tail-aware variants (must run before passes
     # that reorder copy/vector ops).
     # The pass self-gates on TL_ASCEND_TAIL_MASK (default off) and is a no-op
-    # otherwise, so non-tail kernels are unaffected. Reduce rewrite is enabled
-    # only for the AscendC backend; the pass itself keeps a strict allow-list for
-    # float32 sum/max/min over axis 0 of a 2D tile. PTO, last-axis reduction, and
-    # all other reduce forms stay on the established full-tile + pad_value path.
-    rewrite_reduce = target.model == "ascendc" or target.model == "auto"
+    # otherwise, so non-tail kernels are unaffected. The pass itself keeps a
+    # strict allow-list for float32 sum/max/min over axis 0 of a 2D tile. Both
+    # AscendC and PTO lower that contract to backend-native valid-region code;
+    # last-axis reduction and all other forms stay on the established full-tile
+    # + pad_value path.
+    rewrite_reduce = target.model in {"ascendc", "pto", "auto"}
     mod = tilelang.transform.AscendTailMaskPropagation(rewrite_reduce=rewrite_reduce)(mod)
     # Erase manual workspace allocations for virtual CV copy in Ascend
     mod = tilelang.transform.AscendWorkspaceReduction()(mod)


### PR DESCRIPTION
## Summary

This PR extends the tail-mask framework merged by #1360 with a guarded AscendC axis-0 reduction path.

It intentionally supports a strict, correctness-first subset rather than general tail reduction:

* backend: AscendC and `auto` lowering only;
* operations: `reduce_sum`, `reduce_max`, and `reduce_min`;
* input/output dtype: matching `float32`;
* rank/layout: clean 2D UB tiles whose encoded reduce shape matches the physical tile;
* axes: `0` and its equivalent negative-axis spelling `-2`;
* accumulation: `clear=true`;
* output layout: `[1, physical_col]`, with valid region `[1, valid_col]`.

PTO, last-axis reductions (`1`/`-1`), lower-precision reductions, accumulating reductions, explicit shape mismatches, and other unsupported or unproven contracts are not rewritten and remain on their native backend paths. Frontend-invalid output layouts continue to be rejected by the existing reduce shape validation.

## Relationship to #1360

#1360 introduced `TL_ASCEND_TAIL_MASK`, `AscendTailMaskPropagation`, tail-aware unary/binary/scalar helpers, and the hybrid `pad_value` fallback. It deliberately did not rewrite reductions.

This PR is based on the tail-mask framework merged by #1360 and contains only the reduction extension. It reuses the valid-region metadata produced by the existing GM-to-UB copy handling and does not duplicate the base tail-mask implementation.

## Implementation

For a tracked input region `[valid_row, valid_col]` with physical layout `[physical_row, physical_col]`, an eligible axis-0 reduction is rewritten to `tl.ascend_tail_reduce`.

The AscendC helper initializes the output from the first valid row, then applies vector `Add`, `Max`, or `Min` over each remaining valid row. Every operation processes only `valid_col` elements and uses `row * physical_col` as its source offset, so invalid rows and padded columns are never read.

The resulting tail state is:

```text
[valid_row, valid_col] -> [1, valid_col]
[physical_row, physical_col] -> [1, physical_col]
```

This preserves the column tail for downstream unary, binary, and scalar rewriting. Unsupported reductions clear the propagated output state and retain their native implementation.

The internal helper keeps `tmp`, `dim`, and `clear` in its ABI for compatibility with the existing reduction call. The validated implementation does not consume `tmp`; emitted calls are normalized to `dim=0` and are guarded to `clear=true`.

The unvalidated last-axis scalar helper path has been removed. Last-axis reductions remain on the existing native reduce path.

## Tests

Code-generation coverage verifies:

* `sum`, `max`, and `min` helper emission for axis `0` and frontend alias `-2`;
* axis-0 reduce-to-unary tail propagation;
* PTO backend fallback using an otherwise supported axis-0 contract;
* `TL_ASCEND_TAIL_MASK=false` fallback using an otherwise supported contract;
* orthogonal guards for `clear=false`, `float16`, and mismatched `real_shape`;
* last-axis native fallback and downstream tail-state clearing;
* presence of the native reduce marker in negative cases, rather than checking only for the absence of the tail helper.

NPU coverage includes `sum`, `max`, and `min`; axes `0` and `-2`; row-only tails; column-only tails; simultaneous row and column tails; one-valid-row and one-valid-column tails; tensors smaller than a tile; exact tiles; a 64-row physical tile; and NaN, infinity, and signed-zero inputs.

Pure reduction tests use a minimal Vector configuration and do not enable automatic CV combine or CV sync.

## Validation

* C++ sources compile through the TileLang object target.
* `ruff format --check` and `ruff check` pass for the modified Python tests.
* Python byte-compilation and `git diff --check` pass.
* Full NPU numerical execution was not run locally and will be validated by the NPU CI jobs.
