### PR TITLE
新增SwiGLU算子生成与测评

### DIFF
--- a/examples/swiglu/swiglu.py
+++ b/examples/swiglu/swiglu.py
@@ -59,8 +59,8 @@ def swiglu(block_M, block_N, stages, split_dim, dtype="float16"):
 
     @T.prim_func
     def main(
-            A: T.Tensor((M, N), dtype),  # type: ignore
-            B: T.Tensor((M // m_div, N // n_div), dtype),  # type: ignore
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        B: T.Tensor((M // m_div, N // n_div), dtype),  # type: ignore
     ):
         # Offset via ternary (see note above on if-block limitation).
         m_offset = M // 2 if row_split else 0
@@ -222,9 +222,7 @@ def swi_glu(input, dim=-1):
 
     # Validate dtype (only fp16/fp32/bf16 supported)
     if torch_dtype_str not in _TORCH_TO_TL_DTYPE:
-        raise ValueError(
-            f"SwiGLU unsupported dtype: {torch_dtype_str}. Supported: {list(_TORCH_TO_TL_DTYPE.keys())}"
-        )
+        raise ValueError(f"SwiGLU unsupported dtype: {torch_dtype_str}. Supported: {list(_TORCH_TO_TL_DTYPE.keys())}")
     tl_dtype = _TORCH_TO_TL_DTYPE[torch_dtype_str]
 
     # Validate split dim is even (required for equal x0/x1 split)

--- a/examples/swiglu/swiglu.py
+++ b/examples/swiglu/swiglu.py
@@ -1,0 +1,317 @@
+"""SwiGLU activation kernel: output = silu(x0) * x1.
+
+Single-input kernel with offset access to x0/x1 halves (no host chunk).
+Developer mode, persistent + double buffering, T.tile.silu, fp16/bf16 upcast to fp32.
+Dynamic tiling (block_M/block_N by output cols) + per-case stages selection.
+"""
+
+import tilelang
+import tilelang.language as T
+import torch
+
+tilelang.cache.clear_cache()
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+}
+
+
+@tilelang.jit(out_idx=[1], pass_configs=pass_configs)
+def swiglu(block_M, block_N, stages, split_dim, dtype="float16"):
+    """SwiGLU kernel: single input A(M,N), output B(M//m_div, N//n_div).
+
+    Args:
+        block_M: row block size (UB budget checked by caller; no internal clamp).
+        block_N: col block size (must be 32B-aligned for DataCopyNd).
+        stages: double-buffer stages (1 = single buffer, 2 = double buffer).
+            Caller picks per-case via _select_tiling (stages=1 enlarges block_M
+            for large cases reducing iters; stages=2 keeps double-buffer for
+            small cases where iters don't decrease).
+        split_dim: 1 = split last dim (n_div=2); 0/-2 = split row axis (m_div=2).
+        dtype: "float16" / "float" / "float32" / "bfloat16".
+    """
+    M = T.symbolic("M")
+    N = T.symbolic("N")
+
+    need_cast = dtype not in ("float", "float32")
+    ACC_DTYPE = "float32"
+
+    # NOTE: use ternary (single assignment) instead of if-block reassignment.
+    # TileLang prim_func internal Python if-block variable reassignment does not
+    # propagate to codegen (compiler limitation). Ternary expressions are single
+    # assignments and propagate correctly.
+    row_split = split_dim == 0 or split_dim == -2
+    m_div = 2 if row_split else 1
+    n_div = 1 if row_split else 2
+
+    m_num = T.ceildiv(M // m_div, block_M)
+    n_num = T.ceildiv(N // n_div, block_N)
+    num_blocks = m_num * n_num
+
+    VEC_NUM = 2
+    rows_per_vec = block_M // VEC_NUM
+    elem_num = rows_per_vec * block_N
+
+    NUM_CORES = 48
+    num_iters = T.ceildiv(num_blocks, NUM_CORES)
+
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, N), dtype),  # type: ignore
+            B: T.Tensor((M // m_div, N // n_div), dtype),  # type: ignore
+    ):
+        # Offset via ternary (see note above on if-block limitation).
+        m_offset = M // 2 if row_split else 0
+        n_offset = 0 if row_split else N // 2
+
+        with T.Kernel(NUM_CORES, is_npu=True) as (cid, vid):
+            # UB buffers (double-buffered stages dim)
+            a0_ub = T.alloc_ub((stages, rows_per_vec, block_N), ACC_DTYPE)
+            a1_ub = T.alloc_ub((stages, rows_per_vec, block_N), ACC_DTYPE)
+            b_ub = T.alloc_ub((stages, rows_per_vec, block_N), ACC_DTYPE)
+
+            # dtype transit buffers (only allocated; used when need_cast=True)
+            tmp_in0 = T.alloc_ub((rows_per_vec, block_N), dtype)
+            tmp_in1 = T.alloc_ub((rows_per_vec, block_N), dtype)
+            tmp_out = T.alloc_ub((rows_per_vec, block_N), dtype)
+
+            for i in T.serial(num_iters):
+                cur = i % stages
+
+                block_id = cid + i * NUM_CORES
+                if block_id < num_blocks:
+                    bx = block_id // n_num
+                    by = block_id % n_num
+                    row = bx * block_M + vid * rows_per_vec
+                    col = by * block_N
+                    row2 = row + m_offset
+                    col2 = col + n_offset
+
+                    # Load + upcast to fp32
+                    if need_cast:
+                        T.copy(A[row, col], tmp_in0)
+                        T.copy(A[row2, col2], tmp_in1)
+                        T.tile.cast(a0_ub[cur, :, :], tmp_in0, "CAST_NONE", elem_num)
+                        T.tile.cast(a1_ub[cur, :, :], tmp_in1, "CAST_NONE", elem_num)
+                    else:
+                        T.copy(A[row, col], a0_ub[cur, :, :])
+                        T.copy(A[row2, col2], a1_ub[cur, :, :])
+
+                    # SiLU(x0) then gating mul: out = silu(x0) * x1
+                    T.tile.silu(b_ub[cur, :, :], a0_ub[cur, :, :])
+                    T.tile.mul(b_ub[cur, :, :], b_ub[cur, :, :], a1_ub[cur, :, :])
+
+                    # Downcast back to original dtype + store
+                    out_row = bx * block_M + vid * rows_per_vec
+                    out_col = by * block_N
+
+                    if need_cast:
+                        T.tile.cast(tmp_out, b_ub[cur, :, :], "CAST_RINT", elem_num)
+                        T.copy(tmp_out, B[out_row, out_col])
+                    else:
+                        T.copy(b_ub[cur, :, :], B[out_row, out_col])
+
+    return main
+
+
+# ========== Host-side adapter (interface: swi_glu(input, dim)) ==========
+
+_TORCH_TO_TL_DTYPE = {
+    "float16": "float16",
+    "float32": "float",
+    "bfloat16": "bfloat16",
+}
+
+_kernel_cache = {}
+
+# UB budget (A2/A3 = 196352 B). Worst-case byte/element by stages:
+#   stages=1 (single buffer):
+#     cast path (fp16/bf16: a0/a1/b fp32 x1 + tmp_in0/in1/out): 3*1*4 + 3*2 = 18
+#     direct path (fp32: a0/a1/b fp32 x1):                       3*1*4      = 12
+#   stages=2 (double buffer):
+#     cast path: 3*2*4 + 3*2 = 30
+#     direct path: 3*2*4     = 24
+_UB_BUDGET = 196352
+NUM_CORES = 48
+_STAGE_OPTS = (
+    # (stages, cast_bpe, direct_bpe)
+    (1, 18, 12),
+    (2, 30, 24),
+)
+
+
+def _select_tiling(k_out_cols, tl_dtype, m_out):
+    """Pick (block_M, block_N, stages) by output cols, dtype, and output rows.
+
+    block_N: aligned to 32B (DataCopyNd granularity), capped at 128.
+    stages: chosen per-case by minimizing num_iters = ceil(num_blocks / NUM_CORES).
+      - stages=1 enlarges block_M (lower UB/elem) -> fewer blocks -> fewer iters
+        (wins for large cases where iters drop materially).
+      - stages=2 keeps double-buffer; when iters are equal to stages=1, prefer
+        stages=2 (double-buffer hides GM->UB latency for small/medium cases).
+      Ties (equal num_iters) go to stages=2.
+    """
+    dtype_bytes = 2 if tl_dtype in ("bfloat16", "float16") else 4
+    align = max(1, 32 // dtype_bytes)  # fp16/bf16->16, fp32->8
+
+    block_N = min(k_out_cols, 128)
+    block_N = max(align, ((block_N + align - 1) // align) * align)
+    block_N = min(block_N, 128)
+
+    need_cast = tl_dtype in ("bfloat16", "float16")
+    n_num = (k_out_cols + block_N - 1) // block_N
+
+    target_area = 16384
+    best = None  # (num_iters, stages, block_M)
+    for stages, cast_bpe, direct_bpe in _STAGE_OPTS:
+        bpe = cast_bpe if need_cast else direct_bpe
+        block_M = target_area // block_N
+        block_M = (block_M // 32) * 32
+        block_M = max(64, min(1024, block_M))
+        rows_per_vec = block_M // 2
+        while rows_per_vec * block_N * bpe > _UB_BUDGET and block_M > 64:
+            block_M -= 32
+            rows_per_vec = block_M // 2
+        m_num = (m_out + block_M - 1) // block_M
+        num_blocks = m_num * n_num
+        num_iters = (num_blocks + NUM_CORES - 1) // NUM_CORES
+        # Prefer fewer iters; tie -> larger stages (double-buffer)
+        if best is None or num_iters < best[0] or (num_iters == best[0] and stages > best[1]):
+            best = (num_iters, stages, block_M)
+
+    return best[2], block_N, best[1]
+
+
+def _get_kernel(split_dim, tl_dtype, n_cols, m_out):
+    """Get or compile a cached kernel for (split_dim, dtype, n_cols, m_out).
+
+    block_M/block_N/stages chosen by _select_tiling based on output column count
+    and output row count:
+      split_dim=1 -> k_out_cols = n_cols // 2, m_out = M
+      split_dim=0 -> k_out_cols = n_cols, m_out = M // 2
+    T.symbolic M/N means one compile per (split_dim, dtype, block_M, block_N,
+    stages) supports any M/N, so cache key uses the chosen tiling.
+    """
+    k_out_cols = n_cols // 2 if split_dim == 1 else n_cols
+    block_M, block_N, stages = _select_tiling(k_out_cols, tl_dtype, m_out)
+    key = (split_dim, tl_dtype, block_M, block_N, stages)
+    if key not in _kernel_cache:
+        _kernel_cache[key] = swiglu(block_M, block_N, stages, split_dim, dtype=tl_dtype)
+    return _kernel_cache[key]
+
+
+def swi_glu(input, dim=-1):
+    """SwiGLU activation: output = silu(x0) * x1.
+
+    Adapter for cann-bench interface. Normalizes dim, transposes middle dims
+    to last, reshapes to 2D, dispatches to the single-input kernel by
+    (split_dim, dtype), and restores the output rank/shape.
+
+    Args:
+        input: input tensor; size of `dim` axis must be even.
+        dim: split dimension (supports negative index).
+
+    Returns:
+        output tensor with same rank/dtype as input, `dim` axis halved.
+    """
+    ndim = input.ndim
+    dim = dim % ndim
+    torch_dtype_str = str(input.dtype).replace("torch.", "")
+
+    # Validate dtype (only fp16/fp32/bf16 supported)
+    if torch_dtype_str not in _TORCH_TO_TL_DTYPE:
+        raise ValueError(
+            f"SwiGLU unsupported dtype: {torch_dtype_str}. Supported: {list(_TORCH_TO_TL_DTYPE.keys())}"
+        )
+    tl_dtype = _TORCH_TO_TL_DTYPE[torch_dtype_str]
+
+    # Validate split dim is even (required for equal x0/x1 split)
+    if input.shape[dim] % 2 != 0:
+        raise ValueError(f"SwiGLU requires even size on dim={dim}, got {input.shape[dim]}")
+
+    # Strategy: middle dims transposed to last; dim=0 keeps split_dim=0 (row split);
+    # dim==last keeps split_dim=1 (col split).
+    need_transpose = 0 < dim < ndim - 1
+    perm = None
+    if need_transpose:
+        perm = list(range(ndim))
+        perm[dim], perm[-1] = perm[-1], perm[dim]
+        input = input.permute(perm).contiguous()
+        split_dim = 1
+    elif dim == 0:
+        split_dim = 0
+    else:  # dim == ndim - 1
+        split_dim = 1
+
+    # Reshape to 2D (M, N)
+    original_shape = list(input.shape)
+    M = 1
+    for s in original_shape[:-1]:
+        M *= s
+    N = original_shape[-1]
+    input_2d = input.reshape(M, N)
+
+    # Dispatch to kernel
+    # m_out = output rows: split_dim=1 -> M; split_dim=0 -> M//2 (row axis halved)
+    m_out = M if split_dim == 1 else M // 2
+    kernel = _get_kernel(split_dim, tl_dtype, N, m_out)
+    output_2d = kernel(input_2d)
+
+    # Reshape back to original rank (split axis halved)
+    out_shape = list(original_shape)
+    if split_dim == 1:
+        out_shape[-1] = out_shape[-1] // 2
+    else:  # split_dim == 0: row axis halved (M halved -> first axis halved)
+        out_shape[0] = out_shape[0] // 2
+    output = output_2d.reshape(out_shape)
+
+    # Inverse transpose
+    if need_transpose:
+        inv_perm = [0] * ndim
+        for i, p in enumerate(perm):
+            inv_perm[p] = i
+        output = output.permute(inv_perm).contiguous()
+
+    return output
+
+
+# ========== Tests ==========
+
+import torch.nn.functional as F  # noqa: E402
+
+
+def _golden(input, dim=-1):
+    """Torch golden: output = silu(x0) * x1, upcast fp16/bf16 to fp32."""
+    out_dtype = input.dtype
+    x = input.to(torch.float)
+    x0, x1 = x.chunk(2, dim=dim)
+    output = F.silu(x0) * x1
+    return output.to(out_dtype)
+
+
+torch.manual_seed(0)
+
+# Tests: (shape, dim, dtype)
+test_configs = [
+    ((1024, 2048), -1, torch.float16),
+    ((2048, 4096), -1, torch.float32),
+    ((4096, 8192), -1, torch.bfloat16),
+    ((1024, 2048), 0, torch.float16),
+    ((1009, 2016), -1, torch.float16),
+    ((256, 256), -1, torch.float16),
+    ((256, 258), -1, torch.bfloat16),
+    ((4, 8, 256), -1, torch.float16),
+    ((320, 256), 0, torch.float32),
+]
+
+for shape, dim, dtype in test_configs:
+    print(f"Testing SwiGLU shape={shape}, dim={dim}, dtype={dtype}")
+    a = torch.randn(shape, dtype=dtype, device="cpu").npu()
+    b = swi_glu(a, dim=dim)
+    ref = _golden(a, dim=dim)
+    torch.testing.assert_close(b.cpu(), ref.cpu(), rtol=1e-2, atol=1e-2)
+    print("  Test passed!")
+
+print("Kernel Output Match!")


### PR DESCRIPTION
新增 `examples/swiglu` 算子。PTO 后端编译通过，cann-bench 20 case 平均加速比 0.7751x（达 AscendC baseline 的 77.51% > 50%），20/20 精度通过。以下为精度性能测试报告及 simulator 流水图。

# 算子评测报告

- **评测任务**：cann-bench `tasks/level1/swi_glu`（20 个 case）
- **硬件**：Ascend910（910b2 / A2），CANN 9.1.0，torch 2.7.1 / torch_npu 2.7.1
- **性能基线**：torch_npu `npu_swiglu`（AscendC C++ 融合算子）
- **评分**：HAP（硬件锚定性能），综合分 = 编译 0.2 + 精度 0.3 + 性能 0.5
- **计时口径**：纯 NPU kernel 耗时（torch_npu.profiler kernel_details.csv 中所有非 warmup kernel 的 median Duration 之和）

## 概览

| 指标 | 数值 |
|------|------|
| 总用例数 | 20 |
| 精度通过数 | 20 |
| 精度通过率 | 100% |
| 综合得分 | 69.18 |
| 平均加速比 | 0.7751x（= 77.51% > 50% 合入标准） |

## 合入标准核对

### (1) PTO 后端通过 ✓

编译走 PTO 后端（生成代码 `using namespace Catlass`，platform A3，`KERNEL_TYPE_MIX_AIC_1_2`），后续框架归一到 PTO 后端。

### (2) 性能标准 ✓

**a. 有 AscendC 实现，性能达 50% 以上**：baseline = torch_npu `npu_swiglu`（AscendC C++ 融合算子），平均加速比 0.7751x = 77.51% > 50%。

**performance-antipatterns.md 自检**（无影响性能的错误写法）：

| 关注项 | 状态 | 说明 |
|--------|------|------|
| launch core 数 | ✓ | NUM_CORES=48 persistent（Fixed Core 模式），非按 block_num launch |
| Vector for loop 逐元素 | ✓ | block 级 T.serial，非逐元素循环 |
| 冗余全局同步 | ✓ | AUTO_SYNC，无手写 barrier_all，仅循环边界 PipeBarrier |
| 基础指令未融合 | ✓ | `T.tile.silu` 融合指令替代 sub/exp/add/div 4 步 |
| tile size 过小 | ✓ | 动态 tiling，UB 占用 62.6%（122880/196352B） |
| AIC/AIV CV overlap | N/A | 纯元素级无 matmul，不涉及 |
| 纯 AIV 未做双 buffer | ✓ | 已做双缓冲（stages=2，i%2 交替） |
| 多行 tile 循环内归约 | N/A | 无归约操作 |
| 正交轴串行化 | ✓ | 无嵌套标量循环 |

### (3) 优先 developer 原语 ✓

使用 Developer 模式（`T.alloc_ub` + `T.tile.xxx` + AUTO_SYNC + MEMORY_PLANNING），纯元素级融合最适合 Developer，无需注明特殊原因。

### (4) 精度性能报告 + simulator 流水图 ✓

精度性能报告见下方；simulator 流水图见下文。

## 算子实现

| 维度 | 选择 |
|------|------|
| 公式 | `output = silu(x0) * x1 = (x0 * sigmoid(x0)) * x1`，其中 `x0, x1 = input.chunk(2, dim)` |
| 编程模式 | Developer（`T.alloc_ub` 自动映射 UB + `T.tile.xxx` 硬件原语） |
| 输入形式 | **单输入 split kernel**（kernel 内 offset 索引读 x0/x1，无 host chunk+contiguous 拷贝） |
| 核心 API | `T.tile.silu`（一步 silu）+ `T.tile.mul`（门控乘）+ `T.tile.cast`（精度转换） |
| 精度处理 | fp16/bf16 升 FP32 计算（CAST_NONE）→ silu+mul → 降精度（CAST_RINT）；fp32 直接计算 |
| 调度 | persistent kernel，NUM_CORES=48，双缓冲 stages 可参数化（1/2） |
| 动态 shape | `T.symbolic("M"/"N")`，编译一次支持任意 M/N |
| 支持 dtype | float16 / float32 / bfloat16 |

## 优化策略

1. **单输入 split kernel**：kernel 内通过 offset 索引读 x0/x1（`m_offset`/`n_offset`），消除接口层 chunk+contiguous×2 的 host 拷贝。
2. **动态 tiling 自适应**：`block_N = min(K_out, 128)` 对齐 32B（DataCopyNd 粒度硬约束），`block_M` 反向缩放到 tile 面积 ~16384 并做 UB 预算校验。
3. **per-case stages 选择**：kernel 接受 `stages` 参数（1=单缓冲/2=双缓冲），`_select_tiling` 对每 case 尝试两种 stages 选 `num_iters` 更小者，tie 选 stages=2。

## 20 case 逐项评测

| case | shape | dtype | dim | T_base(μs) | 耗时(μs) | 加速比 | 精度误差 |
|------|-------|-------|-----|-----------|---------|--------|---------|
| 1 | [1024,2048] | fp16 | -1 | 15.44 | 11.28 | 1.369x | 0 |
| 2 | [2048,4096] | fp32 | -1 | 35.86 | 37.44 | 0.958x | 0 |
| 3 | [4096,8192] | bf16 | -1 | 58.84 | 141.10 | 0.417x | 0 |
| 4 | [8192,16384] | fp16 | 0 | 288.77 | 629.71 | 0.459x | 0 |
| 5 | [2039,65520] | fp32 | -1 | 748.86 | 1253.21 | 0.598x | 0 |
| 6 | [1022,2047] | bf16 | 0 | 21.79 | 24.26 | 0.898x | 0 |
| 7 | [1009,2016] | fp16 | -1 | 16.10 | 16.62 | 0.969x | 0 |
| 8 | [1538,1537] | fp32 | 0 | 31.04 | 30.48 | 1.018x | 0 |
| 9 | [363,367,14] | bf16 | -1 | 19.43 | 325.37 | 0.060x | 0 |
| 10 | [2049,1024] | fp16 | 1 | 15.46 | 11.22 | 1.378x | 0 |
| 11 | [3,7,13,1018] | fp32 | -1 | 9.62 | 6.94 | 1.386x | 0 |
| 12 | [1000003,2] | bf16 | 1 | 20.83 | 4018.56 | 0.005x | 0 |
| 13 | [11,13,16,67] | fp32 | 2 | 10.00 | 42.68 | 0.234x | 0 |
| 14 | [3,7,11,13,1012] | fp16 | -1 | 21.04 | 31.72 | 0.663x | 0 |
| 15 | [512,4096] | fp32 | -1 | 18.28 | 12.24 | 1.493x | 0 |
| 16 | [254,16383] | bf16 | 0 | 31.28 | 37.22 | 0.840x | 0 |
| 17 | [4096,1023] | fp16 | 0 | 36.56 | 38.98 | 0.938x | 0 |
| 18 | [2,1023,4096] | fp32 | -1 | 36.44 | 38.02 | 0.958x | 0 |
| 19 | [4,510,4097] | bf16 | 1 | 46.80 | 213.12 | 0.220x | 0 |
| 20 | [2,3,17,512,100] | fp32 | -1 | 78.12 | 122.10 | 0.640x | 0 |

- 精度全部 `matched_ratio = 1.0000`（fp16/bf16 走 f32 cast 与 golden 逐位一致）
- 13/20 case 加速比 ≥ 0.6x（多数 >0.9x，最优 case15 = 1.49x）
- 7 个 <0.6x case 为结构性瓶颈（见下）

## 已知结构性瓶颈

| case | 加速比 | 原因 |
|------|--------|------|
| 12 | 0.005x | half_k=1，32B 对齐强制 block_N=16，silu/mul 处理 16 列只 1 列有效 → 16x 计算浪费。需 1D strided UB kernel |
| 9 | 0.060x | half_k=7，block_N=16 >> 7，2.3x 浪费 + 跨行 DMA |
| 13/19 | 0.23/0.22x | dim≠last 触发 permute+contiguous + inverse，各产生一个 NPU copy kernel 计入耗时。需 kernel 支持 stride-input |
| 3/4/5 | 0.42~0.60x | 大 shape 纯元素级难超 AscendC 融合 baseline，受 cast detour 7-buffer 限制 block_M |

## 典型 shape simulator 流水图
<img width="2031" height="1289" alt="流水图-cubecore0" src="https://github.com/user-attachments/assets/c40074a1-9a7d-46ee-9eda-687b59c1a87a" />
<img width="2040" height="1218" alt="流水图-veccore0" src="https://github.com/user-attachments/assets/a83d20e4-785a-4ca9-b6ad-67d7b8dec39a" />
<img width="2015" height="1278" alt="流水图-veccore1" src="https://github.com/user-attachments/assets/9e097a8c-48df-4044-8a14-a83057277886" />


# 9/9 Test passed! (fp16/fp32/bf16, dim=-1/0, 含非对齐/质数/3D)
已运行 bash format.sh（yapf + ruff 通过）。