### PR TITLE
[Fix] Legalize nonzero-min vectorized loops on Ascend

### DIFF
--- a/src/transform/legalize_vectorized_loop.cc
+++ b/src/transform/legalize_vectorized_loop.cc
@@ -22,6 +22,7 @@
  * \brief infer the fragment/shared memory layout
  */
 
+#include <tvm/target/target.h>
 #include <tvm/tir/builtin.h>
 #include <tvm/tir/op.h>
 #include <tvm/tir/stmt_functor.h>
@@ -47,8 +48,15 @@ public:
   // Static method to substitute and transform the given PrimFunc
   static PrimFunc Substitute(PrimFunc f) {
     arith::Analyzer analyzer;
+    bool scalarize_nonzero_min = false;
+    if (auto target = f->GetAttr<Target>(tvm::attr::kTarget)) {
+      String model = target.value()->GetAttr<String>("model").value_or("");
+      scalarize_nonzero_min =
+          target.value()->kind->name == "llvm" &&
+          (model == "ascendc" || model == "pto" || model == "auto");
+    }
     // Create an instance of the legalizer with the analyzer
-    LoopVectorizedLegalizer substituter(&analyzer);
+    LoopVectorizedLegalizer substituter(&analyzer, scalarize_nonzero_min);
     // Get a mutable copy of the function node
     PrimFuncNode *fptr = f.CopyOnWrite();
     // Apply the legalizer to the function body
@@ -58,8 +66,9 @@ public:
 
 private:
   // Constructor initializing the base class with the analyzer
-  LoopVectorizedLegalizer(arith::Analyzer *analyzer)
-      : arith::IRMutatorWithAnalyzer(analyzer) {}
+  LoopVectorizedLegalizer(arith::Analyzer *analyzer, bool scalarize_nonzero_min)
+      : arith::IRMutatorWithAnalyzer(analyzer),
+        scalarize_nonzero_min_(scalarize_nonzero_min) {}
 
   // Override the VisitStmt_ method to handle ForNode (loop statements)
   Stmt VisitStmt_(const ForNode *op) final {
@@ -71,9 +80,17 @@ private:
     }
     // Change the loop kind from vectorized to serial
     for_node.CopyOnWrite()->kind = ForKind::kSerial;
+    // Ascend codegen does not support vector values with an offset base. Keep
+    // explicit nonzero-min loops scalar rather than letting VectorizeLoop
+    // reject them (or emit unsupported vector expressions).
+    if (scalarize_nonzero_min_ && !is_zero(for_node->min)) {
+      return for_node;
+    }
     // Apply vectorization transformation to the loop
     return VectorizeLoop(std::move(for_node));
   }
+
+  bool scalarize_nonzero_min_;
 };
 
 // Create a pass that legalizes vectorized loops in the IRModule

--- a/testing/python/language/test_tilelang_ascend_language_vectorized.py
+++ b/testing/python/language/test_tilelang_ascend_language_vectorized.py
@@ -1,0 +1,45 @@
+"""Ascend NPU regression tests for explicit vectorized loops."""
+
+import tilelang
+import tilelang.language as T
+import torch
+
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+@tilelang.jit(out_idx=[-1], pass_configs=pass_configs)
+def nonzero_min_vectorized_kernel(size, start, stop, dtype="float32"):
+
+    @T.prim_func
+    def main(A: T.Tensor((size,), dtype), B: T.Tensor((size,), dtype)):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((size,), dtype)
+            b_ub = T.alloc_ub((size,), dtype)
+            with T.Scope("V"):
+                T.copy(A, a_ub)
+                T.tile.fill(b_ub, 0.0)
+                for i in T.vectorized(start, stop):
+                    b_ub[i] = a_ub[i] + 1.0
+                T.copy(b_ub, B)
+
+    return main
+
+
+def test_vectorized_nonzero_min():
+    size, start, stop = 128, 32, 96
+    func = nonzero_min_vectorized_kernel(size, start, stop)
+    src = torch.arange(size, dtype=torch.float32).npu()
+
+    torch.npu.synchronize()
+    out = func(src)
+    ref = torch.zeros_like(src)
+    ref[start:stop] = src[start:stop] + 1.0
+    torch.testing.assert_close(out, ref, rtol=1e-5, atol=1e-5)
+
+
+if __name__ == "__main__":
+    test_vectorized_nonzero_min()


### PR DESCRIPTION
## Summary

- detect Ascend targets while legalizing explicit vectorized loops
- keep nonzero-min loops scalar because Ascend codegen cannot represent offset-base vector values
- preserve the existing vectorization path for zero-min loops and all non-Ascend targets
- add an Ascend NPU regression for T.vectorized(start, stop)

## Root cause

The public T.vectorized API accepts start and stop bounds, but the generic VectorizeLoop implementation requires a zero loop minimum. LegalizeVectorizedLoop forwarded nonzero-min Ascend loops to it, triggering an internal min == 0 assertion. Normalizing the loop still produces offset vector expressions unsupported by the Ascend backend, so the minimal correctness fallback is to retain that loop as serial on Ascend.

## Validation

- cmake --build build -j64
- ruff format and ruff check on the regression test
- pytest testing/python/language/test_tilelang_ascend_language_vectorized.py -q -s (Ascend NPU: 1 passed)

Related failure trajectory: nonzero T.vectorized min.