### PR TITLE
[Fix] Preserve 64-bit indices for large Ascend copies

### DIFF
--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -124,14 +124,15 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
 
   auto compute_strideN = [](const Buffer &buf,
                             const Array<PrimExpr> &extents) -> PrimExpr {
-    PrimExpr strideN = buf->shape[buf->shape.size() - 1];
+    PrimExpr strideN =
+        Cast(DataType::Int(64), buf->shape[buf->shape.size() - 1]);
     if (extents.size() > 1) {
       for (int i = extents.size() - 2; i >= 0; --i) {
         auto *extent = extents[i].as<IntImmNode>();
         if (!extent || extent->value != 1) {
           break;
         }
-        strideN = strideN * buf->shape[i];
+        strideN = strideN * Cast(DataType::Int(64), buf->shape[i]);
       }
     }
     return strideN;
@@ -316,14 +317,30 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
   auto src_new_buffer = T.buffer_remap.count(src) ? T.buffer_remap[src] : src;
   auto dst_new_buffer = T.buffer_remap.count(dst) ? T.buffer_remap[dst] : dst;
 
-  PrimExpr src_len = 1;
+  auto widen_global_indices = [](const Buffer &buffer,
+                                 const Array<PrimExpr> &indices) {
+    if (buffer.scope() != "global") {
+      return indices;
+    }
+    Array<PrimExpr> widened;
+    widened.reserve(indices.size());
+    for (const PrimExpr &index : indices) {
+      widened.push_back(Cast(DataType::Int(64, index.dtype().lanes()), index));
+    }
+    return widened;
+  };
+
+  src_new_indices = widen_global_indices(src_new_buffer, src_new_indices);
+  dst_new_indices = widen_global_indices(dst_new_buffer, dst_new_indices);
+
+  PrimExpr src_len = IntImm(DataType::Int(64), 1);
   for (auto &shape : src_extents) {
-    src_len *= shape;
+    src_len *= Cast(DataType::Int(64), shape);
   }
 
-  PrimExpr dst_len = 1;
+  PrimExpr dst_len = IntImm(DataType::Int(64), 1);
   for (auto &shape : dst_extents) {
-    dst_len *= shape;
+    dst_len *= Cast(DataType::Int(64), shape);
   }
 
   auto src_ptr = src_new_buffer.access_ptr(

--- a/testing/python/language/test_tilelang_ascend_language_copy_large_shape.py
+++ b/testing/python/language/test_tilelang_ascend_language_copy_large_shape.py
@@ -1,0 +1,24 @@
+"""Regression tests for Ascend copies from logically large GM buffers."""
+
+import tilelang
+import tilelang.language as T
+
+
+@T.prim_func
+def copy_one_row_from_large_gm(
+    A: T.Tensor((4, 4225, 5, 256, 128), "float16"),
+    C: T.Tensor((128,), "float16"),
+):
+    with T.Kernel(1, is_npu=True) as (cid, vid):
+        a_ub = T.alloc_ub((128,), "float16")
+        with T.Scope("V"):
+            T.copy(A[3, 4224, 4, 255, 0], a_ub)
+            T.copy(a_ub, C)
+
+
+def test_copy_one_row_from_large_gm_lowers_without_int32_overflow():
+    artifact = tilelang.lower(copy_one_row_from_large_gm, target="ascendc")
+    assert "2768895872" in artifact.kernel_source
+    assert "2768896000" in artifact.kernel_source
+    assert "-1526071424" not in artifact.kernel_source
+    assert "-1526071296" not in artifact.kernel_source


### PR DESCRIPTION
### Summary
- widen Ascend global-copy indices and copy lengths to int64 before `OffsetOf`/`access_ptr` lowering
- preserve 64-bit `strideN` arithmetic for large logical GM shapes
- add a regression for a valid 5D GM row that previously emitted negative int32 offsets

### Root cause
Ascend copy lowering kept flattened indices, strides, and lengths in inferred int32 expressions. A valid offset of 2,768,895,872 wrapped to -1,526,071,424 in generated code.

### Validation
- `python3 -m ruff check testing/python/language/test_tilelang_ascend_language_copy_large_shape.py`
- `TORCH_DEVICE_BACKEND_AUTOLOAD=0 python3 -m pytest -q testing/python/language/test_tilelang_ascend_language_copy_large_shape.py`
- full C++ build on the source worktree

Generated code now contains `(int64_t)2768895872` and `(int64_t)2768896000` with no negative wrapped offsets.