### PR TITLE
[Fix] Handle compact unaligned multi-row AscendC UB copies

### DIFF
--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -217,6 +217,8 @@ copy_gm_to_ub(LocalTensor<T> dstTensor, GlobalTensor<T> srcTensor,
       WaitFlag<HardEvent::V_MTE2>(0);
     }
   }
+  static_assert(dstM <= 1 || (dstN * sizeof(T)) % 32 == 0,
+                "multi-row GM-to-UB copy requires a 32-byte-aligned UB row");
   AscendC::DataCopyExtParams dataCopyParams(
       maskShapeM, maskShapeN * sizeof(T), (realSrcN - maskShapeN) * sizeof(T),
       (dstN - maskShapeN) * sizeof(T) / 32, 0);
@@ -229,6 +231,8 @@ CATLASS_DEVICE void
 copy_ub_to_gm(GlobalTensor<T> dstTensor, LocalTensor<T> srcTensor,
               uint32_t realdstN = 1, uint32_t maskShapeM = srcM,
               uint32_t maskShapeN = srcN) {
+  static_assert(srcM <= 1 || (srcN * sizeof(T)) % 32 == 0,
+                "multi-row UB-to-GM copy requires a 32-byte-aligned UB row");
   AscendC::DataCopyExtParams dataCopyParams(
       maskShapeM, maskShapeN * sizeof(T), (srcN - maskShapeN) * sizeof(T) / 32,
       (realdstN - maskShapeN) * sizeof(T), 0);

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -217,12 +217,27 @@ copy_gm_to_ub(LocalTensor<T> dstTensor, GlobalTensor<T> srcTensor,
       WaitFlag<HardEvent::V_MTE2>(0);
     }
   }
-  static_assert(dstM <= 1 || (dstN * sizeof(T)) % 32 == 0,
-                "multi-row GM-to-UB copy requires a 32-byte-aligned UB row");
-  AscendC::DataCopyExtParams dataCopyParams(
-      maskShapeM, maskShapeN * sizeof(T), (realSrcN - maskShapeN) * sizeof(T),
-      (dstN - maskShapeN) * sizeof(T) / 32, 0);
   AscendC::DataCopyPadExtParams<T> padParams(isPad, 0, rightPadding, padValue);
+  AscendC::DataCopyExtParams dataCopyParams;
+  if constexpr (dstM > 1 && (dstN * sizeof(T)) % 32 != 0) {
+    // A compact tile has no row gap on either side. Treat it as one
+    // contiguous burst so the DMA engine never has to form an unaligned
+    // address for a subsequent row.
+    if (realSrcN == dstN && maskShapeN == dstN) {
+      dataCopyParams =
+          AscendC::DataCopyExtParams(1, maskShapeM * maskShapeN * sizeof(T), 0,
+                                     0, 0);
+    } else {
+      dataCopyParams = AscendC::DataCopyExtParams(
+          maskShapeM, maskShapeN * sizeof(T),
+          (realSrcN - maskShapeN) * sizeof(T),
+          (dstN - maskShapeN) * sizeof(T) / 32, 0);
+    }
+  } else {
+    dataCopyParams = AscendC::DataCopyExtParams(
+        maskShapeM, maskShapeN * sizeof(T), (realSrcN - maskShapeN) * sizeof(T),
+        (dstN - maskShapeN) * sizeof(T) / 32, 0);
+  }
   AscendC::DataCopyPad(dstTensor, srcTensor, dataCopyParams, padParams);
 }
 
@@ -231,11 +246,24 @@ CATLASS_DEVICE void
 copy_ub_to_gm(GlobalTensor<T> dstTensor, LocalTensor<T> srcTensor,
               uint32_t realdstN = 1, uint32_t maskShapeM = srcM,
               uint32_t maskShapeN = srcN) {
-  static_assert(srcM <= 1 || (srcN * sizeof(T)) % 32 == 0,
-                "multi-row UB-to-GM copy requires a 32-byte-aligned UB row");
-  AscendC::DataCopyExtParams dataCopyParams(
-      maskShapeM, maskShapeN * sizeof(T), (srcN - maskShapeN) * sizeof(T) / 32,
-      (realdstN - maskShapeN) * sizeof(T), 0);
+  AscendC::DataCopyExtParams dataCopyParams;
+  if constexpr (srcM > 1 && (srcN * sizeof(T)) % 32 != 0) {
+    if (realdstN == srcN && maskShapeN == srcN) {
+      dataCopyParams =
+          AscendC::DataCopyExtParams(1, maskShapeM * maskShapeN * sizeof(T), 0,
+                                     0, 0);
+    } else {
+      dataCopyParams = AscendC::DataCopyExtParams(
+          maskShapeM, maskShapeN * sizeof(T),
+          (srcN - maskShapeN) * sizeof(T) / 32,
+          (realdstN - maskShapeN) * sizeof(T), 0);
+    }
+  } else {
+    dataCopyParams = AscendC::DataCopyExtParams(
+        maskShapeM, maskShapeN * sizeof(T),
+        (srcN - maskShapeN) * sizeof(T) / 32,
+        (realdstN - maskShapeN) * sizeof(T), 0);
+  }
   AscendC::DataCopyPad(dstTensor, srcTensor, dataCopyParams);
 }
 

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -224,14 +224,13 @@ copy_gm_to_ub(LocalTensor<T> dstTensor, GlobalTensor<T> srcTensor,
     // contiguous burst so the DMA engine never has to form an unaligned
     // address for a subsequent row.
     if (realSrcN == dstN && maskShapeN == dstN) {
-      dataCopyParams =
-          AscendC::DataCopyExtParams(1, maskShapeM * maskShapeN * sizeof(T), 0,
-                                     0, 0);
-    } else {
       dataCopyParams = AscendC::DataCopyExtParams(
-          maskShapeM, maskShapeN * sizeof(T),
-          (realSrcN - maskShapeN) * sizeof(T),
-          (dstN - maskShapeN) * sizeof(T) / 32, 0);
+          1, maskShapeM * maskShapeN * sizeof(T), 0, 0, 0);
+    } else {
+      dataCopyParams =
+          AscendC::DataCopyExtParams(maskShapeM, maskShapeN * sizeof(T),
+                                     (realSrcN - maskShapeN) * sizeof(T),
+                                     (dstN - maskShapeN) * sizeof(T) / 32, 0);
     }
   } else {
     dataCopyParams = AscendC::DataCopyExtParams(
@@ -249,20 +248,19 @@ copy_ub_to_gm(GlobalTensor<T> dstTensor, LocalTensor<T> srcTensor,
   AscendC::DataCopyExtParams dataCopyParams;
   if constexpr (srcM > 1 && (srcN * sizeof(T)) % 32 != 0) {
     if (realdstN == srcN && maskShapeN == srcN) {
-      dataCopyParams =
-          AscendC::DataCopyExtParams(1, maskShapeM * maskShapeN * sizeof(T), 0,
-                                     0, 0);
-    } else {
       dataCopyParams = AscendC::DataCopyExtParams(
-          maskShapeM, maskShapeN * sizeof(T),
-          (srcN - maskShapeN) * sizeof(T) / 32,
-          (realdstN - maskShapeN) * sizeof(T), 0);
+          1, maskShapeM * maskShapeN * sizeof(T), 0, 0, 0);
+    } else {
+      dataCopyParams =
+          AscendC::DataCopyExtParams(maskShapeM, maskShapeN * sizeof(T),
+                                     (srcN - maskShapeN) * sizeof(T) / 32,
+                                     (realdstN - maskShapeN) * sizeof(T), 0);
     }
   } else {
-    dataCopyParams = AscendC::DataCopyExtParams(
-        maskShapeM, maskShapeN * sizeof(T),
-        (srcN - maskShapeN) * sizeof(T) / 32,
-        (realdstN - maskShapeN) * sizeof(T), 0);
+    dataCopyParams =
+        AscendC::DataCopyExtParams(maskShapeM, maskShapeN * sizeof(T),
+                                   (srcN - maskShapeN) * sizeof(T) / 32,
+                                   (realdstN - maskShapeN) * sizeof(T), 0);
   }
   AscendC::DataCopyPad(dstTensor, srcTensor, dataCopyParams);
 }

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -50,15 +50,16 @@ def unaligned_multirow_copy():
     return main
 
 
-def test_unaligned_multirow_copy_fails_at_compile_time(capfd):
-    with pytest.raises(RuntimeError, match="Compilation Failed"):
-        tilelang.compile(
-            unaligned_multirow_copy(),
-            out_idx=[-1],
-            pass_configs=pass_configs,
-            target="ascendc",
-        )
-    assert "requires a 32-byte-aligned UB row" in capfd.readouterr().err
+def test_unaligned_multirow_full_rows_supported():
+    kernel = tilelang.compile(
+        unaligned_multirow_copy(),
+        out_idx=[-1],
+        pass_configs=pass_configs,
+        target="ascendc",
+    )
+    a = torch.arange(18, dtype=torch.float16).reshape(2, 9).npu()
+    torch.npu.synchronize()
+    torch.testing.assert_close(kernel(a), a + 1, rtol=0, atol=0)
 
 
 @pytest.fixture

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -32,6 +32,35 @@ def clear_cache():
     yield
 
 
+def unaligned_multirow_copy():
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((2, 9), "float16"),
+        C: T.Tensor((2, 9), "float16"),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((2, 9), "float16")
+            b_ub = T.alloc_ub((2, 9), "float16")
+            with T.Scope("V"):
+                T.copy(A, a_ub)
+                T.tile.add(b_ub, a_ub, 1.0)
+                T.copy(b_ub, C)
+
+    return main
+
+
+def test_unaligned_multirow_copy_fails_at_compile_time(capfd):
+    with pytest.raises(RuntimeError, match="Compilation Failed"):
+        tilelang.compile(
+            unaligned_multirow_copy(),
+            out_idx=[-1],
+            pass_configs=pass_configs,
+            target="ascendc",
+        )
+    assert "requires a 32-byte-aligned UB row" in capfd.readouterr().err
+
+
 @pytest.fixture
 def setup_random_seed():
     """Set random seed for reproducibility"""


### PR DESCRIPTION
## What this fixes

AscendC `DataCopyPad` expresses the local UB row stride in 32-byte blocks. A compact multi-row UB such as `float16[2, 9]` has an 18-byte logical row, so the regular 2D burst can silently corrupt later rows even when the source and destination are both contiguous.

## Changes

- detect compact full-row GM-to-UB and UB-to-GM copies whose logical row is not 32-byte aligned
- issue one contiguous DMA burst for those copies, avoiding unaligned per-row addresses
- preserve the existing 2D path for strided or tail slices used by the vector kernels
- replace the compile-failure regression with an NPU load -> UB add -> store correctness test

This only changes AscendC GM/UB copy lowering; PTO behavior is unchanged.

## Validation

- `python3 -m pytest -q testing/python/language/test_tilelang_ascend_language_elementwise.py::test_unaligned_multirow_full_rows_supported`
- `test_vec_select`, `test_vec_select_scalar`, and AscendC tail-mask regression passed on NPU
- PTO tail-mask test remains blocked by the local PTO compiler missing `__biasbuf__`/`aicore` definitions