### PR TITLE
[Fix] Resolve negative JIT indices before workspace lowering

### DIFF
--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 import tilelang
 import tilelang.language as T
 import tilelang.language.reduce_ascend as reduce_ascend_lang
+from tilelang.utils.target import determine_platform
 
 tir = tilelang.tvm.tir
 
@@ -23,6 +24,50 @@ pass_configs = {
     tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
     tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
 }
+
+
+def _negative_out_idx_auto_workspace_kernel(M=128, N=128, K=128):
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), "float16"),  # type: ignore
+        B: T.Tensor((K, N), "float16"),  # type: ignore
+        C: T.Tensor((M, N), "float16"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((M // 2, K), "float16")
+            a_ub_nz = T.alloc_ub((M // 2, K), "float16")
+            a_l1 = T.alloc_L1((M, K), "float16")
+            b_l1 = T.alloc_L1((K, N), "float16")
+            c_l0 = T.alloc_L0C((M, N), "float32")
+
+            T.copy(A[vid * M // 2 : (vid + 1) * M // 2, :], a_ub)
+            T.copy(a_ub, a_l1, tmp=a_ub_nz)
+            T.copy(B, b_l1)
+            T.gemm_v0(a_l1, b_l1, c_l0, init=True)
+            T.copy(c_l0, C)
+
+    return main
+
+
+@pytest.mark.skipif(determine_platform() == "A5", reason="AscendC test requires A2/A3")
+def test_negative_out_idx_with_auto_workspace():
+    """Negative output indices refer to the original user-facing signature."""
+    M = N = K = 128
+    kernel = tilelang.compile(
+        _negative_out_idx_auto_workspace_kernel(M=M, N=N, K=K),
+        out_idx=[-1],
+        pass_configs=pass_configs,
+        target="ascendc",
+    )
+
+    # CombineCV appends a GM workspace after the original output parameter.
+    assert kernel.out_idx == [2]
+    assert kernel.auto_gm_idx == [3]
+
+    a = torch.randn((M, K), dtype=torch.float16, device="npu")
+    b = torch.randn((K, N), dtype=torch.float16, device="npu")
+    out = kernel(a, b)
+    torch.testing.assert_close(out, a @ b, rtol=1e-3, atol=1e-3)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tilelang/jit/adapter/base.py
+++ b/tilelang/jit/adapter/base.py
@@ -2,52 +2,62 @@
 # Licensed under the MIT License.
 """The profiler and convert to torch utils"""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Any, List, Callable, Optional, Union
+from collections.abc import Callable
+from typing import Any
+
 from tilelang.engine.param import KernelParam
 
 
 class BaseKernelAdapter(ABC):
+    func: Callable | None = None
 
-    func: Optional[Callable] = None
-
-    def __init__(self, mod, params: List[KernelParam], 
-                 result_idx: List[int], workspace_idx: List[int]) -> None:
+    def __init__(
+        self,
+        mod,
+        params: list[KernelParam],
+        result_idx: list[int],
+        workspace_idx: list[int],
+    ) -> None:
         self.mod = mod
         self.params = params
         self.result_idx = self._legalize_auto_memory_idx(result_idx, "result_idx")
         self.workspace_idx = self._legalize_auto_memory_idx(workspace_idx, "workspace_idx")
         self._post_init()
 
-    def _legalize_auto_memory_idx(self, memory_idx: Union[List[int], int, None] = None, memory_name = "auto_memory_idx") -> List[int]:
-        params = self.params
+    @staticmethod
+    def _legalize_memory_idx(
+        memory_idx: list[int] | int | None,
+        num_params: int,
+        memory_name: str = "auto_memory_idx",
+    ) -> list[int]:
         if memory_idx is None:
-            memory_idx = []
-
+            indices = []
         elif isinstance(memory_idx, int):
-            if memory_idx >= len(params) or memory_idx < -len(params):
-                raise ValueError(
-                    f"{memory_name} should be an integer between {-len(params)} and {len(params) - 1}") 
-            if memory_idx < 0:
-                memory_idx = len(params) + memory_idx
-            memory_idx = [memory_idx]
-
+            indices = [memory_idx]
         elif isinstance(memory_idx, list):
-            for i, idx in enumerate(memory_idx):
-                if idx >= len(params) or idx < -len(params):
-                    raise ValueError(
-                        f"{memory_name} should be an integer between {-len(params)} and {len(params) - 1}")
-                if idx < 0:
-                    memory_idx[i] = len(params) + idx
-
+            indices = list(memory_idx)
         else:
             raise ValueError(f"{memory_name} should be a list of integers")
 
-        return memory_idx
-    
+        for i, idx in enumerate(indices):
+            if idx >= num_params or idx < -num_params:
+                raise ValueError(f"{memory_name} should be an integer between {-num_params} and {num_params - 1}")
+            if idx < 0:
+                indices[i] = num_params + idx
+        return indices
+
+    def _legalize_auto_memory_idx(
+        self,
+        memory_idx: list[int] | int | None = None,
+        memory_name: str = "auto_memory_idx",
+    ) -> list[int]:
+        return self._legalize_memory_idx(memory_idx, len(self.params), memory_name)
 
     @abstractmethod
-    def _convert_torch_func(self) -> callable:
+    def _convert_torch_func(self) -> Callable:
         pass
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -138,6 +138,7 @@ class JITKernel:
         """
         Alternative constructor to create a TorchFunction directly from a database.
         """
+        out_idx, workspace_idx = cls._legalize_user_memory_indices(func, out_idx, workspace_idx)
         instance = cls(
             func=func,
             out_idx=out_idx,
@@ -195,6 +196,19 @@ class JITKernel:
         """
         return self.torch_function(*modify_args, **kwds)
 
+    @staticmethod
+    def _legalize_user_memory_indices(
+        tilelang_func: PrimFunc,
+        out_idx: list[int] | int | None,
+        workspace_idx: list[int] | int | None,
+    ) -> tuple[list[int], list[int]]:
+        """Resolve user-facing indices before lowering can append parameters."""
+        num_params = len(tilelang_func.params)
+        return (
+            BaseKernelAdapter._legalize_memory_idx(out_idx, num_params, "result_idx"),
+            BaseKernelAdapter._legalize_memory_idx(workspace_idx, num_params, "workspace_idx"),
+        )
+
     def _compile_and_create_adapter(self, tilelang_func: PrimFunc, out_idx: list[int], workspace_idx: list[int]) -> BaseKernelAdapter:
         """
         Compiles the given TileLang PrimFunc using TVM and creates a kernel adapter.
@@ -215,6 +229,7 @@ class JITKernel:
 
         execution_backend = self.execution_backend
         pass_configs = self.pass_configs
+        out_idx, workspace_idx = self._legalize_user_memory_indices(tilelang_func, out_idx, workspace_idx)
 
         # Compile the function with TVM, optimizing with shared memory lowering.
         enable_host_codegen = execution_backend == "dlpack"


### PR DESCRIPTION
## Summary

- resolve user-facing output and workspace indices against the original PrimFunc signature before lowering
- prevent automatic GM workspaces appended by CombineCV from changing the meaning of negative indices
- return fresh normalized index lists instead of mutating decorator-owned lists
- add an Ascend Cython/NPU regression with an automatically appended workspace

## Root cause

For a three-parameter kernel (A, B, Y), out_idx=[-1] should select Y at index 2. CombineCV can append a fourth automatic GM workspace. The Cython adapter previously normalized -1 only after lowering against the four artifact parameters, selecting workspace index 3 and treating Y as an input. That led to an inputs[2] IndexError when callers supplied only A and B.

## Validation

- ruff format/check and git diff --check
- pytest test_tilelang_ascend_language_elementwise.py::test_negative_out_idx_with_auto_workspace (Ascend NPU: 1 passed; out_idx=[2], auto_gm_idx=[3])
- pytest test_ascend_compile_flags.py excluding its unrelated negative-sync NPU test (17 passed)
- three-way merge-tree check against current origin/ascendc_pto: no conflicts