### PR TITLE
[Example] Ascend: sparse flash MLA (DeepSeek) with shared paged KV

### DIFF
--- a/examples/deepseek_v4/sparse_flash_mla/bench_mark.md
+++ b/examples/deepseek_v4/sparse_flash_mla/bench_mark.md
@@ -1,0 +1,68 @@
+Sparse flash MLA is the attention operator of DeepSeek V4. It reads one shared paged KV cache
+through three access patterns — a sliding window over the original KV (`swa`), original plus
+compressed KV (`hca`), and original plus compressed KV selected by top-k sparse indices (`csa`) —
+so all three variants share the same kernel skeleton and differ only in which KV blocks they visit.
+
+### Performance Testing
+
+Input parameter definitions:
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| B | 1 | Batch size |
+| N1 | 64 | Query heads |
+| N2 | 1 | KV heads (so 64 query heads share one KV head) |
+| D | 512 | Head dimension |
+| layout | TND | Query layout |
+| dtype | bfloat16 | |
+| block_size | 128 | Paged KV block size (original and compressed) |
+| window | 127 | Sliding window, left only (`ori_win_left=127`, `ori_win_right=0`) |
+| K | 512 | Top-k compressed indices (`csa` / `hca`; `swa` uses none) |
+| cmp_ratio | 4 / 128 | Compression ratio — 4 for `swa`/`csa`, 128 for `hca` |
+| S (prefill) | 8192 | Query and KV sequence length |
+| S (decode) | 1 | One query step against a KV cache of 8193 |
+
+Measurement: `msprof` **device Task Duration** from `op_summary`, first launch dropped
+(cold start) and the rest averaged. Both sides run the same shapes and the same dtype.
+
+Best performance results:
+
+| Scenario | AscendC | tileLang | Performance Ratio (AscendC/tileLang) |
+|------|------|------|------|
+| swa prefill | 1850.954u | 1490.930u | 124.1% |
+| hca prefill | 3005.296u | 3141.853u | 95.7% |
+| csa prefill | 6882.407u | 6022.700u | 114.3% |
+| swa decode | 23.916u | 13.824u | 173.0% |
+| hca decode | 24.007u | 18.644u | 128.8% |
+| csa decode | 38.759u | 31.659u | 122.4% |
+
+A ratio above 100% means the TileLang kernel is faster than the hand-written AscendC operator it
+is ported from. Five of the six scenarios are at or above parity; `hca prefill` is the one that
+still trails, at 95.7%.
+
+### Optimization Strategies
+
+The kernel drives the cube pipeline itself instead of calling one all-in-one gemm helper:
+
+1. **KV ring in L1**: the paged KV blocks rotate through a small ring of L1 slots, so the
+   `GM -> L1` fetch of the next block overlaps the current block's matmul
+2. **L0A/L0B double buffering**: the `L1 -> L0` load of the next K chunk runs while the current
+   chunk is being multiplied
+3. **Kernel-driven `L1 -> L0 -> mma -> fixpipe`**: the load / matmul / writeback sequence is issued
+   step by step with `real_k` / `real_n` / `k_actual` / `n_actual` / `unit_flag`, which removes the
+   per-call full-pipe drain that a self-contained gemm helper has to emit
+4. **Runtime contraction and output width**: `k_actual` / `n_actual` cut the matmul down to the
+   window actually covered this round, instead of computing the full buffer width
+5. **Hardware-paired writeback**: the last matmul of a band and its fixpipe both carry
+   `unit_flag=0b11`, so the writeback of one band overlaps the matmul of the next through the
+   L0C ping-pong, with no software handshake in between
+6. **Directional flags instead of full barriers**: synchronization is expressed as pipe-to-pipe
+   flags on individual buffers, so unrelated stages keep running
+
+### Files
+
+| File Name | Description |
+|--------|------|
+| sparse_flash_mla_kernel.py | TileLang kernels (three `@tilelang.jit` builders: swa / hca / csa) |
+| sparse_flash_mla_api.py | The `sparse_flash_mla(...)` entry point; running it checks all three variants |
+| sparse_flash_mla_golden.py | Reference implementation and accuracy checks |

--- a/examples/deepseek_v4/sparse_flash_mla/sparse_flash_mla_api.py
+++ b/examples/deepseek_v4/sparse_flash_mla/sparse_flash_mla_api.py
@@ -1,0 +1,272 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+from typing import Optional, Tuple, Union
+
+import torch
+
+from sparse_flash_mla_kernel import build_sparse_flash_mla, DEFAULT_BLOCK_I, DEFAULT_CORE_NUM
+
+
+_KERNEL_CACHE: dict = {}
+
+
+def _torch_to_tilelang_dtype(t: torch.dtype) -> str:
+    if t == torch.bfloat16:
+        return "bfloat16"
+    if t == torch.float16:
+        return "float16"
+    raise ValueError(f"unsupported torch dtype {t}")
+
+
+def _get_kernel(
+    *,
+    batch: int,
+    max_seq: int,
+    total_tokens: int,
+    ori_block_num: int,
+    ori_block_size: int,
+    ori_table_len: int,
+    cmp_block_num: int,
+    cmp_block_size: int,
+    cmp_table_len: int,
+    n_heads: int,
+    n_kv_heads: int,
+    head_dim: int,
+    topk_cmp: int,
+    cmp_ratio: int,
+    scenario: int,
+    ori_win_left: int,
+    softmax_scale: float,
+    dtype: str,
+    core_num: int,
+):
+    key = (
+        batch,
+        max_seq,
+        total_tokens,
+        ori_block_num,
+        ori_block_size,
+        ori_table_len,
+        cmp_block_num,
+        cmp_block_size,
+        cmp_table_len,
+        n_heads,
+        n_kv_heads,
+        head_dim,
+        topk_cmp,
+        cmp_ratio,
+        scenario,
+        ori_win_left,
+        round(softmax_scale, 8),
+        dtype,
+        core_num,
+    )
+    func = _KERNEL_CACHE.get(key)
+    if func is None:
+        func = build_sparse_flash_mla(
+            batch=batch,
+            max_seq=max_seq,
+            total_tokens=total_tokens,
+            ori_block_num=ori_block_num,
+            ori_block_size=ori_block_size,
+            ori_table_len=ori_table_len,
+            cmp_block_num=cmp_block_num,
+            cmp_block_size=cmp_block_size,
+            cmp_table_len=cmp_table_len,
+            n_heads=n_heads,
+            n_kv_heads=n_kv_heads,
+            head_dim=head_dim,
+            topk_cmp=topk_cmp,
+            cmp_ratio=cmp_ratio,
+            scenario=scenario,
+            ori_win_left=ori_win_left,
+            softmax_scale=softmax_scale,
+            dtype=dtype,
+            core_num=core_num,
+        )
+        _KERNEL_CACHE[key] = func
+    return func
+
+
+def sparse_flash_mla(
+    q: torch.Tensor,
+    *,
+    ori_kv: torch.Tensor,
+    cmp_kv: Optional[torch.Tensor] = None,
+    cmp_sparse_indices: Optional[torch.Tensor] = None,
+    ori_block_table: torch.Tensor,
+    cmp_block_table: Optional[torch.Tensor] = None,
+    cu_seqlens_q: Optional[torch.Tensor] = None,
+    seqused_q: Optional[torch.Tensor] = None,
+    seqused_kv: torch.Tensor,
+    sinks: torch.Tensor,
+    softmax_scale: float,
+    cmp_ratio: Optional[int] = None,
+    ori_mask_mode: int = 4,
+    cmp_mask_mode: int = 3,
+    ori_win_left: int = 127,
+    ori_win_right: int = 0,
+    layout_q: str = "TND",
+    layout_kv: str = "PA_ND",
+    return_softmax_lse: bool = False,
+    core_num: int = DEFAULT_CORE_NUM,
+    topk_cmp: Optional[int] = None,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    del seqused_q
+    assert ori_mask_mode == 4, "only ori_mask_mode=4 supported"
+    assert cmp_mask_mode == 3 or cmp_kv is None, "only cmp_mask_mode=3 supported"
+    assert ori_win_right == 0, "only ori_win_right=0 supported"
+    assert layout_kv == "PA_ND", "only layout_kv=PA_ND supported"
+    assert layout_q in ("TND", "BSND"), f"unsupported layout_q={layout_q!r}"
+
+    dtype = q.dtype
+    tl_dtype = _torch_to_tilelang_dtype(dtype)
+
+    if cmp_kv is None:
+        scenario = 1
+    elif cmp_sparse_indices is None:
+        scenario = 2
+    else:
+        scenario = 3
+
+    if layout_q == "TND":
+        assert cu_seqlens_q is not None, "cu_seqlens_q is required for TND"
+        cu = cu_seqlens_q.to(torch.int32).cpu()
+        B = cu.numel() - 1
+        seq_lens = (cu[1:] - cu[:-1]).tolist()
+        S_max = max(seq_lens) if seq_lens else 0
+        T1, N1, D = q.shape
+        total_tokens = T1
+        q_flat = q
+        q_prefix = cu[:-1].to(q.device)
+        act_q_lens = torch.tensor(seq_lens, dtype=torch.int32, device=q.device)
+        if scenario == 3:
+            cmp_indices_flat = cmp_sparse_indices.to(torch.int32).to(q.device)
+        else:
+            cmp_indices_flat = None
+    else:
+        B, S_max, N1, D = q.shape
+        total_tokens = B * S_max
+        q_flat = q.reshape(total_tokens, N1, D)
+        q_prefix = torch.arange(B, dtype=torch.int32, device=q.device) * S_max
+        seq_lens = [S_max] * B
+        act_q_lens = torch.full((B,), S_max, dtype=torch.int32, device=q.device)
+        if cu_seqlens_q is not None:
+            cu = cu_seqlens_q.to(torch.int32).cpu()
+            seq_lens = (cu[1:] - cu[:-1]).tolist()
+            act_q_lens = torch.tensor(seq_lens, dtype=torch.int32, device=q.device)
+        if scenario == 3:
+            ci = cmp_sparse_indices.to(torch.int32)
+            cmp_indices_flat = ci.reshape(total_tokens, ci.shape[2], ci.shape[3]).to(q.device)
+        else:
+            cmp_indices_flat = None
+
+    seqused_kv_dev = seqused_kv.to(torch.int32).to(q.device)
+
+    if scenario == 3:
+        N2 = cmp_indices_flat.shape[1]
+        K = topk_cmp if topk_cmp is not None else cmp_indices_flat.shape[2]
+        assert cmp_indices_flat.shape[2] == K, "topk_cmp does not match cmp_sparse_indices last dim"
+        cmp_indices_dev = cmp_indices_flat
+    elif scenario == 2:
+        N2 = cmp_kv.shape[2]
+
+        max_cmp = int(seqused_kv.max().item()) // cmp_ratio
+
+        _bi = DEFAULT_BLOCK_I
+        K = max(_bi, ((max_cmp + _bi - 1) // _bi) * _bi)
+        cmp_indices_dev = torch.zeros((total_tokens, N2, K), dtype=torch.int32, device=q.device)
+    else:
+        N2 = ori_kv.shape[2]
+        K = 0
+
+        cmp_indices_dev = torch.zeros((total_tokens, N2, DEFAULT_BLOCK_I), dtype=torch.int32, device=q.device)
+
+    if N1 != 64 or N2 != 1 or D != 512:
+        raise ValueError(f"only N1=64, N2=1, D=512 supported (got N1={N1}, N2={N2}, D={D})")
+
+    cmp_ratio_eff = cmp_ratio if cmp_ratio is not None else 4
+
+    ori_kv_dev = ori_kv.to(q.device)
+    ori_bt_dev = ori_block_table.to(torch.int32).to(q.device)
+    ori_block_num, ori_block_size = ori_kv_dev.shape[0], ori_kv_dev.shape[1]
+    ori_table_len = ori_bt_dev.shape[1]
+
+    if cmp_kv is not None:
+        cmp_kv_dev = cmp_kv.to(q.device)
+        cmp_bt_dev = cmp_block_table.to(torch.int32).to(q.device)
+    else:
+        cmp_kv_dev = torch.zeros((1, 1, N2, D), dtype=dtype, device=q.device)
+        cmp_bt_dev = torch.zeros((B, 1), dtype=torch.int32, device=q.device)
+    cmp_block_num, cmp_block_size = cmp_kv_dev.shape[0], cmp_kv_dev.shape[1]
+    cmp_table_len = cmp_bt_dev.shape[1]
+
+    func = _get_kernel(
+        batch=int(B),
+        max_seq=int(S_max),
+        total_tokens=int(total_tokens),
+        ori_block_num=int(ori_block_num),
+        ori_block_size=int(ori_block_size),
+        ori_table_len=int(ori_table_len),
+        cmp_block_num=int(cmp_block_num),
+        cmp_block_size=int(cmp_block_size),
+        cmp_table_len=int(cmp_table_len),
+        n_heads=N1,
+        n_kv_heads=N2,
+        head_dim=D,
+        topk_cmp=K,
+        cmp_ratio=cmp_ratio_eff,
+        scenario=scenario,
+        ori_win_left=ori_win_left,
+        softmax_scale=float(softmax_scale),
+        dtype=tl_dtype,
+        core_num=core_num,
+    )
+
+    sinks_dev = sinks.to(torch.float32).to(q.device)
+
+    out_flat, lse_flat = func(
+        q_flat.contiguous(),
+        ori_kv_dev.contiguous(),
+        ori_bt_dev.contiguous(),
+        cmp_kv_dev.contiguous(),
+        cmp_bt_dev.contiguous(),
+        cmp_indices_dev.contiguous(),
+        q_prefix.contiguous(),
+        act_q_lens.contiguous(),
+        seqused_kv_dev.contiguous(),
+        sinks_dev.contiguous(),
+    )
+
+    if layout_q == "TND":
+        out = out_flat
+        lse = lse_flat
+    else:
+        out = out_flat.reshape(B, S_max, N1, D)
+        lse = lse_flat.reshape(B, S_max, N1)
+
+    if return_softmax_lse:
+        return out, lse
+    return out
+
+
+if __name__ == "__main__":
+    from sparse_flash_mla_golden import (
+        FAST_SCENARIOS,
+        build_case,
+        run_case,
+        check_lse,
+        check_result,
+    )
+
+    dtype = torch.bfloat16
+    for name, cfg in FAST_SCENARIOS.items():
+        case = build_case(cfg, dtype)
+        out, lse = run_case(case, cfg, sparse_flash_mla)
+        check_lse(lse.cpu(), case["cpu_ref_lse"], dtype)
+        check_result(out.cpu(), case["cpu_ref"])
+        print(f"[{name}] passed")
+    print("Kernel Output Match!")

--- a/examples/deepseek_v4/sparse_flash_mla/sparse_flash_mla_golden.py
+++ b/examples/deepseek_v4/sparse_flash_mla/sparse_flash_mla_golden.py
@@ -1,0 +1,700 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Sequence
+
+import numpy as np
+import torch
+
+
+GOLDEN_S2_TILE = 512
+
+
+def _gather_cmp_kv_tokens(
+    cmp_k_bnsd: torch.Tensor,
+    sparse_indices: torch.Tensor,
+    b: int,
+    n2: int,
+    s_local: int,
+    act_kv: int,
+    act_q: int,
+    cmp_ratio: int,
+    cmp_mask_mode: int = 3,
+    sparse_block_size: int = 1,
+) -> torch.Tensor:
+    K = sparse_indices.shape[-1]
+    cmp_act_kv = math.floor(act_kv / cmp_ratio)
+    if cmp_mask_mode == 3:
+        threshold = math.floor((act_kv - act_q + s_local + 1) / cmp_ratio)
+    else:
+        raise ValueError(f"cmp_mask_mode {cmp_mask_mode} not supported")
+
+    valid_count = min(K, math.ceil(threshold / sparse_block_size))
+    s2 = []
+    for i in range(valid_count):
+        topk_id = sparse_indices[b, s_local, n2, i].item()
+        if topk_id == -1:
+            break
+        begin = topk_id * sparse_block_size
+        end = begin + sparse_block_size
+        if end > cmp_act_kv:
+            end = cmp_act_kv
+        if begin >= threshold:
+            continue
+        if end > threshold:
+            end = threshold
+        s2.extend(range(begin, end))
+
+    if not s2:
+        return cmp_k_bnsd.new_zeros((0, cmp_k_bnsd.shape[-1]))
+    return cmp_k_bnsd[b, n2, s2, :]
+
+
+def sparse_flash_mla_golden_bnsd(
+    q_bnsd: torch.Tensor,
+    ori_k_bnsd: torch.Tensor,
+    sinks: torch.Tensor,
+    *,
+    act_q_lens: Sequence[int],
+    act_kv_lens: Sequence[int],
+    softmax_scale: float,
+    cmp_k_bnsd: Optional[torch.Tensor] = None,
+    cmp_sparse_indices: Optional[torch.Tensor] = None,
+    cmp_ratio: Optional[int] = None,
+    ori_win_left: int = 127,
+    ori_win_right: int = 0,
+    ori_mask_mode: int = 4,
+    cmp_mask_mode: int = 3,
+    s2_tile: int = GOLDEN_S2_TILE,
+    return_lse: bool = False,
+):
+    assert ori_win_right == 0, "only ori_win_right=0 (causal) is supported"
+    assert ori_mask_mode == 4, "only ori_mask_mode=4 supported"
+
+    B, N1, S1, D = q_bnsd.shape
+    N2 = ori_k_bnsd.shape[1]
+    G = N1 // N2
+    dtype = q_bnsd.dtype
+    out = torch.zeros_like(q_bnsd, dtype=dtype)
+    lse = torch.zeros((B, N1, S1), dtype=torch.float32, device=q_bnsd.device) if return_lse else None
+
+    has_cmp = cmp_k_bnsd is not None and cmp_sparse_indices is not None
+    is_dense_cmp = cmp_k_bnsd is not None and cmp_sparse_indices is None
+
+    for b in range(B):
+        act_q = int(act_q_lens[b])
+        act_kv = int(act_kv_lens[b])
+        for n2 in range(N2):
+            head_lo = n2 * G
+            head_hi = (n2 + 1) * G
+            sink_group = sinks[head_lo:head_hi].to(torch.float32)
+            for s in range(act_q):
+                s_global = act_kv - act_q + s
+                q = q_bnsd[b, head_lo:head_hi, s, :].to(torch.float32)
+
+                ori_right = s_global + ori_win_right + 1
+                ori_left = max(s_global - ori_win_left, 0)
+                ori_k = ori_k_bnsd[b, n2, ori_left:ori_right, :].to(torch.float32)
+
+                if has_cmp:
+                    cmp_tokens = _gather_cmp_kv_tokens(
+                        cmp_k_bnsd,
+                        cmp_sparse_indices,
+                        b=b,
+                        n2=n2,
+                        s_local=s,
+                        act_kv=act_kv,
+                        act_q=act_q,
+                        cmp_ratio=cmp_ratio,
+                        cmp_mask_mode=cmp_mask_mode,
+                    ).to(torch.float32)
+                elif is_dense_cmp:
+                    threshold = math.floor((act_kv - act_q + s + 1) / cmp_ratio)
+                    cmp_tokens = cmp_k_bnsd[b, n2, : max(threshold, 0), :].to(torch.float32)
+                else:
+                    cmp_tokens = torch.empty((0, D), dtype=torch.float32, device=q_bnsd.device)
+
+                row_max = sink_group.clone()
+                row_sum = torch.ones(G, dtype=torch.float32, device=q_bnsd.device)
+                acc_o = torch.zeros((G, D), dtype=torch.float32, device=q_bnsd.device)
+
+                ori_tiles = max(1, math.ceil(ori_k.size(0) / s2_tile)) if ori_k.size(0) > 0 else 0
+                cmp_tiles = math.ceil(cmp_tokens.size(0) / s2_tile) if cmp_tokens.size(0) > 0 else 0
+
+                for t in range(ori_tiles + cmp_tiles):
+                    if t < ori_tiles:
+                        k_tile = ori_k[t * s2_tile : (t + 1) * s2_tile, :]
+                    else:
+                        ct = t - ori_tiles
+                        k_tile = cmp_tokens[ct * s2_tile : (ct + 1) * s2_tile, :]
+                    if k_tile.size(0) == 0:
+                        continue
+
+                    score = torch.matmul(q, k_tile.T) * softmax_scale
+                    row_max_old = row_max.clone()
+                    row_max = torch.max(row_max, score.amax(dim=1))
+                    alpha = torch.exp(row_max_old - row_max)
+                    p = torch.exp(score - row_max.unsqueeze(1))
+                    row_sum = alpha * row_sum + p.sum(dim=1)
+
+                    p_low = p.to(dtype).to(torch.float32)
+                    pv = torch.matmul(p_low, k_tile)
+                    acc_o = acc_o * alpha.unsqueeze(1) + pv
+
+                out[b, head_lo:head_hi, s, :] = (acc_o / row_sum.unsqueeze(1)).to(dtype)
+                if return_lse:
+                    lse[b, head_lo:head_hi, s] = row_max + torch.log(row_sum)
+
+    if return_lse:
+        return out, lse
+    return out
+
+
+def sinks_softmax_reference(
+    q_bnsd: torch.Tensor,
+    k_concat_bnsd: torch.Tensor,
+    *,
+    sinks: torch.Tensor,
+    softmax_scale: float,
+    return_lse: bool = False,
+):
+    q = q_bnsd.to(torch.float32)
+    k = k_concat_bnsd.to(torch.float32)
+    score = torch.matmul(q, k.transpose(-1, -2)) * softmax_scale
+    sinks_b = sinks.to(torch.float32).view(-1, 1)
+    x_concat = torch.cat([score, sinks_b.expand(score.shape[:-1] + (1,))], dim=-1)
+    x_max = x_concat.amax(dim=-1, keepdim=True)
+    y = torch.exp(score - x_max)
+    denom = y.sum(dim=-1, keepdim=True) + torch.exp(sinks_b - x_max)
+    p = y / denom
+    out = torch.matmul(p.to(q_bnsd.dtype).to(torch.float32), k).to(q_bnsd.dtype)
+    if return_lse:
+        lse = (x_max + torch.log(denom)).squeeze(-1)
+        return out, lse
+    return out
+
+
+def unpack_paged_kv(
+    kv_pa: torch.Tensor,
+    block_table: torch.Tensor,
+    max_logical_len: int,
+) -> torch.Tensor:
+    block_num, block_size, N2, D = kv_pa.shape
+    B = block_table.shape[0]
+    out = kv_pa.new_zeros((B, N2, max_logical_len, D))
+    for b in range(B):
+        for blk_i in range(block_table.shape[1]):
+            phys = int(block_table[b, blk_i].item())
+            if phys < 0:
+                continue
+            start = blk_i * block_size
+            end = start + block_size
+            if start >= max_logical_len:
+                break
+            end = min(end, max_logical_len)
+            take = end - start
+            out[b, :, start:end, :] = kv_pa[phys, :take, :, :].permute(1, 0, 2)
+    return out
+
+
+def tnd_to_bnsd_q(q_tnd: torch.Tensor, cu_seqlens_q: torch.Tensor) -> torch.Tensor:
+    T, N, D = q_tnd.shape
+    seq_lens = (cu_seqlens_q[1:] - cu_seqlens_q[:-1]).tolist()
+    B = len(seq_lens)
+    S_max = max(seq_lens) if seq_lens else 0
+    out = q_tnd.new_zeros((B, N, S_max, D))
+    for b in range(B):
+        start = int(cu_seqlens_q[b].item())
+        end = int(cu_seqlens_q[b + 1].item())
+        L = end - start
+        out[b, :, :L, :] = q_tnd[start:end, :, :].permute(1, 0, 2)
+    return out
+
+
+def bnsd_to_tnd_out(out_bnsd: torch.Tensor, cu_seqlens_q: torch.Tensor) -> torch.Tensor:
+    B, N, _, D = out_bnsd.shape
+    seq_lens = (cu_seqlens_q[1:] - cu_seqlens_q[:-1]).tolist()
+    T_total = sum(seq_lens)
+    out = out_bnsd.new_zeros((T_total, N, D))
+    for b in range(B):
+        start = int(cu_seqlens_q[b].item())
+        end = int(cu_seqlens_q[b + 1].item())
+        L = end - start
+        out[start:end, :, :] = out_bnsd[b, :, :L, :].permute(1, 0, 2)
+    return out
+
+
+def bnsd_to_tnd_lse(lse_bnsd: torch.Tensor, cu_seqlens_q: torch.Tensor) -> torch.Tensor:
+    B, N, _ = lse_bnsd.shape
+    seq_lens = (cu_seqlens_q[1:] - cu_seqlens_q[:-1]).tolist()
+    T_total = sum(seq_lens)
+    out = lse_bnsd.new_zeros((T_total, N))
+    for b in range(B):
+        start = int(cu_seqlens_q[b].item())
+        end = int(cu_seqlens_q[b + 1].item())
+        L = end - start
+
+        out[start:end, :] = lse_bnsd[b, :, :L].permute(1, 0)
+    return out
+
+
+def gen_ori_kv_paged(
+    *,
+    B: int,
+    N2: int,
+    D: int,
+    block_num: int,
+    block_size: int,
+    seqused_kv: Sequence[int],
+    dtype: torch.dtype,
+    data_range: tuple = (-10, 10),
+    rng: Optional[np.random.Generator] = None,
+) -> tuple:
+    rng = rng or np.random.default_rng(0)
+    max_s = max(seqused_kv)
+    max_blk = math.ceil(max_s / block_size)
+    lo, hi = data_range
+
+    ori_k_bnsd = (torch.rand((B, N2, max_s, D)) * (hi - lo) + lo).to(dtype)
+
+    per_batch_blocks = [math.ceil(s / block_size) for s in seqused_kv]
+    total_blocks = sum(per_batch_blocks)
+    if block_num < total_blocks:
+        raise ValueError(f"ori block_num too small: {block_num} < {total_blocks}")
+
+    phys_ids = rng.permutation(block_num).astype(np.int32)
+    table = np.full((B, max_blk), -1, dtype=np.int32)
+    cursor = 0
+    for b, nb in enumerate(per_batch_blocks):
+        for i in range(nb):
+            table[b, i] = phys_ids[cursor]
+            cursor += 1
+
+    pa = torch.zeros((block_num, block_size, N2, D), dtype=dtype)
+    for b in range(B):
+        for i in range(per_batch_blocks[b]):
+            phys = int(table[b, i])
+            s0 = i * block_size
+            s1 = min(s0 + block_size, max_s)
+            take = s1 - s0
+            pa[phys, :take, :, :] = ori_k_bnsd[b, :, s0:s1, :].permute(1, 0, 2)
+
+    return pa, torch.tensor(table, dtype=torch.int32), ori_k_bnsd
+
+
+def gen_cmp_kv_paged(
+    *,
+    B: int,
+    N2: int,
+    D: int,
+    block_num: int,
+    block_size: int,
+    seqused_kv: Sequence[int],
+    cmp_ratio: int,
+    dtype: torch.dtype,
+    data_range: tuple = (-5, 10),
+    rng: Optional[np.random.Generator] = None,
+) -> tuple:
+    rng = rng or np.random.default_rng(1)
+    cmp_seqs = [math.floor(s / cmp_ratio) for s in seqused_kv]
+    max_cmp = max(cmp_seqs) if cmp_seqs else 0
+    max_blk = math.ceil(max_cmp / block_size) if max_cmp > 0 else 1
+    lo, hi = data_range
+
+    cmp_k_bnsd = (torch.rand((B, N2, max(max_cmp, 1), D)) * (hi - lo) + lo).to(dtype)
+
+    per_batch_blocks = [math.ceil(s / block_size) if s > 0 else 0 for s in cmp_seqs]
+    total_blocks = sum(per_batch_blocks)
+    if block_num < max(total_blocks, 1):
+        raise ValueError(f"cmp block_num too small: {block_num} < {total_blocks}")
+
+    phys_ids = rng.permutation(block_num).astype(np.int32)
+    table = np.full((B, max(max_blk, 1)), -1, dtype=np.int32)
+    cursor = 0
+    for b, nb in enumerate(per_batch_blocks):
+        for i in range(nb):
+            table[b, i] = phys_ids[cursor]
+            cursor += 1
+
+    pa = torch.zeros((block_num, block_size, N2, D), dtype=dtype)
+    for b in range(B):
+        for i in range(per_batch_blocks[b]):
+            phys = int(table[b, i])
+            s0 = i * block_size
+            s1 = min(s0 + block_size, cmp_seqs[b])
+            take = s1 - s0
+            if take > 0:
+                pa[phys, :take, :, :] = cmp_k_bnsd[b, :, s0:s1, :].permute(1, 0, 2)
+
+    return pa, torch.tensor(table, dtype=torch.int32), cmp_k_bnsd, cmp_seqs
+
+
+def gen_cmp_sparse_indices_bsnd(
+    *,
+    B: int,
+    S1: int,
+    N2: int,
+    K: int,
+    seqused_kv: Sequence[int],
+    cmp_ratio: int,
+    cmp_mask_mode: int = 3,
+    rng: Optional[torch.Generator] = None,
+) -> torch.Tensor:
+    if cmp_mask_mode != 3:
+        raise ValueError("only cmp_mask_mode=3 supported")
+    cmp_sparse_indices = torch.full((B, S1, N2, K), fill_value=-1, dtype=torch.int32)
+    for b in range(B):
+        act_kv = int(seqused_kv[b])
+        for n2 in range(N2):
+            for s in range(S1):
+                cur_max = math.floor((act_kv - S1 + s + 1) / cmp_ratio)
+                cur_max = max(0, cur_max)
+                perm = torch.randperm(cur_max, generator=rng).to(torch.int32) if cur_max > 0 else torch.empty((0,), dtype=torch.int32)
+                take = min(cur_max, K)
+                cmp_sparse_indices[b, s, n2, :take] = perm[:take]
+    return cmp_sparse_indices
+
+
+def gen_cmp_sparse_indices_tnd(
+    *,
+    B: int,
+    T1: int,
+    N2: int,
+    K: int,
+    cu_seqlens_q: torch.Tensor,
+    seqused_kv: Sequence[int],
+    cmp_ratio: int,
+    cmp_mask_mode: int = 3,
+    rng: Optional[torch.Generator] = None,
+) -> torch.Tensor:
+    if cmp_mask_mode != 3:
+        raise ValueError("only cmp_mask_mode=3 supported")
+    cmp_sparse_indices = torch.full((T1, N2, K), fill_value=-1, dtype=torch.int32)
+    for b in range(B):
+        s_start = int(cu_seqlens_q[b].item())
+        s_end = int(cu_seqlens_q[b + 1].item())
+        act_q = s_end - s_start
+        act_kv = int(seqused_kv[b])
+        for n2 in range(N2):
+            for s in range(act_q):
+                cur_max = math.floor((act_kv - act_q + s + 1) / cmp_ratio)
+                cur_max = max(0, cur_max)
+                perm = torch.randperm(cur_max, generator=rng).to(torch.int32) if cur_max > 0 else torch.empty((0,), dtype=torch.int32)
+                take = min(cur_max, K)
+                cmp_sparse_indices[s_start + s, n2, :take] = perm[:take]
+    return cmp_sparse_indices
+
+
+FAST_SCENARIOS = {
+    "swa": dict(
+        scenario=1,
+        layout_q="TND",
+        B=1,
+        S1=1024,
+        T1=1024,
+        N1=64,
+        N2=1,
+        D=512,
+        K=0,
+        block_num1=10,
+        block_num2=1,
+        block_size1=128,
+        block_size2=1,
+        cu_seqlens_q=[0, 1024],
+        seqused_kv=[1024],
+        softmax_scale=0.04419417,
+        cmp_ratio=4,
+        ori_win_left=127,
+        ori_win_right=0,
+        ori_mask_mode=4,
+        cmp_mask_mode=3,
+    ),
+    "hca": dict(
+        scenario=2,
+        layout_q="TND",
+        B=1,
+        S1=1024,
+        T1=1024,
+        N1=64,
+        N2=1,
+        D=512,
+        K=512,
+        block_num1=10,
+        block_num2=2,
+        block_size1=128,
+        block_size2=128,
+        cu_seqlens_q=[0, 1024],
+        seqused_kv=[1024],
+        softmax_scale=0.04419417,
+        cmp_ratio=128,
+        ori_win_left=127,
+        ori_win_right=0,
+        ori_mask_mode=4,
+        cmp_mask_mode=3,
+    ),
+    "csa": dict(
+        scenario=3,
+        layout_q="TND",
+        B=1,
+        S1=1024,
+        T1=1024,
+        N1=64,
+        N2=1,
+        D=512,
+        K=512,
+        block_num1=10,
+        block_num2=3,
+        block_size1=128,
+        block_size2=128,
+        cu_seqlens_q=[0, 1024],
+        seqused_kv=[1024],
+        softmax_scale=0.04419417,
+        cmp_ratio=4,
+        ori_win_left=127,
+        ori_win_right=0,
+        ori_mask_mode=4,
+        cmp_mask_mode=3,
+    ),
+}
+
+
+def build_case(cfg, dtype, seed=42):
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+
+    layout_q = cfg["layout_q"]
+    B = cfg["B"]
+    S1 = cfg["S1"]
+    T1 = cfg.get("T1", S1 * B)
+    N1, N2, D = cfg["N1"], cfg["N2"], cfg["D"]
+    K = cfg.get("K", 0)
+    cmp_ratio = cfg["cmp_ratio"]
+    block_size1, block_num1 = cfg["block_size1"], cfg["block_num1"]
+    block_size2, block_num2 = cfg["block_size2"], cfg["block_num2"]
+    seqused_kv = cfg["seqused_kv"]
+    cu_seqlens_q = torch.tensor(cfg["cu_seqlens_q"], dtype=torch.int32)
+    softmax_scale = cfg["softmax_scale"]
+    scenario = cfg["scenario"]
+
+    if layout_q == "TND":
+        q = (torch.rand((T1, N1, D)) * 20 - 10).to(dtype)
+    else:
+        q = (torch.rand((B, S1, N1, D)) * 20 - 10).to(dtype)
+
+    ori_pa, ori_bt, ori_k_bnsd = gen_ori_kv_paged(
+        B=B,
+        N2=N2,
+        D=D,
+        block_num=block_num1,
+        block_size=block_size1,
+        seqused_kv=seqused_kv,
+        dtype=dtype,
+        data_range=(-10, 10),
+        rng=np.random.default_rng(seed),
+    )
+
+    if scenario >= 2:
+        cmp_pa, cmp_bt, cmp_k_bnsd, cmp_seqs = gen_cmp_kv_paged(
+            B=B,
+            N2=N2,
+            D=D,
+            block_num=block_num2,
+            block_size=block_size2,
+            seqused_kv=seqused_kv,
+            cmp_ratio=cmp_ratio,
+            dtype=dtype,
+            data_range=(-5, 10),
+            rng=np.random.default_rng(seed + 1),
+        )
+    else:
+        cmp_pa, cmp_bt, cmp_k_bnsd = None, None, None
+
+    if scenario == 3:
+        rng = torch.Generator()
+        rng.manual_seed(seed + 7)
+        if layout_q == "TND":
+            cmp_idx = gen_cmp_sparse_indices_tnd(
+                B=B,
+                T1=T1,
+                N2=N2,
+                K=K,
+                cu_seqlens_q=cu_seqlens_q,
+                seqused_kv=seqused_kv,
+                cmp_ratio=cmp_ratio,
+                cmp_mask_mode=3,
+                rng=rng,
+            )
+        else:
+            cmp_idx = gen_cmp_sparse_indices_bsnd(
+                B=B,
+                S1=S1,
+                N2=N2,
+                K=K,
+                seqused_kv=seqused_kv,
+                cmp_ratio=cmp_ratio,
+                cmp_mask_mode=3,
+                rng=rng,
+            )
+    else:
+        cmp_idx = None
+
+    sinks = (torch.rand(N1) * 2 - 1).to(torch.float32)
+
+    if layout_q == "TND":
+        q_bnsd_ref = tnd_to_bnsd_q(q, cu_seqlens_q)
+        act_q_lens = (cu_seqlens_q[1:] - cu_seqlens_q[:-1]).tolist()
+    else:
+        q_bnsd_ref = q.permute(0, 2, 1, 3).contiguous()
+        act_q_lens = [S1] * B
+
+    if cmp_idx is not None:
+        if layout_q == "TND":
+            S_max = max(act_q_lens)
+            cmp_idx_bsnd = torch.full((B, S_max, N2, K), -1, dtype=torch.int32)
+            for b in range(B):
+                s_start = int(cu_seqlens_q[b].item())
+                L = int(act_q_lens[b])
+                cmp_idx_bsnd[b, :L, :, :] = cmp_idx[s_start : s_start + L, :, :]
+        else:
+            cmp_idx_bsnd = cmp_idx
+    else:
+        cmp_idx_bsnd = None
+
+    cpu_ref, cpu_ref_lse = sparse_flash_mla_golden_bnsd(
+        q_bnsd_ref,
+        ori_k_bnsd,
+        sinks,
+        act_q_lens=act_q_lens,
+        act_kv_lens=seqused_kv,
+        softmax_scale=softmax_scale,
+        cmp_k_bnsd=cmp_k_bnsd,
+        cmp_sparse_indices=cmp_idx_bsnd if scenario == 3 else None,
+        cmp_ratio=cmp_ratio if scenario >= 2 else None,
+        ori_win_left=cfg["ori_win_left"],
+        ori_win_right=cfg["ori_win_right"],
+        ori_mask_mode=cfg["ori_mask_mode"],
+        cmp_mask_mode=cfg["cmp_mask_mode"],
+        return_lse=True,
+    )
+
+    if layout_q == "TND":
+        cpu_ref = bnsd_to_tnd_out(cpu_ref, cu_seqlens_q)
+        cpu_ref_lse = bnsd_to_tnd_lse(cpu_ref_lse, cu_seqlens_q)
+    else:
+        cpu_ref = cpu_ref.permute(0, 2, 1, 3).contiguous()
+        cpu_ref_lse = cpu_ref_lse.permute(0, 2, 1).contiguous()
+
+    return dict(
+        cfg=cfg,
+        q=q,
+        ori_pa=ori_pa,
+        ori_bt=ori_bt,
+        cmp_pa=cmp_pa,
+        cmp_bt=cmp_bt,
+        cmp_idx=cmp_idx,
+        sinks=sinks,
+        cu_seqlens_q=cu_seqlens_q,
+        seqused_kv=torch.tensor(seqused_kv, dtype=torch.int32),
+        cpu_ref=cpu_ref,
+        cpu_ref_lse=cpu_ref_lse,
+    )
+
+
+def check_result(npu_out, expect):
+    if npu_out.dtype == torch.bfloat16:
+        rtol, atol = 0.0078125, 0.0001
+    else:
+        rtol, atol = 0.005, 0.000025
+
+    real = npu_out.detach().cpu().to(torch.float32).numpy().flatten()
+    expt = expect.detach().cpu().to(torch.float32).numpy().flatten()
+    assert real.size == expt.size, f"size mismatch: {real.size} vs {expt.size}"
+
+    ok = np.isclose(real, expt, rtol=rtol, atol=atol, equal_nan=True)
+    n_err = int((~ok).sum())
+    fulfill_pct = (real.size - n_err) / real.size * 100.0
+
+    diff_thd = 0.005
+    norm_floor = (1.0 / (1 << 14)) / diff_thd
+    b = np.maximum(np.maximum(np.abs(real), np.abs(expt)), norm_floor) + 1e-9
+    rel_err = np.abs(real - expt) / b
+    max_rel = float(rel_err[~ok].max()) if n_err > 0 else 0.0
+
+    assert fulfill_pct >= 99.5, (
+        f"only {fulfill_pct:.4f}% of elements within tol "
+        f"(rtol={rtol}, atol={atol}); 99.5% required; "
+        f"{n_err}/{real.size} failing, max rel err {max_rel:.4f}"
+    )
+    assert max_rel < 10.0, (
+        f"max normalized relative error {max_rel:.4f} exceeds cap 10.0 (fulfill {fulfill_pct:.4f}%, {n_err}/{real.size} failing)"
+    )
+
+
+def check_lse(npu_lse, expect_lse, q_dtype):
+    if q_dtype == torch.bfloat16:
+        rtol, atol = 0.015, 0.005
+    else:
+        rtol, atol = 0.01, 0.001
+
+    real = npu_lse.detach().cpu().to(torch.float32).numpy().flatten()
+    expt = expect_lse.detach().cpu().to(torch.float32).numpy().flatten()
+    assert real.size == expt.size, f"lse size mismatch: {real.size} vs {expt.size}"
+
+    ok = np.isclose(real, expt, rtol=rtol, atol=atol, equal_nan=True)
+    n_err = int((~ok).sum())
+    fulfill_pct = (real.size - n_err) / real.size * 100.0
+
+    diff_thd = 0.005
+    norm_floor = (1.0 / (1 << 14)) / diff_thd
+    b = np.maximum(np.maximum(np.abs(real), np.abs(expt)), norm_floor) + 1e-9
+    rel_err = np.abs(real - expt) / b
+    max_rel = float(rel_err[~ok].max()) if n_err > 0 else 0.0
+
+    assert fulfill_pct >= 99.5, (
+        f"lse: only {fulfill_pct:.4f}% within tol "
+        f"(rtol={rtol}, atol={atol}); 99.5% required; "
+        f"{n_err}/{real.size} failing, max rel err {max_rel:.4f}"
+    )
+    assert max_rel < 10.0, (
+        f"lse: max normalized relative error {max_rel:.4f} exceeds cap 10.0 (fulfill {fulfill_pct:.4f}%, {n_err}/{real.size} failing)"
+    )
+
+
+def run_case(case, cfg, sparse_flash_mla_fn):
+    layout_q = cfg["layout_q"]
+    scenario = cfg["scenario"]
+    K = cfg.get("K", 0)
+
+    def _dev(t):
+        return t.npu().contiguous() if t is not None and hasattr(t, "npu") else t
+
+    cu_seqlens_q_dev = _dev(case["cu_seqlens_q"]) if layout_q == "TND" else None
+    seqused_kv_dev = _dev(case["seqused_kv"])
+
+    with torch.device("npu"):
+        out, lse = sparse_flash_mla_fn(
+            _dev(case["q"]),
+            ori_kv=_dev(case["ori_pa"]),
+            cmp_kv=_dev(case["cmp_pa"]),
+            cmp_sparse_indices=_dev(case["cmp_idx"]),
+            ori_block_table=_dev(case["ori_bt"]),
+            cmp_block_table=_dev(case["cmp_bt"]),
+            cu_seqlens_q=cu_seqlens_q_dev,
+            seqused_kv=seqused_kv_dev,
+            sinks=_dev(case["sinks"]),
+            softmax_scale=cfg["softmax_scale"],
+            cmp_ratio=cfg["cmp_ratio"] if scenario >= 2 else None,
+            ori_mask_mode=cfg["ori_mask_mode"],
+            cmp_mask_mode=cfg["cmp_mask_mode"],
+            ori_win_left=cfg["ori_win_left"],
+            ori_win_right=cfg["ori_win_right"],
+            layout_q=layout_q,
+            layout_kv="PA_ND",
+            return_softmax_lse=True,
+            topk_cmp=K,
+        )
+        torch.npu.synchronize()
+    return out, lse

--- a/examples/deepseek_v4/sparse_flash_mla/sparse_flash_mla_kernel.py
+++ b/examples/deepseek_v4/sparse_flash_mla/sparse_flash_mla_kernel.py
@@ -1,0 +1,2740 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+
+import os
+
+import tilelang
+from tilelang import language as T
+
+tilelang.disable_cache()
+from tvm import tir
+
+
+DEFAULT_BLOCK_I = 128
+
+
+DEFAULT_CORE_NUM = 24
+
+
+def build_sparse_flash_mla(
+    *,
+    batch: int,
+    max_seq: int,
+    total_tokens: int,
+    ori_block_num: int,
+    ori_block_size: int,
+    ori_table_len: int,
+    cmp_block_num: int,
+    cmp_block_size: int,
+    cmp_table_len: int,
+    n_heads: int,
+    n_kv_heads: int,
+    head_dim: int,
+    topk_cmp: int,
+    cmp_ratio: int,
+    scenario: int,
+    ori_win_left: int,
+    softmax_scale: float,
+    dtype: str,
+    core_num: int,
+):
+    if scenario not in (1, 2, 3):
+        raise NotImplementedError(f"only SWA (1), HCA (2), CSA (3) are implemented; got scenario={scenario}")
+    if n_kv_heads != 1 or n_heads != 64 or head_dim != 512:
+        raise ValueError(f"kernel assumes N1=64, N2=1, D=512 (got N1={n_heads}, N2={n_kv_heads}, D={head_dim})")
+    if ori_win_left + 1 > DEFAULT_BLOCK_I:
+        raise ValueError(
+            f"ori_win_left={ori_win_left} exceeds single-tile window (BI={DEFAULT_BLOCK_I}); the ori window is one tile for both SWA and HCA"
+        )
+
+    if scenario == 1:
+        return _build_swa(
+            batch=batch,
+            max_seq=max_seq,
+            total_tokens=total_tokens,
+            ori_block_num=ori_block_num,
+            ori_block_size=ori_block_size,
+            ori_table_len=ori_table_len,
+            cmp_block_num=cmp_block_num,
+            cmp_block_size=cmp_block_size,
+            cmp_table_len=cmp_table_len,
+            n_heads=n_heads,
+            head_dim=head_dim,
+            ori_win_left=ori_win_left,
+            softmax_scale=float(softmax_scale),
+            dtype=dtype,
+            core_num=core_num,
+        )
+
+    if scenario == 3:
+        return _build_csa(
+            batch=batch,
+            max_seq=max_seq,
+            total_tokens=total_tokens,
+            ori_block_num=ori_block_num,
+            ori_block_size=ori_block_size,
+            ori_table_len=ori_table_len,
+            cmp_block_num=cmp_block_num,
+            cmp_block_size=cmp_block_size,
+            cmp_table_len=cmp_table_len,
+            n_heads=n_heads,
+            head_dim=head_dim,
+            topk_cmp=topk_cmp,
+            ori_win_left=ori_win_left,
+            cmp_ratio=cmp_ratio,
+            softmax_scale=float(softmax_scale),
+            dtype=dtype,
+            core_num=core_num,
+        )
+
+    return _build_hca(
+        batch=batch,
+        max_seq=max_seq,
+        total_tokens=total_tokens,
+        ori_block_num=ori_block_num,
+        ori_block_size=ori_block_size,
+        ori_table_len=ori_table_len,
+        cmp_block_num=cmp_block_num,
+        cmp_block_size=cmp_block_size,
+        cmp_table_len=cmp_table_len,
+        n_heads=n_heads,
+        head_dim=head_dim,
+        ori_win_left=ori_win_left,
+        cmp_ratio=cmp_ratio,
+        softmax_scale=float(softmax_scale),
+        dtype=dtype,
+        core_num=core_num,
+    )
+
+
+def _build_hca(
+    *,
+    batch,
+    max_seq,
+    total_tokens,
+    ori_block_num,
+    ori_block_size,
+    ori_table_len,
+    cmp_block_num,
+    cmp_block_size,
+    cmp_table_len,
+    n_heads,
+    head_dim,
+    ori_win_left,
+    cmp_ratio,
+    softmax_scale,
+    dtype,
+    core_num,
+):
+    N1 = n_heads
+    N2 = 1
+    D = head_dim
+    D2 = D // 2
+    G = N1 // N2
+    BI = DEFAULT_BLOCK_I
+    PV_NT = D // BI
+    PV_NW = BI
+
+    KL0 = 128
+    VEC_NUM = 2
+    G2 = G // VEC_NUM
+    BLK = 8
+    S2_BASE = 512
+    MAX_COLBLK = S2_BASE // BI
+
+    M_CHUNK = 16
+    NMC = G2 // M_CHUNK
+
+    accum_dtype = "float"
+    idx_dtype = "int32"
+    out_cast_mode = "CAST_RINT" if dtype == "bfloat16" else "CAST_ROUND"
+
+    max_cmp_len = (max_seq + cmp_ratio - 1) // cmp_ratio
+    MAX_CMP_TILES = (max_cmp_len + S2_BASE - 1) // S2_BASE
+    MAX_TILES = 1 + MAX_CMP_TILES
+
+    block_num = batch * max_seq
+    n_iter = (block_num + core_num - 1) // core_num
+
+    GLOOP = n_iter * MAX_TILES
+
+    EV_QK = 0
+    EV_P = 1
+    EV_PV = 2
+
+    DEBUG_SERIAL = False
+
+    KV_EV0 = 2
+    KV_EV1 = 3
+    KV_EV2 = 6
+
+    Q_EV = 1
+    P_EV = 7
+
+    L0AB_EV0 = 4
+    L0AB_EV1 = 5
+
+    IN_EV = 2
+    ACC_EV = 4
+    OUT_EV = 5
+    LSE_EV = 0
+
+    FENCE = 0
+
+    q_shape = [total_tokens, N1, D]
+    ori_kv_shape = [ori_block_num, ori_block_size, N2, D]
+    cmp_kv_shape = [cmp_block_num, cmp_block_size, N2, D]
+    cmp_idx_shape = [total_tokens, N2, DEFAULT_BLOCK_I]
+
+    @tilelang.jit(out_idx=[10, 11], workspace_idx=[12, 13, 14, 15, 16], target="ascendc")
+    def kernel():
+        @T.prim_func
+        def sparse_flash_mla_hca(
+            Q: T.Tensor(q_shape, dtype),
+            ori_kv: T.Tensor(ori_kv_shape, dtype),
+            ori_block_table: T.Tensor([batch, ori_table_len], idx_dtype),
+            cmp_kv: T.Tensor(cmp_kv_shape, dtype),
+            cmp_block_table: T.Tensor([batch, cmp_table_len], idx_dtype),
+            cmp_indices: T.Tensor(cmp_idx_shape, idx_dtype),
+            q_prefix: T.Tensor([batch], idx_dtype),
+            act_q_lens: T.Tensor([batch], idx_dtype),
+            seqused_kv: T.Tensor([batch], idx_dtype),
+            sinks: T.Tensor([N1], accum_dtype),
+            Output: T.Tensor(q_shape, dtype),
+            LSE: T.Tensor([total_tokens, N1], accum_dtype),
+            workspace_s: T.Tensor([core_num, 2, G, S2_BASE], accum_dtype),
+            workspace_p: T.Tensor([core_num, 2, G, S2_BASE], dtype),
+            workspace_o: T.Tensor([core_num, 2, G, D], accum_dtype),
+            workspace_acc: T.Tensor([core_num, 2, G, D], accum_dtype),
+            workspace_qk: T.Tensor([core_num, G, BI], accum_dtype),
+        ):
+            with T.Kernel(core_num, is_npu=True) as (cid, vid):
+                q_l1 = T.alloc_L1([2, G, D2], dtype)
+
+                kv_ring = T.alloc_L1([3, BI, D2], dtype)
+                p_l1 = T.alloc_L1([G, S2_BASE], dtype)
+                cL0 = T.alloc_L0C([2, G, BI], accum_dtype)
+                p_l0a = T.alloc_L0A([2, G, BI], dtype)
+                v_l0b = T.alloc_L0B([2, BI, BI], dtype)
+
+                kv_iter = T.alloc_var("int32", init=0)
+                cl0_iter = T.alloc_var("int32", init=0)
+                ab_iter = T.alloc_var("int32", init=0)
+
+                in_ub = T.alloc_ub([2, M_CHUNK, S2_BASE], accum_dtype)
+                softmax_cmp = T.alloc_ub([M_CHUNK, S2_BASE], accum_dtype)
+                out_ub = T.alloc_ub([M_CHUNK, S2_BASE], dtype)
+                acc_pre = T.alloc_ub([M_CHUNK, D], accum_dtype)
+                sink_ub = T.alloc_ub([2, M_CHUNK, 1], accum_dtype)
+                lse_ub = T.alloc_ub([M_CHUNK, 1], accum_dtype)
+                ones_ub = T.alloc_ub([M_CHUNK, 1], accum_dtype)
+                brcb_d = T.alloc_ub([M_CHUNK, BLK], accum_dtype)
+
+                sumP = T.alloc_ub([M_CHUNK, 1], accum_dtype)
+
+                part = T.alloc_ub([M_CHUNK, 1], accum_dtype)
+                brcb_s = T.alloc_ub([M_CHUNK, BLK], accum_dtype)
+
+                m_i = T.alloc_ub([2, NMC, M_CHUNK, 1], accum_dtype)
+                denom = T.alloc_ub([2, NMC, M_CHUNK, 1], accum_dtype)
+                expmax = T.alloc_ub([2, NMC, M_CHUNK, 1], accum_dtype)
+
+                with T.Scope("C"):
+                    T.set_flag("m", "mte1", L0AB_EV0)
+                    T.set_flag("m", "mte1", L0AB_EV1)
+                    T.set_flag("mte1", "mte2", KV_EV0)
+                    T.set_flag("mte1", "mte2", KV_EV1)
+                    T.set_flag("mte1", "mte2", KV_EV2)
+                    T.set_flag("mte1", "mte2", Q_EV)
+                    T.set_flag("mte1", "mte2", P_EV)
+                    for g in T.serial(GLOOP + 1):
+                        if g < GLOOP:
+                            buf = g % 2
+                            task = g // MAX_TILES
+                            tile = g % MAX_TILES
+                            pid = task * core_num + cid
+                            if pid < block_num:
+                                b = T.cast(pid // max_seq, "int32")
+                                s = T.cast(pid % max_seq, "int32")
+                                act_q = act_q_lens[b]
+                                if s < act_q:
+                                    act_kv = seqused_kv[b]
+                                    s_global = act_kv - act_q + s
+                                    act_cmp = (s_global + 1) // cmp_ratio
+                                    cmp_tiles = (act_cmp + S2_BASE - 1) // S2_BASE
+                                    s2lt = 1 + cmp_tiles
+                                    if tile < s2lt:
+                                        is_ori = tile == 0
+                                        ori_left = T.max(s_global - ori_win_left, 0)
+                                        win = s_global + 1 - ori_left
+                                        rel = tile - 1
+
+                                        tw = tir.Select(
+                                            is_ori,
+                                            win,
+                                            T.min(S2_BASE, act_cmp - rel * S2_BASE),
+                                        )
+                                        s2base = tir.Select(is_ori, ori_left, rel * S2_BASE)
+                                        tok = q_prefix[b] + s
+
+                                        T.wait_flag("mte1", "mte2", Q_EV)
+                                        T.copy(Q[tok, :, 0:D2], q_l1[0, :, :])
+                                        T.copy(Q[tok, :, D2:D], q_l1[1, :, :])
+                                        T.set_flag("mte2", "mte1", Q_EV)
+                                        T.wait_flag("mte2", "mte1", Q_EV)
+                                        if DEBUG_SERIAL:
+                                            T.barrier_all()
+
+                                        for cb in range(MAX_COLBLK):
+                                            if cb * BI < tw:
+                                                ncols = T.min(BI, tw - cb * BI)
+                                                ncols_a = (ncols + 15) // 16 * 16
+                                                cs = cl0_iter % 2
+
+                                                s0 = kv_iter % 3
+                                                s1 = (kv_iter + 1) % 3
+                                                ev0 = tir.Select(s0 < 2, KV_EV0 + s0, KV_EV2)
+                                                ev1 = tir.Select(s1 < 2, KV_EV0 + s1, KV_EV2)
+                                                for h in range(2):
+                                                    slot = (kv_iter + h) % 3
+                                                    ev = tir.Select(slot < 2, KV_EV0 + slot, KV_EV2)
+                                                    T.wait_flag("mte1", "mte2", ev)
+                                                    if is_ori:
+                                                        pa_start = s2base + cb * BI
+                                                        pa_cur = T.alloc_var("int32", init=pa_start)
+                                                        for _pg in range((BI + ori_block_size - 1) // ori_block_size + 1):
+                                                            pa_done = pa_cur - pa_start
+                                                            if pa_done < ncols:
+                                                                pa_lg = pa_cur // ori_block_size
+                                                                pa_ph = ori_block_table[b, pa_lg]
+                                                                pa_rem = pa_cur % ori_block_size
+                                                                pa_run = T.min(
+                                                                    ori_block_size - pa_rem,
+                                                                    ncols - pa_done,
+                                                                )
+                                                                T.copy(
+                                                                    ori_kv[
+                                                                        pa_ph,
+                                                                        pa_rem : pa_rem + pa_run,
+                                                                        0,
+                                                                        h * D2 : h * D2 + D2,
+                                                                    ],
+                                                                    kv_ring[
+                                                                        slot,
+                                                                        pa_done : pa_done + pa_run,
+                                                                        :,
+                                                                    ],
+                                                                )
+                                                                pa_cur += pa_run
+                                                    else:
+                                                        pc_start = s2base + cb * BI
+                                                        pc_cur = T.alloc_var("int32", init=pc_start)
+                                                        for _pg in range((BI + cmp_block_size - 1) // cmp_block_size + 1):
+                                                            pc_done = pc_cur - pc_start
+                                                            if pc_done < ncols:
+                                                                pc_lg = pc_cur // cmp_block_size
+                                                                pc_ph = cmp_block_table[b, pc_lg]
+                                                                pc_rem = pc_cur % cmp_block_size
+                                                                pc_run = T.min(
+                                                                    cmp_block_size - pc_rem,
+                                                                    ncols - pc_done,
+                                                                )
+                                                                T.copy(
+                                                                    cmp_kv[
+                                                                        pc_ph,
+                                                                        pc_rem : pc_rem + pc_run,
+                                                                        0,
+                                                                        h * D2 : h * D2 + D2,
+                                                                    ],
+                                                                    kv_ring[
+                                                                        slot,
+                                                                        pc_done : pc_done + pc_run,
+                                                                        :,
+                                                                    ],
+                                                                )
+                                                                pc_cur += pc_run
+                                                    T.set_flag("mte2", "mte1", ev)
+                                                if DEBUG_SERIAL:
+                                                    T.barrier_all()
+
+                                                T.wait_flag("mte2", "mte1", ev0)
+                                                if DEBUG_SERIAL:
+                                                    T.gemm_v0(
+                                                        q_l1[0, :, :],
+                                                        kv_ring[s0, :, :],
+                                                        cL0[cs, :, :],
+                                                        transpose_B=True,
+                                                        init=True,
+                                                        n_actual=ncols_a,
+                                                    )
+                                                else:
+                                                    T.wait_flag("m", "mte1", L0AB_EV0)
+                                                    T.copy(
+                                                        q_l1[0, :, 0:KL0],
+                                                        p_l0a[0, :, :],
+                                                    )
+                                                    T.copy(
+                                                        kv_ring[s0, :, 0:KL0],
+                                                        v_l0b[0, :, :],
+                                                        transpose=True,
+                                                        real_k=KL0,
+                                                        real_n=ncols_a,
+                                                    )
+                                                    T.set_flag("mte1", "m", L0AB_EV0)
+                                                    T.wait_flag("mte1", "m", L0AB_EV0)
+                                                    T.mma(
+                                                        p_l0a[0, :, :],
+                                                        v_l0b[0, :, :],
+                                                        cL0[cs, :, :],
+                                                        init=True,
+                                                        k_actual=KL0,
+                                                        n_actual=ncols_a,
+                                                        unit_flag=0b10,
+                                                    )
+
+                                                    if ncols_a < 40:
+                                                        T.pipe_barrier("m")
+                                                    T.set_flag("m", "mte1", L0AB_EV0)
+                                                    T.wait_flag("m", "mte1", L0AB_EV1)
+                                                    T.copy(
+                                                        q_l1[0, :, KL0 : 2 * KL0],
+                                                        p_l0a[1, :, :],
+                                                    )
+                                                    T.copy(
+                                                        kv_ring[s0, :, KL0 : 2 * KL0],
+                                                        v_l0b[1, :, :],
+                                                        transpose=True,
+                                                        real_k=KL0,
+                                                        real_n=ncols_a,
+                                                    )
+                                                    T.set_flag("mte1", "m", L0AB_EV1)
+                                                    T.wait_flag("mte1", "m", L0AB_EV1)
+                                                    T.mma(
+                                                        p_l0a[1, :, :],
+                                                        v_l0b[1, :, :],
+                                                        cL0[cs, :, :],
+                                                        init=False,
+                                                        k_actual=KL0,
+                                                        n_actual=ncols_a,
+                                                        unit_flag=0b10,
+                                                    )
+                                                    if ncols_a < 40:
+                                                        T.pipe_barrier("m")
+                                                    T.set_flag("m", "mte1", L0AB_EV1)
+                                                T.set_flag("mte1", "mte2", ev0)
+                                                T.wait_flag("mte2", "mte1", ev1)
+                                                if DEBUG_SERIAL:
+                                                    T.gemm_v0(
+                                                        q_l1[1, :, :],
+                                                        kv_ring[s1, :, :],
+                                                        cL0[cs, :, :],
+                                                        transpose_B=True,
+                                                        init=False,
+                                                        n_actual=ncols_a,
+                                                    )
+                                                else:
+                                                    T.wait_flag("m", "mte1", L0AB_EV0)
+                                                    T.copy(
+                                                        q_l1[1, :, 0:KL0],
+                                                        p_l0a[0, :, :],
+                                                    )
+                                                    T.copy(
+                                                        kv_ring[s1, :, 0:KL0],
+                                                        v_l0b[0, :, :],
+                                                        transpose=True,
+                                                        real_k=KL0,
+                                                        real_n=ncols_a,
+                                                    )
+                                                    T.set_flag("mte1", "m", L0AB_EV0)
+                                                    T.wait_flag("mte1", "m", L0AB_EV0)
+                                                    T.mma(
+                                                        p_l0a[0, :, :],
+                                                        v_l0b[0, :, :],
+                                                        cL0[cs, :, :],
+                                                        init=False,
+                                                        k_actual=KL0,
+                                                        n_actual=ncols_a,
+                                                        unit_flag=0b10,
+                                                    )
+                                                    if ncols_a < 40:
+                                                        T.pipe_barrier("m")
+                                                    T.set_flag("m", "mte1", L0AB_EV0)
+                                                    T.wait_flag("m", "mte1", L0AB_EV1)
+                                                    T.copy(
+                                                        q_l1[1, :, KL0 : 2 * KL0],
+                                                        p_l0a[1, :, :],
+                                                    )
+                                                    T.copy(
+                                                        kv_ring[s1, :, KL0 : 2 * KL0],
+                                                        v_l0b[1, :, :],
+                                                        transpose=True,
+                                                        real_k=KL0,
+                                                        real_n=ncols_a,
+                                                    )
+                                                    T.set_flag("mte1", "m", L0AB_EV1)
+                                                    T.wait_flag("mte1", "m", L0AB_EV1)
+                                                    T.mma(
+                                                        p_l0a[1, :, :],
+                                                        v_l0b[1, :, :],
+                                                        cL0[cs, :, :],
+                                                        init=False,
+                                                        k_actual=KL0,
+                                                        n_actual=ncols_a,
+                                                        unit_flag=0b11,
+                                                    )
+                                                    if ncols_a < 40:
+                                                        T.pipe_barrier("m")
+                                                    T.set_flag("m", "mte1", L0AB_EV1)
+                                                T.set_flag("mte1", "mte2", ev1)
+                                                kv_iter += 2
+                                                if DEBUG_SERIAL:
+                                                    T.barrier_all()
+
+                                                if DEBUG_SERIAL:
+                                                    T.copy(
+                                                        cL0[cs, :, :],
+                                                        workspace_s[
+                                                            cid,
+                                                            buf,
+                                                            :,
+                                                            cb * BI : (cb + 1) * BI,
+                                                        ],
+                                                    )
+                                                    T.barrier_all()
+                                                else:
+                                                    T.copy(
+                                                        cL0[cs, :, 0:ncols_a],
+                                                        workspace_s[
+                                                            cid,
+                                                            buf,
+                                                            :,
+                                                            cb * BI : cb * BI + ncols_a,
+                                                        ],
+                                                        unit_flag=0b11,
+                                                    )
+                                                cl0_iter += 1
+
+                                        T.set_flag("mte1", "mte2", Q_EV)
+
+                            T.set_cross_flag("FIX", EV_QK)
+
+                        if g >= 1:
+                            T.wait_cross_flag(EV_P)
+                            gm = g - 1
+                            bufm = gm % 2
+                            taskm = gm // MAX_TILES
+                            tilem = gm % MAX_TILES
+                            pidm = taskm * core_num + cid
+                            if pidm < block_num:
+                                bm = T.cast(pidm // max_seq, "int32")
+                                sm = T.cast(pidm % max_seq, "int32")
+                                if sm < act_q_lens[bm]:
+                                    act_kvm = seqused_kv[bm]
+                                    s_globalm = act_kvm - act_q_lens[bm] + sm
+                                    act_cmpm = (s_globalm + 1) // cmp_ratio
+                                    cmp_tilesm = (act_cmpm + S2_BASE - 1) // S2_BASE
+                                    s2ltm = 1 + cmp_tilesm
+                                    if tilem < s2ltm:
+                                        is_orim = tilem == 0
+                                        ori_leftm = T.max(s_globalm - ori_win_left, 0)
+                                        winm = s_globalm + 1 - ori_leftm
+                                        relm = tilem - 1
+
+                                        twm = tir.Select(
+                                            is_orim,
+                                            winm,
+                                            T.min(S2_BASE, act_cmpm - relm * S2_BASE),
+                                        )
+                                        s2basem = tir.Select(is_orim, ori_leftm, relm * S2_BASE)
+
+                                        T.wait_flag("mte1", "mte2", P_EV)
+                                        T.copy(
+                                            workspace_p[cid, bufm, :, 0:S2_BASE],
+                                            p_l1[:, :],
+                                        )
+                                        T.set_flag("mte2", "mte1", P_EV)
+                                        T.wait_flag("mte2", "mte1", P_EV)
+                                        if DEBUG_SERIAL:
+                                            T.barrier_all()
+
+                                        for nl in range(PV_NT):
+                                            cs = cl0_iter % 2
+                                            for ks in range(MAX_COLBLK):
+                                                if ks * BI < twm:
+                                                    krows = T.min(BI, twm - ks * BI)
+                                                    is_first_ks = ks == 0
+                                                    is_last_ks = (ks + 1) * BI >= twm
+                                                    slot = kv_iter % 3
+                                                    ev = tir.Select(slot < 2, KV_EV0 + slot, KV_EV2)
+                                                    pp = ab_iter % 2
+
+                                                    T.wait_flag("mte1", "mte2", ev)
+                                                    if is_orim:
+                                                        pv_start = s2basem + ks * BI
+                                                        pv_cur = T.alloc_var("int32", init=pv_start)
+                                                        for _pg in range((BI + ori_block_size - 1) // ori_block_size + 1):
+                                                            pv_done = pv_cur - pv_start
+                                                            if pv_done < krows:
+                                                                pv_lg = pv_cur // ori_block_size
+                                                                pv_ph = ori_block_table[bm, pv_lg]
+                                                                pv_rem = pv_cur % ori_block_size
+                                                                pv_run = T.min(
+                                                                    ori_block_size - pv_rem,
+                                                                    krows - pv_done,
+                                                                )
+                                                                T.copy(
+                                                                    ori_kv[
+                                                                        pv_ph,
+                                                                        pv_rem : pv_rem + pv_run,
+                                                                        0,
+                                                                        nl * PV_NW : nl * PV_NW + PV_NW,
+                                                                    ],
+                                                                    kv_ring[
+                                                                        slot,
+                                                                        pv_done : pv_done + pv_run,
+                                                                        0:PV_NW,
+                                                                    ],
+                                                                )
+                                                                pv_cur += pv_run
+                                                    else:
+                                                        qv_start = s2basem + ks * BI
+                                                        qv_cur = T.alloc_var("int32", init=qv_start)
+                                                        for _pg in range((BI + cmp_block_size - 1) // cmp_block_size + 1):
+                                                            qv_done = qv_cur - qv_start
+                                                            if qv_done < krows:
+                                                                qv_lg = qv_cur // cmp_block_size
+                                                                qv_ph = cmp_block_table[bm, qv_lg]
+                                                                qv_rem = qv_cur % cmp_block_size
+                                                                qv_run = T.min(
+                                                                    cmp_block_size - qv_rem,
+                                                                    krows - qv_done,
+                                                                )
+                                                                T.copy(
+                                                                    cmp_kv[
+                                                                        qv_ph,
+                                                                        qv_rem : qv_rem + qv_run,
+                                                                        0,
+                                                                        nl * PV_NW : nl * PV_NW + PV_NW,
+                                                                    ],
+                                                                    kv_ring[
+                                                                        slot,
+                                                                        qv_done : qv_done + qv_run,
+                                                                        0:PV_NW,
+                                                                    ],
+                                                                )
+                                                                qv_cur += qv_run
+                                                    T.set_flag("mte2", "mte1", ev)
+                                                    if DEBUG_SERIAL:
+                                                        T.barrier_all()
+
+                                                    T.wait_flag("m", "mte1", L0AB_EV0 + pp)
+                                                    T.wait_flag("mte2", "mte1", ev)
+                                                    T.copy(
+                                                        p_l1[:, ks * BI : (ks + 1) * BI],
+                                                        p_l0a[pp, :, :],
+                                                        real_k=krows,
+                                                    )
+                                                    T.copy(
+                                                        kv_ring[slot, :, 0:PV_NW],
+                                                        v_l0b[pp, :, :],
+                                                        real_k=krows,
+                                                    )
+                                                    T.set_flag("mte1", "m", L0AB_EV0 + pp)
+                                                    T.wait_flag("mte1", "m", L0AB_EV0 + pp)
+
+                                                    uf = 0 if DEBUG_SERIAL else tir.Select(is_last_ks, 0b11, 0b10)
+                                                    T.mma(
+                                                        p_l0a[pp, :, :],
+                                                        v_l0b[pp, :, :],
+                                                        cL0[cs, :, :],
+                                                        init=is_first_ks,
+                                                        k_actual=krows,
+                                                        unit_flag=uf,
+                                                    )
+                                                    T.set_flag("m", "mte1", L0AB_EV0 + pp)
+                                                    T.set_flag("mte1", "mte2", ev)
+                                                    kv_iter += 1
+                                                    ab_iter += 1
+                                                    if DEBUG_SERIAL:
+                                                        T.barrier_all()
+
+                                            if DEBUG_SERIAL:
+                                                T.copy(
+                                                    cL0[cs, :, :],
+                                                    workspace_o[
+                                                        cid,
+                                                        bufm,
+                                                        :,
+                                                        nl * PV_NW : (nl + 1) * PV_NW,
+                                                    ],
+                                                )
+                                                T.barrier_all()
+                                            else:
+                                                T.copy(
+                                                    cL0[cs, :, :],
+                                                    workspace_o[
+                                                        cid,
+                                                        bufm,
+                                                        :,
+                                                        nl * PV_NW : (nl + 1) * PV_NW,
+                                                    ],
+                                                    unit_flag=0b11,
+                                                )
+                                            cl0_iter += 1
+
+                                        T.set_flag("mte1", "mte2", P_EV)
+
+                            T.set_cross_flag("FIX", EV_PV)
+
+                    T.wait_flag("m", "mte1", L0AB_EV0)
+                    T.wait_flag("m", "mte1", L0AB_EV1)
+                    T.wait_flag("mte1", "mte2", KV_EV0)
+                    T.wait_flag("mte1", "mte2", KV_EV1)
+                    T.wait_flag("mte1", "mte2", KV_EV2)
+                    T.wait_flag("mte1", "mte2", Q_EV)
+                    T.wait_flag("mte1", "mte2", P_EV)
+
+                with T.Scope("V"):
+                    T.tile.fill(ones_ub, T.float32(1.0))
+
+                    T.set_flag("v", "mte2", IN_EV)
+                    T.set_flag("v", "mte2", IN_EV + 1)
+                    T.set_flag("v", "mte2", ACC_EV)
+                    T.set_flag("mte3", "v", OUT_EV)
+                    T.set_flag("mte3", "v", LSE_EV)
+                    for g in T.serial(1, GLOOP + 2):
+                        if g < GLOOP + 1:
+                            T.wait_cross_flag(EV_QK)
+                            gs = g - 1
+                            buf = gs % 2
+                            prev = (gs - 1) % 2
+                            task = gs // MAX_TILES
+                            tile = gs % MAX_TILES
+                            pid = task * core_num + cid
+                            if pid < block_num:
+                                b = T.cast(pid // max_seq, "int32")
+                                s = T.cast(pid % max_seq, "int32")
+                                act_q = act_q_lens[b]
+                                if s < act_q:
+                                    act_kv = seqused_kv[b]
+                                    s_global = act_kv - act_q + s
+                                    act_cmp = (s_global + 1) // cmp_ratio
+                                    cmp_tiles = (act_cmp + S2_BASE - 1) // S2_BASE
+                                    s2lt = 1 + cmp_tiles
+                                    if tile < s2lt:
+                                        is_first = tile == 0
+                                        ori_left = T.max(s_global - ori_win_left, 0)
+                                        win = s_global + 1 - ori_left
+                                        rel = tile - 1
+
+                                        tw = tir.Select(
+                                            is_first,
+                                            win,
+                                            T.min(S2_BASE, act_cmp - rel * S2_BASE),
+                                        )
+                                        tw_a = (tw + 15) // 16 * 16
+
+                                        tw_64 = (tw + 63) // 64 * 64
+
+                                        is_narrow = tw <= BI
+                                        for mc in range(NMC):
+                                            r0 = vid * G2 + mc * M_CHUNK
+                                            ps = mc & 1
+
+                                            T.wait_flag("v", "mte2", IN_EV + ps)
+
+                                            T.tile.fill(
+                                                in_ub[ps, :, :],
+                                                -T.infinity(accum_dtype),
+                                            )
+                                            T.set_flag("v", "mte2", IN_EV + ps)
+                                            T.wait_flag("v", "mte2", IN_EV + ps)
+
+                                            T.copy(
+                                                workspace_s[
+                                                    cid,
+                                                    buf,
+                                                    r0 : r0 + M_CHUNK,
+                                                    0:tw,
+                                                ],
+                                                in_ub[ps, :, 0:tw],
+                                            )
+                                            T.copy(
+                                                sinks[r0 : r0 + M_CHUNK],
+                                                sink_ub[ps, :, :],
+                                            )
+
+                                            T.set_flag("mte2", "v", IN_EV + ps)
+                                            T.wait_flag("mte2", "v", IN_EV + ps)
+                                            T.tile.mul(
+                                                in_ub[ps, :, :],
+                                                in_ub[ps, :, :],
+                                                softmax_scale,
+                                            )
+
+                                            T.pipe_barrier("v")
+
+                                            if is_narrow:
+                                                T.tile.fill(
+                                                    m_i[buf, mc, :, :],
+                                                    -T.infinity(accum_dtype),
+                                                )
+                                                for kc in range(BI // 64):
+                                                    if kc * 64 < tw_64:
+                                                        T.reduce_max(
+                                                            in_ub[
+                                                                ps,
+                                                                :,
+                                                                kc * 64 : kc * 64 + 64,
+                                                            ],
+                                                            part,
+                                                            dim=-1,
+                                                        )
+                                                        T.tile.max(
+                                                            m_i[buf, mc, :, :],
+                                                            m_i[buf, mc, :, :],
+                                                            part,
+                                                        )
+                                            else:
+                                                T.reduce_max(
+                                                    in_ub[ps, :, :],
+                                                    m_i[buf, mc, :, :],
+                                                    dim=-1,
+                                                )
+                                            if is_first:
+                                                T.tile.max(
+                                                    m_i[buf, mc, :, :],
+                                                    sink_ub[ps, :, :],
+                                                    m_i[buf, mc, :, :],
+                                                )
+                                                T.tile.sub(
+                                                    expmax[buf, mc, :, :],
+                                                    sink_ub[ps, :, :],
+                                                    m_i[buf, mc, :, :],
+                                                )
+                                            else:
+                                                T.tile.max(
+                                                    m_i[buf, mc, :, :],
+                                                    m_i[prev, mc, :, :],
+                                                    m_i[buf, mc, :, :],
+                                                )
+                                                T.tile.sub(
+                                                    expmax[buf, mc, :, :],
+                                                    m_i[prev, mc, :, :],
+                                                    m_i[buf, mc, :, :],
+                                                )
+                                            T.tile.exp(
+                                                expmax[buf, mc, :, :],
+                                                expmax[buf, mc, :, :],
+                                            )
+
+                                            if is_narrow:
+                                                T.tile.brcb_experiment(
+                                                    brcb_s,
+                                                    m_i[buf, mc, :, :],
+                                                    M_CHUNK // 8,
+                                                    1,
+                                                    8,
+                                                )
+                                                for kc in range(BI // 64):
+                                                    if kc * 64 < tw_64:
+                                                        T.tile.row_expand_sub_experiment(
+                                                            in_ub[
+                                                                ps,
+                                                                :,
+                                                                kc * 64 : kc * 64 + 64,
+                                                            ],
+                                                            in_ub[
+                                                                ps,
+                                                                :,
+                                                                kc * 64 : kc * 64 + 64,
+                                                            ],
+                                                            brcb_s,
+                                                        )
+                                                for kc in range(BI // 64):
+                                                    if kc * 64 < tw_64:
+                                                        T.tile.exp_experiment(
+                                                            in_ub[
+                                                                ps,
+                                                                :,
+                                                                kc * 64 : kc * 64 + 64,
+                                                            ],
+                                                            in_ub[
+                                                                ps,
+                                                                :,
+                                                                kc * 64 : kc * 64 + 64,
+                                                            ],
+                                                        )
+                                            else:
+                                                T.tile.broadcast(softmax_cmp, m_i[buf, mc, :, :])
+                                                T.tile.sub(
+                                                    in_ub[ps, :, :],
+                                                    in_ub[ps, :, :],
+                                                    softmax_cmp,
+                                                )
+                                                T.tile.exp(in_ub[ps, :, :], in_ub[ps, :, :])
+                                            if is_first:
+                                                T.tile.mul(
+                                                    denom[buf, mc, :, :],
+                                                    ones_ub,
+                                                    expmax[buf, mc, :, :],
+                                                )
+                                            else:
+                                                T.tile.mul(
+                                                    denom[buf, mc, :, :],
+                                                    denom[prev, mc, :, :],
+                                                    expmax[buf, mc, :, :],
+                                                )
+
+                                            T.pipe_barrier("v")
+
+                                            T.wait_flag("mte3", "v", OUT_EV)
+                                            T.tile.cast(
+                                                out_ub,
+                                                in_ub[ps, :, :],
+                                                "CAST_ROUND",
+                                                M_CHUNK * S2_BASE,
+                                            )
+
+                                            T.pipe_barrier("v")
+
+                                            if is_narrow:
+                                                T.tile.fill(sumP, T.float32(0.0))
+                                                for kc in range(BI // 64):
+                                                    if kc * 64 < tw_64:
+                                                        T.reduce_sum(
+                                                            in_ub[
+                                                                ps,
+                                                                :,
+                                                                kc * 64 : kc * 64 + 64,
+                                                            ],
+                                                            part,
+                                                            dim=-1,
+                                                        )
+                                                        T.tile.add(sumP, sumP, part)
+                                            else:
+                                                T.reduce_sum(in_ub[ps, :, :], sumP, dim=-1)
+                                            T.tile.add(
+                                                denom[buf, mc, :, :],
+                                                denom[buf, mc, :, :],
+                                                sumP,
+                                            )
+
+                                            T.set_flag("v", "mte2", IN_EV + ps)
+                                            T.set_flag("v", "mte3", OUT_EV)
+                                            T.wait_flag("v", "mte3", OUT_EV)
+
+                                            T.copy(
+                                                out_ub[:, 0:tw_a],
+                                                workspace_p[
+                                                    cid,
+                                                    buf,
+                                                    r0 : r0 + M_CHUNK,
+                                                    0:tw_a,
+                                                ],
+                                            )
+
+                                            T.set_flag("mte3", "v", OUT_EV)
+                            T.set_cross_flag("MTE3", EV_P)
+
+                        if g >= 2:
+                            T.wait_cross_flag(EV_PV)
+                            go = g - 2
+                            bufo = go % 2
+                            prevo = (go - 1) % 2
+                            task = go // MAX_TILES
+                            tile = go % MAX_TILES
+                            pid = task * core_num + cid
+                            if pid < block_num:
+                                b = T.cast(pid // max_seq, "int32")
+                                s = T.cast(pid % max_seq, "int32")
+                                act_q = act_q_lens[b]
+                                if s < act_q:
+                                    act_kv = seqused_kv[b]
+                                    s_global = act_kv - act_q + s
+
+                                    act_cmp = tir.Select(
+                                        s_global < cmp_ratio - 1,
+                                        0,
+                                        (s_global + 1) // cmp_ratio,
+                                    )
+                                    cmp_tiles = (act_cmp + S2_BASE - 1) // S2_BASE
+                                    s2lt = 1 + cmp_tiles
+                                    if tile < s2lt:
+                                        not_first = tile != 0
+                                        is_last = tile == s2lt - 1
+                                        tok = q_prefix[b] + s
+                                        for mc in range(NMC):
+                                            r0 = vid * G2 + mc * M_CHUNK
+                                            po = mc & 1
+
+                                            T.wait_flag("v", "mte2", IN_EV + po)
+                                            T.copy(
+                                                workspace_o[cid, bufo, r0 : r0 + M_CHUNK, :],
+                                                in_ub[po, :, :],
+                                            )
+
+                                            T.set_flag("mte2", "v", IN_EV + po)
+                                            T.wait_flag("mte2", "v", IN_EV + po)
+                                            if not_first:
+                                                T.set_flag("mte3", "mte2", FENCE)
+                                                T.wait_flag("mte3", "mte2", FENCE)
+
+                                                T.wait_flag("v", "mte2", ACC_EV)
+                                                T.copy(
+                                                    workspace_acc[cid, prevo, r0 : r0 + M_CHUNK, :],
+                                                    acc_pre,
+                                                )
+
+                                                T.set_flag("mte2", "v", ACC_EV)
+                                                T.wait_flag("mte2", "v", ACC_EV)
+
+                                                T.tile.brcb_experiment(
+                                                    brcb_d,
+                                                    expmax[bufo, mc, :, :],
+                                                    M_CHUNK // 8,
+                                                    1,
+                                                    8,
+                                                )
+                                                T.pipe_barrier("v")
+                                                for dcol in T.serial(D // (8 * BLK)):
+                                                    cb = dcol * (8 * BLK)
+                                                    T.tile.row_expand_mul_experiment(
+                                                        acc_pre[:, cb : cb + 8 * BLK],
+                                                        acc_pre[:, cb : cb + 8 * BLK],
+                                                        brcb_d,
+                                                    )
+                                                T.pipe_barrier("v")
+                                                T.tile.add(
+                                                    in_ub[po, :, :],
+                                                    in_ub[po, :, :],
+                                                    acc_pre,
+                                                )
+                                                T.pipe_barrier("v")
+
+                                                T.set_flag("v", "mte2", ACC_EV)
+                                            if is_last:
+                                                T.tile.brcb_experiment(
+                                                    brcb_d,
+                                                    denom[bufo, mc, :, :],
+                                                    M_CHUNK // 8,
+                                                    1,
+                                                    8,
+                                                )
+                                                T.pipe_barrier("v")
+                                                for dcol in T.serial(D // (8 * BLK)):
+                                                    cb = dcol * (8 * BLK)
+                                                    T.tile.row_expand_div_experiment(
+                                                        in_ub[po, :, cb : cb + 8 * BLK],
+                                                        in_ub[po, :, cb : cb + 8 * BLK],
+                                                        brcb_d,
+                                                    )
+                                                T.pipe_barrier("v")
+
+                                                T.wait_flag("mte3", "v", OUT_EV)
+                                                T.tile.cast(
+                                                    out_ub,
+                                                    in_ub[po, :, :],
+                                                    out_cast_mode,
+                                                    M_CHUNK * D,
+                                                )
+
+                                                T.set_flag("v", "mte2", IN_EV + po)
+                                                T.set_flag("v", "mte3", OUT_EV)
+                                                T.wait_flag("v", "mte3", OUT_EV)
+                                                T.copy(
+                                                    out_ub,
+                                                    Output[tok, r0 : r0 + M_CHUNK, :],
+                                                )
+
+                                                T.set_flag("mte3", "v", OUT_EV)
+
+                                                T.wait_flag("mte3", "v", LSE_EV)
+                                                T.tile.ln(
+                                                    lse_ub,
+                                                    denom[bufo, mc, :, :],
+                                                )
+                                                T.tile.add(
+                                                    lse_ub,
+                                                    lse_ub,
+                                                    m_i[bufo, mc, :, :],
+                                                )
+                                                T.set_flag("v", "mte3", LSE_EV)
+                                                T.wait_flag("v", "mte3", LSE_EV)
+                                                T.copy(lse_ub, LSE[tok, r0 : r0 + M_CHUNK])
+                                                T.set_flag("mte3", "v", LSE_EV)
+                                            else:
+                                                T.set_flag("v", "mte3", IN_EV + po)
+                                                T.wait_flag("v", "mte3", IN_EV + po)
+                                                T.copy(
+                                                    in_ub[po, :, :],
+                                                    workspace_acc[cid, bufo, r0 : r0 + M_CHUNK, :],
+                                                )
+                                                T.set_flag("mte3", "v", IN_EV + po)
+                                                T.wait_flag("mte3", "v", IN_EV + po)
+                                                T.set_flag("v", "mte2", IN_EV + po)
+
+                            T.set_cross_flag("MTE3", EV_PV)
+
+                    T.wait_flag("v", "mte2", IN_EV)
+                    T.wait_flag("v", "mte2", IN_EV + 1)
+                    T.wait_flag("v", "mte2", ACC_EV)
+                    T.wait_flag("mte3", "v", OUT_EV)
+                    T.wait_flag("mte3", "v", LSE_EV)
+
+        return sparse_flash_mla_hca
+
+    func = kernel()
+    if os.environ.get("SAS_DUMP_SRC"):
+        try:
+            src = func.get_kernel_source()
+            with open("/tmp/hca_gen.cpp", "w") as fh:
+                fh.write(src)
+            print(f"[SAS_DUMP_SRC] wrote {len(src)} chars to /tmp/hca_gen.cpp")
+        except Exception as exc:
+            print(f"[SAS_DUMP_SRC] get_kernel_source failed: {exc!r}")
+    return func
+
+
+def _build_csa(
+    *,
+    batch,
+    max_seq,
+    total_tokens,
+    ori_block_num,
+    ori_block_size,
+    ori_table_len,
+    cmp_block_num,
+    cmp_block_size,
+    cmp_table_len,
+    n_heads,
+    head_dim,
+    topk_cmp,
+    ori_win_left,
+    cmp_ratio,
+    softmax_scale,
+    dtype,
+    core_num,
+):
+    N1 = n_heads
+    N2 = 1
+    D = head_dim
+    D2 = D // 2
+    G = N1 // N2
+    BI = DEFAULT_BLOCK_I
+    PV_NT = D // BI
+    PV_NW = BI
+
+    KL0 = 128
+    VEC_NUM = 2
+    G2 = G // VEC_NUM
+    BLK = 8
+    S2_BASE = 512
+    MAX_COLBLK = S2_BASE // BI
+
+    M_CHUNK = 16
+    NMC = G2 // M_CHUNK
+
+    MERGE_ROWS = 6
+
+    accum_dtype = "float"
+    idx_dtype = "int32"
+    out_cast_mode = "CAST_RINT" if dtype == "bfloat16" else "CAST_ROUND"
+
+    max_cmp_len = min((max_seq + cmp_ratio - 1) // cmp_ratio, topk_cmp)
+    MAX_CMP_TILES = (max_cmp_len + S2_BASE - 1) // S2_BASE
+    MAX_TILES = 1 + MAX_CMP_TILES
+
+    block_num = batch * max_seq
+    n_iter = (block_num + core_num - 1) // core_num
+
+    GLOOP = n_iter * MAX_TILES
+
+    EV_QK = 0
+    EV_P = 1
+    EV_PV = 2
+
+    EV_V0 = 3
+
+    EV_CREDIT = 4
+
+    DEBUG_SERIAL = False
+
+    KV_EV0 = 2
+    KV_EV1 = 3
+    KV_EV2 = 6
+
+    Q_EV = 1
+    P_EV = 7
+
+    L0AB_EV0 = 4
+    L0AB_EV1 = 5
+
+    IN_EV = 2
+    ACC_EV = 4
+    OUT_EV = 5
+    LSE_EV = 0
+
+    FENCE = 0
+
+    MRG_EV = 6
+
+    KVMERGE_RING = 4
+
+    q_shape = [total_tokens, N1, D]
+    ori_kv_shape = [ori_block_num, ori_block_size, N2, D]
+    cmp_kv_shape = [cmp_block_num, cmp_block_size, N2, D]
+
+    cmp_idx_shape = [total_tokens, N2, topk_cmp]
+
+    @tilelang.jit(out_idx=[10, 11], workspace_idx=[12, 13, 14, 15, 16, 17], target="ascendc")
+    def kernel():
+        @T.prim_func
+        def sparse_flash_mla_csa(
+            Q: T.Tensor(q_shape, dtype),
+            ori_kv: T.Tensor(ori_kv_shape, dtype),
+            ori_block_table: T.Tensor([batch, ori_table_len], idx_dtype),
+            cmp_kv: T.Tensor(cmp_kv_shape, dtype),
+            cmp_block_table: T.Tensor([batch, cmp_table_len], idx_dtype),
+            cmp_indices: T.Tensor(cmp_idx_shape, idx_dtype),
+            q_prefix: T.Tensor([batch], idx_dtype),
+            act_q_lens: T.Tensor([batch], idx_dtype),
+            seqused_kv: T.Tensor([batch], idx_dtype),
+            sinks: T.Tensor([N1], accum_dtype),
+            Output: T.Tensor(q_shape, dtype),
+            LSE: T.Tensor([total_tokens, N1], accum_dtype),
+            workspace_s: T.Tensor([core_num, 2, G, S2_BASE], accum_dtype),
+            workspace_p: T.Tensor([core_num, 2, G, S2_BASE], dtype),
+            workspace_o: T.Tensor([core_num, 2, G, D], accum_dtype),
+            workspace_acc: T.Tensor([core_num, 2, G, D], accum_dtype),
+            workspace_qk: T.Tensor([core_num, G, BI], accum_dtype),
+            kvMergeGm: T.Tensor([core_num, KVMERGE_RING, S2_BASE, D], dtype),
+        ):
+            with T.Kernel(core_num, is_npu=True) as (cid, vid):
+                q_l1 = T.alloc_L1([2, G, D2], dtype)
+
+                kv_ring = T.alloc_L1([3, BI, D2], dtype)
+                p_l1 = T.alloc_L1([G, S2_BASE], dtype)
+                cL0 = T.alloc_L0C([2, G, BI], accum_dtype)
+                p_l0a = T.alloc_L0A([2, G, BI], dtype)
+                v_l0b = T.alloc_L0B([2, BI, BI], dtype)
+
+                kv_iter = T.alloc_var("int32", init=0)
+                cl0_iter = T.alloc_var("int32", init=0)
+                ab_iter = T.alloc_var("int32", init=0)
+
+                in_ub = T.alloc_ub([2, M_CHUNK, S2_BASE], accum_dtype)
+                softmax_cmp = T.alloc_ub([M_CHUNK, S2_BASE], accum_dtype)
+                out_ub = T.alloc_ub([M_CHUNK, S2_BASE], dtype)
+                acc_pre = T.alloc_ub([M_CHUNK, D], accum_dtype)
+                sink_ub = T.alloc_ub([2, M_CHUNK, 1], accum_dtype)
+                lse_ub = T.alloc_ub([M_CHUNK, 1], accum_dtype)
+                ones_ub = T.alloc_ub([M_CHUNK, 1], accum_dtype)
+                brcb_d = T.alloc_ub([M_CHUNK, BLK], accum_dtype)
+
+                sumP = T.alloc_ub([M_CHUNK, 1], accum_dtype)
+
+                part = T.alloc_ub([M_CHUNK, 1], accum_dtype)
+                brcb_s = T.alloc_ub([M_CHUNK, BLK], accum_dtype)
+
+                merge_ub = T.alloc_ub([2, MERGE_ROWS, D], dtype)
+
+                m_i = T.alloc_ub([2, NMC, M_CHUNK, 1], accum_dtype)
+                denom = T.alloc_ub([2, NMC, M_CHUNK, 1], accum_dtype)
+                expmax = T.alloc_ub([2, NMC, M_CHUNK, 1], accum_dtype)
+
+                with T.Scope("C"):
+                    T.set_flag("m", "mte1", L0AB_EV0)
+                    T.set_flag("m", "mte1", L0AB_EV1)
+                    T.set_flag("mte1", "mte2", KV_EV0)
+                    T.set_flag("mte1", "mte2", KV_EV1)
+                    T.set_flag("mte1", "mte2", KV_EV2)
+                    T.set_flag("mte1", "mte2", Q_EV)
+                    T.set_flag("mte1", "mte2", P_EV)
+
+                    for _cr in range(KVMERGE_RING):
+                        T.set_cross_flag("MTE2", EV_CREDIT)
+                    for g in T.serial(GLOOP + 1):
+                        if g < GLOOP:
+                            buf = g % 2
+                            task = g // MAX_TILES
+                            tile = g % MAX_TILES
+                            pid = task * core_num + cid
+                            if pid < block_num:
+                                b = T.cast(pid // max_seq, "int32")
+                                s = T.cast(pid % max_seq, "int32")
+                                act_q = act_q_lens[b]
+                                if s < act_q:
+                                    act_kv = seqused_kv[b]
+                                    s_global = act_kv - act_q + s
+                                    act_cmp = (s_global + 1) // cmp_ratio
+                                    cmp_tiles = (T.min(act_cmp, topk_cmp) + S2_BASE - 1) // S2_BASE
+                                    s2lt = 1 + cmp_tiles
+                                    if tile < s2lt:
+                                        is_ori = tile == 0
+                                        ori_left = T.max(s_global - ori_win_left, 0)
+                                        win = s_global + 1 - ori_left
+                                        rel = tile - 1
+
+                                        tw = tir.Select(
+                                            is_ori,
+                                            win,
+                                            T.min(
+                                                S2_BASE,
+                                                T.min(act_cmp, topk_cmp) - rel * S2_BASE,
+                                            ),
+                                        )
+                                        s2base = tir.Select(is_ori, ori_left, rel * S2_BASE)
+                                        tok = q_prefix[b] + s
+
+                                        T.wait_flag("mte1", "mte2", Q_EV)
+                                        T.copy(Q[tok, :, 0:D2], q_l1[0, :, :])
+                                        T.copy(Q[tok, :, D2:D], q_l1[1, :, :])
+                                        T.set_flag("mte2", "mte1", Q_EV)
+                                        T.wait_flag("mte2", "mte1", Q_EV)
+                                        if DEBUG_SERIAL:
+                                            T.barrier_all()
+
+                                        if tile != 0:
+                                            T.wait_cross_flag(EV_V0)
+                                        for cb in range(MAX_COLBLK):
+                                            if cb * BI < tw:
+                                                ncols = T.min(BI, tw - cb * BI)
+                                                ncols_a = (ncols + 15) // 16 * 16
+                                                cs = cl0_iter % 2
+
+                                                s0 = kv_iter % 3
+                                                s1 = (kv_iter + 1) % 3
+                                                ev0 = tir.Select(s0 < 2, KV_EV0 + s0, KV_EV2)
+                                                ev1 = tir.Select(s1 < 2, KV_EV0 + s1, KV_EV2)
+                                                for h in range(2):
+                                                    slot = (kv_iter + h) % 3
+                                                    ev = tir.Select(slot < 2, KV_EV0 + slot, KV_EV2)
+                                                    T.wait_flag("mte1", "mte2", ev)
+                                                    if is_ori:
+                                                        pa_start = s2base + cb * BI
+                                                        pa_cur = T.alloc_var("int32", init=pa_start)
+                                                        for _pg in range((BI + ori_block_size - 1) // ori_block_size + 1):
+                                                            pa_done = pa_cur - pa_start
+                                                            if pa_done < ncols:
+                                                                pa_lg = pa_cur // ori_block_size
+                                                                pa_ph = ori_block_table[b, pa_lg]
+                                                                pa_rem = pa_cur % ori_block_size
+                                                                pa_run = T.min(
+                                                                    ori_block_size - pa_rem,
+                                                                    ncols - pa_done,
+                                                                )
+                                                                T.copy(
+                                                                    ori_kv[
+                                                                        pa_ph,
+                                                                        pa_rem : pa_rem + pa_run,
+                                                                        0,
+                                                                        h * D2 : h * D2 + D2,
+                                                                    ],
+                                                                    kv_ring[
+                                                                        slot,
+                                                                        pa_done : pa_done + pa_run,
+                                                                        :,
+                                                                    ],
+                                                                )
+                                                                pa_cur += pa_run
+                                                    else:
+                                                        T.copy(
+                                                            kvMergeGm[
+                                                                cid,
+                                                                task % KVMERGE_RING,
+                                                                cb * BI : cb * BI + ncols,
+                                                                h * D2 : h * D2 + D2,
+                                                            ],
+                                                            kv_ring[slot, 0:ncols, :],
+                                                        )
+                                                    T.set_flag("mte2", "mte1", ev)
+                                                if DEBUG_SERIAL:
+                                                    T.barrier_all()
+
+                                                T.wait_flag("mte2", "mte1", ev0)
+                                                if DEBUG_SERIAL:
+                                                    T.gemm_v0(
+                                                        q_l1[0, :, :],
+                                                        kv_ring[s0, :, :],
+                                                        cL0[cs, :, :],
+                                                        transpose_B=True,
+                                                        init=True,
+                                                        n_actual=ncols_a,
+                                                    )
+                                                else:
+                                                    T.wait_flag("m", "mte1", L0AB_EV0)
+                                                    T.copy(
+                                                        q_l1[0, :, 0:KL0],
+                                                        p_l0a[0, :, :],
+                                                    )
+                                                    T.copy(
+                                                        kv_ring[s0, :, 0:KL0],
+                                                        v_l0b[0, :, :],
+                                                        transpose=True,
+                                                        real_k=KL0,
+                                                        real_n=ncols_a,
+                                                    )
+                                                    T.set_flag("mte1", "m", L0AB_EV0)
+                                                    T.wait_flag("mte1", "m", L0AB_EV0)
+                                                    T.mma(
+                                                        p_l0a[0, :, :],
+                                                        v_l0b[0, :, :],
+                                                        cL0[cs, :, :],
+                                                        init=True,
+                                                        k_actual=KL0,
+                                                        n_actual=ncols_a,
+                                                        unit_flag=0b10,
+                                                    )
+
+                                                    if ncols_a < 40:
+                                                        T.pipe_barrier("m")
+                                                    T.set_flag("m", "mte1", L0AB_EV0)
+                                                    T.wait_flag("m", "mte1", L0AB_EV1)
+                                                    T.copy(
+                                                        q_l1[0, :, KL0 : 2 * KL0],
+                                                        p_l0a[1, :, :],
+                                                    )
+                                                    T.copy(
+                                                        kv_ring[s0, :, KL0 : 2 * KL0],
+                                                        v_l0b[1, :, :],
+                                                        transpose=True,
+                                                        real_k=KL0,
+                                                        real_n=ncols_a,
+                                                    )
+                                                    T.set_flag("mte1", "m", L0AB_EV1)
+                                                    T.wait_flag("mte1", "m", L0AB_EV1)
+                                                    T.mma(
+                                                        p_l0a[1, :, :],
+                                                        v_l0b[1, :, :],
+                                                        cL0[cs, :, :],
+                                                        init=False,
+                                                        k_actual=KL0,
+                                                        n_actual=ncols_a,
+                                                        unit_flag=0b10,
+                                                    )
+                                                    if ncols_a < 40:
+                                                        T.pipe_barrier("m")
+                                                    T.set_flag("m", "mte1", L0AB_EV1)
+                                                T.set_flag("mte1", "mte2", ev0)
+                                                T.wait_flag("mte2", "mte1", ev1)
+                                                if DEBUG_SERIAL:
+                                                    T.gemm_v0(
+                                                        q_l1[1, :, :],
+                                                        kv_ring[s1, :, :],
+                                                        cL0[cs, :, :],
+                                                        transpose_B=True,
+                                                        init=False,
+                                                        n_actual=ncols_a,
+                                                    )
+                                                else:
+                                                    T.wait_flag("m", "mte1", L0AB_EV0)
+                                                    T.copy(
+                                                        q_l1[1, :, 0:KL0],
+                                                        p_l0a[0, :, :],
+                                                    )
+                                                    T.copy(
+                                                        kv_ring[s1, :, 0:KL0],
+                                                        v_l0b[0, :, :],
+                                                        transpose=True,
+                                                        real_k=KL0,
+                                                        real_n=ncols_a,
+                                                    )
+                                                    T.set_flag("mte1", "m", L0AB_EV0)
+                                                    T.wait_flag("mte1", "m", L0AB_EV0)
+                                                    T.mma(
+                                                        p_l0a[0, :, :],
+                                                        v_l0b[0, :, :],
+                                                        cL0[cs, :, :],
+                                                        init=False,
+                                                        k_actual=KL0,
+                                                        n_actual=ncols_a,
+                                                        unit_flag=0b10,
+                                                    )
+                                                    if ncols_a < 40:
+                                                        T.pipe_barrier("m")
+                                                    T.set_flag("m", "mte1", L0AB_EV0)
+                                                    T.wait_flag("m", "mte1", L0AB_EV1)
+                                                    T.copy(
+                                                        q_l1[1, :, KL0 : 2 * KL0],
+                                                        p_l0a[1, :, :],
+                                                    )
+                                                    T.copy(
+                                                        kv_ring[s1, :, KL0 : 2 * KL0],
+                                                        v_l0b[1, :, :],
+                                                        transpose=True,
+                                                        real_k=KL0,
+                                                        real_n=ncols_a,
+                                                    )
+                                                    T.set_flag("mte1", "m", L0AB_EV1)
+                                                    T.wait_flag("mte1", "m", L0AB_EV1)
+                                                    T.mma(
+                                                        p_l0a[1, :, :],
+                                                        v_l0b[1, :, :],
+                                                        cL0[cs, :, :],
+                                                        init=False,
+                                                        k_actual=KL0,
+                                                        n_actual=ncols_a,
+                                                        unit_flag=0b11,
+                                                    )
+                                                    if ncols_a < 40:
+                                                        T.pipe_barrier("m")
+                                                    T.set_flag("m", "mte1", L0AB_EV1)
+                                                T.set_flag("mte1", "mte2", ev1)
+                                                kv_iter += 2
+                                                if DEBUG_SERIAL:
+                                                    T.barrier_all()
+
+                                                if DEBUG_SERIAL:
+                                                    T.copy(
+                                                        cL0[cs, :, :],
+                                                        workspace_s[
+                                                            cid,
+                                                            buf,
+                                                            :,
+                                                            cb * BI : (cb + 1) * BI,
+                                                        ],
+                                                    )
+                                                    T.barrier_all()
+                                                else:
+                                                    T.copy(
+                                                        cL0[cs, :, 0:ncols_a],
+                                                        workspace_s[
+                                                            cid,
+                                                            buf,
+                                                            :,
+                                                            cb * BI : cb * BI + ncols_a,
+                                                        ],
+                                                        unit_flag=0b11,
+                                                    )
+                                                cl0_iter += 1
+
+                                        T.set_flag("mte1", "mte2", Q_EV)
+
+                            T.set_cross_flag("FIX", EV_QK)
+
+                        if g >= 1:
+                            T.wait_cross_flag(EV_P)
+                            gm = g - 1
+                            bufm = gm % 2
+                            taskm = gm // MAX_TILES
+                            tilem = gm % MAX_TILES
+                            pidm = taskm * core_num + cid
+                            if pidm < block_num:
+                                bm = T.cast(pidm // max_seq, "int32")
+                                sm = T.cast(pidm % max_seq, "int32")
+                                if sm < act_q_lens[bm]:
+                                    act_kvm = seqused_kv[bm]
+                                    s_globalm = act_kvm - act_q_lens[bm] + sm
+                                    act_cmpm = (s_globalm + 1) // cmp_ratio
+                                    cmp_tilesm = (T.min(act_cmpm, topk_cmp) + S2_BASE - 1) // S2_BASE
+                                    s2ltm = 1 + cmp_tilesm
+                                    if tilem < s2ltm:
+                                        is_orim = tilem == 0
+                                        ori_leftm = T.max(s_globalm - ori_win_left, 0)
+                                        winm = s_globalm + 1 - ori_leftm
+                                        relm = tilem - 1
+
+                                        twm = tir.Select(
+                                            is_orim,
+                                            winm,
+                                            T.min(
+                                                S2_BASE,
+                                                T.min(act_cmpm, topk_cmp) - relm * S2_BASE,
+                                            ),
+                                        )
+                                        s2basem = tir.Select(is_orim, ori_leftm, relm * S2_BASE)
+
+                                        T.wait_flag("mte1", "mte2", P_EV)
+                                        T.copy(
+                                            workspace_p[cid, bufm, :, 0:S2_BASE],
+                                            p_l1[:, :],
+                                        )
+                                        T.set_flag("mte2", "mte1", P_EV)
+                                        T.wait_flag("mte2", "mte1", P_EV)
+                                        if DEBUG_SERIAL:
+                                            T.barrier_all()
+
+                                        for nl in range(PV_NT):
+                                            cs = cl0_iter % 2
+                                            for ks in range(MAX_COLBLK):
+                                                if ks * BI < twm:
+                                                    krows = T.min(BI, twm - ks * BI)
+                                                    is_first_ks = ks == 0
+                                                    is_last_ks = (ks + 1) * BI >= twm
+                                                    slot = kv_iter % 3
+                                                    ev = tir.Select(slot < 2, KV_EV0 + slot, KV_EV2)
+                                                    pp = ab_iter % 2
+
+                                                    T.wait_flag("mte1", "mte2", ev)
+                                                    if is_orim:
+                                                        pv_start = s2basem + ks * BI
+                                                        pv_cur = T.alloc_var("int32", init=pv_start)
+                                                        for _pg in range((BI + ori_block_size - 1) // ori_block_size + 1):
+                                                            pv_done = pv_cur - pv_start
+                                                            if pv_done < krows:
+                                                                pv_lg = pv_cur // ori_block_size
+                                                                pv_ph = ori_block_table[bm, pv_lg]
+                                                                pv_rem = pv_cur % ori_block_size
+                                                                pv_run = T.min(
+                                                                    ori_block_size - pv_rem,
+                                                                    krows - pv_done,
+                                                                )
+                                                                T.copy(
+                                                                    ori_kv[
+                                                                        pv_ph,
+                                                                        pv_rem : pv_rem + pv_run,
+                                                                        0,
+                                                                        nl * PV_NW : nl * PV_NW + PV_NW,
+                                                                    ],
+                                                                    kv_ring[
+                                                                        slot,
+                                                                        pv_done : pv_done + pv_run,
+                                                                        0:PV_NW,
+                                                                    ],
+                                                                )
+                                                                pv_cur += pv_run
+                                                    else:
+                                                        T.copy(
+                                                            kvMergeGm[
+                                                                cid,
+                                                                taskm % KVMERGE_RING,
+                                                                ks * BI : ks * BI + krows,
+                                                                nl * PV_NW : nl * PV_NW + PV_NW,
+                                                            ],
+                                                            kv_ring[slot, 0:krows, 0:PV_NW],
+                                                        )
+                                                    T.set_flag("mte2", "mte1", ev)
+                                                    if DEBUG_SERIAL:
+                                                        T.barrier_all()
+
+                                                    T.wait_flag("m", "mte1", L0AB_EV0 + pp)
+                                                    T.wait_flag("mte2", "mte1", ev)
+                                                    T.copy(
+                                                        p_l1[:, ks * BI : (ks + 1) * BI],
+                                                        p_l0a[pp, :, :],
+                                                        real_k=krows,
+                                                    )
+                                                    T.copy(
+                                                        kv_ring[slot, :, 0:PV_NW],
+                                                        v_l0b[pp, :, :],
+                                                        real_k=krows,
+                                                    )
+                                                    T.set_flag("mte1", "m", L0AB_EV0 + pp)
+                                                    T.wait_flag("mte1", "m", L0AB_EV0 + pp)
+
+                                                    uf = 0 if DEBUG_SERIAL else tir.Select(is_last_ks, 0b11, 0b10)
+                                                    T.mma(
+                                                        p_l0a[pp, :, :],
+                                                        v_l0b[pp, :, :],
+                                                        cL0[cs, :, :],
+                                                        init=is_first_ks,
+                                                        k_actual=krows,
+                                                        unit_flag=uf,
+                                                    )
+                                                    T.set_flag("m", "mte1", L0AB_EV0 + pp)
+                                                    T.set_flag("mte1", "mte2", ev)
+                                                    kv_iter += 1
+                                                    ab_iter += 1
+                                                    if DEBUG_SERIAL:
+                                                        T.barrier_all()
+
+                                            if DEBUG_SERIAL:
+                                                T.copy(
+                                                    cL0[cs, :, :],
+                                                    workspace_o[
+                                                        cid,
+                                                        bufm,
+                                                        :,
+                                                        nl * PV_NW : (nl + 1) * PV_NW,
+                                                    ],
+                                                )
+                                                T.barrier_all()
+                                            else:
+                                                T.copy(
+                                                    cL0[cs, :, :],
+                                                    workspace_o[
+                                                        cid,
+                                                        bufm,
+                                                        :,
+                                                        nl * PV_NW : (nl + 1) * PV_NW,
+                                                    ],
+                                                    unit_flag=0b11,
+                                                )
+                                            cl0_iter += 1
+
+                                        T.set_flag("mte1", "mte2", P_EV)
+
+                                        if tilem == s2ltm - 1:
+                                            T.set_cross_flag("MTE2", EV_CREDIT)
+
+                            T.set_cross_flag("FIX", EV_PV)
+
+                    T.wait_flag("m", "mte1", L0AB_EV0)
+                    T.wait_flag("m", "mte1", L0AB_EV1)
+                    T.wait_flag("mte1", "mte2", KV_EV0)
+                    T.wait_flag("mte1", "mte2", KV_EV1)
+                    T.wait_flag("mte1", "mte2", KV_EV2)
+                    T.wait_flag("mte1", "mte2", Q_EV)
+                    T.wait_flag("mte1", "mte2", P_EV)
+
+                with T.Scope("V"):
+                    T.tile.fill(ones_ub, T.float32(1.0))
+
+                    T.set_flag("v", "mte2", IN_EV)
+                    T.set_flag("v", "mte2", IN_EV + 1)
+                    T.set_flag("v", "mte2", ACC_EV)
+                    T.set_flag("mte3", "v", OUT_EV)
+                    T.set_flag("mte3", "v", LSE_EV)
+
+                    V0_NMAX = min(S2_BASE, topk_cmp)
+                    V0_NB = (V0_NMAX + MERGE_ROWS - 1) // MERGE_ROWS
+                    for g in T.serial(1, GLOOP + 2):
+                        if g < GLOOP:
+                            v0task = g // MAX_TILES
+                            v0tile = g % MAX_TILES
+                            v0pid = v0task * core_num + cid
+                            if v0pid < block_num:
+                                v0b = T.cast(v0pid // max_seq, "int32")
+                                v0s = T.cast(v0pid % max_seq, "int32")
+
+                                v0tok = q_prefix[v0b] + v0s
+                                if v0s < act_q_lens[v0b]:
+                                    if v0tile == 0 or g == 1:
+                                        T.wait_cross_flag(EV_CREDIT)
+                                    v0skv = seqused_kv[v0b] - act_q_lens[v0b] + v0s
+                                    v0acmp = (v0skv + 1) // cmp_ratio
+
+                                    v0asparse = T.min(v0acmp, topk_cmp)
+                                    v0ctiles = (v0asparse + S2_BASE - 1) // S2_BASE
+                                    if v0tile != 0 and v0tile < 1 + v0ctiles:
+                                        v0rel = v0tile - 1
+                                        v0n = T.min(S2_BASE, v0asparse - v0rel * S2_BASE)
+
+                                        v0half = (v0n + 1) // 2
+                                        v0start = tir.Select(vid == 0, 0, v0half)
+                                        v0lim = tir.Select(vid == 0, v0half, v0n)
+
+                                        T.set_flag("mte3", "mte2", MRG_EV + 0)
+                                        T.set_flag("mte3", "mte2", MRG_EV + 1)
+                                        for jb in T.serial(V0_NB):
+                                            pp = jb % 2
+                                            if v0start + jb * MERGE_ROWS < v0lim:
+                                                T.wait_flag("mte3", "mte2", MRG_EV + pp)
+                                                for jj in range(MERGE_ROWS):
+                                                    jtok = v0start + jb * MERGE_ROWS + jj
+                                                    if jtok < v0lim:
+                                                        r2 = cmp_indices[
+                                                            v0tok,
+                                                            0,
+                                                            v0rel * S2_BASE + jtok,
+                                                        ]
+                                                        blkid = cmp_block_table[
+                                                            v0b,
+                                                            r2 // cmp_block_size,
+                                                        ]
+
+                                                        T.copy(
+                                                            cmp_kv[
+                                                                blkid,
+                                                                r2 % cmp_block_size,
+                                                                0,
+                                                                :,
+                                                            ],
+                                                            merge_ub[pp, jj, :],
+                                                        )
+
+                                                T.set_flag("mte2", "mte3", MRG_EV + pp)
+                                                T.wait_flag("mte2", "mte3", MRG_EV + pp)
+                                                bcnt = T.min(
+                                                    MERGE_ROWS,
+                                                    v0lim - (v0start + jb * MERGE_ROWS),
+                                                )
+                                                T.copy(
+                                                    merge_ub[pp, 0:bcnt, :],
+                                                    kvMergeGm[
+                                                        cid,
+                                                        v0task % KVMERGE_RING,
+                                                        v0start + jb * MERGE_ROWS : v0start + jb * MERGE_ROWS + bcnt,
+                                                        :,
+                                                    ],
+                                                )
+
+                                                T.set_flag("mte3", "mte2", MRG_EV + pp)
+
+                                        T.wait_flag("mte3", "mte2", MRG_EV + 0)
+                                        T.wait_flag("mte3", "mte2", MRG_EV + 1)
+
+                                        T.set_cross_flag("MTE3", EV_V0)
+
+                        if g < GLOOP + 1:
+                            T.wait_cross_flag(EV_QK)
+                            gs = g - 1
+                            buf = gs % 2
+                            prev = (gs - 1) % 2
+                            task = gs // MAX_TILES
+                            tile = gs % MAX_TILES
+                            pid = task * core_num + cid
+                            if pid < block_num:
+                                b = T.cast(pid // max_seq, "int32")
+                                s = T.cast(pid % max_seq, "int32")
+                                act_q = act_q_lens[b]
+                                if s < act_q:
+                                    act_kv = seqused_kv[b]
+                                    s_global = act_kv - act_q + s
+                                    act_cmp = (s_global + 1) // cmp_ratio
+                                    cmp_tiles = (T.min(act_cmp, topk_cmp) + S2_BASE - 1) // S2_BASE
+                                    s2lt = 1 + cmp_tiles
+                                    if tile < s2lt:
+                                        is_first = tile == 0
+                                        ori_left = T.max(s_global - ori_win_left, 0)
+                                        win = s_global + 1 - ori_left
+                                        rel = tile - 1
+
+                                        tw = tir.Select(
+                                            is_first,
+                                            win,
+                                            T.min(
+                                                S2_BASE,
+                                                T.min(act_cmp, topk_cmp) - rel * S2_BASE,
+                                            ),
+                                        )
+                                        tw_a = (tw + 15) // 16 * 16
+
+                                        tw_64 = (tw + 63) // 64 * 64
+
+                                        is_narrow = tw <= BI
+                                        for mc in range(NMC):
+                                            r0 = vid * G2 + mc * M_CHUNK
+                                            ps = mc & 1
+
+                                            T.wait_flag("v", "mte2", IN_EV + ps)
+
+                                            T.tile.fill(
+                                                in_ub[ps, :, :],
+                                                -T.infinity(accum_dtype),
+                                            )
+                                            T.set_flag("v", "mte2", IN_EV + ps)
+                                            T.wait_flag("v", "mte2", IN_EV + ps)
+
+                                            T.copy(
+                                                workspace_s[
+                                                    cid,
+                                                    buf,
+                                                    r0 : r0 + M_CHUNK,
+                                                    0:tw,
+                                                ],
+                                                in_ub[ps, :, 0:tw],
+                                            )
+                                            T.copy(
+                                                sinks[r0 : r0 + M_CHUNK],
+                                                sink_ub[ps, :, :],
+                                            )
+
+                                            T.set_flag("mte2", "v", IN_EV + ps)
+                                            T.wait_flag("mte2", "v", IN_EV + ps)
+                                            T.tile.mul(
+                                                in_ub[ps, :, :],
+                                                in_ub[ps, :, :],
+                                                softmax_scale,
+                                            )
+
+                                            T.pipe_barrier("v")
+
+                                            if is_narrow:
+                                                T.tile.fill(
+                                                    m_i[buf, mc, :, :],
+                                                    -T.infinity(accum_dtype),
+                                                )
+                                                for kc in range(BI // 64):
+                                                    if kc * 64 < tw_64:
+                                                        T.reduce_max(
+                                                            in_ub[
+                                                                ps,
+                                                                :,
+                                                                kc * 64 : kc * 64 + 64,
+                                                            ],
+                                                            part,
+                                                            dim=-1,
+                                                        )
+                                                        T.tile.max(
+                                                            m_i[buf, mc, :, :],
+                                                            m_i[buf, mc, :, :],
+                                                            part,
+                                                        )
+                                            else:
+                                                T.reduce_max(
+                                                    in_ub[ps, :, :],
+                                                    m_i[buf, mc, :, :],
+                                                    dim=-1,
+                                                )
+                                            if is_first:
+                                                T.tile.max(
+                                                    m_i[buf, mc, :, :],
+                                                    sink_ub[ps, :, :],
+                                                    m_i[buf, mc, :, :],
+                                                )
+                                                T.tile.sub(
+                                                    expmax[buf, mc, :, :],
+                                                    sink_ub[ps, :, :],
+                                                    m_i[buf, mc, :, :],
+                                                )
+                                            else:
+                                                T.tile.max(
+                                                    m_i[buf, mc, :, :],
+                                                    m_i[prev, mc, :, :],
+                                                    m_i[buf, mc, :, :],
+                                                )
+                                                T.tile.sub(
+                                                    expmax[buf, mc, :, :],
+                                                    m_i[prev, mc, :, :],
+                                                    m_i[buf, mc, :, :],
+                                                )
+                                            T.tile.exp(
+                                                expmax[buf, mc, :, :],
+                                                expmax[buf, mc, :, :],
+                                            )
+
+                                            if is_narrow:
+                                                T.tile.brcb_experiment(
+                                                    brcb_s,
+                                                    m_i[buf, mc, :, :],
+                                                    M_CHUNK // 8,
+                                                    1,
+                                                    8,
+                                                )
+                                                for kc in range(BI // 64):
+                                                    if kc * 64 < tw_64:
+                                                        T.tile.row_expand_sub_experiment(
+                                                            in_ub[
+                                                                ps,
+                                                                :,
+                                                                kc * 64 : kc * 64 + 64,
+                                                            ],
+                                                            in_ub[
+                                                                ps,
+                                                                :,
+                                                                kc * 64 : kc * 64 + 64,
+                                                            ],
+                                                            brcb_s,
+                                                        )
+                                                for kc in range(BI // 64):
+                                                    if kc * 64 < tw_64:
+                                                        T.tile.exp_experiment(
+                                                            in_ub[
+                                                                ps,
+                                                                :,
+                                                                kc * 64 : kc * 64 + 64,
+                                                            ],
+                                                            in_ub[
+                                                                ps,
+                                                                :,
+                                                                kc * 64 : kc * 64 + 64,
+                                                            ],
+                                                        )
+                                            else:
+                                                T.tile.broadcast(softmax_cmp, m_i[buf, mc, :, :])
+                                                T.tile.sub(
+                                                    in_ub[ps, :, :],
+                                                    in_ub[ps, :, :],
+                                                    softmax_cmp,
+                                                )
+                                                T.tile.exp(in_ub[ps, :, :], in_ub[ps, :, :])
+                                            if is_first:
+                                                T.tile.mul(
+                                                    denom[buf, mc, :, :],
+                                                    ones_ub,
+                                                    expmax[buf, mc, :, :],
+                                                )
+                                            else:
+                                                T.tile.mul(
+                                                    denom[buf, mc, :, :],
+                                                    denom[prev, mc, :, :],
+                                                    expmax[buf, mc, :, :],
+                                                )
+
+                                            T.pipe_barrier("v")
+
+                                            T.wait_flag("mte3", "v", OUT_EV)
+                                            T.tile.cast(
+                                                out_ub,
+                                                in_ub[ps, :, :],
+                                                "CAST_ROUND",
+                                                M_CHUNK * S2_BASE,
+                                            )
+
+                                            T.pipe_barrier("v")
+
+                                            if is_narrow:
+                                                T.tile.fill(sumP, T.float32(0.0))
+                                                for kc in range(BI // 64):
+                                                    if kc * 64 < tw_64:
+                                                        T.reduce_sum(
+                                                            in_ub[
+                                                                ps,
+                                                                :,
+                                                                kc * 64 : kc * 64 + 64,
+                                                            ],
+                                                            part,
+                                                            dim=-1,
+                                                        )
+                                                        T.tile.add(sumP, sumP, part)
+                                            else:
+                                                T.reduce_sum(in_ub[ps, :, :], sumP, dim=-1)
+                                            T.tile.add(
+                                                denom[buf, mc, :, :],
+                                                denom[buf, mc, :, :],
+                                                sumP,
+                                            )
+
+                                            T.set_flag("v", "mte2", IN_EV + ps)
+                                            T.set_flag("v", "mte3", OUT_EV)
+                                            T.wait_flag("v", "mte3", OUT_EV)
+
+                                            T.copy(
+                                                out_ub[:, 0:tw_a],
+                                                workspace_p[
+                                                    cid,
+                                                    buf,
+                                                    r0 : r0 + M_CHUNK,
+                                                    0:tw_a,
+                                                ],
+                                            )
+
+                                            T.set_flag("mte3", "v", OUT_EV)
+                            T.set_cross_flag("MTE3", EV_P)
+
+                        if g >= 2:
+                            T.wait_cross_flag(EV_PV)
+                            go = g - 2
+                            bufo = go % 2
+                            prevo = (go - 1) % 2
+                            task = go // MAX_TILES
+                            tile = go % MAX_TILES
+                            pid = task * core_num + cid
+                            if pid < block_num:
+                                b = T.cast(pid // max_seq, "int32")
+                                s = T.cast(pid % max_seq, "int32")
+                                act_q = act_q_lens[b]
+                                if s < act_q:
+                                    act_kv = seqused_kv[b]
+                                    s_global = act_kv - act_q + s
+
+                                    act_cmp = tir.Select(
+                                        s_global < cmp_ratio - 1,
+                                        0,
+                                        (s_global + 1) // cmp_ratio,
+                                    )
+                                    cmp_tiles = (T.min(act_cmp, topk_cmp) + S2_BASE - 1) // S2_BASE
+                                    s2lt = 1 + cmp_tiles
+                                    if tile < s2lt:
+                                        not_first = tile != 0
+                                        is_last = tile == s2lt - 1
+                                        tok = q_prefix[b] + s
+                                        for mc in range(NMC):
+                                            r0 = vid * G2 + mc * M_CHUNK
+                                            po = mc & 1
+
+                                            T.wait_flag("v", "mte2", IN_EV + po)
+                                            T.copy(
+                                                workspace_o[cid, bufo, r0 : r0 + M_CHUNK, :],
+                                                in_ub[po, :, :],
+                                            )
+
+                                            T.set_flag("mte2", "v", IN_EV + po)
+                                            T.wait_flag("mte2", "v", IN_EV + po)
+                                            if not_first:
+                                                T.set_flag("mte3", "mte2", FENCE)
+                                                T.wait_flag("mte3", "mte2", FENCE)
+
+                                                T.wait_flag("v", "mte2", ACC_EV)
+                                                T.copy(
+                                                    workspace_acc[cid, prevo, r0 : r0 + M_CHUNK, :],
+                                                    acc_pre,
+                                                )
+
+                                                T.set_flag("mte2", "v", ACC_EV)
+                                                T.wait_flag("mte2", "v", ACC_EV)
+
+                                                T.tile.brcb_experiment(
+                                                    brcb_d,
+                                                    expmax[bufo, mc, :, :],
+                                                    M_CHUNK // 8,
+                                                    1,
+                                                    8,
+                                                )
+                                                T.pipe_barrier("v")
+                                                for dcol in T.serial(D // (8 * BLK)):
+                                                    cb = dcol * (8 * BLK)
+                                                    T.tile.row_expand_mul_experiment(
+                                                        acc_pre[:, cb : cb + 8 * BLK],
+                                                        acc_pre[:, cb : cb + 8 * BLK],
+                                                        brcb_d,
+                                                    )
+                                                T.pipe_barrier("v")
+                                                T.tile.add(
+                                                    in_ub[po, :, :],
+                                                    in_ub[po, :, :],
+                                                    acc_pre,
+                                                )
+                                                T.pipe_barrier("v")
+
+                                                T.set_flag("v", "mte2", ACC_EV)
+                                            if is_last:
+                                                T.tile.brcb_experiment(
+                                                    brcb_d,
+                                                    denom[bufo, mc, :, :],
+                                                    M_CHUNK // 8,
+                                                    1,
+                                                    8,
+                                                )
+                                                T.pipe_barrier("v")
+                                                for dcol in T.serial(D // (8 * BLK)):
+                                                    cb = dcol * (8 * BLK)
+                                                    T.tile.row_expand_div_experiment(
+                                                        in_ub[po, :, cb : cb + 8 * BLK],
+                                                        in_ub[po, :, cb : cb + 8 * BLK],
+                                                        brcb_d,
+                                                    )
+                                                T.pipe_barrier("v")
+
+                                                T.wait_flag("mte3", "v", OUT_EV)
+                                                T.tile.cast(
+                                                    out_ub,
+                                                    in_ub[po, :, :],
+                                                    out_cast_mode,
+                                                    M_CHUNK * D,
+                                                )
+
+                                                T.set_flag("v", "mte2", IN_EV + po)
+                                                T.set_flag("v", "mte3", OUT_EV)
+                                                T.wait_flag("v", "mte3", OUT_EV)
+                                                T.copy(
+                                                    out_ub,
+                                                    Output[tok, r0 : r0 + M_CHUNK, :],
+                                                )
+
+                                                T.set_flag("mte3", "v", OUT_EV)
+
+                                                T.wait_flag("mte3", "v", LSE_EV)
+                                                T.tile.ln(
+                                                    lse_ub,
+                                                    denom[bufo, mc, :, :],
+                                                )
+                                                T.tile.add(
+                                                    lse_ub,
+                                                    lse_ub,
+                                                    m_i[bufo, mc, :, :],
+                                                )
+                                                T.set_flag("v", "mte3", LSE_EV)
+                                                T.wait_flag("v", "mte3", LSE_EV)
+                                                T.copy(lse_ub, LSE[tok, r0 : r0 + M_CHUNK])
+                                                T.set_flag("mte3", "v", LSE_EV)
+                                            else:
+                                                T.set_flag("v", "mte3", IN_EV + po)
+                                                T.wait_flag("v", "mte3", IN_EV + po)
+                                                T.copy(
+                                                    in_ub[po, :, :],
+                                                    workspace_acc[cid, bufo, r0 : r0 + M_CHUNK, :],
+                                                )
+                                                T.set_flag("mte3", "v", IN_EV + po)
+                                                T.wait_flag("mte3", "v", IN_EV + po)
+                                                T.set_flag("v", "mte2", IN_EV + po)
+
+                            T.set_cross_flag("MTE3", EV_PV)
+
+                    T.wait_flag("v", "mte2", IN_EV)
+                    T.wait_flag("v", "mte2", IN_EV + 1)
+                    T.wait_flag("v", "mte2", ACC_EV)
+                    T.wait_flag("mte3", "v", OUT_EV)
+                    T.wait_flag("mte3", "v", LSE_EV)
+
+                    for _cr in range(KVMERGE_RING):
+                        T.wait_cross_flag(EV_CREDIT)
+
+        return sparse_flash_mla_csa
+
+    func = kernel()
+    if os.environ.get("SAS_DUMP_SRC"):
+        try:
+            src = func.get_kernel_source()
+            with open("/tmp/csa_gen.cpp", "w") as fh:
+                fh.write(src)
+            print(f"[SAS_DUMP_SRC] wrote {len(src)} chars to /tmp/csa_gen.cpp")
+        except Exception as exc:
+            print(f"[SAS_DUMP_SRC] get_kernel_source failed: {exc!r}")
+    return func
+
+
+def _build_swa(
+    *,
+    batch,
+    max_seq,
+    total_tokens,
+    ori_block_num,
+    ori_block_size,
+    ori_table_len,
+    cmp_block_num,
+    cmp_block_size,
+    cmp_table_len,
+    n_heads,
+    head_dim,
+    ori_win_left,
+    softmax_scale,
+    dtype,
+    core_num,
+):
+    N1 = n_heads
+    N2 = 1
+    D = head_dim
+
+    D2 = D // 2
+    G = N1 // N2
+    BI = DEFAULT_BLOCK_I
+
+    PV_NT = D // BI
+    PV_NW = BI
+
+    KL0 = 128
+    VEC_NUM = 2
+    G2 = G // VEC_NUM
+    BLK = 8
+
+    DEBUG_SERIAL = False
+
+    accum_dtype = "float"
+    idx_dtype = "int32"
+
+    out_cast_mode = "CAST_RINT" if dtype == "bfloat16" else "CAST_ROUND"
+
+    block_num = batch * max_seq
+    n_iter = (block_num + core_num - 1) // core_num
+
+    EV_QK = 0
+    EV_P = 1
+    EV_PV = 2
+
+    KV_EV0 = 2
+    KV_EV1 = 3
+    KV_EV2 = 6
+
+    Q_EV = 1
+    P_EV = 7
+
+    L0AB_EV0 = 4
+    L0AB_EV1 = 5
+
+    SV_S_EV = 2
+    SV_P_EV = 3
+    VO_O_EV = 4
+    VO_OUT_EV = 5
+    VO_LSE_EV = 6
+
+    q_shape = [total_tokens, N1, D]
+    ori_kv_shape = [ori_block_num, ori_block_size, N2, D]
+    cmp_kv_shape = [cmp_block_num, cmp_block_size, N2, D]
+    cmp_idx_shape = [total_tokens, N2, DEFAULT_BLOCK_I]
+
+    @tilelang.jit(out_idx=[10, 11], workspace_idx=[12, 13, 14], target="ascendc")
+    def kernel():
+        @T.prim_func
+        def sparse_flash_mla_swa(
+            Q: T.Tensor(q_shape, dtype),
+            ori_kv: T.Tensor(ori_kv_shape, dtype),
+            ori_block_table: T.Tensor([batch, ori_table_len], idx_dtype),
+            cmp_kv: T.Tensor(cmp_kv_shape, dtype),
+            cmp_block_table: T.Tensor([batch, cmp_table_len], idx_dtype),
+            cmp_indices: T.Tensor(cmp_idx_shape, idx_dtype),
+            q_prefix: T.Tensor([batch], idx_dtype),
+            act_q_lens: T.Tensor([batch], idx_dtype),
+            seqused_kv: T.Tensor([batch], idx_dtype),
+            sinks: T.Tensor([N1], accum_dtype),
+            Output: T.Tensor(q_shape, dtype),
+            LSE: T.Tensor([total_tokens, N1], accum_dtype),
+            workspace_s: T.Tensor([core_num, 2, G, BI], accum_dtype),
+            workspace_p: T.Tensor([core_num, 2, G, BI], dtype),
+            workspace_o: T.Tensor([core_num, 2, G, D], accum_dtype),
+        ):
+            with T.Kernel(core_num, is_npu=True) as (cid, vid):
+                q_l1_0 = T.alloc_L1([G, D2], dtype)
+                q_l1_1 = T.alloc_L1([G, D2], dtype)
+
+                kv_ring = T.alloc_L1([3, BI, D2], dtype)
+                p_l1 = T.alloc_L1([G, BI], dtype)
+
+                cL0 = T.alloc_L0C([2, G, BI], accum_dtype)
+
+                cl0_iter = T.alloc_var("int32", init=0)
+
+                p_l0a = T.alloc_L0A([2, G, BI], dtype)
+                v_l0b = T.alloc_L0B([2, BI, BI], dtype)
+
+                s_ub = T.alloc_ub([G2, BI], accum_dtype)
+                p_half = T.alloc_ub([G2, BI], dtype)
+
+                m_2d = T.alloc_ub([G2, BI], accum_dtype)
+                sumP = T.alloc_ub([G2, 1], accum_dtype)
+                o_ub = T.alloc_ub([G2, D], accum_dtype)
+                o_half = T.alloc_ub([G2, D], dtype)
+                sink_ub = T.alloc_ub([G2, 1], accum_dtype)
+                lse_ub = T.alloc_ub([G2, 1], accum_dtype)
+
+                ones_ub = T.alloc_ub([G2, 1], accum_dtype)
+                expmax_ub = T.alloc_ub([G2, 1], accum_dtype)
+
+                brcb_d = T.alloc_ub([G2, BLK], accum_dtype)
+
+                m_i = T.alloc_ub([2, G2, 1], accum_dtype)
+                denom = T.alloc_ub([2, G2, 1], accum_dtype)
+
+                with T.Scope("C"):
+                    T.set_flag("m", "mte1", L0AB_EV0)
+                    T.set_flag("m", "mte1", L0AB_EV1)
+
+                    T.set_flag("mte1", "mte2", KV_EV0)
+                    T.set_flag("mte1", "mte2", KV_EV1)
+                    T.set_flag("mte1", "mte2", KV_EV2)
+
+                    T.set_flag("mte1", "mte2", Q_EV)
+                    T.set_flag("mte1", "mte2", P_EV)
+                    for j in T.serial(n_iter + 1):
+                        if j < n_iter:
+                            pid = j * core_num + cid
+                            buf = j % 2
+                            if pid < block_num:
+                                b = T.cast(pid // max_seq, "int32")
+                                s = T.cast(pid % max_seq, "int32")
+                                act_q = act_q_lens[b]
+                                if s < act_q:
+                                    act_kv = seqused_kv[b]
+                                    tok = q_prefix[b] + s
+                                    s_global = act_kv - act_q + s
+                                    ori_left = T.max(s_global - ori_win_left, 0)
+                                    win = s_global + 1 - ori_left
+
+                                    T.wait_flag("mte1", "mte2", Q_EV)
+                                    T.copy(Q[tok, :, 0:D2], q_l1_0)
+                                    T.copy(Q[tok, :, D2:D], q_l1_1)
+                                    T.set_flag("mte2", "mte1", Q_EV)
+
+                                    for h in range(2):
+                                        T.wait_flag("mte1", "mte2", KV_EV0 + h)
+
+                                        pa_start = ori_left
+                                        pa_cur = T.alloc_var("int32", init=pa_start)
+                                        for _pg in range((BI + ori_block_size - 1) // ori_block_size + 1):
+                                            pa_done = pa_cur - pa_start
+                                            if pa_done < win:
+                                                pa_lg = pa_cur // ori_block_size
+                                                pa_ph = ori_block_table[b, pa_lg]
+                                                pa_rem = pa_cur % ori_block_size
+                                                pa_run = T.min(
+                                                    ori_block_size - pa_rem,
+                                                    win - pa_done,
+                                                )
+                                                T.copy(
+                                                    ori_kv[
+                                                        pa_ph,
+                                                        pa_rem : pa_rem + pa_run,
+                                                        0,
+                                                        h * D2 : h * D2 + D2,
+                                                    ],
+                                                    kv_ring[
+                                                        h,
+                                                        pa_done : pa_done + pa_run,
+                                                        :,
+                                                    ],
+                                                )
+                                                pa_cur += pa_run
+                                        T.set_flag("mte2", "mte1", KV_EV0 + h)
+
+                                    win_align = (win + 15) // 16 * 16
+                                    T.wait_flag("mte2", "mte1", Q_EV)
+
+                                    cs = cl0_iter % 2
+
+                                    T.wait_flag("mte2", "mte1", KV_EV0)
+                                    T.wait_flag("m", "mte1", L0AB_EV0)
+                                    T.copy(q_l1_0[:, 0:KL0], p_l0a[0, :, :])
+                                    T.copy(
+                                        kv_ring[0, :, 0:KL0],
+                                        v_l0b[0, :, :],
+                                        transpose=True,
+                                        real_k=KL0,
+                                        real_n=win_align,
+                                    )
+                                    T.set_flag("mte1", "m", L0AB_EV0)
+                                    T.wait_flag("mte1", "m", L0AB_EV0)
+                                    T.mma(
+                                        p_l0a[0, :, :],
+                                        v_l0b[0, :, :],
+                                        cL0[cs, :, :],
+                                        init=True,
+                                        k_actual=KL0,
+                                        n_actual=win_align,
+                                        unit_flag=0b10,
+                                    )
+
+                                    if win_align < 40:
+                                        T.pipe_barrier("m")
+                                    T.set_flag("m", "mte1", L0AB_EV0)
+                                    T.wait_flag("m", "mte1", L0AB_EV1)
+                                    T.copy(q_l1_0[:, KL0 : 2 * KL0], p_l0a[1, :, :])
+                                    T.copy(
+                                        kv_ring[0, :, KL0 : 2 * KL0],
+                                        v_l0b[1, :, :],
+                                        transpose=True,
+                                        real_k=KL0,
+                                        real_n=win_align,
+                                    )
+                                    T.set_flag("mte1", "m", L0AB_EV1)
+                                    T.wait_flag("mte1", "m", L0AB_EV1)
+                                    T.mma(
+                                        p_l0a[1, :, :],
+                                        v_l0b[1, :, :],
+                                        cL0[cs, :, :],
+                                        init=False,
+                                        k_actual=KL0,
+                                        n_actual=win_align,
+                                        unit_flag=0b10,
+                                    )
+                                    if win_align < 40:
+                                        T.pipe_barrier("m")
+                                    T.set_flag("m", "mte1", L0AB_EV1)
+                                    T.set_flag("mte1", "mte2", KV_EV0)
+
+                                    T.wait_flag("mte2", "mte1", KV_EV1)
+                                    T.wait_flag("m", "mte1", L0AB_EV0)
+                                    T.copy(q_l1_1[:, 0:KL0], p_l0a[0, :, :])
+                                    T.copy(
+                                        kv_ring[1, :, 0:KL0],
+                                        v_l0b[0, :, :],
+                                        transpose=True,
+                                        real_k=KL0,
+                                        real_n=win_align,
+                                    )
+                                    T.set_flag("mte1", "m", L0AB_EV0)
+                                    T.wait_flag("mte1", "m", L0AB_EV0)
+                                    T.mma(
+                                        p_l0a[0, :, :],
+                                        v_l0b[0, :, :],
+                                        cL0[cs, :, :],
+                                        init=False,
+                                        k_actual=KL0,
+                                        n_actual=win_align,
+                                        unit_flag=0b10,
+                                    )
+                                    if win_align < 40:
+                                        T.pipe_barrier("m")
+                                    T.set_flag("m", "mte1", L0AB_EV0)
+                                    T.wait_flag("m", "mte1", L0AB_EV1)
+                                    T.copy(q_l1_1[:, KL0 : 2 * KL0], p_l0a[1, :, :])
+                                    T.copy(
+                                        kv_ring[1, :, KL0 : 2 * KL0],
+                                        v_l0b[1, :, :],
+                                        transpose=True,
+                                        real_k=KL0,
+                                        real_n=win_align,
+                                    )
+                                    T.set_flag("mte1", "m", L0AB_EV1)
+                                    T.wait_flag("mte1", "m", L0AB_EV1)
+                                    T.mma(
+                                        p_l0a[1, :, :],
+                                        v_l0b[1, :, :],
+                                        cL0[cs, :, :],
+                                        init=False,
+                                        k_actual=KL0,
+                                        n_actual=win_align,
+                                        unit_flag=0b11,
+                                    )
+                                    if win_align < 40:
+                                        T.pipe_barrier("m")
+                                    T.set_flag("m", "mte1", L0AB_EV1)
+                                    T.set_flag("mte1", "mte2", KV_EV1)
+
+                                    T.copy(
+                                        cL0[cs, :, :],
+                                        workspace_s[cid, buf, :, 0:win_align],
+                                        unit_flag=0b11,
+                                    )
+
+                                    T.set_flag("mte1", "mte2", Q_EV)
+
+                                    cl0_iter += 1
+                            T.set_cross_flag("FIX", EV_QK)
+
+                        if j >= 1:
+                            T.wait_cross_flag(EV_P)
+
+                            pidm = (j - 1) * core_num + cid
+                            bufm = (j - 1) % 2
+                            if pidm < block_num:
+                                bm = T.cast(pidm // max_seq, "int32")
+                                sm = T.cast(pidm % max_seq, "int32")
+                                if sm < act_q_lens[bm]:
+                                    act_kvm = seqused_kv[bm]
+                                    s_globalm = act_kvm - act_q_lens[bm] + sm
+                                    ori_leftm = T.max(s_globalm - ori_win_left, 0)
+                                    winm = s_globalm + 1 - ori_leftm
+
+                                    T.wait_flag("mte1", "mte2", P_EV)
+                                    T.copy(workspace_p[cid, bufm, :, :], p_l1)
+                                    T.set_flag("mte2", "mte1", P_EV)
+                                    T.wait_flag("mte2", "mte1", P_EV)
+
+                                    for nl in range(PV_NT):
+                                        slot = (2 + nl) % 3
+                                        pp = nl % 2
+                                        cs = cl0_iter % 2
+
+                                        ev = T.if_then_else(slot < 2, KV_EV0 + slot, KV_EV2)
+
+                                        T.wait_flag("mte1", "mte2", ev)
+
+                                        pv_start = ori_leftm
+                                        pv_cur = T.alloc_var("int32", init=pv_start)
+                                        for _pg in range((BI + ori_block_size - 1) // ori_block_size + 1):
+                                            pv_done = pv_cur - pv_start
+                                            if pv_done < winm:
+                                                pv_lg = pv_cur // ori_block_size
+                                                pv_ph = ori_block_table[bm, pv_lg]
+                                                pv_rem = pv_cur % ori_block_size
+                                                pv_run = T.min(
+                                                    ori_block_size - pv_rem,
+                                                    winm - pv_done,
+                                                )
+                                                T.copy(
+                                                    ori_kv[
+                                                        pv_ph,
+                                                        pv_rem : pv_rem + pv_run,
+                                                        0,
+                                                        nl * PV_NW : nl * PV_NW + PV_NW,
+                                                    ],
+                                                    kv_ring[
+                                                        slot,
+                                                        pv_done : pv_done + pv_run,
+                                                        0:PV_NW,
+                                                    ],
+                                                )
+                                                pv_cur += pv_run
+                                        T.set_flag("mte2", "mte1", ev)
+
+                                        T.wait_flag("m", "mte1", L0AB_EV0 + pp)
+                                        T.wait_flag("mte2", "mte1", ev)
+                                        T.copy(p_l1[:, :], p_l0a[pp, :, :], real_k=winm)
+                                        T.copy(
+                                            kv_ring[slot, :, 0:PV_NW],
+                                            v_l0b[pp, :, :],
+                                            real_k=winm,
+                                        )
+                                        T.set_flag("mte1", "m", L0AB_EV0 + pp)
+                                        T.wait_flag("mte1", "m", L0AB_EV0 + pp)
+                                        T.mma(
+                                            p_l0a[pp, :, :],
+                                            v_l0b[pp, :, :],
+                                            cL0[cs, :, :],
+                                            init=True,
+                                            k_actual=winm,
+                                            unit_flag=0b11,
+                                        )
+                                        T.set_flag("m", "mte1", L0AB_EV0 + pp)
+
+                                        T.set_flag("mte1", "mte2", ev)
+                                        T.copy(
+                                            cL0[cs, :, :],
+                                            workspace_o[
+                                                cid,
+                                                bufm,
+                                                :,
+                                                nl * PV_NW : (nl + 1) * PV_NW,
+                                            ],
+                                            unit_flag=0b11,
+                                        )
+
+                                        cl0_iter += 1
+
+                                    T.set_flag("mte1", "mte2", P_EV)
+
+                                    if DEBUG_SERIAL:
+                                        T.barrier_all()
+                            T.set_cross_flag("FIX", EV_PV)
+
+                    T.wait_flag("m", "mte1", L0AB_EV0)
+                    T.wait_flag("m", "mte1", L0AB_EV1)
+
+                    T.wait_flag("mte1", "mte2", KV_EV0)
+                    T.wait_flag("mte1", "mte2", KV_EV1)
+                    T.wait_flag("mte1", "mte2", KV_EV2)
+
+                    T.wait_flag("mte1", "mte2", Q_EV)
+                    T.wait_flag("mte1", "mte2", P_EV)
+
+                with T.Scope("V"):
+                    T.tile.fill(ones_ub, T.float32(1.0))
+
+                    T.set_flag("v", "mte2", SV_S_EV)
+                    T.set_flag("mte3", "v", SV_P_EV)
+
+                    T.set_flag("v", "mte2", VO_O_EV)
+                    T.set_flag("mte3", "v", VO_OUT_EV)
+                    T.set_flag("mte3", "v", VO_LSE_EV)
+
+                    for j in T.serial(1, n_iter + 2):
+                        if j < n_iter + 1:
+                            T.wait_cross_flag(EV_QK)
+                            pid = (j - 1) * core_num + cid
+                            buf = (j - 1) % 2
+                            if pid < block_num:
+                                b = T.cast(pid // max_seq, "int32")
+                                s = T.cast(pid % max_seq, "int32")
+                                act_q = act_q_lens[b]
+                                if s < act_q:
+                                    act_kv = seqused_kv[b]
+                                    s_global = act_kv - act_q + s
+                                    ori_left = T.max(s_global - ori_win_left, 0)
+
+                                    winm = s_global + 1 - ori_left
+
+                                    T.wait_flag("v", "mte2", SV_S_EV)
+
+                                    T.tile.fill(s_ub, -T.infinity(accum_dtype))
+                                    T.set_flag("v", "mte2", SV_S_EV)
+                                    T.wait_flag("v", "mte2", SV_S_EV)
+                                    T.copy(
+                                        workspace_s[cid, buf, vid * G2 : (vid + 1) * G2, 0:winm],
+                                        s_ub[:, 0:winm],
+                                    )
+                                    T.copy(sinks[vid * G2 : (vid + 1) * G2], sink_ub)
+
+                                    T.set_flag("mte2", "v", SV_S_EV)
+                                    T.wait_flag("mte2", "v", SV_S_EV)
+                                    T.tile.mul(s_ub, s_ub, softmax_scale)
+
+                                    T.pipe_barrier("v")
+
+                                    T.reduce_max(s_ub, m_i[buf, :, :], dim=-1)
+
+                                    T.tile.max(m_i[buf, :, :], sink_ub, m_i[buf, :, :])
+                                    T.tile.broadcast(m_2d, m_i[buf, :, :])
+                                    T.tile.sub(s_ub, s_ub, m_2d)
+                                    T.tile.exp(s_ub, s_ub)
+
+                                    T.tile.sub(expmax_ub, sink_ub, m_i[buf, :, :])
+                                    T.tile.exp(expmax_ub, expmax_ub)
+
+                                    T.pipe_barrier("v")
+
+                                    T.wait_flag("mte3", "v", SV_P_EV)
+                                    T.tile.cast(p_half, s_ub, "CAST_ROUND", G2 * BI)
+
+                                    T.pipe_barrier("v")
+                                    T.reduce_sum(s_ub, sumP, dim=-1)
+                                    T.tile.add(denom[buf, :, :], expmax_ub, sumP)
+
+                                    T.set_flag("v", "mte2", SV_S_EV)
+                                    T.set_flag("v", "mte3", SV_P_EV)
+                                    T.wait_flag("v", "mte3", SV_P_EV)
+                                    T.copy(
+                                        p_half,
+                                        workspace_p[cid, buf, vid * G2 : (vid + 1) * G2, :],
+                                    )
+
+                                    T.set_flag("mte3", "v", SV_P_EV)
+                            T.set_cross_flag("MTE3", EV_P)
+
+                        if j >= 2:
+                            T.wait_cross_flag(EV_PV)
+                            pidm = (j - 2) * core_num + cid
+                            bufm = (j - 2) % 2
+                            if pidm < block_num:
+                                bm = T.cast(pidm // max_seq, "int32")
+                                sm = T.cast(pidm % max_seq, "int32")
+                                if sm < act_q_lens[bm]:
+                                    tokm = q_prefix[bm] + sm
+
+                                    T.wait_flag("v", "mte2", VO_O_EV)
+                                    T.copy(
+                                        workspace_o[cid, bufm, vid * G2 : (vid + 1) * G2, :],
+                                        o_ub,
+                                    )
+
+                                    T.set_flag("mte2", "v", VO_O_EV)
+                                    T.wait_flag("mte2", "v", VO_O_EV)
+
+                                    T.tile.brcb_experiment(brcb_d, denom[bufm, :, :], G2 // 8, 1, 8)
+                                    T.pipe_barrier("v")
+                                    for dcol in T.serial(D // (8 * BLK)):
+                                        cb = dcol * (8 * BLK)
+                                        T.tile.row_expand_div_experiment(
+                                            o_ub[:, cb : cb + 8 * BLK],
+                                            o_ub[:, cb : cb + 8 * BLK],
+                                            brcb_d,
+                                        )
+
+                                    T.pipe_barrier("v")
+
+                                    T.wait_flag("mte3", "v", VO_OUT_EV)
+                                    T.tile.cast(o_half, o_ub, out_cast_mode, G2 * D)
+
+                                    T.set_flag("v", "mte2", VO_O_EV)
+                                    T.set_flag("v", "mte3", VO_OUT_EV)
+                                    T.wait_flag("v", "mte3", VO_OUT_EV)
+                                    T.copy(
+                                        o_half,
+                                        Output[tokm, vid * G2 : (vid + 1) * G2, :],
+                                    )
+
+                                    T.set_flag("mte3", "v", VO_OUT_EV)
+
+                                    T.wait_flag("mte3", "v", VO_LSE_EV)
+                                    T.tile.ln(lse_ub, denom[bufm, :, :])
+                                    T.tile.add(lse_ub, lse_ub, m_i[bufm, :, :])
+                                    T.set_flag("v", "mte3", VO_LSE_EV)
+                                    T.wait_flag("v", "mte3", VO_LSE_EV)
+                                    T.copy(lse_ub, LSE[tokm, vid * G2 : (vid + 1) * G2])
+                                    T.set_flag("mte3", "v", VO_LSE_EV)
+
+                    T.wait_flag("v", "mte2", SV_S_EV)
+                    T.wait_flag("mte3", "v", SV_P_EV)
+                    T.wait_flag("v", "mte2", VO_O_EV)
+                    T.wait_flag("mte3", "v", VO_OUT_EV)
+                    T.wait_flag("mte3", "v", VO_LSE_EV)
+
+        return sparse_flash_mla_swa
+
+    func = kernel()
+
+    if os.environ.get("SAS_DUMP_SRC"):
+        try:
+            src = func.get_kernel_source()
+            with open("/tmp/swa_gen.cpp", "w") as fh:
+                fh.write(src)
+            print(f"[SAS_DUMP_SRC] wrote {len(src)} chars to /tmp/swa_gen.cpp")
+        except Exception as exc:
+            print(f"[SAS_DUMP_SRC] get_kernel_source failed: {exc!r}")
+    return func
+
+
+if __name__ == "__main__":
+    build_sparse_flash_mla(
+        batch=1,
+        max_seq=1024,
+        total_tokens=1024,
+        ori_block_num=10,
+        ori_block_size=128,
+        ori_table_len=8,
+        cmp_block_num=1,
+        cmp_block_size=1,
+        cmp_table_len=1,
+        n_heads=64,
+        n_kv_heads=1,
+        head_dim=512,
+        topk_cmp=0,
+        cmp_ratio=4,
+        scenario=1,
+        ori_win_left=127,
+        softmax_scale=0.04419417,
+        dtype="bfloat16",
+        core_num=DEFAULT_CORE_NUM,
+    )
+    print("TEST PASSED!")


### PR DESCRIPTION
## What

Add an Ascend example under `examples/deepseek_v4/sparse_flash_mla/` implementing sparse flash MLA with a shared paged KV cache, in three variants:

- `swa` — sliding window over the original KV
- `hca` — original + compressed KV
- `csa` — original + compressed KV + top-k sparse indices

Files:

- `sparse_flash_mla_kernel.py` — TileLang kernels (three `@tilelang.jit` builders)
- `sparse_flash_mla_api.py` — the `sparse_flash_mla(...)` entry point
- `sparse_flash_mla_golden.py` — reference implementation + accuracy checks

## Validation

`python sparse_flash_mla_api.py` runs the three variants against the golden reference and prints `Kernel Output Match!`.
