### PR TITLE
Optimize the add_rms_norm_dynamic_quant operator and extract performance optimization points into tilelang-perf-optimization skills

### DIFF
--- a/.agents/skills/tilelang-perf-optimization/SKILL.md
+++ b/.agents/skills/tilelang-perf-optimization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tilelang-perf-optimization
-description: TileLang 算子性能调优与潜在性能劣化模式检查。提供性能数据采集、瓶颈诊断、优化实施、效果验证能力；也用于生成或评审算子时对照常见性能劣化模式示例检查当前 kernel 代码。触发：算子精度通过后需要优化性能、性能不及预期时。
+description: TileLang 算子性能调优与潜在性能劣化模式检查。提供瓶颈预判、性能数据采集、多维度交叉优化、效果验证能力；也用于生成或评审算子时对照常见性能劣化模式示例检查当前 kernel 代码。触发：算子精度通过后需要优化性能、性能不及预期时。
 ---
 
 # TileLang 性能优化
@@ -8,15 +8,20 @@ description: TileLang 算子性能调优与潜在性能劣化模式检查。提�
 ## 工作流程
 
 ```
-Step 1: 基线采集（性能 + 精度）
+  → Step 0: 瓶颈预判（优化前必做）
+  → Step 1: 基线采集（性能 + 精度）
   → Step 2: 算子类型判断
   → Step 3: 阅读参考文档并识别优化点（输出到 optimization_log.md）
+  → Step 3.5: 多维度交叉实验矩阵（禁止单维度递增）
   → Step 4: 逐项实施优化点
+  → Step 4.5: 组合优化（将各轮最优配置合并验证）
   → Step 5: 效果验证（性能 + 精度）
 ```
 
 ## 核心约束
 
+- **瓶颈先行**：未做瓶颈预判禁止开始优化（Step 0 是门禁）
+- **交叉优先**：存在多个优化维度时，必须做交叉实验矩阵，禁止单维度递增
 - **逐项实施**：每次 Edit 只改一个优化点，改完立即验证
 - **精度优先**：精度未通过禁止性能优化
 - **性能验证**：必须使用 `msprof op`，禁止用 Python/Torch 计时
@@ -26,6 +31,7 @@ Step 1: 基线采集（性能 + 精度）
 
 - **优化指南**：[optimization-guide.md](references/optimization-guide.md)
 - **反模式清单**：[performance-antipatterns.md](references/performance-antipatterns.md)
+- **编译器限制清单**：[compiler-limitations.md](references/compiler-limitations.md)
 - **同步原语**：[api-schedule-sync.md](../tilelang-custom-skill/tilelang-api-best-practices/references/api-schedule-sync.md)（set_flag / wait_flag / barrier_all / cross_flag 语义与用法）
 - **API 用法**：[tilelang-api-best-practices](../tilelang-custom-skill/tilelang-api-best-practices/SKILL.md)
 - **编程模式**：[tilelang-expert-to-developer](../tilelang-custom-skill/tilelang-expert-to-developer/SKILL.md)
@@ -35,6 +41,52 @@ Step 1: 基线采集（性能 + 精度）
 ---
 
 ## 执行步骤
+
+### Step 0: 瓶颈预判（优化前必做，门禁）
+
+**在任何优化开始前，必须先判断瓶颈类型，否则禁止后续步骤。**
+
+#### 0.1 估算理论最小耗时
+
+```python
+# 计算理论最小 GM 带宽
+min_read_bytes = sum(input_tensor.numel() * input_tensor.element_size() for input_tensor in inputs)
+min_write_bytes = sum(output_tensor.numel() * output_tensor.element_size() for output_tensor in outputs)
+total_min_bytes = min_read_bytes + min_write_bytes
+
+# 910B3 HBM 带宽约 1.5 TB/s
+hbm_bandwidth = 1.5e12  # bytes/s
+theoretical_min_us = total_min_bytes / hbm_bandwidth * 1e6
+```
+
+#### 0.2 判断瓶颈类型
+
+| 判断条件 | 瓶颈类型 | 优化方向 |
+|---------|---------|---------|
+| `当前耗时 / 理论最优 > 3x` | **GM bandwidth-bound** | 减少 pass 数、readback、workspace |
+| `当前耗时 / 理论最优 < 2x` | **compute-bound** | 指令融合、AUTO_SYNC=False |
+| `当前耗时 < 50μs` | **launch-bound** | Fixed Core、减少 block 数、消除分发开销 |
+
+#### 0.3 输出瓶颈预判报告
+
+在 `optimization_log.md` 中记录：
+
+```
+[BOTTLENECK-PREASSESS]
+  理论最小耗时: {theoretical_min_us} μs
+  当前耗时: {current_us} μs
+  比值: {ratio}x
+  瓶颈类型: {bandwidth/compute/launch}-bound
+  推荐优化方向: {方向列表}
+  禁止优化方向: {方向列表}
+```
+
+**门禁规则**：
+- bandwidth-bound → 禁止指令融合、AUTO_SYNC=False 等 compute 层优化
+- compute-bound → 禁止减少 pass 数等 bandwidth 层优化
+- launch-bound → 禁止 Double Buffer 等 kernel 内优化
+
+---
 
 ### Step 1: 基线采集
 
@@ -67,7 +119,9 @@ print(func.get_kernel_source())
 
 ### Step 3: 识别优化点（强制，禁止与 Step 4 合并）
 
-根据算子类型阅读 `optimization-guide.md` 对应章节 + `performance-antipatterns.md`，如果是 cube 核额外参考 `best-practices/cube_optimization_path.md`，如果是 vector 核额外参考 `vector-practices/` 目录下的文档，在 `optimization_log.md` 中输出：
+根据算子类型阅读 `optimization-guide.md` 对应章节 + `performance-antipatterns.md`，如果是 cube 核额外参考 `best-practices/cube_optimization_path.md`，如果是 vector 核额外参考 `vector-practices/` 目录下的文档，如果是多 pass Vector 融合算子额外参考 `best-practices/vector_fused_operator_optimization.md`，在 `optimization_log.md` 中输出：
+
+> **优先级提醒**：多 pass 算子应首先审视算法层优化（pass 数量缩减、readback 模式、自适应 tiling），这些优化的收益通常远超核内优化。详见 `optimization-guide.md` §一.五。
 
 **Part A 优化点清单**：逐条标注适用/不适用 + 原因 + 参考文件行号。`pass_configs` 不是独立优化点，是伴随修改。
 
@@ -84,6 +138,77 @@ print(func.get_kernel_source())
 [ORDER-PLAN] 实施顺序：
 1. [#N] [名称] — 前置依赖: [无] — 理由: [...]
 2. [#M] [名称] — 前置依赖: [#N] — 理由: [...]
+```
+
+### Step 3.5: 多维度交叉实验矩阵（禁止单维度递增）
+
+**当存在多个独立优化维度时，必须做交叉实验，禁止逐轮单维度递增。**
+
+#### 3.5.1 识别独立维度
+
+常见独立维度（互不影响代码结构）：
+
+| 维度 | 典型取值 |
+|------|---------|
+| Tiling 参数 | block_M=8/16/32, block_N=128/256/512 |
+| Kernel 架构 | 单 kernel / 双 kernel / 混合 kernel |
+| 同步模式 | AUTO_SYNC=True / False |
+| Pass 数量 | 1-pass / 2-pass / 3-pass |
+
+#### 3.5.2 构建交叉矩阵
+
+选择 2 个最关键维度，构建 2×2 或 3×3 实验矩阵：
+
+```
+[CROSS-MATRIX] 维度 A: {tiling} × 维度 B: {架构}
+
+|                | 单 kernel | 双 kernel |
+|----------------|----------|----------|
+| block_M=16     | 实验 1   | 实验 2   |
+| block_M=32     | 实验 3   | 实验 4   |
+```
+
+#### 3.5.3 执行与选择
+
+1. 快速实现 4 个实验（可简化代码，不要求完整优化）
+2. 每个实验只测 3 个代表性 shape（小/中/大）
+3. 选出最优组合，作为后续精细调优的起点
+
+**门禁**：未完成交叉矩阵禁止进入 Step 4 逐项实施。
+
+#### 3.5.4 分发开销评估（双 kernel 前必做）
+
+引入双 kernel / 混合 kernel 前，必须评估分发开销：
+
+```python
+# 1. 估算分发开销
+dispatch_overhead_us = 10  # .item() host 同步约 5~15μs
+
+# 2. 估算 kernel 耗时
+kernel_us = estimated_current_us
+
+# 3. 判断占比
+overhead_ratio = dispatch_overhead_us / kernel_us
+
+# 4. 决策
+if overhead_ratio > 0.10:
+    # 分发开销 > 10%，不适合双 kernel
+    use_single_kernel = True
+elif overhead_ratio < 0.05:
+    # 分发开销 < 5%，适合双 kernel
+    use_dual_kernel = True
+else:
+    # 5~10% 灰色地带，需要混合策略
+    use_hybrid = True
+```
+
+**日志格式**：
+```
+[DISPATCH-ASSESS]
+  分发开销: {dispatch_overhead_us} μs
+  kernel 耗时: {kernel_us} μs
+  占比: {overhead_ratio}%
+  决策: {single/dual/hybrid}
 ```
 
 ### Step 4: 逐项实施
@@ -112,9 +237,47 @@ print(func.get_kernel_source())
 
 | 算子类型 | 文档 | 核心优化技术 |
 |---------|------|-------------|
-| Vector 型 | [RoPE 优化](references/best-practices/rope-developer-mode.md)、[归约遍数融合](references/vector-practices/vector_reduce_pass_fusion.md) | | NPU 内动态生成 Mask、Tile API 向量化、参数简化 |
+| Vector 型（简单） | [RoPE 优化](references/best-practices/rope-developer-mode.md)、[归约遍数融合](references/vector-practices/vector_reduce_pass_fusion.md) | NPU 内动态生成 Mask、Tile API 向量化、参数简化 |
+| Vector 型（融合） | [AddRmsNormDynamicQuant 优化](references/best-practices/vector_fused_operator_optimization.md) | Pass 缩减、Readback、混合 kernel 策略、交替 buffer |
 | Cube 型 | [GEMM Intrinsic](references/best-practices/gemm_intrinsic_optimize.md) | 多缓冲流水线、细粒度 Flag 同步、MMA intrinsic、L0 分块、负载均衡 |
 | CV 融合型 | [Flash Attention](references/best-practices/flash_attn_optimize.md) | num_stages 流水线、批量 Softmax、Cross-core Semaphore、数据布局优化；**多 shape 适配**（BSND 免转置、Sq==1 decode 窄块、加性 mask 屏蔽变长 Skv） |
+
+### Step 4.5: 组合优化（将各轮最优配置合并验证）
+
+**在所有单维度优化完成后，必须做一轮组合验证，禁止直接结束。**
+
+#### 4.5.1 汇总各轮最优配置
+
+从 `optimization_log.md` 中提取每轮的最优配置：
+
+```
+[COMBO-SUMMARY]
+  最优算法: {R1: 2-pass}
+  最优内存: {R2: Double Buffer}
+  最优 Tiling: {R3: block_M=16, block_N=adaptive}
+  最优架构: {R4: 双 kernel readback/recompute}
+  最优同步: {AUTO_SYNC=True}
+```
+
+#### 4.5.2 检查配置冲突
+
+| 冲突类型 | 示例 | 解决方案 |
+|---------|------|---------|
+| Tiling 与架构冲突 | block_M=16 在双 kernel 下退化 | 混合策略（按 shape 分发） |
+| 同步与指令冲突 | AUTO_SYNC=False 需要交替 buffer | 保持 AUTO_SYNC=True |
+| 内存与 Tiling 冲突 | block_N=512 导致 UB 溢出 | 保持 block_N=256 |
+
+#### 4.5.3 实现组合版本
+
+将所有无冲突的最优配置合并到一个版本中，完整验证精度 + 性能。
+
+**日志格式**：
+```
+[COMBO-IMPL] 组合配置: {配置列表}
+[COMBO-RESULT] 精度: {pass/fail} | 性能: {X us} | 对比最优单轮: [+/-X%]
+```
+
+**门禁**：组合版本性能低于最优单轮版本 → 分析冲突原因，回退到最优单轮版本。
 
 ### Step 5: 效果验证
 

--- a/.agents/skills/tilelang-perf-optimization/references/best-practices/vector_fused_operator_optimization.md
+++ b/.agents/skills/tilelang-perf-optimization/references/best-practices/vector_fused_operator_optimization.md
@@ -1,0 +1,543 @@
+# Vector 融合算子性能优化最佳实践
+
+本文档总结了多 pass Vector 融合算子（含归约 + 归一化 + 量化等多步操作）在 TileLang-Ascend 上的性能优化手段，以 AddRmsNormDynamicQuant（Add + RMSNorm + Dynamic Quantization）为参考案例，对比基线实现与优化版本的关键差异。
+
+> **核心发现**：算法层优化（pass 数量缩减）贡献了 47% 的总性能提升，远超任何核内优化。多 pass 算子应首先审视算法结构，而非直接进入 Double Buffer / Tiling 调优。
+
+## 目录
+
+- [优化概览](#优化概览)
+- [优化手段详解](#优化手段详解)
+  - [1. Pass 数量缩减（算法层，最高优先级）](#1-pass-数量缩减算法层最高优先级)
+  - [2. Readback 模式（避免 Pass 2 重算）](#2-readback-模式避免-pass-2-重算)
+  - [3. Tiling 参数优化（block_M + 自适应 block_N）](#3-tiling-参数优化block_m--自适应-block_n)
+  - [4. Double Buffer 三阶段流水](#4-double-buffer-三阶段流水)
+  - [5. 向量化广播](#5-向量化广播)
+  - [6. 混合 kernel 策略](#6-混合-kernel-策略)
+- [关键代码模式](#关键代码模式)
+- [常见陷阱](#常见陷阱)
+- [最佳实践建议](#最佳实践建议)
+- [适用场景](#适用场景)
+- [检查点](#检查点)
+- [参考资料](#参考资料)
+
+---
+
+## 优化概览
+
+| 优化项 | 基线实现（3-pass 串行） | 优化实现（2-pass + 混合策略） | 性能收益 |
+|--------|------------------------|-------------------------------|---------|
+| Pass 数量 | 3-pass（GM 读取 6x） | 2-pass（GM 读取 4x） | GM 读取 -33%，性能 +117% |
+| Tiling | block_M=4, block_N=128 | block_M=16/32, 自适应 block_N | UB 利用率 10%→83% |
+| 流水策略 | 串行（无 Double Buffer） | Double Buffer 三阶段流水 | MTE2/V/MTE3 重叠 |
+| 广播方式 | scalar 循环 | `T.tile.broadcast` 向量化 | 小 shape +14~27% |
+| Kernel 架构 | 单 kernel | 混合策略（小 shape 单核 / 大 shape 双核） | 解决小 shape 退化 |
+| 同步模式 | AUTO_SYNC=True | AUTO_SYNC=True + 交替 buffer | 消除 V pipe RAW hazard |
+
+### 各轮次贡献占比
+
+| 轮次 | 优化类型 | 核心变化 | 占总提升比 |
+|------|---------|---------|-----------|
+| R1 | **算法层** | 3-pass → 2-pass | **47%** |
+| R3 | **Tiling 层** | block_M=16 + 自适应 block_N | **34%** |
+| R2 | **内存带宽层** | Double Buffer + 向量化广播 | **12%** |
+| R7 | **架构层** | 混合 kernel 策略 | **6%** |
+| R5 | 指令层 | mul_add_dst 融合 | ~0% |
+| R6 | 架构层 | AUTO_SYNC=False + Fixed Core | 失败 |
+
+---
+
+## 优化手段详解
+
+### 1. Pass 数量缩减（算法层，最高优先级）
+
+多 pass 算子的 pass 数量直接决定 GM 带宽消耗。每减少一个 pass，GM 读取次数降低 33%~50%。这是收益最大的优化方向。
+
+#### 基线实现（3-pass，GM 读取 6x）
+
+```
+Pass 1: 读 x1,x2 → h=x1+x2 → 写 x_out + 累加 sum_sq
+Pass 2: 读 x1,x2 → h=x1+x2 → normed=h*inv_rms*gamma → 累加 abs_max  ← 需要 inv_rms
+Pass 3: 读 x1,x2 → h=x1+x2 → normed=h*inv_rms*gamma → 量化 → 写 output  ← 需要 scale
+```
+
+**问题**：Pass 2 需要 inv_rms（Pass 1 产出），Pass 3 需要 scale（Pass 2 产出），三个 pass 必须串行。每个 pass 都重复读 x1、x2 并重算 h = x1 + x2。
+
+#### 优化实现（2-pass，GM 读取 4x）
+
+**关键数学变换**：
+
+```
+max(|h * inv_rms * gamma|) = inv_rms * max(|h * gamma|)
+```
+
+inv_rms 是行级标量，可以提取到 max 外面。因此 Pass 1 可以预计算 `abs_max(|h*gamma|)`（不需要 inv_rms），从而消除整个 Pass 2。
+
+```
+Pass 1: 读 x1,x2 → h=x1+x2 → 写 x_out + 累加 sum_sq + 预计算 abs_max(|h*gamma|)
+Pass 间: inv_rms = rsqrt(sum_sq/H + eps); scale = abs_max * inv_rms / 127
+Pass 2: 读 x1,x2 → h=x1+x2 → normed=h*inv_rms*gamma → 量化 → 写 output
+```
+
+**Pass 1 中 abs_max 预计算的关键代码**：
+
+```python
+# Pass 1 循环体内：在累加 sum_sq 的同时预计算 abs_max(|h*gamma|)
+T.tile.add(h_fp32, x1_fp32, x2_fp32)                    # h = x1 + x2
+T.tile.mul_add_dst(sum_sq_acc, h_fp32, h_fp32)           # sum_sq += h*h
+
+# 预计算 abs_max(|h*gamma|) ← 关键：不需要 inv_rms
+T.tile.cast(gamma_fp32, gamma_ub[cur, :], "CAST_NONE", block_N)
+T.tile.broadcast(gamma_tile, gamma_fp32)
+T.tile.mul(hw_a, h_fp32, gamma_tile)                     # hw_a = h * gamma
+T.tile.abs(hw_b, hw_a)                                   # hw_b = |h * gamma|
+T.reduce_max(hw_b, tile_max, dim=-1)                     # 行内 max
+T.tile.max(abs_max, abs_max, tile_max)                   # 累加全局 max
+```
+
+**Pass 间计算**（在两个 pass 之间执行，不在循环内）：
+
+```python
+# 归约 + Newton-Raphson rsqrt
+T.reduce_sum(sum_sq_acc, sum_sq_row, dim=-1)
+T.tile.mul(sum_sq_row, sum_sq_row, inv_H)                # sum_sq / H
+T.tile.add(sum_sq_row, sum_sq_row, eps_val)              # + eps
+T.tile.rsqrt(inv_rms_ub, sum_sq_row)                     # 1/sqrt(...)
+# Newton-Raphson 精化（2 轮，见"关键代码模式"章节）
+...
+# scale = abs_max * inv_rms / 127
+T.tile.fill(min_val, 1e-12)
+T.tile.max(abs_max, abs_max, min_val)                    # 防止除零
+T.tile.mul(scale_ub, abs_max, inv_rms_ub)
+T.tile.div(scale_ub, scale_ub, 127.0)
+```
+
+**收益**：GM 读取从 6x 降至 4x（-33%），性能得分 +117%，是七轮中收益最大的一步。
+
+**通用排查方法**（适用于其他多 pass 算子）：
+1. 列出每个 pass 的输入/输出和 GM 读取次数
+2. 分析 pass 间的数据依赖：哪些 pass 必须串行？哪些可以合并？
+3. 寻找行级标量（如 inv_rms、mean、std）——这些标量可以在 pass 间计算，不需要额外 pass
+4. 检查 max/min/sum 操作的对象是否包含可提取的标量因子
+
+---
+
+### 2. Readback 模式（避免 Pass 2 重算）
+
+当 Pass 1 已经计算了中间结果 h 并写出到 GM（如 x_out），Pass 2 可以直接读回 x_out 而非重新从 x1+x2 计算 h。
+
+#### 基线实现（recompute，GM 读取 3x）
+
+```python
+# Pass 2: 重新从 x1+x2 计算 h
+T.copy(x1[row_start:row_start+ROWS, col_off:col_off+block_N], x1_ub[cur, :, :])
+T.copy(x2[row_start:row_start+ROWS, col_off:col_off+block_N], x2_ub[cur, :, :])
+T.tile.cast(x1_fp32, x1_ub[cur, :, :], "CAST_NONE", tile_elements)
+T.tile.cast(x2_fp32, x2_ub[cur, :, :], "CAST_NONE", tile_elements)
+T.tile.add(h_fp32, x1_fp32, x2_fp32)                    # 重算 h
+```
+
+#### 优化实现（readback，GM 读取 2x）
+
+```python
+# Pass 2: 直接读回 Pass 1 写出的 x_out（fp16），省去 x1+x2 两次读取
+T.copy(x_out[row_start:row_start+ROWS, col_off:col_off+block_N], xout_ub[cur, :, :])
+T.tile.cast(h_fp32, xout_ub[cur, :, :], "CAST_NONE", tile_elements)  # 从 x_out 恢复 h
+```
+
+**收益**：大 shape GM 读取从 3x 降至 2x（-33%），Case 1 (8192×8192) +14%，Case 6 (524288×128) +65%。
+
+**精度约束**：readback 引入 fp16 往返误差（fp32 → fp16 → fp32）。当 |h| ≥ 100 时 fp16 精度不足，需回退到 recompute。推荐运行时动态选择：
+
+```python
+max_val = max(x1.abs().max().item(), x2.abs().max().item())
+use_readback = max_val < 100.0  # 精度安全阈值
+```
+
+> **注意**：`.item()` host 同步约 5~15μs，对小 shape（kernel 耗时 < 50μs）分发开销占比 > 10%。需配合混合 kernel 策略（见 §6）使用。
+
+---
+
+### 3. Tiling 参数优化（block_M + 自适应 block_N）
+
+#### 3.1 block_M 递增
+
+block_M 决定每个 block 处理的行数，直接影响 UB 利用率和 block 调度开销。
+
+| block_M | ROWS (=block_M/2) | UB 利用率 | block 数 (M=8192) | 效果 |
+|---------|-------------------|----------|-------------------|------|
+| 4 | 2 | ~10% | 2048 | 基线 |
+| 8 | 4 | ~21% | 1024 | +162% |
+| 16 | 8 | ~42% | 512 | +53% |
+| 32 | 16 | ~83% | 256 | 大 shape +8~65%，小 shape -15~47% |
+
+**关键发现**：block_M=32 在大 shape 下优于 block_M=16，但在小 shape 下因 block 数过少导致并行度不足。最优值取决于 kernel 架构（单 kernel vs 双 kernel），必须做交叉实验。
+
+#### 3.2 自适应 block_N
+
+当 H 远小于默认 block_N=256 时，使用实际 H 值可消除尾块处理。
+
+#### 基线实现（固定 block_N=256）
+
+```python
+block_N = 256
+n_num = H // block_N  # H=128 → n_num=0.5，尾块问题
+# 分配 [2, 8, 256] buffer，但只用 [2, 8, 128]
+# 50% 的 UB 被浪费，50% 的计算是无效的（处理填充的 0）
+```
+
+#### 优化实现（自适应 block_N）
+
+```python
+block_N = 256
+if H < block_N and H % 16 == 0:  # 16 元素对齐要求
+    block_N = H  # H=128 → block_N=128，消除尾块
+n_num = (H + block_N - 1) // block_N  # H=128 → n_num=1，无尾块
+```
+
+**收益**：Case 6 (524288×128) 2.06x 加速，Case 19 (1024×128) 2.02x 加速。消除尾块后有效计算比例从 50% → 100%。
+
+---
+
+### 4. Double Buffer 三阶段流水
+
+将每个 Pass 内的 H 维度循环改造为 prefetch → main body → epilogue 结构，MTE2/V/MTE3 三条流水线并行重叠。
+
+#### 基线实现（串行）
+
+```python
+for by in T.serial(0, n_num):
+    T.copy(x1[...], x1_ub)       # MTE2
+    T.copy(x2[...], x2_ub)       # MTE2
+    h_fp32 = x1_fp32 + x2_fp32   # V pipe
+    # ... 计算 ...
+    T.copy(out_ub, x_out[...])    # MTE3
+```
+
+```
+时间线:
+Block0: [MTE2][V][MTE3]
+Block1:                  [MTE2][V][MTE3]
+Block2:                                     [MTE2][V][MTE3]
+```
+
+#### 优化实现（Double Buffer 三阶段）
+
+```python
+stages = 2
+x1_ub = T.alloc_ub([stages, ROWS, block_N], dtype)  # 双份
+x2_ub = T.alloc_ub([stages, ROWS, block_N], dtype)  # 双份
+gamma_ub = T.alloc_ub([stages, block_N], dtype)     # 双份
+
+# Prefetch: 加载第 0 个 tile
+T.wait_flag("mte3", "mte2", 0)
+T.copy(x1[..., 0:block_N], x1_ub[0, :, :])
+T.copy(x2[..., 0:block_N], x2_ub[0, :, :])
+T.copy(gamma[0:block_N], gamma_ub[0, :])
+T.set_flag("mte2", "v", 0)
+
+# Main body: 流水执行
+for by in T.serial(0, n_num - 1):
+    cur = by % stages
+    nxt = (by + 1) % stages
+
+    # MTE2: 预取下一个 tile（与 V pipe 并行）
+    T.wait_flag("mte3", "mte2", nxt)
+    T.copy(x1[..., col_off_nxt:col_off_nxt+block_N], x1_ub[nxt, :, :])
+    T.copy(x2[..., col_off_nxt:col_off_nxt+block_N], x2_ub[nxt, :, :])
+    T.copy(gamma[col_off_nxt:col_off_nxt+block_N], gamma_ub[nxt, :])
+    T.set_flag("mte2", "v", nxt)
+
+    # V pipe: 计算当前 tile（与 MTE2/MTE3 并行）
+    T.wait_flag("mte2", "v", cur)
+    # ... 计算 ...
+    T.set_flag("v", "mte3", cur)
+
+    # MTE3: 写回当前 tile（与 V pipe 并行）
+    T.wait_flag("v", "mte3", cur)
+    T.copy(out_dtype_ub, x_out[..., col_off_cur:col_off_cur+block_N])
+    T.set_flag("mte3", "mte2", cur)
+
+# Epilogue: 处理最后一个 tile
+last = (n_num - 1) % stages
+T.wait_flag("mte2", "v", last)
+# ... 计算 ...
+T.set_flag("v", "mte3", last)
+T.wait_flag("v", "mte3", last)
+T.copy(out_dtype_ub, x_out[..., col_off_last:col_off_last+block_N])
+T.set_flag("mte3", "mte2", last)
+```
+
+```
+时间线:
+Prefetch: [MTE2→s0]
+Main[0]:    [MTE2→s1] [V→s0] [MTE3→s0]
+Main[1]:      [MTE2→s0] [V→s1] [MTE3→s1]
+Epilogue:                 [V→last] [MTE3→last]
+```
+
+**收益**：MTE2/V/MTE3 三条流水线并行重叠，小 shape +14~27%。
+
+> **同步模式**：使用 `AUTO_SYNC=True` + 手动 `set_flag`/`wait_flag`。`AUTO_SYNC=False` 存在 V pipe 队列排空问题（详见 [compiler-limitations.md](../compiler-limitations.md) §1）。
+
+---
+
+### 5. 向量化广播
+
+#### 基线实现（scalar 循环）
+
+```python
+# gamma 在 V pipe 中间加载（MTE2 操作混入 V pipe）
+T.copy(gamma[...], gamma_ub)
+
+# scalar 循环广播
+for i in range(ROWS):
+    for j in range(block_N):
+        gamma_tile[i, j] = gamma_fp32[j]
+```
+
+#### 优化实现（tile 指令 + prefetch 阶段加载）
+
+```python
+# gamma 在 prefetch 阶段与 x1/x2 一起加载（MTE2 操作集中）
+T.copy(gamma[col_off:col_off+block_N], gamma_ub[cur, :])
+
+# 向量化广播（1 条指令替代 ROWS×block_N 次 scalar）
+T.tile.cast(gamma_fp32, gamma_ub[cur, :], "CAST_NONE", block_N)
+T.tile.broadcast(gamma_tile, gamma_fp32)
+```
+
+**收益**：gamma 的 DMA 传输与 x1/x2 合并为一批；1 条 tile 指令替代 1024 次 scalar 操作（ROWS=4, block_N=256）。
+
+---
+
+### 6. 混合 kernel 策略
+
+当不同 shape 范围的最优配置矛盾时（如 block_M=16 小 shape 优、block_M=32 大 shape 优），按维度动态分发到不同 kernel。
+
+#### 基线实现（单一 kernel）
+
+```python
+# 所有 shape 使用同一 kernel（block_M=32 + 双 kernel）
+kernel = _kernel_readback(M, H, block_M=32, ...)
+# 小 shape (M=256): 8.9μs ← 分发开销占比 > 10%
+```
+
+#### 优化实现（按 M 维度分发）
+
+```python
+HYBRID_THRESHOLD = 1024
+
+def _get_kernel(M, H, tl_dtype, eps, use_readback):
+    if M < HYBRID_THRESHOLD:
+        # 小 shape: 单 kernel (block_M=16, 无分发开销)
+        block_M, block_N = _get_tiling_small(M, H)  # block_M=16
+        return _kernel_single(M, H, block_M, block_N, eps, dtype=tl_dtype)
+    else:
+        # 大 shape: 双 kernel (block_M=32, readback/recompute)
+        block_M, block_N = _get_tiling_large(M, H)  # block_M=32
+        if use_readback:
+            return _kernel_readback(M, H, block_M, block_N, eps, dtype=tl_dtype)
+        else:
+            return _kernel_recompute(M, H, block_M, block_N, eps, dtype=tl_dtype)
+```
+
+**分发开销评估**（引入双 kernel 前必做）：
+
+```python
+dispatch_overhead_us = 10  # .item() host 同步约 5~15μs
+kernel_us = estimated_current_us
+overhead_ratio = dispatch_overhead_us / kernel_us
+
+if overhead_ratio > 0.10:
+    use_single_kernel = True   # 分发开销 > 10%，不适合双 kernel
+elif overhead_ratio < 0.05:
+    use_dual_kernel = True     # 分发开销 < 5%，适合双 kernel
+else:
+    use_hybrid = True          # 5~10% 灰色地带，需要混合策略
+```
+
+**收益**：小 shape +15~46%（Case 17: 8.9μs → 4.8μs），大 shape 保持不变。
+
+---
+
+## 关键代码模式
+
+### Newton-Raphson rsqrt 精化
+
+硬件 `rsqrt` 精度有限，通过 2 轮 Newton-Raphson 迭代提升精度（`x = x * (1.5 - 0.5 * a * x²)`）：
+
+```python
+T.tile.rsqrt(inv_rms_ub, sum_sq_row)
+# 第 1 轮迭代
+T.tile.mul(nr_temp, inv_rms_ub, inv_rms_ub)
+T.tile.mul(nr_temp, nr_temp, sum_sq_row)
+T.tile.mul(nr_temp, nr_temp, -0.5)
+T.tile.add(nr_temp, nr_temp, 1.5)
+T.tile.mul(inv_rms_ub, inv_rms_ub, nr_temp)
+# 第 2 轮迭代（同上）
+T.tile.mul(nr_temp, inv_rms_ub, inv_rms_ub)
+T.tile.mul(nr_temp, nr_temp, sum_sq_row)
+T.tile.mul(nr_temp, nr_temp, -0.5)
+T.tile.add(nr_temp, nr_temp, 1.5)
+T.tile.mul(inv_rms_ub, inv_rms_ub, nr_temp)
+T.tile.broadcast(inv_rms_tile, inv_rms_ub)
+```
+
+### 交替 buffer 消除 V pipe RAW hazard
+
+`AUTO_SYNC=True` 下连续 tile 指令存在 RAW 依赖时（dst → src），使用两个独立 buffer 交替：
+
+```python
+hw_a = T.alloc_ub([ROWS, block_N], "float32")
+hw_b = T.alloc_ub([ROWS, block_N], "float32")
+
+# Pass 1: abs_max 计算链
+T.tile.mul(hw_a, h_fp32, gamma_tile)   # hw_a = h * gamma
+T.tile.abs(hw_b, hw_a)                 # hw_b = |hw_a|（避免 hw_a → hw_a RAW）
+
+# Pass 2: 量化链（更长的交替链）
+T.tile.mul(hw_a, h_fp32, inv_rms_tile)
+T.tile.mul(hw_b, hw_a, gamma_tile)
+T.tile.div(hw_a, hw_b, scale_tile)
+T.tile.round(hw_b, hw_a, tile_elements)
+T.tile.clamp(hw_a, hw_b, -128.0, 127.0, tile_elements)
+```
+
+> **UB 开销**：额外 1 个 `[ROWS, block_N]` fp32 buffer（ROWS=8, block_N=256 → 8KB），通常可接受。
+> 详细说明见 [optimization-guide.md](../optimization-guide.md) §2.2.2。
+
+---
+
+## 常见陷阱
+
+### 陷阱 1：在 bandwidth-bound 算子上尝试指令融合
+
+```python
+# 错误：算子当前耗时 1558μs / 理论最优 299μs = 5.2x > 3x → bandwidth-bound
+# 在 bandwidth-bound 上做 mul_add_dst 融合 → 性能变化在噪声范围内（±1%）
+
+# 正确：先做瓶颈预判（Step 0），bandwidth-bound 禁止指令融合
+# 优先优化 GM 带宽（减少 pass 数、readback）
+```
+
+### 陷阱 2：AUTO_SYNC=False 导致精度失败
+
+```python
+# 错误：AUTO_SYNC=False → barrier_all() 无法排空 V pipe 指令队列
+# 当 n_num > 1 时，后续 scalar 操作（reduce_sum、rsqrt）读到旧值
+# 结果：17/20 精度失败
+
+# 正确：保持 AUTO_SYNC=True，使用交替 buffer（hw_a/hw_b）消除 RAW 依赖
+```
+
+### 陷阱 3：Fixed Core 在 m_num < CORE_NUM 时编译失败
+
+```python
+# 错误：m_num=8 < 24 cores → TVM StmtSimplifier InternalError
+# 空循环 range 约束冲突
+
+# 正确：使用标准 m_num launch，不做 Fixed Core
+```
+
+### 陷阱 4：单维度递增搜索 block_M（未做交叉实验）
+
+```python
+# 错误：逐轮递增 block_M (4→8→16→32)，未与 kernel 架构做交叉实验
+# 结果：block_M=16 在双 kernel 下退化 15~28%（R5a 失败）
+
+# 正确：构建 2×2 交叉矩阵（block_M × kernel 架构），一轮实验覆盖所有组合
+# 发现：单 kernel + block_M=16 和 双 kernel + block_M=32 的组合最优
+```
+
+### 陷阱 5：双 kernel 未评估分发开销
+
+```python
+# 错误：引入双 kernel（readback/recompute）但未评估 .item() 分发开销
+# 小 shape (M=256, kernel 4.7μs)：分发开销 10μs 占比 > 100% → 退化 -89%
+
+# 正确：引入双 kernel 前评估分发开销占比
+# overhead_ratio = 10μs / kernel_us > 10% → 使用混合策略
+```
+
+---
+
+## 最佳实践建议
+
+### ✅ 推荐做法
+
+1. **多 pass 算子首先审视 pass 数量**
+   - 列出每个 pass 的 GM 读取次数，寻找可合并的 pass
+   - 寻找行级标量（inv_rms、mean、std），提取到 pass 间计算
+   - 检查 max/min/sum 操作是否包含可提取的标量因子
+
+2. **优化前先做瓶颈预判**
+   - 计算理论最小耗时（基于 GM 带宽），判断 bandwidth/compute/launch-bound
+   - bandwidth-bound → 减少 pass 数、readback；禁止指令融合
+   - compute-bound → 指令融合、流水优化
+
+3. **使用 Double Buffer + 交替 buffer**
+   - `AUTO_SYNC=True` + 手动 `set_flag`/`wait_flag` 控制三路流水
+   - 连续 tile 指令的 dst/src 使用 hw_a/hw_b 交替，消除 RAW hazard
+
+4. **存在多个优化维度时做交叉实验**
+   - 构建 2×2 矩阵（如 block_M × kernel 架构），快速验证所有组合
+   - 避免单维度递增搜索导致的紧耦合问题
+
+5. **引入双 kernel 前评估分发开销**
+   - `.item()` host 同步约 5~15μs
+   - 分发开销占比 > 10% → 使用混合策略（按 shape 分发）
+
+### ❌ 避免做法
+
+1. **避免在 bandwidth-bound 算子上尝试 compute-bound 优化**
+   - 指令融合（mul_add_dst）、AUTO_SYNC=False 等在 bandwidth-bound 上无收益
+
+2. **避免 AUTO_SYNC=False（当前编译器）**
+   - V pipe 指令队列排空问题未解决，保持 AUTO_SYNC=True
+
+3. **避免 Fixed Core（m_num < CORE_NUM 时）**
+   - TVM StmtSimplifier bug，使用标准 m_num launch
+
+4. **避免跳过交叉实验直接单维度递增**
+   - Tiling 参数与 kernel 架构紧耦合，必须做交叉验证
+
+---
+
+## 适用场景
+
+本优化方案适用于以下算子：
+
+- ✅ 多 pass Vector 融合算子（含归约 + 归一化 + 量化/激活等多步操作）
+- ✅ 需要多次遍历 GM 数据的算子（pass 数量 > 1）
+- ✅ 包含行级标量计算的算子（如 RMSNorm 的 inv_rms、LayerNorm 的 mean/std）
+- ✅ 多 shape 范围性能差异大的算子（需要混合策略）
+- ✅ bandwidth-bound 的 Vector 算子（当前耗时 / 理论最优 > 3x）
+
+**核心思想**：算法层优化（pass 缩减）> Tiling 优化 > 内存带宽优化 > 架构层优化。先减少 GM 读取次数，再优化每次读取的效率。
+
+---
+
+## 检查点
+
+- [ ] 瓶颈预判完成？（bandwidth/compute/launch-bound）
+- [ ] pass 数量是否已最小化？（行级标量是否提取到 pass 间？）
+- [ ] Double Buffer 三阶段流水是否实现？（prefetch/main/epilogue）
+- [ ] 交替 buffer（hw_a/hw_b）是否用于连续 tile 指令链？
+- [ ] block_M 是否通过交叉实验确定？（与 kernel 架构做 2×2 矩阵）
+- [ ] 自适应 block_N 是否处理？（H < 256 且 H % 16 == 0 时 block_N = H）
+- [ ] 双 kernel 分发开销是否评估？（`.item()` 占比 < 10%？）
+- [ ] 混合策略是否实现？（小 shape 单核 / 大 shape 双核）
+- [ ] 生成的 Ascend C 中能看到 `MTE3_MTE2`、`MTE2_V`、`V_MTE3` 三类事件？
+- [ ] AUTO_SYNC=True 保持？（当前编译器限制）
+
+---
+
+## 参考资料
+
+- **完整代码**：`examples/add_rms_norm_dynamic_quant/example_add_rms_norm_dynamic_quant.py`
+- **优化日志**：`.agents/skills/tilelang-op-test-design/cann-bench/add_rms_norm_dynamic_quant/optimization_log.md`
+- **详细分析**：`.agents/skills/tilelang-op-test-design/cann-bench/add_rms_norm_dynamic_quant/All_profiling.md`
+- **Double Buffer 流水模板**：[vector_add_pipeline.md](vector_add_pipeline.md)
+- **编译器限制**：[compiler-limitations.md](../compiler-limitations.md)
+- **优化指南**：[optimization-guide.md](../optimization-guide.md)（§一.五 算法层优化、§2.2.2 交替 buffer）

--- a/.agents/skills/tilelang-perf-optimization/references/compiler-limitations.md
+++ b/.agents/skills/tilelang-perf-optimization/references/compiler-limitations.md
@@ -1,0 +1,122 @@
+# TileLang 编译器已知限制清单
+
+> **用途**：在优化前快速检查计划使用的特性是否受编译器支持，避免无效尝试。
+> 
+> **更新频率**：每次遇到编译器限制时追加记录，标注发现日期和算子名称。
+
+---
+
+## 使用方式
+
+1. 在 Step 0（瓶颈预判）或 Step 3（识别优化点）时，对照本清单检查计划使用的优化特性
+2. 如果计划使用的特性在"已知限制"表中，直接跳过或选择替代方案
+3. 如果遇到新的编译器限制，追加到本文件末尾
+
+---
+
+## 已知限制
+
+### 1. AUTO_SYNC=False + V pipe 指令队列排空
+
+| 项目 | 内容 |
+|------|------|
+| **特性** | `TL_ASCEND_AUTO_SYNC: False` |
+| **限制** | `barrier_all()` 无法排空 V pipe 异步指令队列。当 `n_num > 1`（H 维度循环次数 > 1）时，V pipe 队列中残留未完成的指令，后续 scalar 操作（reduce_sum、rsqrt 等）读取到旧值，导致精度失败 |
+| **触发条件** | Pass 1 的 V pipe 循环结束后，立即执行 reduce_sum/rsqrt 等 scalar 操作 |
+| **表现** | 精度错误量级与 n_num 正相关（n_num=1 通过，n_num=32 误差 3.9，n_num=16 误差 3936） |
+| **发现日期** | 2026-07-17 |
+| **发现算子** | AddRmsNormDynamicQuant (R6) |
+| **替代方案** | 保持 `AUTO_SYNC=True`，使用交替 buffer（hw_a/hw_b）消除 RAW 依赖，为未来编译器支持做准备 |
+| **参考** | optimization-guide.md §2.2.0 同步模式决策表 |
+
+### 2. Fixed Core 模式 + 空循环 range 约束
+
+| 项目 | 内容 |
+|------|------|
+| **特性** | Fixed Core（按物理核数 launch，内层循环处理多个 block） |
+| **限制** | 当 `m_num < CORE_NUM` 时，部分 core 的循环范围为空（如 `T.serial(16, 17)` 但 `if block_idx < 16` 永远为 False），TVM `StmtSimplifier` 无法处理 `block_idx` 的 range 约束冲突，报 `InternalError: Trying to update var with a different maximum value` |
+| **触发条件** | `m_num < CORE_NUM`（如 M=256, block_M=32 → m_num=8 < 24 cores） |
+| **表现** | JIT 编译阶段 InternalError，无法生成 kernel |
+| **发现日期** | 2026-07-17 |
+| **发现算子** | AddRmsNormDynamicQuant (R6) |
+| **尝试的修复** | 将 `single_core_load` 作为 kernel 参数传入 → 仍失败；使用 `T.min(m_num, CORE_NUM)` 动态 launch → 仍失败 |
+| **替代方案** | 使用标准 `m_num` launch，不做 Fixed Core |
+| **参考** | optimization-guide.md §2.9 Fixed Core 模式 |
+
+### 3. mul_add_dst 在 bandwidth-bound 算子上的收益
+
+| 项目 | 内容 |
+|------|------|
+| **特性** | `T.tile.mul_add_dst(dst, src0, src1)` 融合乘加指令 |
+| **限制** | 在 GM bandwidth-bound 算子上无性能收益（±1% 噪声范围）。瓶颈在 GM 带宽而非 V pipe 指令数时，减少 1 条 V pipe 指令不影响总耗时 |
+| **触发条件** | 算子当前耗时 / 理论最优 > 3x（bandwidth-bound） |
+| **表现** | 性能变化在测量噪声范围内，无统计显著差异 |
+| **发现日期** | 2026-07-15 |
+| **发现算子** | AddRmsNormDynamicQuant (R5) |
+| **替代方案** | 优先优化 GM 带宽（减少 pass 数、readback），指令融合留到 compute-bound 场景 |
+| **参考** | performance-antipatterns.md §基础指令拼接未融合 |
+
+### 4. 双 kernel 分发开销对小 shape 的影响
+
+| 项目 | 内容 |
+|------|------|
+| **特性** | 双 kernel / 混合 kernel（Python wrapper 按条件分发到不同 kernel） |
+| **限制** | `.item()` host 同步开销约 5~15μs（NPU→CPU 数据传输），当 kernel 耗时 < 50μs 时，分发开销占比 > 10%，导致小 shape 性能退化 |
+| **触发条件** | kernel 耗时 < 50μs（通常 M < 1024 且 H < 1024） |
+| **表现** | 小 shape 用例退化 15~47%（Case 17: 4.7μs → 8.9μs） |
+| **发现日期** | 2026-07-15 |
+| **发现算子** | AddRmsNormDynamicQuant (R4) |
+| **替代方案** | 混合策略：小 shape 用单 kernel，大 shape 用双 kernel |
+| **参考** | SKILL.md Step 3.5.4 分发开销评估 |
+
+### 5. AUTO_SYNC=True 下连续 tile 指令的 V pipe RAW hazard
+
+| 项目 | 内容 |
+|------|------|
+| **特性** | `AUTO_SYNC=True` 下连续 tile 指令的 dst→src 链（如 `mul(hw, h, gamma)` → `abs(hw, hw)`） |
+| **限制** | `AUTO_SYNC=True` 时编译器自动插入 `PipeBarrier<PIPE_V>`，V pipe 串行化，大多数 in-place 操作安全。但特定连续 tile 指令链中，后一条指令的 src 是前一条的 dst 时，V pipe 流水线可能读到旧值 |
+| **触发条件** | 连续 tile 指令形成 RAW 依赖链，且中间 buffer 被复用 |
+| **表现** | 计算结果不确定，精度测试偶发失败 |
+| **发现日期** | 2026-07-17 |
+| **发现算子** | AddRmsNormDynamicQuant (R6) |
+| **替代方案** | 使用交替 buffer（hw_a/hw_b），让连续 tile 指令的 dst 和 src 使用不同 buffer。详见 optimization-guide.md §2.2.2 |
+| **参考** | optimization-guide.md §2.2.2 交替 buffer 消除 V pipe RAW hazard |
+
+---
+
+## 安全特性清单（已验证可用）
+
+以下特性在 AddRmsNormDynamicQuant 优化中已验证可用，无编译器限制：
+
+| 特性 | 验证轮次 | 备注 |
+|------|---------|------|
+| `TL_ASCEND_AUTO_SYNC: True` | R0-R7 | 所有轮次均使用 |
+| `TL_ASCEND_MEMORY_PLANNING: True` | R0-R7 | 自动复用已死亡 buffer |
+| Double Buffer（三阶段流水） | R2-R7 | prefetch → main → epilogue |
+| 交替 buffer（hw_a/hw_b） | R6-R7 | 消除 V pipe RAW 依赖 |
+| `T.tile.broadcast` | R2-R7 | 向量化广播替代 scalar 循环 |
+| `T.tile.mul_add_dst` | R5-R7 | 代码质量提升，性能中性 |
+| 自适应 block_N（H<256→H） | R3-R7 | 消除尾块处理 |
+| 混合 kernel 分发 | R7 | 按 M 维度动态选择 kernel |
+
+---
+
+## 追加记录模板
+
+遇到新的编译器限制时，按以下格式追加：
+
+```markdown
+### N. {特性名称}
+
+| 项目 | 内容 |
+|------|------|
+| **特性** | {特性描述} |
+| **限制** | {限制描述} |
+| **触发条件** | {触发条件} |
+| **表现** | {错误表现} |
+| **发现日期** | {YYYY-MM-DD} |
+| **发现算子** | {算子名称} ({轮次}) |
+| **尝试的修复** | {尝试过的修复方案} |
+| **替代方案** | {替代方案} |
+| **参考** | {相关文档} |
+```

--- a/.agents/skills/tilelang-perf-optimization/references/optimization-guide.md
+++ b/.agents/skills/tilelang-perf-optimization/references/optimization-guide.md
@@ -3,7 +3,13 @@
 ## 目录
 
 - [一、优化优先级与算子类型对应](#一优化优先级与算子类型对应)
+- [一.五、算法层优化（最高优先级，先于核内优化）](#一五算法层优化最高优先级先于核内优化)
+  - [1.1 Pass 数量缩减](#11-pass-数量缩减)
+  - [1.2 Readback 模式（避免 Pass 2 重算）](#12-readback-模式避免-pass-2-重算)
+  - [1.3 自适应 Tiling 参数](#13-自适应-tiling-参数)
 - [二、核内优化](#二核内优化)
+  - [2.2.0 同步模式决策表](#220-同步模式决策表double-buffer-实施前必须先判断)
+  - [2.2.2 交替 buffer 消除 V pipe RAW hazard](#222-交替-buffer-消除-v-pipe-raw-hazardauto_synctrue-下)
   - [2.11 UB 预算优化（Vector 核 tile size 首选方法）](#211-ub-预算优化vector-核-tile-size-首选方法)
   - [2.12 Host 侧预处理内化（消除 pad / contiguous）](#212-host-侧预处理内化消除-pad--contiguous)
   - [2.13 多行 Tile 粒度扩展（Multi-row Tile Granularity）](#213-多行-tile-粒度扩展multi-row-tile-granularity)
@@ -26,7 +32,7 @@
 | 算子类型 | 判断依据 | 优化范围 |
 |---------|---------|---------|
 | **Cube 型** | 代码含 `IS_ASCEND_AIC` | Cube 核内优化 + Fixed Core |
-| **Vector 型** | 代码含 `IS_ASCEND_AIV` | Vector 核内优化 + Fixed Core |
+| **Vector 型** | 代码含 `IS_ASCEND_AIV` | **算法层优化**（§一.五）→ Vector 核内优化 + Fixed Core |
 | **CV 融合型** | 代码两者均有 | 先核内优化（Cube + Vector）→ 再核间优化 + Fixed Core |
 
 > **Fixed Core 模式**适用于所有算子类型（核内/核间均可使能），见 2.9 节。
@@ -34,9 +40,76 @@
 优先使用 Developer 特性（自动同步、自动内存规划），按以下顺序尝试优化：
 
 ```
-核内优化 → 核间优化
+算法层优化（多 pass 算子）→ 核内优化 → 核间优化
 ```
 > `pass_configs`（`AUTO_SYNC`、`MEMORY_PLANNING` 等）是其他优化的**伴随修改**，不是独立步骤。需要改动时在对应优化点内部一并处理（如 Double Buffer 时同步设 `AUTO_SYNC=False`）。
+
+---
+
+## 一.五、算法层优化（最高优先级，先于核内优化）
+
+> **核心发现**：AddRmsNormDynamicQuant 七轮优化中，算法层优化贡献了 47% 的总性能提升（R1: 3-pass → 2-pass），远超任何核内优化。多 pass 算子应首先审视算法结构。
+
+### 1.1 Pass 数量缩减
+
+多 pass 算子（需要多次遍历 GM 数据）的 pass 数量直接决定 GM 带宽消耗。每减少一个 pass，GM 读取次数降低 33%~50%。
+
+**排查方法**：
+1. 列出每个 pass 的输入/输出和 GM 读取次数
+2. 分析 pass 间的数据依赖：哪些 pass 必须串行？哪些可以合并？
+3. 寻找行级标量（如 inv_rms、mean、std）——这些标量可以在 pass 间计算，不需要额外 pass
+
+**典型模式**：
+
+```
+3-pass → 2-pass（提取行级标量到 pass 间计算）：
+
+原始 3-pass:
+  Pass 1: 读 x → 写 x_out + 累加 sum_sq
+  Pass 2: 读 x → 计算 normed → 累加 abs_max     ← 需要 inv_rms，必须等 Pass 1
+  Pass 3: 读 x → 计算 normed → 量化 → 写 output  ← 需要 scale，必须等 Pass 2
+
+优化后 2-pass:
+  Pass 1: 读 x → 写 x_out + 累加 sum_sq + 预计算 abs_max(|h*gamma|)
+  Pass 间: inv_rms = rsqrt(sum_sq/H + eps); scale = abs_max * inv_rms / 127
+  Pass 2: 读 x → 计算 normed = h * inv_rms * gamma → 量化 → 写 output
+```
+
+**关键数学变换**：当 max 操作的对象包含行级标量因子时，标量可以提取到 max 外面：
+
+```
+max(|h * inv_rms * gamma|) = inv_rms * max(|h * gamma|)
+```
+
+这使得 Pass 1 可以预计算 `abs_max(|h*gamma|)`（不需要 inv_rms），从而消除 Pass 2。
+
+### 1.2 Readback 模式（避免 Pass 2 重算）
+
+当 Pass 1 已经计算了中间结果 h 并写出到 GM（如 x_out），Pass 2 可以直接读回 x_out 而非重新从 x1+x2 计算 h，减少 GM 读取次数。
+
+**适用条件**：
+- Pass 1 已写出中间结果到 GM
+- 中间结果的 dtype 与计算 dtype 不同（如 fp16 → fp32），readback 引入的精度损失可接受
+- GM 读取从 3x（x1 + x2 + gamma）降至 2x（x_out + gamma）
+
+**精度注意**：readback 引入 dtype 往返误差（如 fp32 → fp16 → fp32）。当输入值域较大（如 |h| ≥ 100 时 fp16 精度不足），应回退到 recompute 模式。推荐做法：运行时检测输入值域，动态选择 readback / recompute kernel。
+
+```python
+max_val = max(x1.abs().max().item(), x2.abs().max().item())
+use_readback = max_val < 100.0  # 精度安全阈值
+```
+
+### 1.3 自适应 Tiling 参数
+
+当某个维度远小于默认 block size 时，使用实际维度作为 block size 可消除尾块处理，提升有效计算比例。
+
+```python
+block_N = 256
+if H < block_N and H % 16 == 0:  # 16 元素对齐要求
+    block_N = H  # 消除尾块，有效计算比例从 50% → 100%
+```
+
+**收益**：H=128 时（block_N=256 → 50% 无效计算），自适应后 2x 加速。
 
 ---
 
@@ -96,20 +169,24 @@ for k in T.serial(loop_k):
 
 | 算子类型 | 判断条件 | AUTO_SYNC | 需要同步的 flag 对 |
 |---------|---------|-----------|------------------|
-| **纯 AIV Vector 算子** | MSProf 报告 aicore compute < 20%，无 MMA/Conv | **False** | `mte3→mte2`、`mte2→v`、`v→mte3` |
+| **纯 AIV Vector 算子** | MSProf 报告 aicore compute < 20%，无 MMA/Conv | **True**（当前编译器推荐） | `mte3→mte2`、`mte2→v`、`v→mte3`（手动 flag + AUTO_SYNC=True 共存） |
 | **纯 AIC Cube 算子（`T.gemm_v0`）** | 使用 `T.gemm_v0`（C++ 模板内部已处理双 buffer 流水同步） | **True** 即可 | 模板内部处理，无需手动 flag |
 | **纯 AIC Cube 算子（`T.mma`）** | 使用 `T.mma` 原语 | **False** | MTE1/M/Cube 层 flag，需手动控制 |
 | **CV 融合算子** | 同时有 AIC+AIV（`KERNEL_TYPE_MIX`） | **False** | `mte3→mte2`、`mte2→v`、`v→mte3`（AIV 侧）+ cross flag（核间） |
 | **任何需要 MTE2↔MTE1 overlap 的场景** | 需要 MTE2 与 MTE1 搬运重叠 | **False** | 手动控制 MTE1/MTE2 flag |
 
-> **铁律**：`AUTO_SYNC=True` 时编译器会在每个 stage 之间自动插入冗余同步，破坏流水线并行重叠。以下场景 **必须从 `AUTO_SYNC=False` 开始**：
-> - **纯 AIV Vector 算子**：使 MTE2/V/MTE3 三条流水线无法并行重叠，双缓冲形同虚设
-> - **使用 `T.mma` 的 Cube 算子**：与 AIV 侧同理，冗余同步破坏 L0 层流水
-> - **需要 MTE2 与 MTE1 overlap 的场景**：无论 `T.gemm_v0` 还是 `T.mma`，均需关闭自动同步
+> **⚠️ 编译器限制（2026-07 验证）**：`AUTO_SYNC=False` 在纯 AIV Vector 算子上存在 V pipe 指令队列排空问题——`barrier_all()` 无法排空 V pipe 异步队列，当 `n_num > 1` 时后续 scalar 操作（reduce_sum、rsqrt 等）读到旧值导致精度失败。详见 [compiler-limitations.md](compiler-limitations.md) §1。
 >
-> 唯一例外：使用 `T.gemm_v0` 且不需要 MTE2↔MTE1 overlap 时，可保持 `AUTO_SYNC=True`（模板内部已处理 L1 内部流水同步）。
+> **当前推荐做法**（纯 AIV Vector 算子）：
+> - 保持 `AUTO_SYNC=True`，手动写 `set_flag`/`wait_flag` 控制 MTE2/V/MTE3 三路流水
+> - 编译器在 `AUTO_SYNC=True` 下会自动插入 `PipeBarrier<PIPE_V>`，V pipe 串行化，连续 tile 指令可安全 in-place 复用 buffer
+> - 若连续 tile 指令存在 RAW 依赖（如 `mul(hw, h, gamma)` → `abs(hw, hw)`），使用**交替 buffer**（hw_a/hw_b）消除 hazard（见 §2.2.2）
 >
-> **自检**：实施 Double Buffer 后性能无明显提升（相对基线 < 10%），第一时间检查 `AUTO_SYNC` 是否为 True。
+> **Cube 算子说明**：
+> - `AUTO_SYNC=True` 时编译器会在每个 stage 之间自动插入同步。对于 `T.gemm_v0`，模板内部已处理 L1 层流水，不受影响
+> - 对于 `T.mma` 或需要 MTE2↔MTE1 overlap 的场景，仍需 `AUTO_SYNC=False`
+>
+> **自检**：实施 Double Buffer 后性能无明显提升（相对基线 < 10%），检查同步模式是否正确、flag 时序是否完整。
 
 **原理**：
 ```
@@ -183,6 +260,8 @@ for k in T.serial(loop_k):
 
 **Vector 核示例**：
 
+> **当前编译器推荐**：Vector 核使用 `AUTO_SYNC=True` + 手动 `set_flag`/`wait_flag` 控制三路流水。`AUTO_SYNC=False` 存在 V pipe 队列排空问题（详见 [compiler-limitations.md](compiler-limitations.md) §1），仅当编译器修复此问题后才可切换到 False。
+
 **优化前**（串行执行）：
 ```python
 for k in T.serial(loop_k):
@@ -191,10 +270,10 @@ for k in T.serial(loop_k):
     T.copy(result_buf, GM_out[k])
 ```
 
-**优化后**（手写 Ping-Pong 双缓冲 + 手动三路 flag，AUTO_SYNC=False）：
+**优化后**（手写 Ping-Pong 双缓冲 + 手动三路 flag，AUTO_SYNC=True）：
 ```python
 pass_configs = {
-    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False,  # Vector 核必须 False
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,  # 当前编译器推荐 True
     tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
 }
 
@@ -276,6 +355,43 @@ T.wait_flag("mte3", "mte2", 1)
 > **常见错误**：把 V pipe 的中间计算 buffer（如 `data_cal`、`tmp`）也分配为 `[2, ...]` 双缓冲。这会浪费 `cpg × block_S × dtype_bytes` 的 UB 空间，在 cpg 较大时（如 GroupNorm cpg=257）直接导致 UB 溢出（`Memory allocation failed`），且不带来任何性能收益。
 >
 > **自检方法**：每个 `[2, ...]` buffer 必须能找到对应的 `T.copy(GM_buf, ...)` 或 `T.copy(..., GM_buf)` 语句。找不到 → 该 buffer 改为单份。
+
+#### 2.2.2 交替 buffer 消除 V pipe RAW hazard（AUTO_SYNC=True 下）
+
+**适用场景**：`AUTO_SYNC=True` 下连续 tile 指令存在 RAW（Read-After-Write）依赖，即后一条指令的 src 是前一条指令的 dst。
+
+**原理**：`AUTO_SYNC=True` 时编译器自动插入 `PipeBarrier<PIPE_V>`，V pipe 串行化，in-place 复用 buffer 通常是安全的。但当两条连续 tile 指令形成 `dst → src` 链时（如 `mul(hw, h, gamma)` → `abs(hw, hw)`），V pipe 流水线可能在第二条指令读到第一条的旧值。使用两个独立 buffer 交替可消除此 hazard。
+
+**优化前**（RAW hazard）：
+```python
+hw_fp32 = T.alloc_ub([ROWS, block_N], "float32")
+# ❌ hw_fp32 既是 mul 的 dst 又是 abs 的 src → RAW hazard
+T.tile.mul(hw_fp32, h_fp32, gamma_tile)
+T.tile.abs(hw_fp32, hw_fp32)
+```
+
+**优化后**（交替 buffer）：
+```python
+hw_a = T.alloc_ub([ROWS, block_N], "float32")
+hw_b = T.alloc_ub([ROWS, block_N], "float32")
+# ✅ hw_a → hw_b，无 RAW 依赖
+T.tile.mul(hw_a, h_fp32, gamma_tile)
+T.tile.abs(hw_b, hw_a)
+```
+
+**在 Pass 2 量化链中的应用**（更长的计算链需要交替使用）：
+```python
+# Pass 2: h → normed → quantized
+T.tile.mul(hw_a, h_fp32, inv_rms_tile)     # hw_a = h * inv_rms
+T.tile.mul(hw_b, hw_a, gamma_tile)          # hw_b = hw_a * gamma
+T.tile.div(hw_a, hw_b, scale_tile)          # hw_a = hw_b / scale
+T.tile.round(hw_b, hw_a, tile_elements)     # hw_b = round(hw_a)
+T.tile.clamp(hw_a, hw_b, -128.0, 127.0, tile_elements)  # hw_a = clamp(hw_b)
+```
+
+> **UB 开销**：额外 1 个 `[ROWS, block_N]` fp32 buffer（如 ROWS=8, block_N=256 → 8KB），通常可接受。
+>
+> **参考实现**：`examples/add_rms_norm_dynamic_quant/example_add_rms_norm_dynamic_quant.py` 的 `_kernel_single` 中 hw_a/hw_b 交替模式。
 
 ### 2.3 MTE2 预取优化（Cube 核）
 

--- a/.agents/skills/tilelang-perf-optimization/references/performance-antipatterns.md
+++ b/.agents/skills/tilelang-perf-optimization/references/performance-antipatterns.md
@@ -14,6 +14,7 @@
 - [AIC/AIV 混合算子未开启 CV overlap](#aicaiv-混合算子未开启-cv-overlap)
 - [纯 AIV memory bound 算子未做流水/双 buffer](#纯-aiv-memory-bound-算子未做流水双-buffer)
 - [正交轴串行化（Scalar Scan on Parallelizable Axis）](#正交轴串行化scalar-scan-on-parallelizable-axis)
+- [单维度递增搜索（未做交叉实验）](#单维度递增搜索未做交叉实验)
 - [评审记录模板](#评审记录模板)
 
 ---
@@ -455,6 +456,23 @@ for j in range(1, L):
 - 内层是否是标量 `if`/`GetValue`/`SetValue` 而非 `T.tile` 操作？
 - 扫描轴是否有真依赖（无法直接消除内层循环）？
 - 若全部满足，参考 §2.15 正交轴向量化
+
+---
+
+## 单维度递增搜索（未做交叉实验）
+
+**识别特征**：优化过程中逐轮递增某个参数（如 block_M: 4→8→16→32），每轮只改一个维度，未与其他维度做交叉实验。
+
+**性能原因**：不同优化维度之间可能存在紧耦合关系。例如 block_M 的最优值取决于 kernel 架构（单 kernel vs 双 kernel），单维度递增无法发现这种交互效应，导致：
+- 在错误方向上浪费多轮迭代（如 R4→R5a 的 block_M 递增搜索）
+- 错过全局最优组合（如"单 kernel + block_M=16"和"双 kernel + block_M=32"的混合策略）
+
+**替代写法**：当存在多个独立优化维度时，构建 2×2 或 3×3 交叉实验矩阵，一轮实验覆盖所有组合。详见 SKILL.md Step 3.5。
+
+**检查点**：
+- 是否识别了所有独立优化维度（Tiling、架构、同步模式、Pass 数量）？
+- 是否构建了交叉矩阵并快速验证了所有组合？
+- 是否在引入双 kernel 前评估了分发开销（`.item()` host 同步约 5~15μs）？
 
 ---
 

--- a/examples/add_rms_norm_dynamic_quant/example_add_rms_norm_dynamic_quant.py
+++ b/examples/add_rms_norm_dynamic_quant/example_add_rms_norm_dynamic_quant.py
@@ -1,0 +1,1194 @@
+"""
+Fused Add + RMS Norm + Dynamic Quantization operator for Ascend NPU.
+
+2-pass architecture with hybrid kernel dispatch:
+  - M < 1024: single kernel (block_M=16, no dispatch overhead)
+  - M >= 1024: dual kernel (block_M=32, readback/recompute based on input range)
+
+Pass 1: sum_sq + abs_max(|h*gamma|) + write x_out
+  Math: max(|h*inv_rms*gamma|) = inv_rms * max(|h*gamma|)
+Pass 2: quantize (readback or recompute h)
+
+All kernels use Double Buffer with 3-stage pipeline (prefetch/main/epilogue).
+Adaptive block_N: if H < 256 and H % 16 == 0, block_N = H (eliminates tail block).
+
+Outputs: INT8 quantized data, FP32 scale per token, FP16/BF16 residual add result.
+
+Programming mode: Hybrid (Expert alloc_ub + Developer pass_configs).
+Reference: examples/normalization/rms_norm.py, examples/deepseek_v4/act_quant.py.
+"""
+
+import argparse
+import sys
+
+import torch
+
+import tilelang
+from tilelang import language as T
+
+
+# ============================================================================
+# Constants
+# ============================================================================
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+HYBRID_THRESHOLD = 1024
+
+_kernel_cache = {}
+
+
+def _torch_dtype_to_tl(dtype):
+    if dtype == torch.float16:
+        return "float16"
+    elif dtype == torch.bfloat16:
+        return "bfloat16"
+    elif dtype == torch.float32:
+        return "float"
+    raise ValueError(f"Unsupported dtype: {dtype}")
+
+
+# ============================================================================
+# Dual Kernel: block_M=32, readback
+# Pass 2 reads x_out (fp16) instead of recomputing h from x1+x2
+# Used for M >= 1024 when max(|x1|, |x2|) < 100
+# ============================================================================
+
+
+@tilelang.jit(out_idx=[-3, -2, -1], pass_configs=PASS_CONFIGS)
+def _kernel_readback(M, H, block_M, block_N, eps, dtype="float16"):
+    VEC_NUM = 2
+    ROWS = block_M // VEC_NUM
+    tile_elements = ROWS * block_N
+    stages = 2
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(H, block_N)
+
+    @T.macro
+    def init_flags():
+        T.set_flag("mte3", "mte2", 0)
+        T.set_flag("mte3", "mte2", 1)
+
+    @T.macro
+    def drain_flags():
+        T.wait_flag("mte3", "mte2", 0)
+        T.wait_flag("mte3", "mte2", 1)
+
+    @T.prim_func
+    def main(
+        x1: T.Tensor((M, H), dtype),
+        x2: T.Tensor((M, H), dtype),
+        gamma: T.Tensor((H,), dtype),
+        output: T.Tensor((M, H), "int8"),
+        x_out: T.Tensor((M, H), dtype),
+        scale_out: T.Tensor((M,), "float32"),
+    ):
+        with T.Kernel(m_num, is_npu=True) as (cid, vid):
+            row_start = cid * block_M + vid * ROWS
+
+            x1_ub = T.alloc_ub([stages, ROWS, block_N], dtype)
+            x2_ub = T.alloc_ub([stages, ROWS, block_N], dtype)
+            gamma_ub = T.alloc_ub([stages, block_N], dtype)
+            x1_fp32 = T.alloc_ub([ROWS, block_N], "float32")
+            x2_fp32 = T.alloc_ub([ROWS, block_N], "float32")
+            h_fp32 = T.alloc_ub([ROWS, block_N], "float32")
+            hw_fp32 = T.alloc_ub([ROWS, block_N], "float32")
+            out_dtype_ub = T.alloc_ub([ROWS, block_N], dtype)
+            out_fp16 = T.alloc_ub([ROWS, block_N], "float16")
+            out_int8 = T.alloc_ub([stages, ROWS, block_N], "int8")
+            sum_sq_acc = T.alloc_ub([ROWS, block_N], "float32")
+            sum_sq_row = T.alloc_ub([ROWS, 1], "float32")
+            inv_rms_ub = T.alloc_ub([ROWS, 1], "float32")
+            inv_rms_tile = T.alloc_ub([ROWS, block_N], "float32")
+            nr_temp = T.alloc_ub([ROWS, 1], "float32")
+            gamma_fp32 = T.alloc_ub([block_N], "float32")
+            gamma_tile = T.alloc_ub([ROWS, block_N], "float32")
+            abs_ub = T.alloc_ub([ROWS, block_N], "float32")
+            tile_max = T.alloc_ub([ROWS, 1], "float32")
+            abs_max = T.alloc_ub([ROWS, 1], "float32")
+            scale_ub = T.alloc_ub([ROWS, 1], "float32")
+            scale_tile = T.alloc_ub([ROWS, block_N], "float32")
+            min_val = T.alloc_ub([ROWS, 1], "float32")
+            xout_ub = T.alloc_ub([stages, ROWS, block_N], dtype)
+            gamma_p2_ub = T.alloc_ub([stages, block_N], dtype)
+
+            T.tile.fill(sum_sq_acc, 0.0)
+            T.tile.fill(abs_max, 0.0)
+            init_flags()
+
+            # --- Pass 1: sum_sq + abs_max(|h*gamma|) + write x_out ---
+            if n_num > 0:
+                T.wait_flag("mte3", "mte2", 0)
+                T.tile.fill(x1_ub[0, :, :], 0.0)
+                T.tile.fill(x2_ub[0, :, :], 0.0)
+                T.tile.fill(gamma_ub[0, :], 0.0)
+                T.copy(x1[row_start:row_start + ROWS, 0:block_N], x1_ub[0, :, :])
+                T.copy(x2[row_start:row_start + ROWS, 0:block_N], x2_ub[0, :, :])
+                T.copy(gamma[0:block_N], gamma_ub[0, :])
+                T.set_flag("mte2", "v", 0)
+
+            for by in T.serial(0, n_num - 1):
+                cur = by % stages
+                nxt = (by + 1) % stages
+                col_off_cur = by * block_N
+                col_off_nxt = (by + 1) * block_N
+
+                T.wait_flag("mte3", "mte2", nxt)
+                T.tile.fill(x1_ub[nxt, :, :], 0.0)
+                T.tile.fill(x2_ub[nxt, :, :], 0.0)
+                T.tile.fill(gamma_ub[nxt, :], 0.0)
+                T.copy(
+                    x1[row_start:row_start + ROWS, col_off_nxt:col_off_nxt + block_N],
+                    x1_ub[nxt, :, :],
+                )
+                T.copy(
+                    x2[row_start:row_start + ROWS, col_off_nxt:col_off_nxt + block_N],
+                    x2_ub[nxt, :, :],
+                )
+                T.copy(gamma[col_off_nxt:col_off_nxt + block_N], gamma_ub[nxt, :])
+                T.set_flag("mte2", "v", nxt)
+
+                T.wait_flag("mte2", "v", cur)
+                T.tile.cast(x1_fp32, x1_ub[cur, :, :], "CAST_NONE", tile_elements)
+                T.tile.cast(x2_fp32, x2_ub[cur, :, :], "CAST_NONE", tile_elements)
+                T.tile.add(h_fp32, x1_fp32, x2_fp32)
+                T.tile.cast(out_dtype_ub, h_fp32, "CAST_RINT", tile_elements)
+                T.tile.mul_add_dst(sum_sq_acc, h_fp32, h_fp32)
+                T.tile.cast(gamma_fp32, gamma_ub[cur, :], "CAST_NONE", block_N)
+                T.tile.broadcast(gamma_tile, gamma_fp32)
+                T.tile.mul(hw_fp32, h_fp32, gamma_tile)
+                T.tile.abs(abs_ub, hw_fp32)
+                T.reduce_max(abs_ub, tile_max, dim=-1)
+                T.tile.max(abs_max, abs_max, tile_max)
+                T.set_flag("v", "mte3", cur)
+
+                T.wait_flag("v", "mte3", cur)
+                T.copy(
+                    out_dtype_ub,
+                    x_out[row_start:row_start + ROWS, col_off_cur:col_off_cur + block_N],
+                )
+                T.set_flag("mte3", "mte2", cur)
+
+            if n_num > 0:
+                last = (n_num - 1) % stages
+                col_off_last = (n_num - 1) * block_N
+                T.wait_flag("mte2", "v", last)
+                T.tile.cast(x1_fp32, x1_ub[last, :, :], "CAST_NONE", tile_elements)
+                T.tile.cast(x2_fp32, x2_ub[last, :, :], "CAST_NONE", tile_elements)
+                T.tile.add(h_fp32, x1_fp32, x2_fp32)
+                T.tile.cast(out_dtype_ub, h_fp32, "CAST_RINT", tile_elements)
+                T.tile.mul_add_dst(sum_sq_acc, h_fp32, h_fp32)
+                T.tile.cast(gamma_fp32, gamma_ub[last, :], "CAST_NONE", block_N)
+                T.tile.broadcast(gamma_tile, gamma_fp32)
+                T.tile.mul(hw_fp32, h_fp32, gamma_tile)
+                T.tile.abs(abs_ub, hw_fp32)
+                T.reduce_max(abs_ub, tile_max, dim=-1)
+                T.tile.max(abs_max, abs_max, tile_max)
+                T.set_flag("v", "mte3", last)
+
+                T.wait_flag("v", "mte3", last)
+                T.copy(
+                    out_dtype_ub,
+                    x_out[
+                        row_start:row_start + ROWS,
+                        col_off_last:col_off_last + block_N,
+                    ],
+                )
+                T.set_flag("mte3", "mte2", last)
+
+            drain_flags()
+
+            # --- Reduction: inv_rms + Newton-Raphson + scale ---
+            T.reduce_sum(sum_sq_acc, sum_sq_row, dim=-1)
+            inv_H = T.cast(1.0 / H, "float32")
+            eps_val = T.cast(eps, "float32")
+            T.tile.mul(sum_sq_row, sum_sq_row, inv_H)
+            T.tile.add(sum_sq_row, sum_sq_row, eps_val)
+            T.tile.rsqrt(inv_rms_ub, sum_sq_row)
+            T.tile.mul(nr_temp, inv_rms_ub, inv_rms_ub)
+            T.tile.mul(nr_temp, nr_temp, sum_sq_row)
+            T.tile.mul(nr_temp, nr_temp, -0.5)
+            T.tile.add(nr_temp, nr_temp, 1.5)
+            T.tile.mul(inv_rms_ub, inv_rms_ub, nr_temp)
+            T.tile.mul(nr_temp, inv_rms_ub, inv_rms_ub)
+            T.tile.mul(nr_temp, nr_temp, sum_sq_row)
+            T.tile.mul(nr_temp, nr_temp, -0.5)
+            T.tile.add(nr_temp, nr_temp, 1.5)
+            T.tile.mul(inv_rms_ub, inv_rms_ub, nr_temp)
+            T.tile.broadcast(inv_rms_tile, inv_rms_ub)
+
+            T.tile.fill(min_val, 1e-12)
+            T.tile.max(abs_max, abs_max, min_val)
+            T.tile.mul(scale_ub, abs_max, inv_rms_ub)
+            T.tile.div(scale_ub, scale_ub, 127.0)
+
+            # --- Pass 2: read x_out + gamma, quantize ---
+            init_flags()
+
+            if n_num > 0:
+                T.wait_flag("mte3", "mte2", 0)
+                T.tile.fill(xout_ub[0, :, :], 0.0)
+                T.tile.fill(gamma_p2_ub[0, :], 0.0)
+                T.copy(x_out[row_start:row_start + ROWS, 0:block_N], xout_ub[0, :, :])
+                T.copy(gamma[0:block_N], gamma_p2_ub[0, :])
+                T.set_flag("mte2", "v", 0)
+
+            for by in T.serial(0, n_num - 1):
+                cur = by % stages
+                nxt = (by + 1) % stages
+                col_off_cur = by * block_N
+                col_off_nxt = (by + 1) * block_N
+
+                T.wait_flag("mte3", "mte2", nxt)
+                T.tile.fill(xout_ub[nxt, :, :], 0.0)
+                T.tile.fill(gamma_p2_ub[nxt, :], 0.0)
+                T.copy(
+                    x_out[
+                        row_start:row_start + ROWS,
+                        col_off_nxt:col_off_nxt + block_N,
+                    ],
+                    xout_ub[nxt, :, :],
+                )
+                T.copy(gamma[col_off_nxt:col_off_nxt + block_N], gamma_p2_ub[nxt, :])
+                T.set_flag("mte2", "v", nxt)
+
+                T.wait_flag("mte2", "v", cur)
+                T.tile.cast(h_fp32, xout_ub[cur, :, :], "CAST_NONE", tile_elements)
+                T.tile.mul(hw_fp32, h_fp32, inv_rms_tile)
+                T.tile.cast(gamma_fp32, gamma_p2_ub[cur, :], "CAST_NONE", block_N)
+                T.tile.broadcast(gamma_tile, gamma_fp32)
+                T.tile.mul(hw_fp32, hw_fp32, gamma_tile)
+                T.tile.broadcast(scale_tile, scale_ub)
+                T.tile.div(hw_fp32, hw_fp32, scale_tile)
+                T.tile.round(hw_fp32, hw_fp32, tile_elements)
+                T.tile.clamp(hw_fp32, hw_fp32, -128.0, 127.0, tile_elements)
+                T.tile.cast(out_fp16, hw_fp32, "CAST_RINT", tile_elements)
+                T.tile.cast(out_int8[cur, :, :], out_fp16, "CAST_NONE", tile_elements)
+                T.set_flag("v", "mte3", cur)
+
+                T.wait_flag("v", "mte3", cur)
+                T.copy(
+                    out_int8[cur, :, :],
+                    output[
+                        row_start:row_start + ROWS,
+                        col_off_cur:col_off_cur + block_N,
+                    ],
+                )
+                T.set_flag("mte3", "mte2", cur)
+
+            if n_num > 0:
+                last = (n_num - 1) % stages
+                col_off_last = (n_num - 1) * block_N
+                T.wait_flag("mte2", "v", last)
+                T.tile.cast(h_fp32, xout_ub[last, :, :], "CAST_NONE", tile_elements)
+                T.tile.mul(hw_fp32, h_fp32, inv_rms_tile)
+                T.tile.cast(gamma_fp32, gamma_p2_ub[last, :], "CAST_NONE", block_N)
+                T.tile.broadcast(gamma_tile, gamma_fp32)
+                T.tile.mul(hw_fp32, hw_fp32, gamma_tile)
+                T.tile.broadcast(scale_tile, scale_ub)
+                T.tile.div(hw_fp32, hw_fp32, scale_tile)
+                T.tile.round(hw_fp32, hw_fp32, tile_elements)
+                T.tile.clamp(hw_fp32, hw_fp32, -128.0, 127.0, tile_elements)
+                T.tile.cast(out_fp16, hw_fp32, "CAST_RINT", tile_elements)
+                T.tile.cast(
+                    out_int8[last, :, :], out_fp16, "CAST_NONE", tile_elements
+                )
+                T.set_flag("v", "mte3", last)
+
+                T.wait_flag("v", "mte3", last)
+                T.copy(
+                    out_int8[last, :, :],
+                    output[
+                        row_start:row_start + ROWS,
+                        col_off_last:col_off_last + block_N,
+                    ],
+                )
+                T.set_flag("mte3", "mte2", last)
+
+            drain_flags()
+            T.copy(scale_ub, scale_out[row_start:row_start + ROWS])
+
+    return main
+
+
+# ============================================================================
+# Dual Kernel: block_M=32, recompute
+# Pass 2 recomputes h from x1+x2 (fp32 precision)
+# Used for M >= 1024 when max(|x1|, |x2|) >= 100
+# ============================================================================
+
+
+@tilelang.jit(out_idx=[-3, -2, -1], pass_configs=PASS_CONFIGS)
+def _kernel_recompute(M, H, block_M, block_N, eps, dtype="float16"):
+    VEC_NUM = 2
+    ROWS = block_M // VEC_NUM
+    tile_elements = ROWS * block_N
+    stages = 2
+    m_num = T.ceildiv(M, block_M)
+    n_num = T.ceildiv(H, block_N)
+
+    @T.macro
+    def init_flags():
+        T.set_flag("mte3", "mte2", 0)
+        T.set_flag("mte3", "mte2", 1)
+
+    @T.macro
+    def drain_flags():
+        T.wait_flag("mte3", "mte2", 0)
+        T.wait_flag("mte3", "mte2", 1)
+
+    @T.prim_func
+    def main(
+        x1: T.Tensor((M, H), dtype),
+        x2: T.Tensor((M, H), dtype),
+        gamma: T.Tensor((H,), dtype),
+        output: T.Tensor((M, H), "int8"),
+        x_out: T.Tensor((M, H), dtype),
+        scale_out: T.Tensor((M,), "float32"),
+    ):
+        with T.Kernel(m_num, is_npu=True) as (cid, vid):
+            row_start = cid * block_M + vid * ROWS
+
+            x1_ub = T.alloc_ub([stages, ROWS, block_N], dtype)
+            x2_ub = T.alloc_ub([stages, ROWS, block_N], dtype)
+            gamma_ub = T.alloc_ub([stages, block_N], dtype)
+            x1_fp32 = T.alloc_ub([ROWS, block_N], "float32")
+            x2_fp32 = T.alloc_ub([ROWS, block_N], "float32")
+            h_fp32 = T.alloc_ub([ROWS, block_N], "float32")
+            hw_fp32 = T.alloc_ub([ROWS, block_N], "float32")
+            out_dtype_ub = T.alloc_ub([ROWS, block_N], dtype)
+            out_fp16 = T.alloc_ub([ROWS, block_N], "float16")
+            out_int8 = T.alloc_ub([stages, ROWS, block_N], "int8")
+            sum_sq_acc = T.alloc_ub([ROWS, block_N], "float32")
+            sum_sq_row = T.alloc_ub([ROWS, 1], "float32")
+            inv_rms_ub = T.alloc_ub([ROWS, 1], "float32")
+            inv_rms_tile = T.alloc_ub([ROWS, block_N], "float32")
+            nr_temp = T.alloc_ub([ROWS, 1], "float32")
+            gamma_fp32 = T.alloc_ub([block_N], "float32")
+            gamma_tile = T.alloc_ub([ROWS, block_N], "float32")
+            abs_ub = T.alloc_ub([ROWS, block_N], "float32")
+            tile_max = T.alloc_ub([ROWS, 1], "float32")
+            abs_max = T.alloc_ub([ROWS, 1], "float32")
+            scale_ub = T.alloc_ub([ROWS, 1], "float32")
+            scale_tile = T.alloc_ub([ROWS, block_N], "float32")
+            min_val = T.alloc_ub([ROWS, 1], "float32")
+
+            T.tile.fill(sum_sq_acc, 0.0)
+            T.tile.fill(abs_max, 0.0)
+            init_flags()
+
+            # --- Pass 1: sum_sq + abs_max(|h*gamma|) + write x_out ---
+            if n_num > 0:
+                T.wait_flag("mte3", "mte2", 0)
+                T.tile.fill(x1_ub[0, :, :], 0.0)
+                T.tile.fill(x2_ub[0, :, :], 0.0)
+                T.tile.fill(gamma_ub[0, :], 0.0)
+                T.copy(x1[row_start:row_start + ROWS, 0:block_N], x1_ub[0, :, :])
+                T.copy(x2[row_start:row_start + ROWS, 0:block_N], x2_ub[0, :, :])
+                T.copy(gamma[0:block_N], gamma_ub[0, :])
+                T.set_flag("mte2", "v", 0)
+
+            for by in T.serial(0, n_num - 1):
+                cur = by % stages
+                nxt = (by + 1) % stages
+                col_off_cur = by * block_N
+                col_off_nxt = (by + 1) * block_N
+
+                T.wait_flag("mte3", "mte2", nxt)
+                T.tile.fill(x1_ub[nxt, :, :], 0.0)
+                T.tile.fill(x2_ub[nxt, :, :], 0.0)
+                T.tile.fill(gamma_ub[nxt, :], 0.0)
+                T.copy(
+                    x1[row_start:row_start + ROWS, col_off_nxt:col_off_nxt + block_N],
+                    x1_ub[nxt, :, :],
+                )
+                T.copy(
+                    x2[row_start:row_start + ROWS, col_off_nxt:col_off_nxt + block_N],
+                    x2_ub[nxt, :, :],
+                )
+                T.copy(gamma[col_off_nxt:col_off_nxt + block_N], gamma_ub[nxt, :])
+                T.set_flag("mte2", "v", nxt)
+
+                T.wait_flag("mte2", "v", cur)
+                T.tile.cast(x1_fp32, x1_ub[cur, :, :], "CAST_NONE", tile_elements)
+                T.tile.cast(x2_fp32, x2_ub[cur, :, :], "CAST_NONE", tile_elements)
+                T.tile.add(h_fp32, x1_fp32, x2_fp32)
+                T.tile.cast(out_dtype_ub, h_fp32, "CAST_RINT", tile_elements)
+                T.tile.mul_add_dst(sum_sq_acc, h_fp32, h_fp32)
+                T.tile.cast(gamma_fp32, gamma_ub[cur, :], "CAST_NONE", block_N)
+                T.tile.broadcast(gamma_tile, gamma_fp32)
+                T.tile.mul(hw_fp32, h_fp32, gamma_tile)
+                T.tile.abs(abs_ub, hw_fp32)
+                T.reduce_max(abs_ub, tile_max, dim=-1)
+                T.tile.max(abs_max, abs_max, tile_max)
+                T.set_flag("v", "mte3", cur)
+
+                T.wait_flag("v", "mte3", cur)
+                T.copy(
+                    out_dtype_ub,
+                    x_out[row_start:row_start + ROWS, col_off_cur:col_off_cur + block_N],
+                )
+                T.set_flag("mte3", "mte2", cur)
+
+            if n_num > 0:
+                last = (n_num - 1) % stages
+                col_off_last = (n_num - 1) * block_N
+                T.wait_flag("mte2", "v", last)
+                T.tile.cast(x1_fp32, x1_ub[last, :, :], "CAST_NONE", tile_elements)
+                T.tile.cast(x2_fp32, x2_ub[last, :, :], "CAST_NONE", tile_elements)
+                T.tile.add(h_fp32, x1_fp32, x2_fp32)
+                T.tile.cast(out_dtype_ub, h_fp32, "CAST_RINT", tile_elements)
+                T.tile.mul_add_dst(sum_sq_acc, h_fp32, h_fp32)
+                T.tile.cast(gamma_fp32, gamma_ub[last, :], "CAST_NONE", block_N)
+                T.tile.broadcast(gamma_tile, gamma_fp32)
+                T.tile.mul(hw_fp32, h_fp32, gamma_tile)
+                T.tile.abs(abs_ub, hw_fp32)
+                T.reduce_max(abs_ub, tile_max, dim=-1)
+                T.tile.max(abs_max, abs_max, tile_max)
+                T.set_flag("v", "mte3", last)
+
+                T.wait_flag("v", "mte3", last)
+                T.copy(
+                    out_dtype_ub,
+                    x_out[
+                        row_start:row_start + ROWS,
+                        col_off_last:col_off_last + block_N,
+                    ],
+                )
+                T.set_flag("mte3", "mte2", last)
+
+            drain_flags()
+
+            # --- Reduction: inv_rms + Newton-Raphson + scale ---
+            T.reduce_sum(sum_sq_acc, sum_sq_row, dim=-1)
+            inv_H = T.cast(1.0 / H, "float32")
+            eps_val = T.cast(eps, "float32")
+            T.tile.mul(sum_sq_row, sum_sq_row, inv_H)
+            T.tile.add(sum_sq_row, sum_sq_row, eps_val)
+            T.tile.rsqrt(inv_rms_ub, sum_sq_row)
+            T.tile.mul(nr_temp, inv_rms_ub, inv_rms_ub)
+            T.tile.mul(nr_temp, nr_temp, sum_sq_row)
+            T.tile.mul(nr_temp, nr_temp, -0.5)
+            T.tile.add(nr_temp, nr_temp, 1.5)
+            T.tile.mul(inv_rms_ub, inv_rms_ub, nr_temp)
+            T.tile.mul(nr_temp, inv_rms_ub, inv_rms_ub)
+            T.tile.mul(nr_temp, nr_temp, sum_sq_row)
+            T.tile.mul(nr_temp, nr_temp, -0.5)
+            T.tile.add(nr_temp, nr_temp, 1.5)
+            T.tile.mul(inv_rms_ub, inv_rms_ub, nr_temp)
+            T.tile.broadcast(inv_rms_tile, inv_rms_ub)
+
+            T.tile.fill(min_val, 1e-12)
+            T.tile.max(abs_max, abs_max, min_val)
+            T.tile.mul(scale_ub, abs_max, inv_rms_ub)
+            T.tile.div(scale_ub, scale_ub, 127.0)
+
+            # --- Pass 2: recompute h from x1+x2, quantize ---
+            init_flags()
+
+            if n_num > 0:
+                T.wait_flag("mte3", "mte2", 0)
+                T.tile.fill(x1_ub[0, :, :], 0.0)
+                T.tile.fill(x2_ub[0, :, :], 0.0)
+                T.tile.fill(gamma_ub[0, :], 0.0)
+                T.copy(x1[row_start:row_start + ROWS, 0:block_N], x1_ub[0, :, :])
+                T.copy(x2[row_start:row_start + ROWS, 0:block_N], x2_ub[0, :, :])
+                T.copy(gamma[0:block_N], gamma_ub[0, :])
+                T.set_flag("mte2", "v", 0)
+
+            for by in T.serial(0, n_num - 1):
+                cur = by % stages
+                nxt = (by + 1) % stages
+                col_off_cur = by * block_N
+                col_off_nxt = (by + 1) * block_N
+
+                T.wait_flag("mte3", "mte2", nxt)
+                T.tile.fill(x1_ub[nxt, :, :], 0.0)
+                T.tile.fill(x2_ub[nxt, :, :], 0.0)
+                T.tile.fill(gamma_ub[nxt, :], 0.0)
+                T.copy(
+                    x1[row_start:row_start + ROWS, col_off_nxt:col_off_nxt + block_N],
+                    x1_ub[nxt, :, :],
+                )
+                T.copy(
+                    x2[row_start:row_start + ROWS, col_off_nxt:col_off_nxt + block_N],
+                    x2_ub[nxt, :, :],
+                )
+                T.copy(gamma[col_off_nxt:col_off_nxt + block_N], gamma_ub[nxt, :])
+                T.set_flag("mte2", "v", nxt)
+
+                T.wait_flag("mte2", "v", cur)
+                T.tile.cast(x1_fp32, x1_ub[cur, :, :], "CAST_NONE", tile_elements)
+                T.tile.cast(x2_fp32, x2_ub[cur, :, :], "CAST_NONE", tile_elements)
+                T.tile.add(h_fp32, x1_fp32, x2_fp32)
+                T.tile.mul(hw_fp32, h_fp32, inv_rms_tile)
+                T.tile.cast(gamma_fp32, gamma_ub[cur, :], "CAST_NONE", block_N)
+                T.tile.broadcast(gamma_tile, gamma_fp32)
+                T.tile.mul(hw_fp32, hw_fp32, gamma_tile)
+                T.tile.broadcast(scale_tile, scale_ub)
+                T.tile.div(hw_fp32, hw_fp32, scale_tile)
+                T.tile.round(hw_fp32, hw_fp32, tile_elements)
+                T.tile.clamp(hw_fp32, hw_fp32, -128.0, 127.0, tile_elements)
+                T.tile.cast(out_fp16, hw_fp32, "CAST_RINT", tile_elements)
+                T.tile.cast(out_int8[cur, :, :], out_fp16, "CAST_NONE", tile_elements)
+                T.set_flag("v", "mte3", cur)
+
+                T.wait_flag("v", "mte3", cur)
+                T.copy(
+                    out_int8[cur, :, :],
+                    output[
+                        row_start:row_start + ROWS,
+                        col_off_cur:col_off_cur + block_N,
+                    ],
+                )
+                T.set_flag("mte3", "mte2", cur)
+
+            if n_num > 0:
+                last = (n_num - 1) % stages
+                col_off_last = (n_num - 1) * block_N
+                T.wait_flag("mte2", "v", last)
+                T.tile.cast(x1_fp32, x1_ub[last, :, :], "CAST_NONE", tile_elements)
+                T.tile.cast(x2_fp32, x2_ub[last, :, :], "CAST_NONE", tile_elements)
+                T.tile.add(h_fp32, x1_fp32, x2_fp32)
+                T.tile.mul(hw_fp32, h_fp32, inv_rms_tile)
+                T.tile.cast(gamma_fp32, gamma_ub[last, :], "CAST_NONE", block_N)
+                T.tile.broadcast(gamma_tile, gamma_fp32)
+                T.tile.mul(hw_fp32, hw_fp32, gamma_tile)
+                T.tile.broadcast(scale_tile, scale_ub)
+                T.tile.div(hw_fp32, hw_fp32, scale_tile)
+                T.tile.round(hw_fp32, hw_fp32, tile_elements)
+                T.tile.clamp(hw_fp32, hw_fp32, -128.0, 127.0, tile_elements)
+                T.tile.cast(out_fp16, hw_fp32, "CAST_RINT", tile_elements)
+                T.tile.cast(
+                    out_int8[last, :, :], out_fp16, "CAST_NONE", tile_elements
+                )
+                T.set_flag("v", "mte3", last)
+
+                T.wait_flag("v", "mte3", last)
+                T.copy(
+                    out_int8[last, :, :],
+                    output[
+                        row_start:row_start + ROWS,
+                        col_off_last:col_off_last + block_N,
+                    ],
+                )
+                T.set_flag("mte3", "mte2", last)
+
+            drain_flags()
+            T.copy(scale_ub, scale_out[row_start:row_start + ROWS])
+
+    return main
+
+
+# ============================================================================
+# Single Kernel: block_M=16, alternating buffers
+# Used for M < 1024 (small shapes, no dispatch overhead)
+# ============================================================================
+
+
+@tilelang.jit(out_idx=[-3, -2, -1], pass_configs=PASS_CONFIGS)
+def _kernel_single(M, H, block_M, block_N, eps, dtype="float16"):
+    VEC_NUM = 2
+    ROWS = block_M // VEC_NUM
+    tile_elements = ROWS * block_N
+    stages = 2
+    m_num = (M + block_M - 1) // block_M
+    n_num = (H + block_N - 1) // block_N
+
+    @T.prim_func
+    def main(
+        x1: T.Tensor((M, H), dtype),
+        x2: T.Tensor((M, H), dtype),
+        gamma: T.Tensor((H,), dtype),
+        output: T.Tensor((M, H), "int8"),
+        x_out: T.Tensor((M, H), dtype),
+        scale_out: T.Tensor((M,), "float32"),
+    ):
+        with T.Kernel(m_num, is_npu=True) as (cid, vid):
+            row_start = cid * block_M + vid * ROWS
+
+            x1_ub = T.alloc_ub([stages, ROWS, block_N], dtype)
+            x2_ub = T.alloc_ub([stages, ROWS, block_N], dtype)
+            gamma_ub = T.alloc_ub([stages, block_N], dtype)
+            x1_fp32 = T.alloc_ub([ROWS, block_N], "float32")
+            x2_fp32 = T.alloc_ub([ROWS, block_N], "float32")
+            h_fp32 = T.alloc_ub([ROWS, block_N], "float32")
+            hw_a = T.alloc_ub([ROWS, block_N], "float32")
+            hw_b = T.alloc_ub([ROWS, block_N], "float32")
+            out_dtype_ub = T.alloc_ub([ROWS, block_N], dtype)
+            out_fp16 = T.alloc_ub([ROWS, block_N], "float16")
+            out_int8 = T.alloc_ub([stages, ROWS, block_N], "int8")
+            sum_sq_acc = T.alloc_ub([ROWS, block_N], "float32")
+            sum_sq_row = T.alloc_ub([ROWS, 1], "float32")
+            inv_rms_ub = T.alloc_ub([ROWS, 1], "float32")
+            inv_rms_tile = T.alloc_ub([ROWS, block_N], "float32")
+            nr_temp = T.alloc_ub([ROWS, 1], "float32")
+            gamma_fp32 = T.alloc_ub([block_N], "float32")
+            gamma_tile = T.alloc_ub([ROWS, block_N], "float32")
+            abs_ub = T.alloc_ub([ROWS, block_N], "float32")
+            tile_max = T.alloc_ub([ROWS, 1], "float32")
+            abs_max = T.alloc_ub([ROWS, 1], "float32")
+            scale_ub = T.alloc_ub([ROWS, 1], "float32")
+            scale_tile = T.alloc_ub([ROWS, block_N], "float32")
+            min_val = T.alloc_ub([ROWS, 1], "float32")
+
+            T.tile.fill(sum_sq_acc, 0.0)
+            T.tile.fill(abs_max, 0.0)
+            T.set_flag("mte3", "mte2", 0)
+            T.set_flag("mte3", "mte2", 1)
+
+            # --- Pass 1: sum_sq + abs_max(|h*gamma|) + write x_out ---
+            if n_num > 0:
+                T.wait_flag("mte3", "mte2", 0)
+                T.tile.fill(x1_ub[0, :, :], 0.0)
+                T.tile.fill(x2_ub[0, :, :], 0.0)
+                T.tile.fill(gamma_ub[0, :], 0.0)
+                T.copy(x1[row_start:row_start + ROWS, 0:block_N], x1_ub[0, :, :])
+                T.copy(x2[row_start:row_start + ROWS, 0:block_N], x2_ub[0, :, :])
+                T.copy(gamma[0:block_N], gamma_ub[0, :])
+                T.set_flag("mte2", "v", 0)
+
+            for by in T.serial(0, n_num - 1):
+                cur = by % stages
+                nxt = (by + 1) % stages
+                col_off_cur = by * block_N
+                col_off_nxt = (by + 1) * block_N
+
+                T.wait_flag("mte3", "mte2", nxt)
+                T.tile.fill(x1_ub[nxt, :, :], 0.0)
+                T.tile.fill(x2_ub[nxt, :, :], 0.0)
+                T.tile.fill(gamma_ub[nxt, :], 0.0)
+                T.copy(
+                    x1[row_start:row_start + ROWS, col_off_nxt:col_off_nxt + block_N],
+                    x1_ub[nxt, :, :],
+                )
+                T.copy(
+                    x2[row_start:row_start + ROWS, col_off_nxt:col_off_nxt + block_N],
+                    x2_ub[nxt, :, :],
+                )
+                T.copy(gamma[col_off_nxt:col_off_nxt + block_N], gamma_ub[nxt, :])
+                T.set_flag("mte2", "v", nxt)
+
+                T.wait_flag("mte2", "v", cur)
+                T.tile.cast(x1_fp32, x1_ub[cur, :, :], "CAST_NONE", tile_elements)
+                T.tile.cast(x2_fp32, x2_ub[cur, :, :], "CAST_NONE", tile_elements)
+                T.tile.add(h_fp32, x1_fp32, x2_fp32)
+                T.tile.cast(out_dtype_ub, h_fp32, "CAST_RINT", tile_elements)
+                T.tile.mul_add_dst(sum_sq_acc, h_fp32, h_fp32)
+                T.tile.cast(gamma_fp32, gamma_ub[cur, :], "CAST_NONE", block_N)
+                T.tile.broadcast(gamma_tile, gamma_fp32)
+                T.tile.mul(hw_a, h_fp32, gamma_tile)
+                T.tile.abs(hw_b, hw_a)
+                T.reduce_max(hw_b, tile_max, dim=-1)
+                T.tile.max(abs_max, abs_max, tile_max)
+                T.set_flag("v", "mte3", cur)
+
+                T.wait_flag("v", "mte3", cur)
+                T.copy(
+                    out_dtype_ub,
+                    x_out[row_start:row_start + ROWS, col_off_cur:col_off_cur + block_N],
+                )
+                T.set_flag("mte3", "mte2", cur)
+
+            if n_num > 0:
+                last = (n_num - 1) % stages
+                col_off_last = (n_num - 1) * block_N
+                T.wait_flag("mte2", "v", last)
+                T.tile.cast(x1_fp32, x1_ub[last, :, :], "CAST_NONE", tile_elements)
+                T.tile.cast(x2_fp32, x2_ub[last, :, :], "CAST_NONE", tile_elements)
+                T.tile.add(h_fp32, x1_fp32, x2_fp32)
+                T.tile.cast(out_dtype_ub, h_fp32, "CAST_RINT", tile_elements)
+                T.tile.mul_add_dst(sum_sq_acc, h_fp32, h_fp32)
+                T.tile.cast(gamma_fp32, gamma_ub[last, :], "CAST_NONE", block_N)
+                T.tile.broadcast(gamma_tile, gamma_fp32)
+                T.tile.mul(hw_a, h_fp32, gamma_tile)
+                T.tile.abs(hw_b, hw_a)
+                T.reduce_max(hw_b, tile_max, dim=-1)
+                T.tile.max(abs_max, abs_max, tile_max)
+                T.set_flag("v", "mte3", last)
+
+                T.wait_flag("v", "mte3", last)
+                T.copy(
+                    out_dtype_ub,
+                    x_out[
+                        row_start:row_start + ROWS,
+                        col_off_last:col_off_last + block_N,
+                    ],
+                )
+                T.set_flag("mte3", "mte2", last)
+
+            T.wait_flag("mte3", "mte2", 0)
+            T.wait_flag("mte3", "mte2", 1)
+
+            # --- Reduction: inv_rms + Newton-Raphson + scale ---
+            T.reduce_sum(sum_sq_acc, sum_sq_row, dim=-1)
+            inv_H = T.cast(1.0 / H, "float32")
+            eps_val = T.cast(eps, "float32")
+            T.tile.mul(sum_sq_row, sum_sq_row, inv_H)
+            T.tile.add(sum_sq_row, sum_sq_row, eps_val)
+            T.tile.rsqrt(inv_rms_ub, sum_sq_row)
+            T.tile.mul(nr_temp, inv_rms_ub, inv_rms_ub)
+            T.tile.mul(nr_temp, nr_temp, sum_sq_row)
+            T.tile.mul(nr_temp, nr_temp, -0.5)
+            T.tile.add(nr_temp, nr_temp, 1.5)
+            T.tile.mul(inv_rms_ub, inv_rms_ub, nr_temp)
+            T.tile.mul(nr_temp, inv_rms_ub, inv_rms_ub)
+            T.tile.mul(nr_temp, nr_temp, sum_sq_row)
+            T.tile.mul(nr_temp, nr_temp, -0.5)
+            T.tile.add(nr_temp, nr_temp, 1.5)
+            T.tile.mul(inv_rms_ub, inv_rms_ub, nr_temp)
+            T.tile.broadcast(inv_rms_tile, inv_rms_ub)
+
+            T.tile.fill(min_val, 1e-12)
+            T.tile.max(abs_max, abs_max, min_val)
+            T.tile.mul(scale_ub, abs_max, inv_rms_ub)
+            T.tile.div(scale_ub, scale_ub, 127.0)
+
+            # --- Pass 2: recompute h from x1+x2, quantize ---
+            T.set_flag("mte3", "mte2", 0)
+            T.set_flag("mte3", "mte2", 1)
+
+            if n_num > 0:
+                T.wait_flag("mte3", "mte2", 0)
+                T.tile.fill(x1_ub[0, :, :], 0.0)
+                T.tile.fill(x2_ub[0, :, :], 0.0)
+                T.tile.fill(gamma_ub[0, :], 0.0)
+                T.copy(x1[row_start:row_start + ROWS, 0:block_N], x1_ub[0, :, :])
+                T.copy(x2[row_start:row_start + ROWS, 0:block_N], x2_ub[0, :, :])
+                T.copy(gamma[0:block_N], gamma_ub[0, :])
+                T.set_flag("mte2", "v", 0)
+
+            for by in T.serial(0, n_num - 1):
+                cur = by % stages
+                nxt = (by + 1) % stages
+                col_off_cur = by * block_N
+                col_off_nxt = (by + 1) * block_N
+
+                T.wait_flag("mte3", "mte2", nxt)
+                T.tile.fill(x1_ub[nxt, :, :], 0.0)
+                T.tile.fill(x2_ub[nxt, :, :], 0.0)
+                T.tile.fill(gamma_ub[nxt, :], 0.0)
+                T.copy(
+                    x1[row_start:row_start + ROWS, col_off_nxt:col_off_nxt + block_N],
+                    x1_ub[nxt, :, :],
+                )
+                T.copy(
+                    x2[row_start:row_start + ROWS, col_off_nxt:col_off_nxt + block_N],
+                    x2_ub[nxt, :, :],
+                )
+                T.copy(gamma[col_off_nxt:col_off_nxt + block_N], gamma_ub[nxt, :])
+                T.set_flag("mte2", "v", nxt)
+
+                T.wait_flag("mte2", "v", cur)
+                T.tile.cast(x1_fp32, x1_ub[cur, :, :], "CAST_NONE", tile_elements)
+                T.tile.cast(x2_fp32, x2_ub[cur, :, :], "CAST_NONE", tile_elements)
+                T.tile.add(h_fp32, x1_fp32, x2_fp32)
+                T.tile.mul(hw_a, h_fp32, inv_rms_tile)
+                T.tile.cast(gamma_fp32, gamma_ub[cur, :], "CAST_NONE", block_N)
+                T.tile.broadcast(gamma_tile, gamma_fp32)
+                T.tile.mul(hw_b, hw_a, gamma_tile)
+                T.tile.broadcast(scale_tile, scale_ub)
+                T.tile.div(hw_a, hw_b, scale_tile)
+                T.tile.round(hw_b, hw_a, tile_elements)
+                T.tile.clamp(hw_a, hw_b, -128.0, 127.0, tile_elements)
+                T.tile.cast(out_fp16, hw_a, "CAST_RINT", tile_elements)
+                T.tile.cast(out_int8[cur, :, :], out_fp16, "CAST_NONE", tile_elements)
+                T.set_flag("v", "mte3", cur)
+
+                T.wait_flag("v", "mte3", cur)
+                T.copy(
+                    out_int8[cur, :, :],
+                    output[
+                        row_start:row_start + ROWS,
+                        col_off_cur:col_off_cur + block_N,
+                    ],
+                )
+                T.set_flag("mte3", "mte2", cur)
+
+            if n_num > 0:
+                last = (n_num - 1) % stages
+                col_off_last = (n_num - 1) * block_N
+                T.wait_flag("mte2", "v", last)
+                T.tile.cast(x1_fp32, x1_ub[last, :, :], "CAST_NONE", tile_elements)
+                T.tile.cast(x2_fp32, x2_ub[last, :, :], "CAST_NONE", tile_elements)
+                T.tile.add(h_fp32, x1_fp32, x2_fp32)
+                T.tile.mul(hw_a, h_fp32, inv_rms_tile)
+                T.tile.cast(gamma_fp32, gamma_ub[last, :], "CAST_NONE", block_N)
+                T.tile.broadcast(gamma_tile, gamma_fp32)
+                T.tile.mul(hw_b, hw_a, gamma_tile)
+                T.tile.broadcast(scale_tile, scale_ub)
+                T.tile.div(hw_a, hw_b, scale_tile)
+                T.tile.round(hw_b, hw_a, tile_elements)
+                T.tile.clamp(hw_a, hw_b, -128.0, 127.0, tile_elements)
+                T.tile.cast(out_fp16, hw_a, "CAST_RINT", tile_elements)
+                T.tile.cast(
+                    out_int8[last, :, :], out_fp16, "CAST_NONE", tile_elements
+                )
+                T.set_flag("v", "mte3", last)
+
+                T.wait_flag("v", "mte3", last)
+                T.copy(
+                    out_int8[last, :, :],
+                    output[
+                        row_start:row_start + ROWS,
+                        col_off_last:col_off_last + block_N,
+                    ],
+                )
+                T.set_flag("mte3", "mte2", last)
+
+            T.wait_flag("mte3", "mte2", 0)
+            T.wait_flag("mte3", "mte2", 1)
+            T.copy(scale_ub, scale_out[row_start:row_start + ROWS])
+
+    return main
+
+
+# ============================================================================
+# Tiling and Hybrid Dispatch
+# ============================================================================
+
+
+def _get_tiling_large(M, H):
+    block_M = 32
+    block_N = 256
+    if H < block_N and H % 16 == 0:
+        block_N = H
+    max_blocks = 65535
+    m_num = (M + block_M - 1) // block_M
+    if m_num > max_blocks:
+        block_M = ((M + max_blocks - 1) // max_blocks + 1) // 2 * 2
+        if block_M < 8:
+            block_M = 8
+    return block_M, block_N
+
+
+def _get_tiling_small(M, H):
+    block_M = 16
+    block_N = 256
+    if H < block_N and H % 16 == 0:
+        block_N = H
+    max_blocks = 65535
+    m_num = (M + block_M - 1) // block_M
+    if m_num > max_blocks:
+        block_M = ((M + max_blocks - 1) // max_blocks + 1) // 2 * 2
+        if block_M < 8:
+            block_M = 8
+    return block_M, block_N
+
+
+def _get_kernel(M, H, tl_dtype, eps, use_readback):
+    if M < HYBRID_THRESHOLD:
+        block_M, block_N = _get_tiling_small(M, H)
+        key = ("single", M, H, tl_dtype, eps, block_M, block_N)
+        if key not in _kernel_cache:
+            _kernel_cache[key] = _kernel_single(M, H, block_M, block_N, eps, dtype=tl_dtype)
+        return _kernel_cache[key]
+    else:
+        block_M, block_N = _get_tiling_large(M, H)
+        key = ("dual", M, H, tl_dtype, eps, block_M, block_N, use_readback)
+        if key not in _kernel_cache:
+            if use_readback:
+                _kernel_cache[key] = _kernel_readback(
+                    M, H, block_M, block_N, eps, dtype=tl_dtype
+                )
+            else:
+                _kernel_cache[key] = _kernel_recompute(
+                    M, H, block_M, block_N, eps, dtype=tl_dtype
+                )
+        return _kernel_cache[key]
+
+
+def add_rms_norm_dynamic_quant(x1, x2, gamma, eps=1e-6):
+    """Fused Add + RMSNorm + Dynamic Quantization.
+
+    Args:
+        x1: [*, H] fp16/bf16 input tensor.
+        x2: [*, H] fp16/bf16 residual tensor.
+        gamma: [H] fp16/bf16 RMSNorm weight.
+        eps: RMSNorm epsilon.
+
+    Returns:
+        output: [*, H] int8 quantized output.
+        x_out: [*, H] fp16/bf16 residual add result.
+        scale_out: [*] fp32 per-token dequantization scale.
+    """
+    original_dtype = x1.dtype
+    original_shape = x1.shape
+    H = x1.size(-1)
+    M = x1.numel() // H
+
+    x1_flat = x1.reshape(M, H).contiguous()
+    x2_flat = x2.reshape(M, H).contiguous()
+    gamma_flat = gamma.reshape(H).contiguous()
+
+    kernel_dtype = _torch_dtype_to_tl(original_dtype)
+
+    use_readback = False
+    if M >= HYBRID_THRESHOLD:
+        max_val = max(x1_flat.abs().max().item(), x2_flat.abs().max().item())
+        use_readback = max_val < 100.0
+
+    kernel = _get_kernel(M, H, kernel_dtype, eps, use_readback)
+    output, x_out, scale_out = kernel(x1_flat, x2_flat, gamma_flat)
+
+    output = output.reshape(original_shape)
+    x_out = x_out.reshape(original_shape)
+
+    return output, scale_out, x_out
+
+
+# ============================================================================
+# Golden Function (PyTorch reference implementation)
+# ============================================================================
+
+
+def golden_add_rms_norm_dynamic_quant(x1, x2, gamma, eps=1e-6):
+    """PyTorch reference: fp32 computation throughout, no fp16 round-trip."""
+    out_dtype = x1.dtype
+    x1_f = x1.float()
+    x2_f = x2.float()
+    gamma_f = gamma.float()
+
+    h_fp32 = x1_f + x2_f
+    x_out = h_fp32.to(out_dtype)
+
+    rms = torch.sqrt(h_fp32.pow(2).mean(dim=-1, keepdim=True) + eps)
+    inv_rms = 1.0 / rms
+    normed = h_fp32 * inv_rms * gamma_f
+
+    abs_max = normed.abs().amax(dim=-1, keepdim=True)
+    abs_max = torch.clamp(abs_max, min=1e-12)
+    scale = (abs_max / 127.0).float()
+    quantized = torch.clamp(torch.round(normed / scale), -128, 127)
+    output = quantized.to(torch.float16).to(torch.int8)
+
+    scale_out = scale.squeeze(-1).reshape(-1).float()
+    return output, scale_out, x_out
+
+
+# ============================================================================
+# L0 Threshold Tests
+# ============================================================================
+
+L0_CONFIGS = [
+    (1, 4, 256),
+    (2, 8, 512),
+    (1, 32, 1024),
+    (2, 16, 256),
+]
+
+
+def test_add_rms_norm_dynamic_quant_l0():
+    ok = True
+    for B, S, H in L0_CONFIGS:
+        try:
+            M = B * S
+            x1 = torch.randn(B, S, H, device="npu", dtype=torch.float16)
+            x2 = torch.randn(B, S, H, device="npu", dtype=torch.float16)
+            gamma = torch.randn(H, device="npu", dtype=torch.float16)
+
+            output, scale_out, x_out_k = add_rms_norm_dynamic_quant(x1, x2, gamma)
+            ref_output, ref_scale, ref_x_out = golden_add_rms_norm_dynamic_quant(
+                x1.cpu(), x2.cpu(), gamma.cpu()
+            )
+
+            output_3d = output.cpu().reshape(B, S, H).float()
+            scale_1d = scale_out.cpu().float()
+            x_out_3d = x_out_k.cpu().reshape(B, S, H).float()
+
+            torch.testing.assert_close(output_3d, ref_output.float(), atol=1, rtol=0)
+            torch.testing.assert_close(scale_1d, ref_scale.float(), atol=1e-2, rtol=1e-2)
+            torch.testing.assert_close(x_out_3d, ref_x_out.float(), atol=1e-2, rtol=1e-2)
+            print(f"[PRECISION_PASS] l0 shape=({B},{S},{H}) dtype=float16")
+        except Exception as e:
+            print(f"[PRECISION_FAIL] l0 shape=({B},{S},{H}) dtype=float16: {e}")
+            ok = False
+    return ok
+
+
+# ============================================================================
+# Shared Test Helpers
+# ============================================================================
+
+
+def _run_single_test(level, B, S, H, dtype_str="float16"):
+    M = B * S
+    torch_dtype = torch.float16 if dtype_str == "float16" else torch.bfloat16
+
+    x1 = torch.randn(B, S, H, device="npu", dtype=torch_dtype)
+    x2 = torch.randn(B, S, H, device="npu", dtype=torch_dtype)
+    gamma = torch.randn(H, device="npu", dtype=torch_dtype)
+
+    output, scale_out, x_out_k = add_rms_norm_dynamic_quant(x1, x2, gamma)
+    ref_output, ref_scale, ref_x_out = golden_add_rms_norm_dynamic_quant(
+        x1.cpu(), x2.cpu(), gamma.cpu()
+    )
+
+    output_3d = output.cpu().reshape(B, S, H).float()
+    scale_1d = scale_out.cpu().float()
+    x_out_3d = x_out_k.cpu().reshape(B, S, H).float()
+
+    torch.testing.assert_close(output_3d, ref_output.float(), atol=1, rtol=0)
+    torch.testing.assert_close(scale_1d, ref_scale.float(), atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(x_out_3d, ref_x_out.float(), atol=1e-2, rtol=1e-2)
+
+
+def _run_precision(level, B, S, H, dtype_str="float16"):
+    try:
+        _run_single_test(level, B, S, H, dtype_str)
+        print(f"[PRECISION_PASS] {level} shape=({B},{S},{H}) dtype={dtype_str}")
+        return True
+    except Exception as e:
+        print(f"[PRECISION_FAIL] {level} shape=({B},{S},{H}) dtype={dtype_str}: {e}")
+        return False
+
+
+def _run_boundary(level, name, fn):
+    try:
+        fn()
+        print(f"[BOUNDARY_PASS] {level} {name}")
+    except Exception as e:
+        print(f"[BOUNDARY_WARN] {level} {name}: {e}")
+
+
+# ============================================================================
+# L1 Functional Tests
+# ============================================================================
+
+L1_CONFIGS = [
+    (4, 4, 256),
+    (1, 8, 512),
+    (2, 4, 1024),
+    (1, 5, 256),
+    (1, 7, 256),
+    (1, 3, 512),
+    (1, 4, 128),
+    (2, 8, 200),
+    (1, 1024, 256),
+    (2, 512, 512),
+]
+
+
+def test_add_rms_norm_dynamic_quant_l1():
+    ok = True
+    for B, S, H in L1_CONFIGS:
+        ok &= _run_precision("l1", B, S, H)
+    for B, S, H in [(1, 4, 256), (2, 8, 512)]:
+        ok &= _run_precision("l1", B, S, H, dtype_str="bfloat16")
+    return ok
+
+
+# ============================================================================
+# L2 Exception Tests (non-blocking)
+# ============================================================================
+
+
+def test_add_rms_norm_dynamic_quant_l2():
+
+    def _test_zero_inputs():
+        B, S, H = 1, 4, 256
+        x1 = torch.zeros(B, S, H, device="npu", dtype=torch.float16)
+        x2 = torch.zeros(B, S, H, device="npu", dtype=torch.float16)
+        gamma = torch.randn(H, device="npu", dtype=torch.float16)
+        output, _, _ = add_rms_norm_dynamic_quant(x1, x2, gamma)
+        assert output.cpu().abs().max().item() <= 1
+
+    def _test_large_magnitude():
+        B, S, H = 1, 4, 256
+        x1 = torch.randn(B, S, H, device="npu", dtype=torch.float16) * 100
+        x2 = torch.randn(B, S, H, device="npu", dtype=torch.float16) * 100
+        gamma = torch.ones(H, device="npu", dtype=torch.float16)
+        output, _, _ = add_rms_norm_dynamic_quant(x1, x2, gamma)
+        assert output.cpu().min().item() >= -128
+        assert output.cpu().max().item() <= 127
+
+    def _test_unit_gamma():
+        B, S, H = 1, 4, 256
+        x1 = torch.randn(B, S, H, device="npu", dtype=torch.float16)
+        x2 = torch.randn(B, S, H, device="npu", dtype=torch.float16)
+        gamma = torch.ones(H, device="npu", dtype=torch.float16)
+        output, _, _ = add_rms_norm_dynamic_quant(x1, x2, gamma)
+        M = B * S
+        assert output.shape == (M, H)
+
+    _run_boundary("l2", "zero_inputs", _test_zero_inputs)
+    _run_boundary("l2", "large_magnitude", _test_large_magnitude)
+    _run_boundary("l2", "unit_gamma", _test_unit_gamma)
+
+
+# ============================================================================
+# Boundary Tests (non-blocking)
+# ============================================================================
+
+
+def test_add_rms_norm_dynamic_quant_boundary():
+
+    def _test_inf_input():
+        B, S, H = 1, 4, 256
+        x1 = torch.randn(B, S, H, device="npu", dtype=torch.float16)
+        x1[0, 0, 0] = float("inf")
+        x2 = torch.randn(B, S, H, device="npu", dtype=torch.float16)
+        gamma = torch.randn(H, device="npu", dtype=torch.float16)
+        add_rms_norm_dynamic_quant(x1, x2, gamma)
+
+    def _test_nan_input():
+        B, S, H = 1, 4, 256
+        x1 = torch.randn(B, S, H, device="npu", dtype=torch.float16)
+        x1[0, 0, 0] = float("nan")
+        x2 = torch.randn(B, S, H, device="npu", dtype=torch.float16)
+        gamma = torch.randn(H, device="npu", dtype=torch.float16)
+        add_rms_norm_dynamic_quant(x1, x2, gamma)
+
+    def _test_extreme_residual():
+        B, S, H = 1, 4, 256
+        x1 = torch.full((B, S, H), 30000.0, device="npu", dtype=torch.float16)
+        x2 = torch.full((B, S, H), 30000.0, device="npu", dtype=torch.float16)
+        gamma = torch.randn(H, device="npu", dtype=torch.float16)
+        output, _, _ = add_rms_norm_dynamic_quant(x1, x2, gamma)
+        assert output.cpu().min().item() >= -128
+        assert output.cpu().max().item() <= 127
+
+    _run_boundary("boundary", "inf_input", _test_inf_input)
+    _run_boundary("boundary", "nan_input", _test_nan_input)
+    _run_boundary("boundary", "extreme_residual", _test_extreme_residual)
+
+
+# ============================================================================
+# Main Entry Point
+# ============================================================================
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Test add_rms_norm_dynamic_quant operator")
+    parser.add_argument(
+        "--level",
+        default="l0",
+        choices=["l0", "l1", "l2", "boundary", "all"],
+        help="Test level to run (default: l0)",
+    )
+    args = parser.parse_args()
+
+    tilelang.disable_cache()
+    torch.manual_seed(0)
+
+    blocking_ok = True
+    if args.level in ("l0", "all"):
+        blocking_ok &= test_add_rms_norm_dynamic_quant_l0()
+    if args.level in ("l1", "all"):
+        blocking_ok &= test_add_rms_norm_dynamic_quant_l1()
+    if args.level in ("l2", "all"):
+        test_add_rms_norm_dynamic_quant_l2()
+    if args.level in ("boundary", "all"):
+        test_add_rms_norm_dynamic_quant_boundary()
+
+    if blocking_ok:
+        print("Test Passed!")
+        sys.exit(0)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# PR内容：Skill 优化&新增算子

## Skill 优化

### 问题简述
**背景：** add_rms_norm_dynamic_quant算子实际优化过程经过R0 - R7多轮迭代，之前遇到优化瓶颈等相关问题，PR基于实际开发中的相关问题，对于skill提出相应的优化建议。其中，R0 - R7的优化流程如下：

| 轮次 | 优化类型 | 核心变化 | 性能得分 | 提升 | 状态 | 关键问题/经验 |
| :---: | :--- | :--- | :---: | :---: | :---: | :--- |
| **R0** | 基线实现 | 3-pass 串行架构<br>GM 读取 6x | 4.94 | - | ✅ 基线 | 每个 pass 重复读 x1/x2 并重算 h |
| **R1** | 算法层 | 3-pass → 2-pass<br>数学变换：`max(\|h * inv_rms * gamma\|) = inv_rms * max(\|h * gamma\|)`<br>GM 读取 6x → 4x | - | - | - | *(注：原文本缺失 R1 得分，据前文约贡献 47% 性能提升)* |
| **R2** | 内存带宽层 | Double Buffer 三阶段流水<br>gamma 预加载<br>向量化广播 | 11.41 | +6.1% | ✅ 成功 | 贡献 12%<br>MTE2/V/MTE3 流水线重叠 |
| **R3** | Tiling 层 | `block_M`: 4→16<br>自适应 `block_N`（H<256 时 `block_N=H`） | 15.61 | +36.8% | ✅ 成功 | 贡献 34%<br>UB 利用率 10%→42%<br>消除尾块 |
| **R4** | 架构层 | `block_M`: 16→32<br>条件性 `x_out` readback（双 kernel） | 16.40 | +5.1% | ⚠️ 部分成功 | 贡献 6%<br>**问题**：小 shape 退化 15\~47%<br>**原因**：未评估分发开销（`.item()` 约 5~15μs） |
| **R5** | 指令层 | `mul_add_dst` 融合 | 16.40 | ±1% | ❌ 失败 | 浪费 1 轮<br>**问题**：bandwidth-bound 上尝试 compute-bound 优化<br>**原因**：缺少瓶颈预判 |
| **R5a** | Tiling 层探索 | 单维度递增 `block_M`<br>（4→8→16→32） | - | - | ❌ 失败 | 浪费 1 轮<br>**问题**：`block_M=16` 在双 kernel 下退化 15~28%<br>**原因**：未做交叉实验，错过全局最优组合 |
| **R6** | 架构层探索 | `AUTO_SYNC=False`<br>Fixed Core | - | - | ❌ 失败 | 浪费 1 轮<br>**问题 1**：`AUTO_SYNC=False` 导致 17/20 精度失败（V pipe 队列排空问题）<br>**问题 2**：Fixed Core 编译失败（TVM StmtSimplifier bug）<br>**原因**：编译器限制未记录<br>**意外发现**：`AUTO_SYNC=True` 下需要交替 buffer（`hw_a`/`hw_b`）消除 RAW hazard |
| **R7** | 架构层优化 | 混合策略<br>M<1024: 单 kernel + `block_M=16`<br>M≥1024: 双 kernel + `block_M=32` | 17.19 | +4.8% | ✅ 成功 | 新最高分 67.19<br>解决 R4 小 shape 退化<br>分发开销评估 |

### 一、优化角度（5个维度）

#### 1. 工作流程优化（新增3个强制门禁步骤）

**优化内容：**
- **Step 0: 瓶颈预判（强制门禁）**
  - 计算理论最小耗时（基于 GM 带宽）
  - 判断瓶颈类型（bandwidth/compute/launch-bound）
  - 根据瓶颈类型推荐/禁止优化方向
- **Step 3.5: 多维度交叉实验矩阵（禁止单维度递增）**
  - 识别独立维度（Tiling、架构、同步模式、Pass 数量）
  - 构建 2×2 或 3×3 交叉矩阵
  - 快速验证所有组合，选出最优配置
- **Step 4.5: 组合优化（将各轮最优配置合并验证）**
  - 汇总各轮最优配置
  - 检查配置冲突（Tiling vs 架构、同步 vs 指令）
  - 实现组合版本，完整验证精度 + 性能

**优化理由：**
- R5 在 bandwidth-bound 上尝试 compute-bound 优化（浪费 1 轮）
- R5a 单维度递增 `block_M`（浪费 1 轮）
- R7 的混合策略事后才发现（缺少组合验证）

#### 2. 参考文档完善（新增2个关键文档）

**优化内容：**
- **新增 `references/compiler-limitations.md`**
  - 记录 5 个已知编译器限制：
    1. `AUTO_SYNC=False` + V pipe 指令队列排空问题
    2. Fixed Core + 空循环 range 约束冲突
    3. `mul_add_dst` 在 bandwidth-bound 上无收益
    4. 双 kernel 分发开销对小 shape 的影响
    5. `AUTO_SYNC=True` 下连续 tile 指令的 V pipe RAW hazard
  - 提供安全特性清单（已验证可用）
- **新增 `references/best-practices/vector_fused_operator_optimization.md`**
  - 完整的 R0-R7 优化经验总结
  - 6 个优化手段详解（Pass 缩减、Readback、Tiling、Double Buffer、向量化广播、混合策略）
  - 关键代码模式（Newton-Raphson rsqrt、交替 buffer）
  - 5 个常见陷阱
  - 最佳实践建议和检查点

**优化理由：**
- R6 尝试 `AUTO_SYNC=False` 和 Fixed Core 都失败（编译器限制未记录）
- 多 pass Vector 融合算子缺少完整的优化案例

#### 3. 决策指导强化（新增3个关键章节）

**优化内容：**
- **新增 §一.五 算法层优化（最高优先级，先于核内优化）**
  - Pass 数量缩减（GM 读取 -33%~50%）
  - Readback 模式（避免 Pass 2 重算）
  - 自适应 Tiling 参数（消除尾块）
  - 关键数学变换：`max(|h * inv_rms * gamma|) = inv_rms * max(|h * gamma|)`
- **新增 §2.2.2 交替 buffer 消除 V pipe RAW hazard**
  - 问题：`AUTO_SYNC=True` 下连续 tile 指令存在 RAW 依赖
  - 解决：使用 `hw_a`/`hw_b` 交替 buffer
  - 代码示例：Pass 1 abs_max 计算链、Pass 2 量化链
- **新增 Step 3.5.4 分发开销评估（双 kernel 前必做）**
  - 评估 `.item()` host 同步开销（约 5~15μs）
  - 计算开销占比：`overhead_ratio = dispatch_overhead_us / kernel_us`
  - 决策：占比 > 10% → 单 kernel；< 5% → 双 kernel；5~10% → 混合策略

**优化理由：**
- R1 的 3-pass → 2-pass 贡献 47% 性能提升，但原 skill 未强调算法层优先级
- R6 发现 `AUTO_SYNC=True` 下存在 RAW hazard，需要交替 buffer
- R4 引入双 kernel 未评估分发开销，小 shape 退化 15~47%

#### 4. 反模式识别（新增2个反模式）

**优化内容：**
- **新增“单维度递增搜索（未做交叉实验）”反模式**
  - 识别特征：逐轮递增某个参数（如 `block_M`: 4→8→16→32）
  - 性能原因：不同维度紧耦合，单维度递增无法发现交互效应
  - 替代写法：构建交叉实验矩阵，一轮覆盖所有组合
- **新增“正交轴串行化（Scalar Scan on Parallelizable Axis）”反模式**
  - 识别特征：两层嵌套循环，外层遍历正交轴，内层是标量操作
  - 性能原因：串行处理正交轴浪费向量化并行能力
  - 替代写法：transpose 使并行轴内存连续，折叠为向量操作

**优化理由：**
- R5a 单维度递增 `block_M`，未与 kernel 架构做交叉实验（浪费 1 轮）
- 某些算子（如 cummin）存在正交轴串行化问题，但原反模式清单未覆盖

#### 5. 代码示例更新（更新同步模式和Vector核示例）

**优化内容：**
- **更新 §2.2.0 同步模式决策表**
  - 原推荐：纯 AIV Vector 算子 → `AUTO_SYNC=False`
  - 新推荐：纯 AIV Vector 算子 → `AUTO_SYNC=True`（当前编译器推荐）
  - 添加编译器限制说明和替代方案
- **更新 Vector 核示例代码**
  - 原示例：使用 `AUTO_SYNC=False`
  - 新示例：使用 `AUTO_SYNC=True` + 手动三路 flag（mte3→mte2、mte2→v、v→mte3）
  - 添加详细的 flag 时序说明和易错点提示

**优化理由：**
- R6 发现 `AUTO_SYNC=False` 存在 V pipe 队列排空问题（17/20 精度失败）
- 原示例代码使用 `AUTO_SYNC=False`，会误导后续 Vector 算子

---

## 二、之前 Skill 的漏洞和优化逻辑问题（8个问题）

### 漏洞1：缺少瓶颈预判机制
- **问题描述**：原 skill 没有强制在优化前做瓶颈类型判断，导致在 bandwidth-bound 算子上尝试 compute-bound 优化。
- **具体表现**：
  ```python
  # R5 的错误做法
  # 算子当前耗时 1558μs / 理论最优 299μs = 5.2x > 3x → bandwidth-bound
  # 在 bandwidth-bound 上尝试 mul_add_dst 融合 → 性能变化在噪声范围内（±1%）
  T.tile.mul_add_dst(sum_sq_acc, h_fp32, h_fp32)  # 无效优化
  ```
- **后果**：浪费 1 轮迭代。
- **修复方案**：**新增 Step 0 瓶颈预判（强制门禁）**

### 漏洞2：允许单维度递增搜索
- **问题描述**：原 skill 没有要求做交叉实验，允许逐轮单维度递增搜索，导致 `block_M` 与 kernel 架构的紧耦合关系未被发现。
- **具体表现**：
  ```python
  # R5a 的错误做法
  # 逐轮递增 block_M: 4→8→16→32
  # block_M=16 在双 kernel 下退化 15~28%（与 kernel 架构紧耦合）
  # 错过全局最优组合："单 kernel + block_M=16" 和 "双 kernel + block_M=32"
  ```
- **后果**：浪费 1 轮迭代，错过全局最优。
- **修复方案**：**新增 Step 3.5 多维度交叉实验矩阵**

### 漏洞3：缺少组合优化验证
- **问题描述**：原 skill 没有强制在所有单维度优化后做组合验证，导致混合策略事后才被发现。
- **具体表现**：
  ```python
  # R4 的问题
  # 所有 shape 使用同一 kernel（block_M=32 + 双 kernel）
  # 小 shape (M=256): 8.9μs ← 分发开销占比 > 10%
  # R7 事后才发现需要混合策略
  ```
- **后果**：小 shape 退化 15~47%，R7 才修复。
- **修复方案**：**新增 Step 4.5 组合优化**

### 漏洞4：编译器限制未记录
- **问题描述**：原 skill 没有记录已知的编译器限制，导致尝试已知失败的特性。
- **具体表现**：
  ```python
  # R6 的错误做法 1: AUTO_SYNC=False
  # barrier_all() 无法排空 V pipe 指令队列
  # 当 n_num > 1 时，后续 scalar 操作读到旧值
  # 结果：17/20 精度失败
  
  # R6 的错误做法 2: Fixed Core
  # m_num=8 < 24 cores → TVM StmtSimplifier InternalError
  # 空循环 range 约束冲突
  # 结果：编译失败
  ```
- **后果**：浪费 1 轮迭代（`AUTO_SYNC=False` + Fixed Core 都失败）。
- **修复方案**：**新增 `references/compiler-limitations.md`**

### 漏洞5：算法层优化优先级不明确
- **问题描述**：原 skill 没有强调算法层优化（pass 数量缩减）的最高优先级，可能导致直接进入核内优化，错过最大收益。
- **具体表现**：
  ```python
  # 可能的错误做法
  # 直接进入 Double Buffer / Tiling 调优
  # 错过 3-pass → 2-pass 的算法层优化（GM 读取 -33%，性能 +117%）
  ```
- **后果**：可能错过 47% 的性能提升（R1 贡献）。
- **修复方案**：**新增 §一.五 算法层优化（最高优先级）**

### 漏洞6：分发开销评估缺失
- **问题描述**：原 skill 没有要求在引入双 kernel 前评估分发开销，导致小 shape 退化。
- **具体表现**：
  ```python
  # R4 的问题
  # 引入双 kernel（readback/recompute）但未评估 .item() 分发开销
  # 小 shape (M=256, kernel 4.7μs)：分发开销 10μs 占比 > 100% → 退化 -89%
  ```
- **后果**：小 shape 退化 15~47%，R7 才通过混合策略修复。
- **修复方案**：**新增 Step 3.5.4 分发开销评估（双 kernel 前必做）**

---

## 新增算子

新增 add_rms_norm_dynamic_quant 算子，以下为CANN-BENCH测试报告，在A3上进行测试，对比baseline为pytorch npu下实现的实测结果，加速比为0.64x，以下为精度与性能对比测试报告：

## 算子评测报告

**评测代号**: cann_final_eval_20260717_191555
**评测时间**: 2026-07-17T19:15:55.319301
**设备**: npu:0
**框架版本**: V0.4.0
**评测集版本**: tasks-v0.4.0

### 概览

| 指标 | 数值 |
|------|------|
| 评测算子数 | 1 |
| 总用例数 | 20 |
| 通过用例数 | 20 |
| 失败用例数 | 0 |
| 通过率 | 100.00% |
| 综合得分 | 67.19 |

### 算子详情

#### AddRmsNormDynamicQuant（level3/add_rms_norm_dynamic_quant）

| 指标 | 数值 |
|------|------|
| 用例数 | 20 |
| 通过数 | 20 |
| 失败数 | 0 |
| 通过率 | 100.00% |
| 平均加速比 | 0.64x |
| 编译/运行得分 | 20.00 |
| 精度得分 | 30.00 |
| 性能得分 | 17.19 |
| 得分 | 67.19 |

| 用例ID | 状态 | 耗时(μs) | 加速比 | 精度误差 |
|--------|------|----------|--------|----------|
| level3/add_rms_norm_dynamic_quant_1 | ✅ | 1541.89 | 0.37x | 1.000000 |
| level3/add_rms_norm_dynamic_quant_2 | ✅ | 1575.25 | 0.44x | 1.000000 |
| level3/add_rms_norm_dynamic_quant_3 | ✅ | 1542.77 | 0.37x | 1.000000 |
| level3/add_rms_norm_dynamic_quant_4 | ✅ | 1453.83 | 0.52x | 1.000000 |
| level3/add_rms_norm_dynamic_quant_5 | ✅ | 1645.39 | 0.38x | 1.000000 |
| level3/add_rms_norm_dynamic_quant_6 | ✅ | 2761.10 | 0.57x | 1.000000 |
| level3/add_rms_norm_dynamic_quant_7 | ✅ | 360.85 | 0.44x | 1.000000 |
| level3/add_rms_norm_dynamic_quant_8 | ✅ | 414.49 | 0.36x | 1.000000 |
| level3/add_rms_norm_dynamic_quant_9 | ✅ | 345.27 | 0.52x | 1.000000 |
| level3/add_rms_norm_dynamic_quant_10 | ✅ | 376.95 | 0.85x | 1.000000 |
| level3/add_rms_norm_dynamic_quant_11 | ✅ | 433.91 | 0.52x | 1.000000 |
| level3/add_rms_norm_dynamic_quant_12 | ✅ | 454.63 | 0.38x | 1.000000 |
| level3/add_rms_norm_dynamic_quant_13 | ✅ | 246.11 | 0.44x | 1.000000 |
| level3/add_rms_norm_dynamic_quant_14 | ✅ | 352.87 | 0.51x | 1.000000 |
| level3/add_rms_norm_dynamic_quant_15 | ✅ | 10.94 | 0.91x | 0.000000 |
| level3/add_rms_norm_dynamic_quant_16 | ✅ | 45.56 | 0.54x | 1.000000 |
| level3/add_rms_norm_dynamic_quant_17 | ✅ | 4.80 | 2.08x | 0.000000 |
| level3/add_rms_norm_dynamic_quant_18 | ✅ | 7.66 | 1.31x | 0.000000 |
| level3/add_rms_norm_dynamic_quant_19 | ✅ | 12.22 | 0.82x | 0.000000 |
| level3/add_rms_norm_dynamic_quant_20 | ✅ | 219.50 | 0.39x | 1.000000 |