### PR TITLE
[Fix] Handle rank-changing T.Parallel copies on Ascend

### DIFF
--- a/src/transform/ascend_lower_parallel_to_vector.cc
+++ b/src/transform/ascend_lower_parallel_to_vector.cc
@@ -901,8 +901,9 @@ private:
     if (auto load = expr.as<BufferLoadNode>()) {
       Buffer input_buffer = load->buffer;
 
-      // Rank-changing copies require projection-aware regions, which the
-      // vector copy helper cannot represent. Use the scalar serial fallback.
+      // GenerateAscendCopy indexes source and destination shapes symmetrically.
+      // Rank-changing copies require projection-aware regions, which the vector
+      // copy helper cannot represent. Use the scalar serial fallback.
       if (input_buffer->shape.size() != output_buffer->shape.size()) {
         return false;
       }

--- a/src/transform/ascend_lower_parallel_to_vector.cc
+++ b/src/transform/ascend_lower_parallel_to_vector.cc
@@ -901,6 +901,12 @@ private:
     if (auto load = expr.as<BufferLoadNode>()) {
       Buffer input_buffer = load->buffer;
 
+      // Rank-changing copies require projection-aware regions, which the
+      // vector copy helper cannot represent. Use the scalar serial fallback.
+      if (input_buffer->shape.size() != output_buffer->shape.size()) {
+        return false;
+      }
+
       // Compact->aligned UB->UB copy (different inner/row width) cannot be
       // lowered to copy_ub_to_ub safely: the strided variant needs 32B-aligned
       // per-row UB addresses (sub-32B compact rows trap the VEC instruction),

--- a/testing/python/language/parallel/test_tilelang_ascend_language_parallel_ub_stride.py
+++ b/testing/python/language/parallel/test_tilelang_ascend_language_parallel_ub_stride.py
@@ -53,6 +53,7 @@ def setup_random_seed():
 # ---------------------------------------------------------------------------
 @tilelang.jit(out_idx=[-1], pass_configs=pass_configs)
 def compact_to_aligned_kernel(G, src_cols, dst_cols, dtype="int32"):
+
     @T.prim_func
     def main(SRC: T.Tensor((G, src_cols), dtype), DST: T.Tensor((G, dst_cols), dtype)):
         with T.Kernel(1, is_npu=True) as (cid, vid):
@@ -99,6 +100,7 @@ def test_parallel_compact_to_aligned(setup_random_seed, src_cols, dst_cols, dtyp
 # ---------------------------------------------------------------------------
 @tilelang.jit(out_idx=[-1], pass_configs=pass_configs)
 def row_projection_kernel(rows, lanes, dtype="float32"):
+
     @T.prim_func
     def main(SRC: T.Tensor((rows, lanes), dtype), DST: T.Tensor((lanes,), dtype)):
         with T.Kernel(1, is_npu=True) as (cid, vid):

--- a/testing/python/language/parallel/test_tilelang_ascend_language_parallel_ub_stride.py
+++ b/testing/python/language/parallel/test_tilelang_ascend_language_parallel_ub_stride.py
@@ -1,16 +1,18 @@
-"""Regression tests for issue #1194: T.Parallel compact-to-aligned UB store.
+"""Regression tests for T.Parallel scalar serial fallbacks.
 
-A T.Parallel copy from a compact UB layout to an aligned/padded UB layout
-(different inner/row width, e.g. dst[g, inner] = src[g, inner] with src [G, 8]
-and dst [G, 16]) used to be miscompiled into a copy_ub_to_ub whose source width
-was taken from the destination, packing two source rows into one destination row
-and producing wrong results.
+Issue #1194 covers a T.Parallel copy from a compact UB layout to an
+aligned/padded UB layout (different inner/row width, e.g.
+dst[g, inner] = src[g, inner] with src [G, 8] and dst [G, 16]) that used to be
+miscompiled into a copy_ub_to_ub whose source width was taken from the
+destination, packing two source rows into one destination row and producing
+wrong results.
 
 The fix refuses to vectorize such UB->UB stride-mismatched copies and lowers any
 T.Parallel that cannot be vectorized to a scalar serial loop (codegen emits
 SetValue / GetValue element by element).  The same serial fallback also fixes
 the "Find undefined Variable v_thread" codegen error for parallel loops whose
-body cannot be vectorized (e.g. a data-dependent if/else).
+body cannot be vectorized (e.g. a data-dependent if/else), and rank-changing
+UB projections that cannot be represented by the vector copy helper.
 
 All row widths here are 32B-aligned (int32 multiples of 8, float16 multiples of
 16) on purpose, so the surrounding GM<->UB T.copy is valid and only the
@@ -88,6 +90,37 @@ def test_parallel_compact_to_aligned(setup_random_seed, src_cols, dst_cols, dtyp
 
     torch.testing.assert_close(out[:, :src_cols], src, rtol=1e-2, atol=1e-2)
     torch.testing.assert_close(out[:, src_cols:], torch.zeros_like(out[:, src_cols:]), rtol=1e-2, atol=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# Rank-changing UB projection. The vector copy helper requires matching source
+# and destination ranks, so this 2D -> 1D row projection uses the serial
+# fallback.
+# ---------------------------------------------------------------------------
+@tilelang.jit(out_idx=[-1], pass_configs=pass_configs)
+def row_projection_kernel(rows, lanes, dtype="float32"):
+    @T.prim_func
+    def main(SRC: T.Tensor((rows, lanes), dtype), DST: T.Tensor((lanes,), dtype)):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            src = T.alloc_ub((rows, lanes), dtype)
+            dst = T.alloc_ub((lanes,), dtype)
+            with T.Scope("V"):
+                T.copy(SRC, src)
+                for lane in T.Parallel(lanes):
+                    dst[lane] = src[rows - 1, lane]
+                T.copy(dst, DST)
+
+    return main
+
+
+def test_parallel_rank_changing_row_projection(setup_random_seed):
+    rows, lanes = 256, 8
+    func = row_projection_kernel(rows, lanes)
+    src = torch.randn(rows, lanes, dtype=torch.float32).npu()
+
+    torch.npu.synchronize()
+    out = func(src)
+    torch.testing.assert_close(out, src[-1], rtol=1e-5, atol=1e-5)
 
 
 # ---------------------------------------------------------------------------

--- a/testing/python/language/parallel/test_tilelang_ascend_language_parallel_ub_stride.py
+++ b/testing/python/language/parallel/test_tilelang_ascend_language_parallel_ub_stride.py
@@ -12,7 +12,8 @@ T.Parallel that cannot be vectorized to a scalar serial loop (codegen emits
 SetValue / GetValue element by element).  The same serial fallback also fixes
 the "Find undefined Variable v_thread" codegen error for parallel loops whose
 body cannot be vectorized (e.g. a data-dependent if/else), and rank-changing
-UB projections that cannot be represented by the vector copy helper.
+projections between buffers of different ranks that cannot be represented by
+the vector copy helper.
 
 All row widths here are 32B-aligned (int32 multiples of 8, float16 multiples of
 16) on purpose, so the surrounding GM<->UB T.copy is valid and only the
@@ -123,6 +124,40 @@ def test_parallel_rank_changing_row_projection(setup_random_seed):
     torch.npu.synchronize()
     out = func(src)
     torch.testing.assert_close(out, src[-1], rtol=1e-5, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Rank-changing GM -> UB element mapping. This is the shape pattern from a
+# second failure trajectory: a 2D UB tile selects two fixed axes from a 4D GM
+# tensor. GenerateAscendCopy cannot express the differing index ranks, so the
+# T.Parallel loop must use the serial fallback.
+# ---------------------------------------------------------------------------
+@tilelang.jit(out_idx=[-1], pass_configs=pass_configs)
+def rank4_gm_to_rank2_ub_kernel(rows, lanes, dtype="float32"):
+
+    @T.prim_func
+    def main(
+        SRC: T.Tensor((2, rows, 2, lanes), dtype),
+        DST: T.Tensor((rows, lanes), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            dst = T.alloc_ub((rows, lanes), dtype)
+            with T.Scope("V"):
+                for row, lane in T.Parallel(rows, lanes):
+                    dst[row, lane] = SRC[1, row, 0, lane]
+                T.copy(dst, DST)
+
+    return main
+
+
+def test_parallel_rank4_gm_to_rank2_ub(setup_random_seed):
+    rows, lanes = 4, 8
+    func = rank4_gm_to_rank2_ub_kernel(rows, lanes)
+    src = torch.randn(2, rows, 2, lanes, dtype=torch.float32).npu()
+
+    torch.npu.synchronize()
+    out = func(src)
+    torch.testing.assert_close(out, src[1, :, 0, :], rtol=1e-5, atol=1e-5)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`AscendLowerParallelToVector` accepts a one-dimensional `T.Parallel` destination as vectorizable even when the direct `BufferLoad` source has a different rank. For a 2D UB-to-1D UB row projection such as:

```python
for lane in T.Parallel(lanes):
    dst[lane] = src[rows - 1, lane]
```

`GenerateAscendCopy` takes its 2D-source path, then unconditionally reads `dst_gm->shape[1]`. Since the destination rank is one, compilation fails with:

```text
InternalError: IndexError: indexing 1 on an array of size 1
```

Changing the extent to a source dimension would not be correct: row and column projections require different region geometry, and the current vector-copy helper no longer retains enough information to distinguish them.

## Fix

Reject rank-changing direct copies in vector-copy decomposition and reuse the existing correctness-first `T.Parallel` to serial fallback introduced for #1194. Matching-rank vector copies and the existing 1D-to-2D broadcast lowering remain unchanged.

Add an NPU regression that projects the final row of a `(256, 8)` float32 UB into a rank-1 UB and checks the result against the source row.

## Validation

- Before the fix, the new regression reproduces the exact `AscendLowerParallelToVector -> GenerateAscendCopy -> Array::operator[]` failure.
- `cmake --build build -j64`
- `pytest testing/python/language/parallel/test_tilelang_ascend_language_parallel_ub_stride.py -q -s`: **6 passed**
- Four existing row/column scalar-buffer broadcast tests: **4 passed**
- Executor-compatible `msprof op` run on Ascend NPU:
  - max absolute error: `0.0`
  - end-to-end wrapper latency: `1.1905607767403126 ms`
  - captured kernel task duration: `11.900238 us`
  - matched op: `row_projection_profile_kernel_mix_aic`
