### PR TITLE
[Fix] Lower compound unary expressions in T.Parallel 🤖

### DIFF
--- a/.agents/skills/tilelang-pass-analyzer/references/pass-designs/ascend_lower_parallel_to_vector_design.md
+++ b/.agents/skills/tilelang-pass-analyzer/references/pass-designs/ascend_lower_parallel_to_vector_design.md
@@ -283,6 +283,13 @@ struct BroadcastInfo {
     // Case 3: 一元操作
     if IsUnaryOp(expr):
         生成 GenerateUnaryVectorCall(op, out, in, count)
+
+    // Case 3.1: 参数为复合表达式的一元操作
+    if MatchTIRUnaryCall(expr, op, operand):
+        校验 operand 与 output dtype 一致且不包含 Cast
+        CreateTempBuffer(operand_tmp)
+        DecomposeExpression(operand → operand_tmp)
+        GenerateUnaryVectorCall(op, operand_tmp → out)
     
     // Case 4: 二元操作
     if IsBinaryOp(expr):
@@ -410,6 +417,7 @@ evaluate(call tl.ascend_add(
 | `test_tilelang_ascend_language_parallel.py` | 基础功能 | 二元操作、一元操作、复合操作、1D操作、广播操作 |
 | `test_tilelang_ascend_language_parallel_auto_copy.py` | GM写入 | 自动UB→GM复制、不同dtype、复杂表达式、L0C输出 |
 | `test_tilelang_ascend_language_parallel_complex.py` | 复杂场景 | 多buffer赋值、链式操作、嵌套计算、多临时buffer |
+| `test_tilelang_ascend_language_parallel_compound_unary.py` | 复合一元操作 | 递归参数分解、双后端codegen、Ascend NPU正确性 |
 | `test_tilelang_ascend_language_parallel_discrete.py` | 离散索引 | gather操作、离散索引访问 |
 
 ### 4.2 测试用例设计
@@ -448,6 +456,8 @@ evaluate(call tl.ascend_add(
 | `test_fused_mul_add` | `a * b + a` | 复合表达式分解、临时buffer |
 | `test_fused_add_mul` | `a * (b + a)` | 右侧复杂→临时buffer |
 | `test_scalar_operation` | `a + 1.0` | Scalar→ascend_adds |
+| `test_compound_unary_codegen_uses_mapped_vector_ops` | `unary(a + eps)` | 先物化参数，再生成一元向量指令 |
+| `test_compound_rsqrt_inside_outer_binary_tree` | `rsqrt(a + eps) * scale + bias` | 复合一元操作作为外层二元子树递归分解 |
 
 #### 4.2.4 广播语义测试
 
@@ -489,6 +499,7 @@ evaluate(call tl.ascend_add(
 针对 Pass 特点，可构造 IR 校验测试验证：
 - 二元操作 IR 变换正确性
 - 复杂表达式分解（Complex-Complex 场景）
+- 复合一元表达式分解（`ascend_adds` 后接 `ascend_rsqrt`，且不残留 `tir.rsqrt`）
 - 广播 IR 生成（`tl.ascend_broadcast` 调用）
 - GM 自动复制（temp_ub allocation + `tl.ascend_copy`）
 
@@ -520,6 +531,7 @@ evaluate(call tl.ascend_add(
 3. **离散索引 fallback**：非简单变量索引（如 `a[idx[i]]`）退回到 serial 循环
 4. **广播限制**：仅支持1D→2D广播，且索引必须是简单变量
 5. **常量要求**：element_count 必须可简化为 IntImm（常量）
+6. **复合一元操作 dtype 限制**：参数表达式与输出必须同 dtype；包含显式 Cast 的参数保守回退
 
 ### 5.4 与其他 Pass 的关系
 

--- a/src/transform/ascend_lower_parallel_to_vector.cc
+++ b/src/transform/ascend_lower_parallel_to_vector.cc
@@ -876,6 +876,67 @@ private:
                combined);
   }
 
+  bool MatchTIRUnaryCall(const PrimExpr &expr, Op *op_type, PrimExpr *operand) {
+    const auto *call = expr.as<CallNode>();
+    if (call == nullptr || call->args.size() != 1) {
+      return false;
+    }
+
+    const auto *op = call->op.as<OpNode>();
+    if (op == nullptr) {
+      return false;
+    }
+
+    auto it = kTIRUnaryOpMap.find(op->name);
+    if (it == kTIRUnaryOpMap.end()) {
+      return false;
+    }
+
+    if (op_type != nullptr) {
+      *op_type = it->second;
+    }
+    if (operand != nullptr) {
+      *operand = call->args[0];
+    }
+    return true;
+  }
+
+  bool ContainsCast(const PrimExpr &expr) {
+    class CastChecker : public ExprVisitor {
+    public:
+      bool found{false};
+
+      void VisitExpr_(const CastNode *op) override {
+        found = true;
+        ExprVisitor::VisitExpr_(op);
+      }
+    };
+
+    CastChecker checker;
+    checker(expr);
+    return checker.found;
+  }
+
+  bool MatchSupportedTIRUnaryCall(const PrimExpr &expr, DataType output_dtype,
+                                  Op *op_type, PrimExpr *operand) {
+    Op matched_op;
+    PrimExpr matched_operand;
+    if (!MatchTIRUnaryCall(expr, &matched_op, &matched_operand) ||
+        expr.dtype() != output_dtype ||
+        matched_operand.dtype() != output_dtype ||
+        ContainsCast(matched_operand)) {
+      return false;
+    }
+
+    if (op_type != nullptr) {
+      *op_type = matched_op;
+    }
+    if (operand != nullptr) {
+      *operand = matched_operand;
+    }
+    return true;
+  }
+
   bool
   DecomposeExpression(const PrimExpr &expr, const Buffer &output_buffer,
                       const PrimExpr &output_offset, int64_t element_count,
@@ -946,6 +1007,36 @@ private:
       return true;
     }
 
+    PrimExpr unary_operand;
+    if (MatchSupportedTIRUnaryCall(expr, output_buffer->dtype, &unary_op_type,
+                                   &unary_operand)) {
+      size_t saved_temp_buffer_count = temp_buffers_.size();
+      int saved_temp_buffer_id = temp_buffer_id_;
+      Buffer operand_buffer =
+          CreateTempBufferLike(output_buffer, element_count, inner_vec_len);
+      PrimExpr operand_offset = IntImm(DataType::Int(32), 0);
+      Array<Stmt> operand_statements;
+
+      if (!DecomposeExpression(unary_operand, operand_buffer, operand_offset,
+                               element_count, parallel_vars,
+                               &operand_statements, is_2d, inner_vec_len)) {
+        temp_buffers_.resize(saved_temp_buffer_count);
+        temp_buffer_id_ = saved_temp_buffer_id;
+        return false;
+      }
+
+      for (const Stmt &stmt : operand_statements) {
+        statements->push_back(stmt);
+      }
+      statements->push_back(GenerateUnaryVectorCall(
+          unary_op_type, output_buffer, output_offset, operand_buffer,
+          operand_offset, element_count, is_2d));
+      return true;
+    }
+    if (MatchTIRUnaryCall(expr, nullptr, nullptr)) {
+      return false;
+    }
+
     Op op_type;
     Array<PrimExpr> operands;
 
@@ -962,9 +1053,13 @@ private:
 
     bool left_is_complex =
         IsBinaryOp(operands[0], nullptr, nullptr) ||
+        MatchSupportedTIRUnaryCall(operands[0], output_buffer->dtype, nullptr,
+                                   nullptr) ||
         IsUnaryOp(operands[0], nullptr, nullptr, nullptr, parallel_vars);
     bool right_is_complex =
         IsBinaryOp(operands[1], nullptr, nullptr) ||
+        MatchSupportedTIRUnaryCall(operands[1], output_buffer->dtype, nullptr,
+                                   nullptr) ||
         IsUnaryOp(operands[1], nullptr, nullptr, nullptr, parallel_vars);
 
     if (left_is_simple && right_is_simple) {
@@ -1018,20 +1113,21 @@ private:
                  Optional<Buffer> *input_buffer, PrimExpr *input_offset,
                  const std::unordered_set<const VarNode *> &parallel_vars) {
     if (auto call = expr.as<CallNode>()) {
-      std::string op_name;
-
-      if (auto *op_ptr = call->op.as<OpNode>()) {
-        op_name = op_ptr->name;
-      } else {
+      PrimExpr operand;
+      if (MatchTIRUnaryCall(expr, op_type, &operand)) {
+        if (auto load = operand.as<BufferLoadNode>()) {
+          if (input_buffer)
+            *input_buffer = load->buffer;
+          if (input_offset)
+            *input_offset = CalculateBufferOffset(load->indices, load->buffer,
+                                                  parallel_vars);
+          return true;
+        }
         return false;
       }
 
-      auto it = kTIRUnaryOpMap.find(op_name);
-      if (it != kTIRUnaryOpMap.end()) {
-        if (op_type)
-          *op_type = it->second;
-      } else if (call->op.same_as(builtin::bitwise_not()) ||
-                 call->op.same_as(tl::ascend_bitwise_not())) {
+      if (call->op.same_as(builtin::bitwise_not()) ||
+          call->op.same_as(tl::ascend_bitwise_not())) {
         if (op_type)
           *op_type = tl::ascend_bitwise_not();
       } else {

--- a/testing/python/language/parallel/test_tilelang_ascend_language_parallel_compound_unary.py
+++ b/testing/python/language/parallel/test_tilelang_ascend_language_parallel_compound_unary.py
@@ -1,0 +1,221 @@
+import pytest
+import torch
+import tvm
+from tvm import tir
+
+import tilelang
+import tilelang.language as T
+
+
+N = 256
+ROWS = 4
+COLS = 64
+EPS = 1.0e-5
+SCALE = 1.25
+BIAS = 0.125
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+UNARY_OPS = {
+    "exp": lambda value: T.exp(value),
+    "log": lambda value: T.log(value),
+    "sqrt": lambda value: T.sqrt(value),
+    "rsqrt": lambda value: T.rsqrt(value),
+    "abs": lambda value: T.abs(value),
+}
+
+UNARY_SOURCE_MARKERS = {
+    "ascendc": {
+        "exp": "AscendC::Exp",
+        "log": "AscendC::Ln",
+        "sqrt": "AscendC::Sqrt",
+        "rsqrt": "AscendC::Rsqrt",
+        "abs": "AscendC::Abs",
+    },
+    "pto": {
+        "exp": "TEXP(",
+        "log": "TLOG(",
+        "sqrt": "TSQRT(",
+        "rsqrt": "TRSQRT(",
+        "abs": "TABS(",
+    },
+}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    tilelang.disable_cache()
+    yield
+
+
+def _compound_unary_1d(dtype, op_name):
+    op = UNARY_OPS[op_name]
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),
+        B: T.Tensor((N,), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (_cid, _vid):
+            a_ub = T.alloc_ub((N,), dtype)
+            b_ub = T.alloc_ub((N,), dtype)
+            T.copy(A, a_ub)
+            for i in T.Parallel(N):
+                b_ub[i] = op(a_ub[i] + T.cast(EPS, dtype))
+            T.copy(b_ub, B)
+
+    return main
+
+
+def _compound_rsqrt_2d(dtype):
+    @T.prim_func
+    def main(
+        A: T.Tensor((ROWS, COLS), dtype),
+        B: T.Tensor((ROWS, COLS), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (_cid, _vid):
+            a_ub = T.alloc_ub((ROWS, COLS), dtype)
+            b_ub = T.alloc_ub((ROWS, COLS), dtype)
+            T.copy(A, a_ub)
+            for i, j in T.Parallel(ROWS, COLS):
+                b_ub[i, j] = T.rsqrt(a_ub[i, j] + T.cast(EPS, dtype))
+            T.copy(b_ub, B)
+
+    return main
+
+
+def _normalization_expression(dtype):
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),
+        B: T.Tensor((N,), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (_cid, _vid):
+            a_ub = T.alloc_ub((N,), dtype)
+            b_ub = T.alloc_ub((N,), dtype)
+            T.copy(A, a_ub)
+            for i in T.Parallel(N):
+                b_ub[i] = T.rsqrt(a_ub[i] + T.cast(EPS, dtype)) * T.cast(SCALE, dtype) + T.cast(BIAS, dtype)
+            T.copy(b_ub, B)
+
+    return main
+
+
+def _lower_through_parallel_to_vector(program):
+    target = tvm.target.Target({"kind": "llvm", "model": "ascendc"})
+    with tvm.transform.PassContext(opt_level=3, config=PASS_CONFIGS):
+        mod = tvm.IRModule({program.attrs["global_symbol"]: program})
+        mod = tilelang.transform.InjectTmpBuffer(target)(mod)
+        mod = tilelang.transform.AscendInferBufferScope()(mod)
+        mod = tilelang.transform.AscendVidReduction()(mod)
+        mod = tilelang.transform.BufferShapeCollector()(mod)
+        mod = tir.transform.BindTarget(target)(mod)
+        mod = tilelang.transform.HostProcesser()(mod)
+        mod = tir.transform.Simplify()(mod)
+        return tilelang.transform.AscendLowerParallelToVector()(mod)
+
+
+def _lower_source(program, target):
+    with tvm.transform.PassContext(opt_level=3, config=PASS_CONFIGS):
+        return tilelang.lower(program, target=target).kernel_source
+
+
+def _assert_ordered(source, *markers):
+    positions = [source.index(marker) for marker in markers]
+    assert positions == sorted(positions), source
+
+
+@pytest.mark.parametrize("dtype", ["float16", "float32"])
+def test_compound_rsqrt_materializes_operand_in_vector_ir(dtype):
+    lowered = _lower_through_parallel_to_vector(_compound_unary_1d(dtype, "rsqrt"))
+    ir_text = str(lowered)
+
+    assert "T.rsqrt" not in ir_text
+    assert "_tmp_" in ir_text
+    assert 'scope="shared.ub"' in ir_text
+    _assert_ordered(ir_text, "T.ascend_adds", "T.ascend_rsqrt")
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("op_name", UNARY_OPS)
+def test_compound_unary_codegen_uses_mapped_vector_ops(target, op_name):
+    source = _lower_source(_compound_unary_1d("float32", op_name), target)
+    add_marker = "AscendC::Adds" if target == "ascendc" else "TADDS("
+
+    _assert_ordered(source, add_marker, UNARY_SOURCE_MARKERS[target][op_name])
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_compound_rsqrt_2d_preserves_vector_plan(target):
+    source = _lower_source(_compound_rsqrt_2d("float32"), target)
+    add_marker = "AscendC::Adds" if target == "ascendc" else "TADDS("
+
+    _assert_ordered(source, add_marker, UNARY_SOURCE_MARKERS[target]["rsqrt"])
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_compound_rsqrt_inside_outer_binary_tree(target):
+    source = _lower_source(_normalization_expression("float32"), target)
+    if target == "ascendc":
+        add_marker = "AscendC::Adds"
+        rsqrt_marker = "AscendC::Rsqrt"
+        mul_marker = "AscendC::Muls"
+    else:
+        add_marker = "TADDS("
+        rsqrt_marker = "TRSQRT("
+        mul_marker = "TMULS("
+
+    positions = [
+        source.index(add_marker),
+        source.index(rsqrt_marker),
+        source.index(mul_marker),
+        source.rindex(add_marker),
+    ]
+    assert len(set(positions)) == len(positions), source
+    assert positions == sorted(positions), source
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="compound unary correctness requires an Ascend NPU runtime",
+)
+@pytest.mark.parametrize("dtype", ["float16", "float32"])
+def test_compound_rsqrt_runtime_matches_torch(dtype):
+    torch_dtype = getattr(torch, dtype)
+    kernel = tilelang.compile(
+        _compound_unary_1d(dtype, "rsqrt"),
+        target="ascendc",
+        pass_configs=PASS_CONFIGS,
+    )
+    a = torch.linspace(0.25, 4.0, N, dtype=torch_dtype, device="npu")
+    b = torch.empty_like(a)
+    expected = torch.rsqrt(a + torch.tensor(EPS, dtype=torch_dtype, device="npu"))
+
+    for _ in range(3):
+        kernel(a, b)
+        torch.npu.synchronize()
+        torch.testing.assert_close(b, expected, rtol=5.0e-3, atol=5.0e-4)
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="normalization expression correctness requires an Ascend NPU runtime",
+)
+def test_compound_rsqrt_inside_outer_binary_runtime_matches_torch():
+    kernel = tilelang.compile(
+        _normalization_expression("float32"),
+        target="ascendc",
+        pass_configs=PASS_CONFIGS,
+    )
+    a = torch.linspace(0.25, 4.0, N, dtype=torch.float32, device="npu")
+    b = torch.empty_like(a)
+    expected = torch.rsqrt(a + EPS) * SCALE + BIAS
+
+    kernel(a, b)
+    torch.npu.synchronize()
+    torch.testing.assert_close(b, expected, rtol=5.0e-3, atol=5.0e-4)


### PR DESCRIPTION
## Summary

- Lower mapped TIR unary calls whose operands are decomposable expressions inside `T.Parallel`.
- Materialize the operand in UB before emitting the Ascend vector unary call, avoiding late failures such as `Unresolved call Op(tir.rsqrt)` for `T.rsqrt(a[i] + eps)`.
- Keep the existing direct-buffer-load path unchanged and reject cast or dtype-mismatched compound operands conservatively.

## Changes

- Separate mapped-unary recognition from direct `BufferLoad` extraction.
- Recursively decompose supported compound operands, with temporary-buffer rollback when decomposition fails.
- Recognize supported compound unary subtrees when classifying outer binary expressions, including normalization-shaped `rsqrt -> mul -> add` expressions.
- Document the lowering contract and add 1D/2D regression coverage for `exp`, `log`, `sqrt`, `rsqrt`, and `fabs` across AscendC and PTO code generation.
- Add real Ascend runtime coverage for float16/float32 compound `rsqrt` and normalization-shaped expressions.

## Testing

- Clean `USE_ASCEND=true` build from the latest `ascendc_pto` base.
- `python3 -m pytest --forked -n 4 -q testing/python/language/parallel` — 114 passed.
- `python3 -m pytest -q testing/python/language/parallel/test_tilelang_ascend_language_parallel_compound_unary.py` — 19 passed after the final safety guard.
- Ascend 910B, five deterministic repeats: maximum relative error 0.3145% for float16 and 0.2866% for float32; all outputs finite.
- AscendC/PTO code generation verified for all five mapped unary operations and ordered normalization lowering.
- `clang-format` 18 dry run, Ruff format/lint, and codespell passed.

## Non-goals

- This change does not extend `DetectVectorPlan` to rank-4 GM stores and does not add scalar/serial unary lowering. Those paths fail before compound-expression decomposition and should be handled separately.
