### PR TITLE
[Test] Add flash_attn_bhsd Pytest migration sample

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -397,7 +397,7 @@ jobs:
         needs.check_changes.outputs.merged != 'true' &&
         needs.check_changes.outputs.should_skip != 'true'
       )
-    timeout-minutes: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 360 || 60 }}
+    timeout-minutes: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 360 || 120 }}
     env:
       FULL_BUILD: ${{ github.event_name == 'schedule' || github.event.inputs.full_build == 'true' }}
     steps:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -57,9 +57,9 @@ jobs:
       merged: ${{ steps.pr_info.outputs.merged || steps.pr_status.outputs.merged || steps.default_changes.outputs.merged }}
       test_dirs: ${{ steps.detect_changes.outputs.test_dirs || steps.default_changes.outputs.test_dirs }}
       experiment_dirs: ${{ steps.detect_changes.outputs.experiment_dirs || steps.default_changes.outputs.experiment_dirs }}
-      pytest_files: ${{ steps.detect_changes.outputs.pytest_files || steps.default_changes.outputs.pytest_files }}
+      pytest_targets: ${{ steps.detect_changes.outputs.pytest_targets || steps.default_changes.outputs.pytest_targets }}
       run_examples: ${{ steps.detect_changes.outputs.run_examples || steps.default_changes.outputs.run_examples }}
-      run_pytest_only: ${{ steps.detect_changes.outputs.run_pytest_only || steps.default_changes.outputs.run_pytest_only }}
+      run_pytest: ${{ steps.detect_changes.outputs.run_pytest || steps.default_changes.outputs.run_pytest }}
       should_skip: ${{ steps.detect_changes.outputs.should_skip || steps.default_changes.outputs.should_skip }}
     steps:
       - name: Set default changes for full test events
@@ -69,9 +69,9 @@ jobs:
           echo "merged=false" >> $GITHUB_OUTPUT
           echo "test_dirs=" >> $GITHUB_OUTPUT
           echo "experiment_dirs=" >> $GITHUB_OUTPUT
-          echo "pytest_files=" >> $GITHUB_OUTPUT
+          echo "pytest_targets=" >> $GITHUB_OUTPUT
           echo "run_examples=true" >> $GITHUB_OUTPUT
-          echo "run_pytest_only=false" >> $GITHUB_OUTPUT
+          echo "run_pytest=true" >> $GITHUB_OUTPUT
           echo "should_skip=false" >> $GITHUB_OUTPUT
 
       - name: Get PR info
@@ -195,12 +195,32 @@ jobs:
           echo "$changed_files"
           
           run_examples=false
-          run_pytest_only=false
+          run_pytest=false
+          full_test=false
           should_skip=true
           test_dirs_array=()
           experiment_dirs_array=()
-          pytest_files_array=()
+          pytest_targets_array=()
           pytest_dirs_array=()
+
+          python scripts/ci/resolve_operator_tests.py validate
+
+          declare -A source_to_test=()
+          declare -A test_to_test=()
+          while IFS=$'\t' read -r source test; do
+            [[ -n "$source" && -n "$test" ]] || continue
+            source_to_test["$source"]="$test"
+            test_to_test["$test"]="$test"
+          done < <(python scripts/ci/resolve_operator_tests.py list --format tsv)
+
+          append_pytest_target() {
+            local target="$1"
+            local existing
+            for existing in "${pytest_targets_array[@]}"; do
+              [[ "$existing" == "$target" ]] && return
+            done
+            pytest_targets_array+=("$target")
+          }
 
           for file in $changed_files; do
             # 排除 .agents 目录（skill 配置，无需测试）
@@ -218,7 +238,7 @@ jobs:
             # testing/ 修改 → 收集 pytest 文件/目录
             if [[ "$file" =~ ^testing/python/ ]]; then
               if [[ "$file" =~ \.py$ ]]; then
-                pytest_files_array+=("$file")
+                append_pytest_target "$file"
                 # 提取子目录
                 if [[ "$file" =~ ^testing/python/([^/]+)/ ]]; then
                   pytest_subdir="${BASH_REMATCH[1]}"
@@ -228,8 +248,7 @@ jobs:
                   fi
                 fi
               fi
-              run_examples=false
-              run_pytest_only=true
+              run_pytest=true
               should_skip=false
               continue
             fi
@@ -244,14 +263,48 @@ jobs:
             if [[ "$file" =~ ^tilelang/ ]] || [[ "$file" =~ ^src/ ]] || \
                [[ "$file" =~ CMakeLists\.txt ]] || [[ "$file" =~ requirements ]] || [[ "$file" =~ install_ascend\.sh ]]; then
               echo "Core file modified: $file - will run full examples + pytest"
+              full_test=true
               run_examples=true
-              run_pytest_only=false
+              run_pytest=true
               should_skip=false
               test_dirs_array=()
               experiment_dirs_array=()
-              pytest_files_array=()
+              pytest_targets_array=()
               pytest_dirs_array=()
               break
+            fi
+
+            if [[ "$file" == ".github/workflows/ci_cd.yml" ]] || \
+               [[ "$file" == "examples/bench_test.sh" ]] || \
+               [[ "$file" == "scripts/ci/resolve_operator_tests.py" ]] || \
+               [[ "$file" == "ci/operator_test_manifest.yaml" ]]; then
+              echo "Operator CI file modified: $file - will run full examples + pytest"
+              full_test=true
+              run_examples=true
+              run_pytest=true
+              should_skip=false
+              test_dirs_array=()
+              experiment_dirs_array=()
+              pytest_targets_array=()
+              pytest_dirs_array=()
+              break
+            fi
+
+            if [[ -n "${source_to_test[$file]:-}" ]]; then
+              mapped_test="${source_to_test[$file]}"
+              append_pytest_target "$mapped_test"
+              run_pytest=true
+              should_skip=false
+              echo "Mapped migrated source $file -> $mapped_test"
+              continue
+            fi
+
+            if [[ -n "${test_to_test[$file]:-}" ]]; then
+              append_pytest_target "$file"
+              run_pytest=true
+              should_skip=false
+              echo "Mapped migrated test: $file"
+              continue
             fi
             
             # examples 文件 → 增量 examples + pytest
@@ -264,7 +317,6 @@ jobs:
                   echo "Mapped $file → example dir: $test_dir"
                 fi
                 run_examples=true
-                run_pytest_only=false
                 should_skip=false
               fi
               continue
@@ -278,7 +330,6 @@ jobs:
                 echo "Mapped $file → experiment dir: $exp_dir"
               fi
               run_examples=true
-              run_pytest_only=false
               should_skip=false
               continue
             fi
@@ -291,12 +342,13 @@ jobs:
                 continue
               fi
               echo "Experiment root file modified: $file - will run full examples + pytest"
+              full_test=true
               run_examples=true
-              run_pytest_only=false
+              run_pytest=true
               should_skip=false
               test_dirs_array=()
               experiment_dirs_array=()
-              pytest_files_array=()
+              pytest_targets_array=()
               pytest_dirs_array=()
               break
             fi
@@ -311,12 +363,13 @@ jobs:
               fi
               # 关键文件（bench_test.sh 等）→ 全量测试
               echo "Examples root file modified: $file - will run full examples + pytest"
+              full_test=true
               run_examples=true
-              run_pytest_only=false
+              run_pytest=true
               should_skip=false
               test_dirs_array=()
               experiment_dirs_array=()
-              pytest_files_array=()
+              pytest_targets_array=()
               pytest_dirs_array=()
               break
             fi
@@ -328,57 +381,60 @@ jobs:
                [[ ! "$file" =~ ^src/ ]] && [[ ! "$file" =~ ^examples/ ]] && \
                [[ ! "$file" =~ ^examples_experiment/ ]]; then
               echo "Other file modified: $file - will run full tests"
+              full_test=true
               run_examples=true
-              run_pytest_only=false
+              run_pytest=true
               should_skip=false
               test_dirs_array=()
               experiment_dirs_array=()
-              pytest_files_array=()
+              pytest_targets_array=()
               pytest_dirs_array=()
               break
             fi
           done
           
           # 决定 pytest 测试范围
-          pytest_files=""
-          if [[ ${#pytest_files_array[@]} -gt 0 ]]; then
+          pytest_targets=""
+          if [[ ${#pytest_targets_array[@]} -gt 0 ]]; then
             # 如果所有修改在同一个子目录，只跑该子目录
-            if [[ ${#pytest_dirs_array[@]} -eq 1 ]]; then
-              pytest_files="testing/python/${pytest_dirs_array[0]}/"
+            if [[ ${#pytest_dirs_array[@]} -eq 1 && ${#pytest_targets_array[@]} -eq 1 ]]; then
+              pytest_targets="testing/python/${pytest_dirs_array[0]}/"
               echo "All testing files in same subdir: ${pytest_dirs_array[0]}"
-            elif [[ ${#pytest_files_array[@]} -le 3 ]]; then
+            elif [[ ${#pytest_targets_array[@]} -le 3 ]]; then
               # 少量文件（≤3），只跑具体文件
-              pytest_files="${pytest_files_array[*]}"
-              echo "Few testing files modified: ${pytest_files_array[*]}"
+              pytest_targets="${pytest_targets_array[*]}"
+              echo "Few pytest targets modified: ${pytest_targets_array[*]}"
             else
               # 多文件散布不同目录，跑全量 pytest
-              pytest_files=""
-              echo "Many testing files scattered, will run full pytest"
+              pytest_targets=""
+              echo "Many pytest targets changed, will run full pytest"
             fi
           fi
           
           test_dirs="${test_dirs_array[*]}"
           experiment_dirs="${experiment_dirs_array[*]}"
           echo "run_examples=${run_examples}" >> $GITHUB_OUTPUT
-          echo "run_pytest_only=${run_pytest_only}" >> $GITHUB_OUTPUT
+          echo "run_pytest=${run_pytest}" >> $GITHUB_OUTPUT
           echo "test_dirs=${test_dirs}" >> $GITHUB_OUTPUT
           echo "experiment_dirs=${experiment_dirs}" >> $GITHUB_OUTPUT
-          echo "pytest_files=${pytest_files}" >> $GITHUB_OUTPUT
+          echo "pytest_targets=${pytest_targets}" >> $GITHUB_OUTPUT
           echo "should_skip=${should_skip}" >> $GITHUB_OUTPUT
           
-          if [[ "$run_pytest_only" == "true" ]]; then
-            if [[ -n "$pytest_files" ]]; then
-              echo "Will run incremental pytest for: $pytest_files"
-            else
-              echo "Will run full pytest (testing/ modified)"
-            fi
-          elif [[ "$run_examples" == "true" ]]; then
+          if [[ "$run_examples" == "true" ]]; then
             if [[ -n "$test_dirs" || -n "$experiment_dirs" ]]; then
-              echo "Will run incremental examples + pytest for: examples=[$test_dirs] experiment=[$experiment_dirs]"
+              echo "Will run legacy examples: examples=[$test_dirs] experiment=[$experiment_dirs]"
             else
-              echo "Will run full examples + pytest (core files modified)"
+              echo "Will run all legacy examples"
             fi
-          elif [[ "$should_skip" == "true" ]]; then
+          fi
+          if [[ "$run_pytest" == "true" ]]; then
+            if [[ -n "$pytest_targets" ]]; then
+              echo "Will run incremental pytest for: $pytest_targets"
+            else
+              echo "Will run full pytest plus all migrated operator tests"
+            fi
+          fi
+          if [[ "$should_skip" == "true" ]]; then
             echo "No testable files modified (docs/images only) - will skip"
           fi
 
@@ -406,44 +462,6 @@ jobs:
         with:
           submodules: false
           fetch-depth: 0
-
-      - name: Check if skip pytest
-        id: check_skip_pytest
-        if: github.event_name == 'pull_request'
-        run: |
-          BASE_REF="${{ github.base_ref }}"
-          git fetch origin $BASE_REF
-          changed_files=$(git diff --name-only origin/$BASE_REF HEAD)
-          
-          skip_pytest=true
-          
-          for file in $changed_files; do
-            if [[ "$file" =~ ^\.agents/ ]]; then
-              echo "Agents skill file: $file - ignored for pytest skip check"
-              continue
-            fi
-            if [[ "$file" =~ \.md$ ]] || [[ "$file" =~ \.png$ ]]; then
-              echo "Doc/image file: $file - ignored for pytest skip check"
-              continue
-            fi
-            if [[ ! "$file" =~ ^examples/ ]] && [[ ! "$file" =~ ^examples_experiment/ ]]; then
-              echo "File outside examples/ and examples_experiment/: $file"
-              skip_pytest=false
-              break
-            fi
-            if [[ ! "$file" =~ \.py$ ]] && [[ ! "$file" =~ \.md$ ]] && [[ ! "$file" =~ \.png$ ]]; then
-              echo "File type not allowed: $file"
-              skip_pytest=false
-              break
-            fi
-          done
-          
-          echo "skip_pytest=${skip_pytest}" >> $GITHUB_OUTPUT
-          if [ "$skip_pytest" = true ]; then
-            echo "Will skip pytest: only .py/.md/.png files in examples/ or examples_experiment/ modified"
-          else
-            echo "Will run full tests"
-          fi
 
       # 非全量编译，缓存编译产物，除非关键文件变更
       - name: Restore build cache
@@ -477,54 +495,33 @@ jobs:
             INCREMENTAL_FLAG=""
           fi
           
-          SKIP_PYTEST_VALUE="${{ steps.check_skip_pytest.outputs.skip_pytest }}"
-          
           # 确定 TEST_DIRS 参数和测试策略
           # schedule/workflow_dispatch 事件：全量测试
           # PR 事件：根据 check_changes outputs
           if [[ "$GITHUB_EVENT_NAME" == "schedule" ]] || [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
             TEST_DIRS_ARG=""
             EXPERIMENT_DIRS_ARG=""
-            PYTEST_FILES_ARG=""
+            PYTEST_TARGETS_ARG=""
             RUN_EXAMPLES="true"
-            RUN_PYTEST_ONLY="false"
-            echo "Event: $GITHUB_EVENT_NAME - running full tests (examples + experiment)"
+            RUN_PYTEST="true"
+            echo "Event: $GITHUB_EVENT_NAME - running full legacy and Pytest suites"
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             TEST_DIRS_VALUE="${{ needs.check_changes.outputs.test_dirs }}"
             EXPERIMENT_DIRS_VALUE="${{ needs.check_changes.outputs.experiment_dirs }}"
-            PYTEST_FILES_VALUE="${{ needs.check_changes.outputs.pytest_files }}"
+            PYTEST_TARGETS_VALUE="${{ needs.check_changes.outputs.pytest_targets }}"
             RUN_EXAMPLES="${{ needs.check_changes.outputs.run_examples }}"
-            RUN_PYTEST_ONLY="${{ needs.check_changes.outputs.run_pytest_only }}"
+            RUN_PYTEST="${{ needs.check_changes.outputs.run_pytest }}"
 
-            if [[ "$RUN_PYTEST_ONLY" == "true" ]]; then
-              TEST_DIRS_ARG=""
-              EXPERIMENT_DIRS_ARG=""
-              if [[ -n "$PYTEST_FILES_VALUE" ]]; then
-                PYTEST_FILES_ARG="$PYTEST_FILES_VALUE"
-                echo "Running incremental pytest for: $PYTEST_FILES_VALUE"
-              else
-                PYTEST_FILES_ARG=""
-                echo "Running full pytest (testing/ modified)"
+            TEST_DIRS_ARG=""
+            EXPERIMENT_DIRS_ARG=""
+            PYTEST_TARGETS_ARG="$PYTEST_TARGETS_VALUE"
+
+            if [[ "$RUN_EXAMPLES" == "true" ]]; then
+              if [[ -n "$TEST_DIRS_VALUE" ]]; then
+                TEST_DIRS_ARG="--dirs ${TEST_DIRS_VALUE}"
               fi
-            elif [[ "$RUN_EXAMPLES" == "true" ]]; then
-              PYTEST_FILES_ARG=""
-              # 只有 examples 和 experiment 目录都为空才是全量；任一非空则走增量
-              if [[ -z "$TEST_DIRS_VALUE" && -z "$EXPERIMENT_DIRS_VALUE" ]]; then
-                TEST_DIRS_ARG=""
-                EXPERIMENT_DIRS_ARG=""
-                echo "Running full examples + pytest (core files modified)"
-              else
-                if [[ -n "$TEST_DIRS_VALUE" ]]; then
-                  TEST_DIRS_ARG="--dirs ${TEST_DIRS_VALUE}"
-                else
-                  TEST_DIRS_ARG=""
-                fi
-                if [[ -n "$EXPERIMENT_DIRS_VALUE" ]]; then
-                  EXPERIMENT_DIRS_ARG="--experiment-dirs ${EXPERIMENT_DIRS_VALUE}"
-                else
-                  EXPERIMENT_DIRS_ARG=""
-                fi
-                echo "Running incremental examples + pytest for: examples=[$TEST_DIRS_VALUE] experiment=[$EXPERIMENT_DIRS_VALUE]"
+              if [[ -n "$EXPERIMENT_DIRS_VALUE" ]]; then
+                EXPERIMENT_DIRS_ARG="--experiment-dirs ${EXPERIMENT_DIRS_VALUE}"
               fi
             fi
           fi
@@ -544,12 +541,11 @@ jobs:
             -e GITHUB_OUTPUT=$GITHUB_OUTPUT \
             -e BASH_ENV=/root/.bashrc \
             -e INCREMENTAL_FLAG="$INCREMENTAL_FLAG" \
-            -e SKIP_PYTEST=$SKIP_PYTEST_VALUE \
             -e TEST_DIRS_ARG="$TEST_DIRS_ARG" \
             -e EXPERIMENT_DIRS_ARG="$EXPERIMENT_DIRS_ARG" \
-            -e PYTEST_FILES_ARG="$PYTEST_FILES_ARG" \
+            -e PYTEST_TARGETS_ARG="$PYTEST_TARGETS_ARG" \
             -e RUN_EXAMPLES="$RUN_EXAMPLES" \
-            -e RUN_PYTEST_ONLY="$RUN_PYTEST_ONLY" \
+            -e RUN_PYTEST="$RUN_PYTEST" \
             -e PYTEST_MARKERS="$PYTEST_MARKERS" \
             tilelang_x1 \
             bash -c "
@@ -587,36 +583,60 @@ jobs:
                 echo 'Applying pytest marker filter: -m '\$PYTEST_MARKERS
               fi
 
-              if [ \"\$RUN_PYTEST_ONLY\" = true ]; then
-                # 只跑 pytest（testing/ 修改）
-                if [ -n \"\$PYTEST_FILES_ARG\" ]; then
-                  echo 'Running incremental pytest for: '\$PYTEST_FILES_ARG
-                  set +e
-                  pytest --forked ../\$PYTEST_FILES_ARG -v -n 4 \"\${PYTEST_MARKER_ARGS[@]}\" 2>&1 | tee test_output.log
-                else
-                  echo 'Running full pytest (testing/ modified)'
-                  set +e
-                  pytest --forked ../testing/python/ -v -n 8 \"\${PYTEST_MARKER_ARGS[@]}\" 2>&1 | tee test_output.log
-                fi
-                TEST_EXIT_CODE=\${PIPESTATUS[0]}
-                set -e
-              elif [ \"\$RUN_EXAMPLES\" = true ]; then
-                # 跑 examples + experiment + pytest
+              BENCH_EXIT_CODE=0
+              PYTEST_EXIT_CODE=0
+              rm -f bench_output.log pytest_output.log test_output.log
+
+              if [ \"\$RUN_EXAMPLES\" = true ]; then
                 echo 'Running benchmark tests with args: '\$TEST_DIRS_ARG' '\$EXPERIMENT_DIRS_ARG
                 set +e
-                if [ \"\$SKIP_PYTEST\" = true ]; then
-                  ./bench_test.sh --skip-pytest \$TEST_DIRS_ARG \$EXPERIMENT_DIRS_ARG 2>&1 | tee test_output.log
-                else
-                  if [ -n \"\$PYTEST_MARKERS\" ]; then
-                    ./bench_test.sh --pytest-markers \"\$PYTEST_MARKERS\" \$TEST_DIRS_ARG \$EXPERIMENT_DIRS_ARG 2>&1 | tee test_output.log
-                  else
-                    ./bench_test.sh \$TEST_DIRS_ARG \$EXPERIMENT_DIRS_ARG 2>&1 | tee test_output.log
-                  fi
-                fi
-                TEST_EXIT_CODE=\${PIPESTATUS[0]}
+                ./bench_test.sh --skip-pytest \$TEST_DIRS_ARG \$EXPERIMENT_DIRS_ARG 2>&1 | tee bench_output.log
+                BENCH_EXIT_CODE=\${PIPESTATUS[0]}
                 set -e
               fi
 
+              if [ \"\$RUN_PYTEST\" = true ]; then
+                PYTEST_TARGETS=()
+                if [ -n \"\$PYTEST_TARGETS_ARG\" ]; then
+                  read -ra PYTEST_TARGETS <<< \"\$PYTEST_TARGETS_ARG\"
+                else
+                  PYTEST_TARGETS+=(../testing/python/)
+                  while IFS= read -r test_file; do
+                    [ -n \"\$test_file\" ] || continue
+                    PYTEST_TARGETS+=(\"../\$test_file\")
+                  done < <(python ../scripts/ci/resolve_operator_tests.py list-tests)
+                fi
+
+                NORMALIZED_TARGETS=()
+                for target in \"\${PYTEST_TARGETS[@]}\"; do
+                  if [[ \"\$target\" == ../* ]]; then
+                    NORMALIZED_TARGETS+=(\"\$target\")
+                  else
+                    NORMALIZED_TARGETS+=(\"../\$target\")
+                  fi
+                done
+
+                echo 'Running Pytest targets: '\${NORMALIZED_TARGETS[*]}
+                set +e
+                pytest --forked \"\${NORMALIZED_TARGETS[@]}\" -v -n 1 \"\${PYTEST_MARKER_ARGS[@]}\" 2>&1 | tee pytest_output.log
+                PYTEST_EXIT_CODE=\${PIPESTATUS[0]}
+                set -e
+              fi
+
+              if [ -f bench_output.log ]; then
+                cat bench_output.log >> test_output.log
+              fi
+              if [ -f pytest_output.log ]; then
+                cat pytest_output.log >> test_output.log
+              fi
+
+              TEST_EXIT_CODE=0
+              if [ \"\$BENCH_EXIT_CODE\" -ne 0 ] || [ \"\$PYTEST_EXIT_CODE\" -ne 0 ]; then
+                TEST_EXIT_CODE=1
+              fi
+
+              echo 'Bench exit code: '\$BENCH_EXIT_CODE
+              echo 'Pytest exit code: '\$PYTEST_EXIT_CODE
               echo 'Test exit code: '\$TEST_EXIT_CODE
               echo \"test_exit_code=\$TEST_EXIT_CODE\" >> \$GITHUB_OUTPUT
               

--- a/ci/operator_test_manifest.yaml
+++ b/ci/operator_test_manifest.yaml
@@ -1,0 +1,4 @@
+version: 1
+mappings:
+  examples/batch_gemm/batch_gemm.py: examples/batch_gemm/test_batch_gemm.py
+  examples/flash_attention/flash_attn_bhsd.py: examples/flash_attention/test_flash_attn_bhsd.py

--- a/examples/batch_gemm/test_batch_gemm.py
+++ b/examples/batch_gemm/test_batch_gemm.py
@@ -1,0 +1,53 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_batch_gemm_example() -> ModuleType:
+    source = Path(__file__).with_name("batch_gemm.py")
+    spec = importlib.util.spec_from_file_location("_batch_gemm_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        # batch_gemm.py parses arguments at import time. Hide Pytest arguments
+        # while loading it without changing the original Example.
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_batch_gemm_accuracy() -> None:
+    import torch
+
+    example = _load_batch_gemm_example()
+
+    batch = 8
+    m = 1024
+    n = 1024
+    k = 1024
+
+    kernel = example.batch_matmul(
+        batch,
+        m,
+        n,
+        k,
+        block_M=128,
+        block_N=256,
+        K_L1=64,
+    )
+
+    torch.manual_seed(0)
+    lhs = torch.randn(batch, m, k).half().npu()
+    rhs = torch.randn(batch, k, n).half().npu()
+
+    actual = kernel(lhs, rhs)
+    expected = torch.matmul(lhs, rhs)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)

--- a/examples/bench_test.sh
+++ b/examples/bench_test.sh
@@ -61,6 +61,16 @@ done
 # ================= 全局环境变量设置 =================
 PROJECT_ROOT="$(cd .. && pwd)"
 
+declare -A MIGRATED_SOURCES=()
+OPERATOR_TEST_RESOLVER="${PROJECT_ROOT}/scripts/ci/resolve_operator_tests.py"
+if [ -f "$OPERATOR_TEST_RESOLVER" ]; then
+    python "$OPERATOR_TEST_RESOLVER" validate
+    while IFS=$'\t' read -r source test; do
+        [ -n "$source" ] || continue
+        MIGRATED_SOURCES["$source"]=1
+    done < <(python "$OPERATOR_TEST_RESOLVER" list --format tsv)
+fi
+
 # experiment 算子根目录（相对 examples 工作目录）
 EXPERIMENT_ROOT="../examples_experiment"
 
@@ -148,6 +158,26 @@ total_scripts=0
 passed_scripts=0
 all_scripts=()
 
+should_skip_python_script() {
+    local candidate="$1"
+    local filename
+    local repo_relative
+
+    filename=$(basename "$candidate")
+    if [[ "$filename" == test_*.py ]]; then
+        echo "Skip Pytest file in legacy runner: $candidate" >&2
+        return 0
+    fi
+
+    repo_relative=$(realpath --relative-to="$PROJECT_ROOT" "$candidate")
+    if [[ -n "${MIGRATED_SOURCES[$repo_relative]:-}" ]]; then
+        echo "Skip migrated source in legacy runner: $candidate" >&2
+        return 0
+    fi
+
+    return 1
+}
+
 # 函数：收集单个目录下的测试脚本
 collect_test_scripts() {
     local dir="$1"
@@ -169,9 +199,12 @@ collect_test_scripts() {
             # 收集主目录的 py 文件（排除 fa_opt）
             local py_files=$(find "$dir" -maxdepth 1 -name "*.py" \
                 -not -name "__init__.py" \
+                -not -name "test_*.py" \
                 -not -name "*_golden.py" \
                 | sort)
-            for f in $py_files; do scripts+=("$f"); done
+            for f in $py_files; do
+                should_skip_python_script "$f" || scripts+=("$f")
+            done
             
             echo "${scripts[@]}"
             return
@@ -181,6 +214,7 @@ collect_test_scripts() {
     # 搜索 maxdepth 2 的 py 文件（排除特殊文件和 bench_sfa 子目录）
     local py_files=$(find "$dir" -maxdepth 2 -name "*.py" \
         -not -name "__init__.py" \
+        -not -name "test_*.py" \
         -not -name "*_golden.py" \
         -not -name "sfa_golden.py" \
         -not -name "utils.py" \
@@ -188,7 +222,9 @@ collect_test_scripts() {
         -not -path "*/generative_recommendation/golden.py" \
         -not -path "*/generative_recommendation/testcase.py" \
         | sort)
-    for f in $py_files; do scripts+=("$f"); done
+    for f in $py_files; do
+        should_skip_python_script "$f" || scripts+=("$f")
+    done
     
     # 搜索 bash 脚本（特定命名模式）
     local sh_files=$(find "$dir" -maxdepth 2 \( -name "run_*.sh" -o -name "test_*.sh" \) | sort)
@@ -248,9 +284,12 @@ if [ -n "$TEST_DIRS" ] || [ -n "$EXPERIMENT_DIRS" ]; then
     if [[ " ${DIR_ARRAY[*]} " =~ " flash_attention " ]]; then
         fa_dir="./flash_attention/fa_opt"
         if [ -d "$fa_dir" ]; then
-            fa_python_files=$(find "$fa_dir" -maxdepth 1 -name "flash_*.py" | sort)
+            fa_python_files=$(find "$fa_dir" -maxdepth 1 -name "flash_*.py" \
+                -not -name "test_*.py" | sort)
             if [ -n "$fa_python_files" ]; then
-                for file in $fa_python_files; do all_scripts+=("$file"); done
+                for file in $fa_python_files; do
+                    should_skip_python_script "$file" || all_scripts+=("$file")
+                done
             fi
         fi
     fi
@@ -278,9 +317,12 @@ else
     # flash_attention/fa_opt 单独处理
     fa_dir="./flash_attention/fa_opt"
     if [ -d "$fa_dir" ]; then
-        fa_python_files=$(find "$fa_dir" -maxdepth 1 -name "flash_*.py" | sort)
+        fa_python_files=$(find "$fa_dir" -maxdepth 1 -name "flash_*.py" \
+            -not -name "test_*.py" | sort)
         if [ -n "$fa_python_files" ]; then
-            for file in $fa_python_files; do all_scripts+=("$file"); done
+            for file in $fa_python_files; do
+                should_skip_python_script "$file" || all_scripts+=("$file")
+            done
         fi
     fi
 
@@ -393,8 +435,11 @@ echo "====================================="
 # 4. 最后执行 pytest 自动发现并运行所有测试
 if [ "$SKIP_PYTEST" = true ]; then
     echo -e "\n====================================="
-    echo "Skipping pytest (only examples/ .py/.md/.png files modified)"
+    echo "Skipping pytest (pytest is maintained by the CI workflow)"
     echo "====================================="
+    if [ "$failed_scripts" -ne 0 ]; then
+        exit 1
+    fi
     exit 0
 fi
 

--- a/examples/flash_attention/test_flash_attn_bhsd.py
+++ b/examples/flash_attention/test_flash_attn_bhsd.py
@@ -1,0 +1,65 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+# Values mirror the argparse defaults in flash_attn_bhsd.py's __main__ block.
+B, S, H, D = 1, 128, 1, 512
+
+
+def _load_flash_attn_example() -> ModuleType:
+    source = Path(__file__).with_name("flash_attn_bhsd.py")
+    spec = importlib.util.spec_from_file_location("_flash_attn_bhsd_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        # Hide Pytest arguments while loading the example without changing it.
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def _ref_flash_attn(q, k, v):
+    # Mirrors ref_flash_attn defined inside the example's __main__ block, which
+    # is not importable from the module scope.
+    import torch
+
+    q = q.float()
+    k = k.float()
+    v = v.float()
+
+    acc = torch.einsum("bhsd,bhkd->bhsk", q, k) * (1.0 / q.shape[-1]) ** 0.5
+    acc = acc.softmax(dim=-1)
+    o = torch.einsum("bhsk,bhkd->bhsd", acc, v)
+    return o.to(torch.float16)
+
+
+def test_flash_attn_bhsd_accuracy() -> None:
+    import torch
+
+    example = _load_flash_attn_example()
+
+    torch.manual_seed(0)
+
+    func = example.flash_attention_fwd(
+        batch=B,
+        seq_len=S,
+        heads=H,
+        dim=D,
+    )
+
+    q = torch.randn((B, H, S, D), dtype=torch.float16, device="npu")
+    k = torch.randn((B, H, S, D), dtype=torch.float16, device="npu")
+    v = torch.randn((B, H, S, D), dtype=torch.float16, device="npu")
+
+    output = func(q, k, v)
+    ref_output = _ref_flash_attn(q, k, v)
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(ref_output, output, rtol=1e-2, atol=1e-2)

--- a/scripts/ci/resolve_operator_tests.py
+++ b/scripts/ci/resolve_operator_tests.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Validate and query the operator-to-Pytest migration manifest."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path, PurePosixPath
+
+
+DEFAULT_MANIFEST = Path("ci/operator_test_manifest.yaml")
+VERSION_PATTERN = re.compile(r"^version:\s*(\d+)\s*$")
+
+
+class ManifestError(ValueError):
+    """Raised when the operator test manifest is invalid."""
+
+
+def _parse_manifest(manifest_path: Path) -> list[tuple[str, str]]:
+    version: int | None = None
+    in_mappings = False
+    mappings: list[tuple[str, str]] = []
+
+    for line_number, raw_line in enumerate(
+        manifest_path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        version_match = VERSION_PATTERN.fullmatch(stripped)
+        if version_match:
+            if version is not None:
+                raise ManifestError(f"{manifest_path}:{line_number}: duplicate version")
+            version = int(version_match.group(1))
+            continue
+
+        if stripped == "mappings:":
+            if in_mappings:
+                raise ManifestError(f"{manifest_path}:{line_number}: duplicate mappings section")
+            in_mappings = True
+            continue
+
+        if not in_mappings or not raw_line.startswith("  ") or ":" not in stripped:
+            raise ManifestError(f"{manifest_path}:{line_number}: expected an indented source: test mapping")
+
+        source, test = (part.strip() for part in stripped.split(":", maxsplit=1))
+        if not source or not test:
+            raise ManifestError(f"{manifest_path}:{line_number}: source and test are required")
+        mappings.append((source, test))
+
+    if version != 1:
+        raise ManifestError(f"{manifest_path}: unsupported or missing version: {version}")
+    if not in_mappings:
+        raise ManifestError(f"{manifest_path}: missing mappings section")
+    if not mappings:
+        raise ManifestError(f"{manifest_path}: mappings must not be empty")
+    return mappings
+
+
+def _validate_relative_path(value: str, field: str) -> PurePosixPath:
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or str(path) != value:
+        raise ManifestError(f"{field} must be a normalized repo-relative POSIX path: {value}")
+    return path
+
+
+def load_mappings(repo_root: Path, manifest_path: Path) -> list[tuple[str, str]]:
+    if not manifest_path.is_absolute():
+        manifest_path = repo_root / manifest_path
+    if not manifest_path.is_file():
+        raise ManifestError(f"manifest does not exist: {manifest_path}")
+
+    mappings = _parse_manifest(manifest_path)
+    seen_sources: set[str] = set()
+    seen_tests: set[str] = set()
+
+    for source, test in mappings:
+        source_path = _validate_relative_path(source, "source")
+        test_path = _validate_relative_path(test, "test")
+
+        if source in seen_sources:
+            raise ManifestError(f"duplicate source: {source}")
+        if test in seen_tests:
+            raise ManifestError(f"duplicate test: {test}")
+        if source == test:
+            raise ManifestError(f"source and test must be different: {source}")
+        if source_path.suffix != ".py":
+            raise ManifestError(f"source must be a Python file: {source}")
+        if test_path.suffix != ".py" or not test_path.name.startswith("test_"):
+            raise ManifestError(f"test must be named test_*.py: {test}")
+        if not (repo_root / Path(*source_path.parts)).is_file():
+            raise ManifestError(f"source does not exist: {source}")
+        if not (repo_root / Path(*test_path.parts)).is_file():
+            raise ManifestError(f"test does not exist: {test}")
+
+        seen_sources.add(source)
+        seen_tests.add(test)
+
+    return mappings
+
+
+def _print_lines(values: Iterable[str]) -> None:
+    for value in values:
+        print(value)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="repository root (defaults to the resolver's repository)",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help="manifest path, relative to the repository root by default",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("validate", help="validate the manifest and referenced files")
+
+    list_parser = subparsers.add_parser("list", help="list source-to-test mappings")
+    list_parser.add_argument("--format", choices=("tsv",), default="tsv")
+
+    subparsers.add_parser("list-tests", help="list all migrated Pytest files")
+    subparsers.add_parser("list-sources", help="list all sources excluded from the legacy runner")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        mappings = load_mappings(args.repo_root.resolve(), args.manifest)
+    except (ManifestError, OSError) as error:
+        print(f"operator test manifest error: {error}", file=sys.stderr)
+        return 1
+
+    if args.command == "validate":
+        print(f"Validated {len(mappings)} operator test mapping(s)")
+    elif args.command == "list":
+        _print_lines(f"{source}\t{test}" for source, test in mappings)
+    elif args.command == "list-tests":
+        _print_lines(test for _, test in mappings)
+    elif args.command == "list-sources":
+        _print_lines(source for source, _ in mappings)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
[Test] Add flash_attn_bhsd Pytest migration sample
Follows the operator-test migration pattern introduced in https://github.com/tile-ai/tilelang-ascend/pull/1459.

Carried over from https://github.com/tile-ai/tilelang-ascend/pull/1459, byte-identical:

  scripts/ci/resolve_operator_tests.py
  examples/bench_test.sh
  .github/workflows/ci_cd.yml
  examples/batch_gemm/test_batch_gemm.py

New in this change:

  examples/flash_attention/test_flash_attn_bhsd.py
  ci/operator_test_manifest.yaml   +1 mapping

flash_attn_bhsd.py is loaded with importlib and sys.argv is swapped while
exec_module runs, so the example itself is left untouched. Parameters, the
reference implementation and the tolerances are copied from its __main__
block (B=1, S=128, H=1, D=512, rtol=atol=1e-2). ref_flash_attn is nested
inside __main__ and therefore not importable, so it is mirrored in the test.

Verified on an Ascend NPU:

  pytest examples/flash_attention/test_flash_attn_bhsd.py -v
    -> 1 passed in 11.15s

  python scripts/ci/resolve_operator_tests.py validate
    -> Validated 2 operator test mapping(s)

  bash examples/bench_test.sh --dirs flash_attention --skip-pytest
    -> Skip migrated source in legacy runner: ./flash_attention/flash_attn_bhsd.py
