### PR TITLE
[Feat] Ascend: let the kernel drive the L1->L0->mma->fixpipe sequence

### DIFF
--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -69,6 +69,22 @@ AscendCopy::AscendCopy(Array<PrimExpr> args, BufferMap vmap) : args_(args) {
     }
     // If tmp_expr is IntImm(0), leave tmp as undefined (default)
   }
+  // Optional trailing runtime arguments for the kernel-driven cube path. All
+  // default to 0, which reproduces the previous behaviour exactly: unitFlag 0
+  // is a standalone fixpipe, and realK/realN 0 mean "take the extent from the
+  // destination L0 buffer".
+  unitFlag = Integer(0);
+  realK = Integer(0);
+  realN = Integer(0);
+  if (args.size() >= 7) {
+    unitFlag = args[6];
+  }
+  if (args.size() >= 8) {
+    realK = args[7];
+  }
+  if (args.size() >= 9) {
+    realN = args[8];
+  }
   std::tie(this->src, this->dst) = std::tie(bf[0], bf[1]);
   std::tie(this->src_range, this->dst_range) = std::tie(rgs[0], rgs[1]);
   std::tie(this->src_extents, this->dst_extents) = std::tie(ets[0], ets[1]);
@@ -489,8 +505,27 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
 
   if (config.l0_dst_split) {
     int dst_dim = dst->shape.size();
-    new_args.push_back(dst->shape[dst_dim - 2]);
-    new_args.push_back(dst->shape[dst_dim - 1]);
+    PrimExpr dm = dst->shape[dst_dim - 2];
+    PrimExpr dn = dst->shape[dst_dim - 1];
+    // realK overrides the L0 fractal's K extent so it matches the following
+    // mma's runtime K. K is the trailing dim for matrix_a ([M, K]) and the
+    // leading one for matrix_b ([K, N]). realK == 0 keeps dst->shape, which is
+    // byte-identical for every existing L1->L0 copy.
+    const auto *rk_imm = realK.as<IntImmNode>();
+    if (!(rk_imm && rk_imm->value == 0)) {
+      if (dst.scope() == "wmma.matrix_a") {
+        dn = realK;
+      } else if (dst.scope() == "wmma.matrix_b") {
+        dm = realK;
+      }
+    }
+    // realN overrides matrix_b's N extent, the axis realK does not cover.
+    const auto *rn_imm = realN.as<IntImmNode>();
+    if (!(rn_imm && rn_imm->value == 0) && dst.scope() == "wmma.matrix_b") {
+      dn = realN;
+    }
+    new_args.push_back(dm);
+    new_args.push_back(dn);
   }
 
   if (config.l0c2gm) {
@@ -500,6 +535,11 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     new_args.push_back(src->shape[src->shape.size() - 2]);
     new_args.push_back(src->shape[src->shape.size() - 1]);
     new_args.push_back(Bool(enRelu)); // Add enable_relu parameter
+    // unitFlag goes last, not in call order: this list is shared with the PTO
+    // codegen, which reads several of these by position (the pad enum and the
+    // relu flag among them). The ascendc codegen picks it up off the end and
+    // emits it in the position the C++ helper expects.
+    new_args.push_back(unitFlag);
   }
 
   if (config.gm2l1) {
@@ -1330,8 +1370,10 @@ TIR_DEFINE_TL_BUILTIN(ascend_use_swizzle)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
+// -1 = variadic: the 6 required args (name, A, B, C, init, K) plus the optional
+// trailing n_actual / unitFlag pair.
 TIR_DEFINE_TL_BUILTIN(ascend_mma)
-    .set_num_inputs(6)
+    .set_num_inputs(-1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 

--- a/src/op/ascend.h
+++ b/src/op/ascend.h
@@ -38,6 +38,21 @@ private:
   Buffer tmp;
   Array<Range> tmp_range;
   Array<PrimExpr> tmp_extents;
+  // L0C->GM fixpipe unitFlag (default 0 = a standalone fixpipe). Threaded into
+  // copy_l0c_to_gm so a kernel-driven fixpipe can pair with the preceding mma's
+  // unitFlag and overlap across an L0C ping-pong.
+  PrimExpr unitFlag;
+  // L1->L0 runtime contraction length (default 0 = take the K extent from the
+  // destination L0 buffer). Overrides copy_l1_to_l0a's dstN / copy_l1_to_l0b's
+  // dstM so the loaded fractal matches a following mma's runtime K -- a
+  // full-width load feeding a shorter mma otherwise reads mismatched fractals.
+  PrimExpr realK;
+  // L1->L0B runtime output width (default 0 = take N from the destination L0
+  // buffer). The other axis of what realK covers: L0B's fractal derives its
+  // K-block stride from the column count, so a full-width load followed by a
+  // shorter mma addresses the wrong K-blocks. Applies to matrix_b only, since
+  // matrix_a is [M, K] and has no N.
+  PrimExpr realN;
 };
 
 class AscendAtomicAdd : public Operator {

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -474,7 +474,12 @@ void CodeGenTileLangAscend::VisitExpr_(const BufferLoadNode *op,
   if (scope == "local.var") {
     os << var_name;
   } else {
-    os << var_name << ".GetValue(" << PrintExpr(op->indices.back()) << ")";
+    // Flatten every index, not just the innermost one: a scalar access into a
+    // multi-dimensional buffer such as table[b, i] otherwise drops the leading
+    // dimensions and aliases every row onto row 0. OffsetOf is the identity for
+    // a 1-D buffer, so single-dimension accesses are unchanged.
+    os << var_name << ".GetValue("
+       << PrintExpr(op->buffer.OffsetOf(op->indices).back()) << ")";
   }
 }
 
@@ -486,7 +491,8 @@ void CodeGenTileLangAscend::VisitStmt_(const BufferStoreNode *op) {
     this->PrintIndent();
     this->stream << var_name << " = " << value << ";\n";
   } else {
-    std::string index = PrintExpr(op->indices.back());
+    // See VisitExpr_(BufferLoadNode): flatten across all dimensions.
+    std::string index = PrintExpr(op->buffer.OffsetOf(op->indices).back());
     std::string value = PrintExpr(op->value);
     this->PrintIndent();
     this->stream << var_name << ".SetValue(" << index << ", " << value
@@ -1959,6 +1965,16 @@ void CodeGenTileLangAscend::ReduceOpCodegen(const CallNode *op) {
 
   bool is_reduce_sum = (op_name.find("reduce_sum") != std::string::npos);
   int buffer_arg_end = static_cast<int>(op->args.size());
+  // Optional trailing physical row width, emitted only when the logical width
+  // is narrower than the row the data sits in (a sliced region, or a real_shape
+  // narrower than the buffer). It follows `clear`, so peel it off first.
+  int64_t physical_row = 0;
+  if (buffer_arg_end > 0 && !op->args[buffer_arg_end - 1].dtype().is_bool()) {
+    if (const auto *row_imm = op->args[buffer_arg_end - 1].as<IntImmNode>()) {
+      physical_row = row_imm->value;
+      buffer_arg_end--;
+    }
+  }
   bool clear = true;
   if (buffer_arg_end > 0 && op->args[buffer_arg_end - 1].dtype().is_bool()) {
     clear = !is_zero(op->args[buffer_arg_end - 1]);
@@ -1973,6 +1989,85 @@ void CodeGenTileLangAscend::ReduceOpCodegen(const CallNode *op) {
   }
 
   this->PrintIndent();
+
+  // Narrow row-reduce: the logical width is only part of a wider physical row,
+  // so the source cannot be walked as one contiguous M x N block. Route to the
+  // WholeReduce* helpers, which take an explicit per-repeat source stride.
+  if (physical_row > 0) {
+    size_t tpos1 = op_name.find("<");
+    size_t tpos2 = op_name.rfind(">");
+    std::string tparams = op_name.substr(tpos1 + 1, tpos2 - tpos1 - 1);
+    size_t c1 = tparams.find(",");
+    size_t c2 = tparams.find(",", c1 + 1);
+    size_t c3 = tparams.find(",", c2 + 1);
+    auto trim = [](std::string s) {
+      size_t b = s.find_first_not_of(" \t");
+      if (b == std::string::npos)
+        return std::string("");
+      return s.substr(b, s.find_last_not_of(" \t") - b + 1);
+    };
+    std::string ndtype = trim(tparams.substr(0, c1));
+    // The front end only attaches a physical row width once it has resolved the
+    // logical extents to constants, so these parse. Guard anyway: a symbolic
+    // extent reaching here would otherwise throw out of std::stoll and take the
+    // compiler down with it.
+    int64_t nm = 0, nn = 0, ndim = 0;
+    try {
+      nm = std::stoll(trim(tparams.substr(c1 + 1, c2 - c1 - 1)));
+      nn = std::stoll(trim(tparams.substr(c2 + 1, c3 - c2 - 1)));
+      ndim = std::stoll(trim(tparams.substr(c3 + 1)));
+    } catch (const std::exception &) {
+      LOG(FATAL) << "narrow reduce needs compile-time extents, but could not "
+                    "parse the template parameters: "
+                 << tparams;
+    }
+
+    // Enumerated rather than defaulted: guessing 4 bytes for an unrecognised
+    // type would silently scale the stride wrong instead of failing.
+    int64_t elem_bytes = 0;
+    if (ndtype == "float" || ndtype == "int32_t" || ndtype == "uint32_t") {
+      elem_bytes = 4;
+    } else if (ndtype == "half" || ndtype == "bfloat16_t" ||
+               ndtype == "int16_t" || ndtype == "uint16_t") {
+      elem_bytes = 2;
+    } else if (ndtype == "int8_t" || ndtype == "uint8_t" ||
+               ndtype == "float8_e4m3_t" || ndtype == "float8_e5m2_t") {
+      elem_bytes = 1;
+    }
+    ICHECK(elem_bytes > 0)
+        << "narrow reduce does not know the element size of '" << ndtype << "'";
+    ICHECK(ndim == -1) << "narrow reduce is only implemented for a row reduce "
+                          "(dim == -1); got dim "
+                       << ndim << " over a logical width of " << nn
+                       << " inside a physical row of " << physical_row;
+    ICHECK(nn * elem_bytes <= 256)
+        << "narrow reduce needs the logical width to fit one vector repeat "
+           "(256 "
+           "bytes); got "
+        << nn << " elements of " << elem_bytes << " bytes. Split the range and "
+        << "combine the partial results.";
+    ICHECK(clear) << "narrow reduce cannot merge into the destination "
+                     "(clear == false); reduce into a scratch and combine.";
+
+    std::string narrow = "reduce_max_narrow";
+    if (is_reduce_sum) {
+      narrow = "reduce_sum_narrow";
+    } else if (op_name.find("reduce_min") != std::string::npos) {
+      narrow = "reduce_min_narrow";
+    }
+    // srcRepStride steps one physical row, counted in 32-byte blocks, so the
+    // row has to be a whole number of them -- otherwise the division truncates
+    // and the reduce walks a stride that is short (or zero).
+    ICHECK((physical_row * elem_bytes) % 32 == 0)
+        << "narrow reduce needs the physical row (" << physical_row
+        << " elements of " << elem_bytes
+        << " bytes) to be a multiple of the 32-byte block";
+    int64_t src_rep_stride = physical_row * elem_bytes / 32;
+    this->stream << "tl::ascend::" << narrow << "<" << ndtype << ">("
+                 << var_names[0] << ", " << var_names[1] << ", " << nn << ", "
+                 << nm << ", " << src_rep_stride << ");\n";
+    return;
+  }
 
   if (is_reduce_sum) {
     size_t pos1 = op_name.find("<");
@@ -2580,8 +2675,13 @@ void CodeGenTileLangAscend::MmaCodegen(const CallNode *op) {
   this->PrintIndent();
   this->stream << op_name << "(" << a_name << "[" << a_offset << "]," << b_name
                << "[" << b_offset << "]," << c_name << "[" << c_offset << "], "
-               << PrintExpr(op->args[4]) << ", " << PrintExpr(op->args[5])
-               << ");\n";
+               << PrintExpr(op->args[4]) << ", " << PrintExpr(op->args[5]);
+  // Optional trailing args (n_actual, unitFlag). Absent for the legacy 6-arg
+  // form, where the template supplies n_actual = N and unitFlag = 0.
+  for (size_t i = 6; i < op->args.size(); ++i) {
+    this->stream << ", " << PrintExpr(op->args[i]);
+  }
+  this->stream << ");\n";
 }
 
 void CodeGenTileLangAscend::CopyCodegen(const CallNode *op) {
@@ -2634,6 +2734,16 @@ void CodeGenTileLangAscend::CopyCodegen(const CallNode *op) {
   }
 
   if (found) {
+    // The count above is the most a call can carry. Not every producer supplies
+    // all of them -- passes that rewrite a copy in place (AscendWorkspace-
+    // Reduction turning copy_l0c_to_ub into copy_l0c_to_gm, say) build their
+    // own argument list and stop at the ones they care about. Every trailing
+    // parameter has a C++ default that reproduces the old behaviour, so emit
+    // what is actually there rather than indexing past the end.
+    int available = static_cast<int>(op->args.size()) - 3;
+    if (extra_args > available) {
+      extra_args = available;
+    }
     std::vector<std::string> var_names;
     for (int i = 0; i < extra_args; ++i) {
       auto expr = op->args[3 + i];
@@ -2658,6 +2768,17 @@ void CodeGenTileLangAscend::CopyCodegen(const CallNode *op) {
     // natural owner of the tail-padding clear.
     if (op_name.find("copy_gm_to_l1") != std::string::npos) {
       this->stream << ", " << (is_zero(dst_offset_expr) ? "true" : "false");
+    }
+
+    // copy_l0c_to_gm's unitFlag rides at the end of the argument list rather
+    // than in call order: the list is shared with the PTO codegen, which reads
+    // the entries in between by position. Emit it where the C++ helper expects
+    // it. A producer that predates it leaves the template default of 0, which
+    // is a standalone fixpipe.
+    constexpr int kL0cToGmArgc = 10;
+    if (op_name.find("copy_l0c_to_gm") != std::string::npos &&
+        static_cast<int>(op->args.size()) >= kL0cToGmArgc) {
+      this->stream << ", " << PrintExpr(op->args[kL0cToGmArgc - 1]);
     }
 
     this->stream << ");\n";

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -3497,7 +3497,15 @@ void CodeGenTileLangAscendPto::ReduceOpCodegen(const CallNode *op) {
   std::string op_name_str = Downcast<StringImm>(op->args[0])->value;
 
   ReduceOpInfo op_info = ParseReduceOpInfo(op_name_str);
-  bool clear = ParseConstBoolArg(op->args[op->args.size() - 1], true);
+  // A narrow reduce may carry a trailing physical row width after `clear`. PTO
+  // tiles keep a strided view, so the width is not needed here -- just skip
+  // past it to find `clear`.
+  int clear_idx = static_cast<int>(op->args.size()) - 1;
+  if (clear_idx > 0 && !op->args[clear_idx].dtype().is_bool() &&
+      op->args[clear_idx].as<IntImmNode>()) {
+    clear_idx--;
+  }
+  bool clear = ParseConstBoolArg(op->args[clear_idx], true);
   ShapeInfo dst = GetSliceInfo(op->args[1].as<CallNode>());
   ShapeInfo src = GetSliceInfo(op->args[2].as<CallNode>());
   bool is_slice = src.slice_valid_row != op_info.buffer_slice_row ||

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -143,7 +143,18 @@ CATLASS_DEVICE void mma(LocalTensor<T1> const A, LocalTensor<T1> const B,
   mmadParams.n = n_actual;
   mmadParams.k = K;
   mmadParams.cmatrixInitVal = init;
-  // mmadParams.unitFlag = unitFlag;
+  // MmadParams does not default-initialise cmatrixSource, and the hardware
+  // reads it whenever cmatrixInitVal == false (an accumulating mma, C sourced
+  // from L0C). A single-mma caller never notices, but a K-accumulating sequence
+  // that also sets unitFlag reads the uninitialised field and hangs the cube.
+  // false ("source from L0C") is what every accumulating caller already means.
+  mmadParams.cmatrixSource = false;
+  // unitFlag drives the hardware mma->fixpipe pipeline: 0b10 keeps the result
+  // in L0C, 0b11 releases it to a paired fixpipe. That is what lets
+  // fixpipe(tile i) overlap mma(tile i+1) across a two-slot L0C ping-pong,
+  // without a software M_FIX/FIX_M handshake. Defaults to 0 (off), so every
+  // existing caller is byte-for-byte unchanged.
+  mmadParams.unitFlag = unitFlag;
 
   Mmad(C, A, B, mmadParams);
 
@@ -159,7 +170,7 @@ template <typename T1, typename T2, typename LayoutGM, uint32_t srcM,
 CATLASS_DEVICE void
 copy_l0c_to_gm(GlobalTensor<T2> dstTensor, LocalTensor<T1> srcTensor,
                uint32_t realDstN = 1, uint32_t realTailM = 0,
-               uint32_t realTailN = 0) {
+               uint32_t realTailN = 0, uint8_t unitFlag = 0) {
   uint32_t tailM = realTailM == 0 ? srcM : realTailM;
   uint32_t tailN = realTailN == 0 ? srcN : realTailN;
   auto layoutInL0C = tla::MakeLayoutL0C(srcM, srcN);
@@ -176,7 +187,10 @@ copy_l0c_to_gm(GlobalTensor<T2> dstTensor, LocalTensor<T1> srcTensor,
   CopyL0CToGmTla<ArchTag, decltype(src), decltype(dst),
                  ScaleGranularity::NO_QUANT, enRelu>
       tileCopier;
-  tileCopier(dst, src, 0);
+  // unitFlag (default 0 = a standalone fixpipe) pairs with the Mmad unitFlag to
+  // form the hardware mma->fixpipe pipeline; CopyL0CToGmTla already plumbs it
+  // through to FixpipeParams.
+  tileCopier(dst, src, unitFlag);
 }
 
 template <uint32_t M, uint32_t N, uint32_t K, uint32_t block_M,
@@ -443,6 +457,45 @@ CATLASS_DEVICE void
 reduce_sum_half(LocalTensor<T> const &dstTensor,
                 LocalTensor<T> const &srcTensor, const int32_t mask,
                 const int32_t repeatTime, const int32_t srcRepStride) {
+  AscendC::WholeReduceSum<T>(dstTensor, srcTensor, mask, repeatTime, 1, 1,
+                             srcRepStride);
+}
+
+// Row-reduce a narrow column range of a wider tile.
+//
+// AscendC's Reduce* takes a {M, N} shape and reads the source as a CONTIGUOUS
+// M x N block, so it cannot express "N columns out of each row of a wider
+// buffer": for a [M, 512] tile and a logical width of 64 it reads elements
+// [0, M*64), which is row 0's first eight chunks, not the first 64 columns of
+// each of the M rows. WholeReduce* instead takes an explicit per-repeat source
+// stride, so one repeat per row with srcRepStride set to the PHYSICAL row width
+// reduces the intended region. One repeat covers at most 256 bytes, which is
+// what bounds the usable width.
+template <typename T>
+CATLASS_DEVICE void
+reduce_max_narrow(LocalTensor<T> const &dstTensor,
+                  LocalTensor<T> const &srcTensor, const int32_t mask,
+                  const int32_t repeatTime, const int32_t srcRepStride) {
+  AscendC::WholeReduceMax<T>(dstTensor, srcTensor, mask, repeatTime, 1, 1,
+                             srcRepStride,
+                             AscendC::ReduceOrder::ORDER_ONLY_VALUE);
+}
+
+template <typename T>
+CATLASS_DEVICE void
+reduce_min_narrow(LocalTensor<T> const &dstTensor,
+                  LocalTensor<T> const &srcTensor, const int32_t mask,
+                  const int32_t repeatTime, const int32_t srcRepStride) {
+  AscendC::WholeReduceMin<T>(dstTensor, srcTensor, mask, repeatTime, 1, 1,
+                             srcRepStride,
+                             AscendC::ReduceOrder::ORDER_ONLY_VALUE);
+}
+
+template <typename T>
+CATLASS_DEVICE void
+reduce_sum_narrow(LocalTensor<T> const &dstTensor,
+                  LocalTensor<T> const &srcTensor, const int32_t mask,
+                  const int32_t repeatTime, const int32_t srcRepStride) {
   AscendC::WholeReduceSum<T>(dstTensor, srcTensor, mask, repeatTime, 1, 1,
                              srcRepStride);
 }

--- a/testing/python/language/test_tilelang_ascend_language_kernel_driven_mma.py
+++ b/testing/python/language/test_tilelang_ascend_language_kernel_driven_mma.py
@@ -1,0 +1,143 @@
+"""Kernel-driven cube decomposition: a K-accumulating mma with a fused fixpipe.
+
+The gemm helpers own the whole L1->L0->mma->fixpipe sequence internally, which
+is fine when the operands are ready up front. A kernel that keeps its own KV
+ring, or splits the contraction into chunks that arrive at different times,
+needs to drive that sequence itself: load each L0 tile, issue the mma, and copy
+the accumulated result out when the last tile lands.
+
+Doing that from the front end needs four runtime arguments, all of which this
+test exercises together:
+
+  * ``T.copy(L1->L0A, real_k=)``  -- the fractal's K extent, so a full-width L0
+    buffer is loaded as the ``[M, real_k]`` fractal the mma will read.
+  * ``T.copy(L1->L0B, real_n=)``  -- the same for L0B's other axis. L0B's
+    fractal derives its K-block stride from the column count, so a full-width
+    load feeding a shorter mma addresses the wrong K-blocks.
+  * ``T.mma(k_actual=, n_actual=, unit_flag=)`` -- contract only part of the
+    operands, and mark whether the result stays in L0C (0b10) or is released to
+    a paired fixpipe (0b11).
+  * ``T.copy(L0C->GM, unit_flag=0b11)`` -- the paired fixpipe.
+
+The kernel computes A @ B^T over K=256 as two hand-walked 128-wide tiles that
+accumulate into one L0C slot, with only the second one flushing. That covers
+the accumulating path (``cmatrixInitVal == false``), which is also what reads
+``cmatrixSource``; leaving that field uninitialised hangs the cube once the mma
+carries a unitFlag.
+
+``n_act`` is a runtime value so ``real_n`` / ``n_actual`` take their runtime
+path. A single tile would pass with a wrong K-block offset (its offset is 0),
+so both tiles are required to make the test meaningful.
+"""
+
+import pytest
+
+import torch
+
+import tilelang
+import tilelang.language as T
+
+M, N, K = 64, 128, 256
+KL0 = 128  # kL0 tile width: K = 2 tiles
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+def kernel_driven_mma(dtype="float16", accum_dtype="float"):
+    @T.prim_func
+    def main(
+        A: T.Tensor([M, K], dtype),
+        B: T.Tensor([N, K], dtype),  # K^T layout: the gemm is A @ B^T
+        nact: T.Tensor([1], "int32"),  # runtime output-column count
+        C: T.Tensor([M, N], accum_dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_l1 = T.alloc_L1([M, K], dtype)
+            b_l1 = T.alloc_L1([N, K], dtype)
+            a_l0 = T.alloc_L0A([2, M, KL0], dtype)
+            b_l0 = T.alloc_L0B([2, N, KL0], dtype)
+            c_l0 = T.alloc_L0C([1, M, N], accum_dtype)
+            with T.Scope("C"):
+                n_act = nact[0]
+                T.barrier_all()
+                T.copy(A, a_l1)
+                T.copy(B, b_l1)
+                T.barrier_all()
+                # kL0 tile 0: initialise the L0C slot, hold it (0b10).
+                T.copy(a_l1[:, 0:KL0], a_l0[0, :, :])
+                T.copy(
+                    b_l1[:, 0:KL0],
+                    b_l0[0, :, :],
+                    transpose=True,
+                    real_k=KL0,
+                    real_n=n_act,
+                )
+                T.barrier_all()
+                T.mma(
+                    a_l0[0, :, :],
+                    b_l0[0, :, :],
+                    c_l0[0, :, :],
+                    init=True,
+                    k_actual=KL0,
+                    n_actual=n_act,
+                    unit_flag=0b10,
+                )
+                T.barrier_all()
+                # kL0 tile 1: accumulate into the same slot, then flush (0b11).
+                T.copy(a_l1[:, KL0 : 2 * KL0], a_l0[1, :, :])
+                T.copy(
+                    b_l1[:, KL0 : 2 * KL0],
+                    b_l0[1, :, :],
+                    transpose=True,
+                    real_k=KL0,
+                    real_n=n_act,
+                )
+                T.barrier_all()
+                T.mma(
+                    a_l0[1, :, :],
+                    b_l0[1, :, :],
+                    c_l0[0, :, :],
+                    init=False,
+                    k_actual=KL0,
+                    n_actual=n_act,
+                    unit_flag=0b11,
+                )
+                T.barrier_all()
+                # The fixpipe paired with the flushing mma. Its column count must
+                # equal the mma's n, or it waits on L0C columns no mma marked
+                # ready.
+                T.copy(c_l0[0, :, :], C[:, 0:n_act], unit_flag=0b11)
+                T.barrier_all()
+
+    return main
+
+
+@pytest.mark.parametrize("n_act", [N, 96, 32])
+def test_kernel_driven_mma(n_act):
+    torch.manual_seed(0)
+    tilelang.cache.clear_cache()
+
+    func = tilelang.compile(
+        kernel_driven_mma(),
+        out_idx=[-1],
+        target="ascendc",
+        pass_configs=pass_configs,
+    )
+
+    a = (torch.randn(M, K) * 0.1).half()
+    b = (torch.randn(N, K) * 0.1).half()
+    nact = torch.tensor([n_act], dtype=torch.int32)
+
+    out = func(a.npu(), b.npu(), nact.npu())
+
+    ref = (a.float() @ b.float().T)[:, :n_act]
+    torch.testing.assert_close(out.cpu()[:, :n_act], ref, rtol=1e-2, atol=1e-2)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/testing/python/language/test_tilelang_ascend_language_narrow_reduce.py
+++ b/testing/python/language/test_tilelang_ascend_language_narrow_reduce.py
@@ -1,0 +1,128 @@
+"""Row-reduce over part of a wider row.
+
+A reduce whose logical width is only part of the row the data physically sits
+in has to step by the PHYSICAL row width to move between rows. That happens
+whenever a region is sliced along the columns (``ub[:, a:b]``) or ``real_shape``
+names fewer columns than the buffer holds -- an online softmax over a sliding
+window is the usual source of both.
+
+The {M, N} shape alone cannot express it: AscendC's Reduce* walks the source as
+one contiguous M x N block, so for a [M, 512] tile reduced over 64 columns it
+consumes elements [0, M*64) -- row 0's first eight chunks -- and returns those
+as if they were the per-row results. Row 0 lands on the right answer (it starts
+at offset 0), every other row does not, and nothing reports an error.
+
+Both spellings are covered, and the padding is filled with a value that changes
+the result if it is read, so a wrong walk cannot pass by luck. The first row is
+excluded from that poisoning on purpose: it is correct either way, and a test
+that only looked at it would pass against the broken walk.
+"""
+
+import pytest
+
+import torch
+
+import tilelang
+import tilelang.language as T
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+def _reduce_fn(op):
+    return {"sum": T.reduce_sum, "max": T.reduce_max, "min": T.reduce_min}[op]
+
+
+def narrow_via_real_shape(M, buf_n, valid, op, dtype="float"):
+    """Whole buffer in, logical width given by real_shape."""
+    reduce_fn = _reduce_fn(op)
+
+    @T.prim_func
+    def main(src: T.Tensor([M, buf_n], dtype), out: T.Tensor([M], dtype)):
+        with T.Kernel(1, is_npu=True) as (_, vid):
+            ub = T.alloc_ub([M, buf_n], dtype)
+            acc = T.alloc_ub([M], dtype)
+            if vid == 0:
+                T.copy(src, ub)
+                reduce_fn(ub, acc, dim=-1, real_shape=[M, valid])
+                T.copy(acc, out)
+
+    return main
+
+
+def narrow_via_slice(M, buf_n, valid, op, offset, dtype="float"):
+    """A column range of the buffer, named by slicing the region."""
+    reduce_fn = _reduce_fn(op)
+
+    @T.prim_func
+    def main(src: T.Tensor([M, buf_n], dtype), out: T.Tensor([M], dtype)):
+        with T.Kernel(1, is_npu=True) as (_, vid):
+            ub = T.alloc_ub([M, buf_n], dtype)
+            acc = T.alloc_ub([M], dtype)
+            if vid == 0:
+                T.copy(src, ub)
+                reduce_fn(ub[:, offset : offset + valid], acc, dim=-1)
+                T.copy(acc, out)
+
+    return main
+
+
+def _reference(data, op, lo, hi):
+    window = data[:, lo:hi]
+    if op == "sum":
+        return window.sum(dim=-1)
+    if op == "max":
+        return window.max(dim=-1).values
+    return window.min(dim=-1).values
+
+
+def _data(M, buf_n, op, lo, hi):
+    torch.manual_seed(0)
+    data = torch.randn(M, buf_n, dtype=torch.float32)
+    # Outside the reduced range, plant a value that would dominate the result if
+    # it were read. Row 0 is left alone: it is correct under either walk, so
+    # poisoning it would hide which rows actually went wrong.
+    poison = {"sum": 7.0, "max": 100.0, "min": -100.0}[op]
+    data[1:, :lo] = poison
+    data[1:, hi:] = poison
+    return data
+
+
+@pytest.mark.parametrize("op", ["sum", "max", "min"])
+@pytest.mark.parametrize("valid", [64, 32, 16])
+def test_narrow_reduce_real_shape(op, valid):
+    M, buf_n = 16, 512
+    tilelang.cache.clear_cache()
+    func = tilelang.compile(
+        narrow_via_real_shape(M, buf_n, valid, op),
+        out_idx=[-1],
+        target="ascendc",
+        pass_configs=pass_configs,
+    )
+    data = _data(M, buf_n, op, 0, valid)
+    out = func(data.npu()).cpu()
+    torch.testing.assert_close(out, _reference(data, op, 0, valid), rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("op", ["sum", "max", "min"])
+@pytest.mark.parametrize("offset", [0, 64, 448])
+def test_narrow_reduce_column_slice(op, offset):
+    M, buf_n, valid = 16, 512, 64
+    tilelang.cache.clear_cache()
+    func = tilelang.compile(
+        narrow_via_slice(M, buf_n, valid, op, offset),
+        out_idx=[-1],
+        target="ascendc",
+        pass_configs=pass_configs,
+    )
+    data = _data(M, buf_n, op, offset, offset + valid)
+    out = func(data.npu()).cpu()
+    torch.testing.assert_close(out, _reference(data, op, offset, offset + valid), rtol=1e-3, atol=1e-3)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/testing/python/language/test_tilelang_ascend_language_scalar_index.py
+++ b/testing/python/language/test_tilelang_ascend_language_scalar_index.py
@@ -1,0 +1,66 @@
+"""Scalar element access on a multi-dimensional buffer.
+
+A scalar read/write like ``table[b, i]`` has to flatten the index across every
+dimension. Emitting only the innermost index makes every row alias row 0, which
+stays silent whenever the leading index happens to be 0 -- a single-batch test
+passes while a multi-batch one returns the first batch's data.
+
+The kernel varies both indices on a [B, N] buffer, so a dropped leading index
+shows up as rows 1.. holding row 0's values. It exercises the scalar load and
+the scalar store together.
+
+The pto codegen carries the same defect, but fixing it there needs a separate
+look at how its global-buffer accesses are addressed, so this covers ascendc
+only and the pto side is tracked as its own issue.
+"""
+
+import pytest
+
+import torch
+
+import tilelang
+import tilelang.language as T
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+}
+
+
+def scalar_index_2d(B, N, dtype="int32"):
+    @T.prim_func
+    def main(
+        table: T.Tensor([B, N], dtype),
+        out: T.Tensor([B, N], dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            buf = T.alloc_ub([B, N], dtype)
+            if vid == 0:
+                for b in range(B):
+                    for i in range(N):
+                        # 2-D scalar load AND 2-D scalar store
+                        buf[b, i] = table[b, i] * 2
+                T.copy(buf, out)
+
+    return main
+
+
+@pytest.mark.parametrize("target", ["ascendc"])
+@pytest.mark.parametrize("B,N", [(4, 8), (3, 16), (2, 32)])
+def test_scalar_index_2d(B, N, target):
+    tilelang.cache.clear_cache()
+    func = tilelang.compile(
+        scalar_index_2d(B, N),
+        out_idx=[1],
+        target=target,
+        pass_configs=pass_configs,
+    )
+    table = torch.arange(B * N, dtype=torch.int32).reshape(B, N)
+    out = func(table.npu())
+    torch.testing.assert_close(out.cpu(), table * 2)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tilelang/language/copy_op.py
+++ b/tilelang/language/copy_op.py
@@ -261,6 +261,9 @@ def npu_copy_v2(
     transpose: bool | None = False,  # for copy_l1_to_l0 param: transpose l1
     pad_value: float | int | tir.PrimExpr | None = None,
     tmp: tir.Buffer | tir.BufferLoad | None = None,
+    unit_flag: int | None = None,
+    real_k: int | tir.PrimExpr | None = None,
+    real_n: int | tir.PrimExpr | None = None,
 ):
     """Copy data between memory regions.
 
@@ -278,6 +281,25 @@ def npu_copy_v2(
         tmp (tir.Buffer | tir.BufferLoad | None): Temporary buffer for UB->L1 copy
             on A5 platform. Used for ND->Nz format conversion. Defaults to None.
             Only required when copying from UB to L1 on A5.
+        unit_flag (int | None): L0C->GM fixpipe unitFlag (0b10 accumulate / 0b11
+            flush). Defaults to None -> the C++ default 0, a standalone fixpipe,
+            leaving every existing copy byte-for-byte unchanged. Set 0b11 to fuse
+            this fixpipe with a preceding ``T.mma(unit_flag=0b11)`` through the
+            hardware mma->fixpipe pipeline; the row stride already comes from the
+            destination buffer's last dim.
+        real_k (int | tir.PrimExpr | None): L1->L0 runtime contraction length.
+            Defaults to None -> the L0 fractal's K extent comes from the
+            destination L0 buffer's dim (byte-identical for every existing copy).
+            Set it so a full-width L0 buffer is loaded as an ``[M, real_k]``
+            (matrix_a) / ``[real_k, N]`` (matrix_b) fractal matching a following
+            ``T.mma(k_actual=real_k)``; a full-width load feeding a shorter mma
+            otherwise reads mismatched fractals and addresses the wrong M-blocks.
+        real_n (int | tir.PrimExpr | None): L1->L0B runtime output width. Defaults
+            to None -> N comes from the destination L0 buffer's dim. The other
+            axis of what ``real_k`` covers: L0B's fractal derives its K-block
+            stride from the column count, so a full-width load followed by a
+            shorter ``T.mma(n_actual=...)`` addresses the wrong K-blocks. Applies
+            to matrix_b only, since matrix_a is ``[M, K]`` and has no N.
 
     Raises:
         TypeError: If copy extents cannot be deduced from arguments
@@ -359,7 +381,23 @@ def npu_copy_v2(
     else:
         tmp_region = _to_region(tmp, "rw")
 
-    return tir.call_intrin("handle", tir.op.Op.get("tl.ascend_copy"), src, dst, enable_relu, transpose, pad_value_expr, tmp_region)
+    copy_args = [src, dst, enable_relu, transpose, pad_value_expr, tmp_region]
+
+    # Optional trailing runtime args, appended only when used so every existing
+    # caller emits the exact same 6-argument call. They are positional, so an
+    # inner one has to be materialised (as its no-op default) when an outer one
+    # is set.
+    def _as_expr(value):
+        return value if isinstance(value, tir.PrimExpr) else tir.IntImm("int32", int(value))
+
+    if unit_flag is not None or real_k is not None or real_n is not None:
+        copy_args.append(tir.IntImm("int32", int(unit_flag) if unit_flag is not None else 0))
+        if real_k is not None or real_n is not None:
+            copy_args.append(_as_expr(real_k) if real_k is not None else tir.IntImm("int32", 0))
+            if real_n is not None:
+                copy_args.append(_as_expr(real_n))
+
+    return tir.call_intrin("handle", tir.op.Op.get("tl.ascend_copy"), *copy_args)
 
 
 class CopyCVMode(IntEnum):

--- a/tilelang/language/customize.py
+++ b/tilelang/language/customize.py
@@ -112,8 +112,24 @@ def view(src: Buffer, shape: list[PrimExpr] | None = None, dtype: str | None = N
     return T.Buffer(shape, dtype, src.data)
 
 
-def npu_gemm(A, B, C, init=False):
-    """NPU GEMM intrinsic. A, B, C can be 2D or higher-order (leading dims must be 1)."""
+def npu_gemm(A, B, C, init=False, n_actual=None, unit_flag=None, k_actual=None):
+    """NPU GEMM intrinsic. A, B, C can be 2D or higher-order (leading dims must be 1).
+
+    n_actual / unit_flag (both default ``None``): optional trailing args mapping to
+    the C++ ``mma`` template's ``n_actual`` (runtime output-column count, <= N) and
+    ``unitFlag`` (0b10 accumulate / 0b11 flush, driving the hardware mma->fixpipe
+    pipeline). When both are ``None`` the call emits the legacy 6-argument form, so
+    every existing caller is byte-for-byte unchanged (the C++ defaults are
+    ``n_actual = N`` and ``unitFlag = 0``). Setting ``unit_flag=0b11`` here and on a
+    following ``T.copy(L0C->GM, unit_flag=0b11)`` fuses the two, letting the fixpipe
+    of one tile overlap the mma of the next across an L0C ping-pong.
+
+    k_actual (default ``None``): runtime contraction length, passed as the C++ mma's
+    ``K`` argument and overriding the value derived from ``A``'s last dim. This lets
+    the operands stay full buffers while the mma contracts only ``k_actual`` columns.
+    Passing a symbolic slice instead (``a_l0[pp, :, 0:k]``) is not an option, since
+    ``access_ptr`` would need a concrete extent.
+    """
 
     def legalize_arguments(arg: Buffer | Var):
         """Convert let-bound variables to their corresponding buffers.
@@ -198,7 +214,18 @@ def npu_gemm(A, B, C, init=False):
     Bptr = retrieve_ptr(B, "r")
     Cptr = retrieve_ptr(C, "w" if init is True else "rw")
 
-    return tir.call_intrin("handle", tir.op.Op.get("tl.ascend_mma"), f"mma<{_dtype(A)}, {_dtype(C)}, {M}, {N}>", Aptr, Bptr, Cptr, init, K)
+    # k_actual overrides the K derived from A's last dim, so the operands can stay
+    # full buffers while the mma contracts fewer columns. The <M, N> template
+    # params are unaffected.
+    K_runtime = K if k_actual is None else k_actual
+
+    mma_args = [f"mma<{_dtype(A)}, {_dtype(C)}, {M}, {N}>", Aptr, Bptr, Cptr, init, K_runtime]
+    # Trailing args are positional, so n_actual must be materialised (as its no-op
+    # default N) whenever unit_flag is set.
+    if n_actual is not None or unit_flag is not None:
+        mma_args.append(n_actual if n_actual is not None else N)
+        mma_args.append(unit_flag if unit_flag is not None else 0)
+    return tir.call_intrin("handle", tir.op.Op.get("tl.ascend_mma"), *mma_args)
 
 
 def loop_break():

--- a/tilelang/language/reduce_ascend.py
+++ b/tilelang/language/reduce_ascend.py
@@ -326,13 +326,36 @@ def reduce(
         raise ValueError(f"Unsupported buffer rank {len(buffer_extent)} for Ascend fast-path reduce: {buffer_extent}")
     shape = f"{M}, {N}"
 
-    return tir.call_intrin(
-        "handle",
-        tir.op.Op.get("tl.ascend_reduce"),
+    # The logical width can be narrower than the row the data actually sits in --
+    # a sliced region (``ub[:, a:b]``) or a ``real_shape`` narrower than the
+    # buffer. The reduce then has to step by the PHYSICAL row width to move
+    # between rows, which the {M, N} shape alone cannot express, so pass that
+    # width along when it differs. Emitted only when it differs, so every
+    # existing call is byte-identical.
+    physical_row = None
+    src_buffer = buffer.buffer if isinstance(buffer, BufferRegion) else buffer
+    if isinstance(src_buffer, Buffer) and len(src_buffer.shape) >= 1:
+        physical_row = src_buffer.shape[-1]
+
+    args = [
         f"{reduce_type}<{dtype}, {shape}, {dim}>",
         out_ptr,
         buffer_ptr,
         tir.const(clear, "bool"),
+    ]
+    # Attached only once every extent involved is a constant: the codegen has to
+    # read them back out of the template parameters to size the stride, and a
+    # symbolic one there has nothing it can do.
+    m_const = _try_get_const_int(M)
+    n_const = _try_get_const_int(N)
+    row_const = _try_get_const_int(physical_row)
+    if None not in (m_const, n_const, row_const) and row_const != n_const:
+        args.append(tir.IntImm("int32", row_const))
+
+    return tir.call_intrin(
+        "handle",
+        tir.op.Op.get("tl.ascend_reduce"),
+        *args,
     )
 
 


### PR DESCRIPTION
## What

Lets a kernel drive the `L1 -> L0 -> mma -> fixpipe` sequence itself, instead of
having a gemm helper own it end to end.

No new primitives: these are four optional runtime arguments on the existing
`T.copy` and `T.mma`, each defaulting to today's behaviour so every existing
caller is byte-for-byte unchanged.

| argument | what it does |
| --- | --- |
| `T.copy(L1->L0, real_k=)` | The L0 fractal's K extent, so a full-width L0 buffer is loaded as the `[M, real_k]` / `[real_k, N]` fractal the mma will read. |
| `T.copy(L1->L0B, real_n=)` | The same for L0B's other axis: its fractal derives the K-block stride from the column count. |
| `T.mma(k_actual=, unit_flag=)` | Contract fewer columns than the operands hold; mark whether the result stays in L0C (`0b10`) or is released to a paired fixpipe (`0b11`). |
| `T.copy(L0C->GM, unit_flag=0b11)` | The paired fixpipe. |

## Why

The gemm helpers work well when the operands are ready up front. They are a poor
fit when the kernel keeps its own L1 ring, or splits a contraction into chunks
that arrive at different times: the helper re-primes its own flags and fences at
every call boundary, which serialises against whatever the kernel is trying to
overlap.

With these arguments the kernel can express the same sequence directly — load
each L0 tile, issue the mma, copy the accumulated result out when the last tile
lands — and keep its own flags around it.

`real_k` / `real_n` are what make a *partial* mma addressable. Both L0 fractals
derive a stride from a dimension of the load: L0A's M-block stride from K, L0B's
K-block stride from N. Loading a full-width tile and then issuing a shorter mma
reads mismatched fractals, so the runtime extent has to be given to the load, not
just to the mma. `real_n` is the counterpart of the mma's existing `n_actual`,
the same way `real_k` is the counterpart of its runtime `K`.

`unit_flag` connects a hook that was already in the `mma` signature but whose
assignment was commented out. Paired with the fixpipe's flag it forms the
hardware `mma -> fixpipe` pipeline, so the fixpipe of one tile overlaps the mma
of the next across an L0C ping-pong, with no software `M_FIX`/`FIX_M` handshake.

## Also in this PR

**`cmatrixSource` is now set explicitly.** `MmadParams` does not
default-initialise it, and the hardware reads it whenever `cmatrixInitVal` is
false — an accumulating mma, C sourced from L0C. A single mma never notices, but
a K-accumulating sequence that also carries a `unitFlag` reads the uninitialised
field and hangs the cube. `false` ("source from L0C") is what every accumulating
caller already means.

**Scalar access on a multi-dimensional buffer emitted only the innermost
index.** A load or store like `table[b, i]` dropped the leading dimensions, so
every row aliased row 0. It stays invisible whenever the leading index happens to
be 0, which means a single-batch kernel passes while a multi-batch one silently
reads the first batch's data. `Buffer::OffsetOf` is the identity for a 1-D
buffer, so single-dimension accesses are unchanged.

**A row reduce over part of a wider row read the wrong elements.** `reduce_*`
takes a `{M, N}` shape, and `AscendC::Reduce*` walks the source as one contiguous
`M x N` block. When the logical width is only part of the row the data physically
sits in — a column-sliced region `ub[:, a:b]`, or a `real_shape` narrower than the
buffer — that walk consumes row 0's successive chunks instead of the first `N`
columns of each row. Row 0 happens to come out right, every other row does not,
and nothing reports an error.

The physical row width is only known in the front end, so it is passed down as an
optional trailing argument, emitted solely when it differs from the logical width;
every existing call is byte-identical. The ascendc codegen routes those to
`WholeReduce*`, which takes an explicit per-repeat source stride. PTO keeps its
current path — its tiles carry a strided view, so it was already correct — and
just skips the extra argument.

Guarded rather than silently narrowed: a row reduce only (`dim == -1`), a width
that fits one 256-byte repeat, and `clear == true`. Each of those is wrong today
rather than unsupported, so an explicit check is an improvement over the current
silence.

## Tests

`test_tilelang_ascend_language_kernel_driven_mma.py` — a hand-driven two-tile
K-accumulating mma with a fused fixpipe over a runtime column count. Two tiles
are required for the test to mean anything: a single tile sits at K-block offset
0 and would pass even with the offset computed wrongly.

`test_tilelang_ascend_language_scalar_index.py` — a multi-batch scalar index
round-trip, which fails on the old emission and passes on the new one.

`test_tilelang_ascend_language_narrow_reduce.py` — both spellings that reach the
narrow row reduce (a `real_shape` narrower than the buffer, and a sliced column
range at a non-zero offset), across sum/max/min and several widths. Everything
outside the reduced range is filled with a value that would dominate the result
if it were read, except on row 0, which is correct under either walk and is left
clean so it cannot mask the rows that are not.

## Notes

The changes are on the ascendc path. The pto codegen carries the same scalar
index defect, but its global-buffer accesses are addressed differently and want a
separate look, so it is not touched here.
