### PR TITLE
[Bugfix] Fix A5 vector-pipe deadlock from AscendSyncInsertVS PIPE_V b…

### DIFF
--- a/src/transform/ascend_sync_insert_vs.cc
+++ b/src/transform/ascend_sync_insert_vs.cc
@@ -760,15 +760,21 @@ private:
     } else if (sync_type.find("PipeBarrier_") == 0) {
       std::string pipeline = sync_type.substr(12);
       if (pipeline == "PIPE_V" && platform_ == "A5") {
-        // A5 does not support pipe_barrier(PIPE_V);
-        // raise error: the range of 1st parameter must be [4, 6]
-        // use V_V event pair
-        int event_id = AllocateEventId();
-        stmts.push_back(CreateSetFlag("V_V", event_id));
-        stmts.push_back(CreateWaitFlag("V_V", event_id));
-      } else {
-        stmts.push_back(CreatePipeBarrier(pipeline));
+        // A5 does not support pipe_barrier(PIPE_V) (its 1st parameter must be
+        // in [4, 6]). A V->V ordering is redundant anyway: the vector pipe is
+        // in-order, so a later vector op never starts before an earlier one
+        // finishes. AscendSyncInsert already drops PipeBarrier_PIPE_V on A5 for
+        // the same reason. Previously this pass instead emitted a
+        // set_flag/wait_flag(PIPE_V, PIPE_V, id) pair; when that pair landed
+        // immediately after a set_flag/wait_flag(PIPE_MTE2, PIPE_V, id) fence
+        // from AscendSyncInsert (a vector op reading one GM-copied and one
+        // just-filled buffer, e.g. examples/activation/tanh.py), the vector
+        // pipe deadlocked on A5 (AI Core stuck at 100% util, host hangs in
+        // aclrtSynchronize). Dropping it, consistent with AscendSyncInsert,
+        // fixes the hang without losing correctness.
+        return;
       }
+      stmts.push_back(CreatePipeBarrier(pipeline));
     } else if (sync_type.find("EventPair_") == 0) {
       std::string event_type = sync_type.substr(10);
       int event_id = AllocateEventId();


### PR DESCRIPTION
## Root cause
  Two auto-sync passes run back-to-back (`tilelang/engine/phase.py:118-119`): `AscendSyncInsert` then `AscendSyncInsertVS`.
  For a V→V dependency both would emit `pipe_barrier(PIPE_V)`, which A5 does not support (1st param must be in [4,6]).
  `AscendSyncInsert` **drops** it on A5 (`ascend_sync_insert.cc:1611-1613`); `AscendSyncInsertVS` instead **converted** it to
  a `set_flag/wait_flag(PIPE_V, PIPE_V, id)` pair. When that pair lands immediately after a `set_flag/wait_flag(PIPE_MTE2,
  PIPE_V, id)` fence from `AscendSyncInsert` — with no vector op between them (a vector op reading one GM-copied and one
  just-`fill`ed buffer) — the vector pipe deadlocks: AI Core stuck at 100% util, host hangs in `aclrtSynchronize` right after
  "Init successful!" (silent, no compile error).

 ## Fix
  Drop the `PIPE_V` barrier on A5 instead of converting it, matching `AscendSyncInsert`. The vector pipe is in-order, so a
  V→V ordering barrier is always redundant — correctness is preserved. One file, ~15-line diff.

 ## Testing (real A5 / Ascend 950)
  - `examples/activation/tanh.py` (3 configs incl. 1100×50000): **hung before, now `Kernel Output Match!`**
  - No regressions: `gemm_pto_developer`, `matmul_add_developer_vec_cast`, row/col `reduce` slice_buffer, 
  `sparse_flash_attn_gqa_pto_developer`
  - `clang-format` 15.0.7 clean