### PR TITLE
[Fix] Substitute affine T.Parallel outer indices on Ascend

### DIFF
--- a/src/transform/ascend_lower_parallel_to_vector.cc
+++ b/src/transform/ascend_lower_parallel_to_vector.cc
@@ -488,14 +488,15 @@ private:
       plan->inner_vec_len = inner_vec_len;
       plan->outer_extent = element_count / inner_vec_len;
 
-      // Try to extract outer variable from the outer index
-      plan->outer_index_var = store->indices[0].as<VarNode>();
-
       // Check if outer index contains the outer dimension variable (for 2D
       // vectorization)
-      plan->is_2d_vectorizable =
+      bool uses_parallel_outer_dim =
           (outer_dim_var_ != nullptr &&
            ContainsVar(store->indices[0], outer_dim_var_));
+      plan->outer_index_var = uses_parallel_outer_dim
+                                  ? outer_dim_var_
+                                  : store->indices[0].as<VarNode>();
+      plan->is_2d_vectorizable = uses_parallel_outer_dim;
       return true;
     }
 
@@ -523,10 +524,13 @@ private:
 
       plan->inner_vec_len = inner_vec_len;
       plan->outer_extent = element_count / inner_vec_len;
-      plan->outer_index_var = store->indices[1].as<VarNode>();
-      plan->is_2d_vectorizable =
+      bool uses_parallel_outer_dim =
           (outer_dim_var_ != nullptr &&
            ContainsVar(store->indices[1], outer_dim_var_));
+      plan->outer_index_var = uses_parallel_outer_dim
+                                  ? outer_dim_var_
+                                  : store->indices[1].as<VarNode>();
+      plan->is_2d_vectorizable = uses_parallel_outer_dim;
       return true;
     }
     return false;

--- a/testing/python/language/parallel/test_tilelang_ascend_language_parallel_mixed.py
+++ b/testing/python/language/parallel/test_tilelang_ascend_language_parallel_mixed.py
@@ -199,5 +199,49 @@ def test_parallel_mixed_serial_nest(setup_random_seed):
     torch.testing.assert_close(out, a * b + a, rtol=1e-2, atol=1e-2)
 
 
+# ---------------------------------------------------------------------------
+# A serial loop gives the first T.Parallel axis an affine output index. The
+# vector fallback must replace the loop variable inside ``base + g`` rather
+# than leaving ``g`` free in the generated TIR.
+# ---------------------------------------------------------------------------
+@tilelang.jit(out_idx=[-1], pass_configs=pass_configs)
+def parallel_affine_outer_index_kernel(dtype="float"):
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((2, 64), dtype),
+        W: T.Tensor((4, 8), dtype),
+        C: T.Tensor((8, 64), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((2, 64), dtype)
+            w_ub = T.alloc_ub((4, 8), dtype)
+            c_ub = T.alloc_ub((8, 64), dtype)
+            with T.Scope("V"):
+                T.copy(A, a_ub)
+                T.copy(W, w_ub)
+                T.tile.fill(c_ub, 0.0)
+                for k in T.serial(2):
+                    base = k % 2 * 4
+                    for g, n in T.Parallel(4, 64):
+                        c_ub[base + g, n] = c_ub[base + g, n] + a_ub[k, n] * w_ub[g, k]
+                T.copy(c_ub, C)
+
+    return main
+
+
+def test_parallel_affine_outer_index(setup_random_seed):
+    func = parallel_affine_outer_index_kernel()
+    a = torch.randn(2, 64).npu()
+    w = torch.randn(4, 8).npu()
+    torch.npu.synchronize()
+
+    out = func(a, w)
+    ref = torch.empty_like(out)
+    ref[:4] = w[:, 0, None] * a[0]
+    ref[4:] = w[:, 1, None] * a[1]
+    torch.testing.assert_close(out, ref, rtol=1e-5, atol=1e-5)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-n", "8"])


### PR DESCRIPTION
## Summary

- retain the known outer T.Parallel axis when a BufferStore index is affine, such as base + g
- let the existing broadcast/serial fallback replace that axis instead of emitting a free TIR variable
- cover both 2D and 3D store-plan detection
- add an Ascend NPU regression nested under a serial loop

## Root cause

DetectVectorPlan tried to recover the outer variable with index.as<VarNode>(). That returns null for affine expressions such as base + g. If expression analysis later disables 2D vectorization, the fallback creates outer_broadcast_idx but has no variable to replace, so generated code still references the unbound g and codegen fails with Find undefined Variable g.

## Validation

- pre-fix minimal regression: reproducible Find undefined Variable g
- full TileLang C++ build with Ascend targets
- pytest test_tilelang_ascend_language_parallel_mixed.py::test_parallel_affine_outer_index (NPU: 1 passed)
- full parallel mixed test file (NPU: 5 passed)
- ruff format/check; clang-format reports no content changes
- three-way merge-tree check against current origin/ascendc_pto: no conflicts