### PR TITLE
[CI] Raise the pull_request test budget from 60 to 120 minutes

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -397,7 +397,7 @@ jobs:
         needs.check_changes.outputs.merged != 'true' &&
         needs.check_changes.outputs.should_skip != 'true'
       )
-    timeout-minutes: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 360 || 60 }}
+    timeout-minutes: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 360 || 120 }}
     env:
       FULL_BUILD: ${{ github.event_name == 'schedule' || github.event.inputs.full_build == 'true' }}
     steps:


### PR DESCRIPTION
The `schedule` / `workflow_dispatch` budget (360 min) is unchanged.

Measured duration of full scheduled runs on this repo:

  run     conclusion   duration
  #2206   success      51 min
  #2132   success      51 min
  #2081   success      54 min
  #2026   success      52 min

A full run takes ~51-54 minutes against a 60-minute `pull_request` budget, leaving under 10 minutes of headroom. Any load spike on the self-hosted runner pushes a healthy run past the limit.

Observed twice today, both cancelled at exactly 60.4 minutes rather than failing a test:

  PR #1459   01:27:31 -> 02:27:55   cancelled
  PR #1468   08:20:06 -> 09:20:31   cancelled

The second one was an incremental build (cache restored, full rebuild skipped) and still did not finish.

A cancelled run is not free: the work is re-triggered, so a near-miss costs the runner ~60 wasted minutes plus a full re-run. Raising the ceiling to 120 restores a comfortable margin while still bounding a hung job.