### PR TITLE
[Add] add example_gqa_bwd

### DIFF
--- a/examples_experiment/example_gqa_bwd/design.md
+++ b/examples_experiment/example_gqa_bwd/design.md
@@ -1,0 +1,992 @@
+# GQA Flash Attention 算子设计文档
+
+> **算子名**: flash_attention (GQA forward + backward)
+> **目标平台**: Ascend 910B3 NPU
+> **编程模式**: Expert（手动 L1/UB/L0C 分配 + 手动 Scope("C"/"V") + 手动同步）
+> **来源**: GPU TileLang `examples/flash_attention/example_gqa_bwd.py` 移植
+
+---
+
+## 1. 算子概述
+
+### 1.1 计算语义
+
+GQA (Grouped Query Attention) Flash Attention 是标准 Multi-Head Attention 的变体，其中 Q 的 head 数量是 K/V 的 `groups` 倍。计算分为 forward 和 backward 两部分：
+
+**Forward**:
+```
+S = Q @ K^T * scale          # [B, H, N, N] attention scores
+P = softmax(S, causal_mask)   # [B, H, N, N] attention probabilities
+O = P @ V                     # [B, H, N, D_v] output
+lse = log(sum(exp(S)))        # [B, H, N] log-sum-exp for backward
+```
+
+**Backward** (给定 dO, 利用 forward 的 lse):
+```
+Delta = sum(O * dO, dim=-1)   # [B, H, N]
+dV += P^T @ dO                # [B, H_kv, N, D_v]
+dP = V @ dO^T                 # [B, H, N, N]
+dS = P * (dP - Delta) * scale # [B, H, N, N]
+dK += dS^T @ Q                # [B, H_kv, N, D_qk]
+dQ += dS @ K                  # [B, H, N, D_qk]
+```
+
+### 1.2 GQA 分组机制
+
+- Q 有 `H` 个 head，K/V 有 `H_kv = H / groups` 个 head
+- 每个 Q head 索引 `by` 对应 K/V head 索引 `by // groups`
+- backward 中 dK/dV 需要跨 groups 累加（atomic_add 或 split+sum）
+
+### 1.3 适用场景
+
+- LLM 推理/训练中的注意力层（如 LLaMA-2 70B 使用 GQA groups=8）
+- 长序列注意力（seq_len 可达 4096+）
+- 支持 causal（自回归）和 non-causal 两种模式
+
+### 1.4 Kernel 组成（4 个 Kernel + 1 个优化变体）
+
+| # | 函数名 | 功能 | 计算类型 |
+|---|--------|------|---------|
+| 1 | `flashattn_fwd` | Forward 基础版: QK^T → softmax → PV → O, lse | Cube + Vector 融合 |
+| 1b | `flashattn_fwd_v4` | Forward 优化版: L0 双缓冲 + Fixed Core + 批处理 | Cube + Vector 融合 |
+| 2 | `flashattn_bwd_preprocess` | 预处理: Delta = sum(O * dO, dim=-1) | 纯 Vector |
+| 3 | `flashattn_bwd_postprocess` | 后处理: dQ fp32 → fp16 转换 | 纯 Vector |
+| 4 | `flashattn_bwd_pipeline` | 主反向: 5 GEMM + 批处理 + fine-grained sync | Cube + Vector 融合 |
+
+> **实现说明**: Forward 提供基础版（v1）和优化版（v4）两个变体，v4 通过 L0 双缓冲和 Fixed Core 实现 1.88x 加速。Backward 采用 pipeline 版本（批处理 + fine-grained flag sync），相比原始 atomic_add 版本实现 1.41x 加速。
+
+---
+
+## 2. I/O 规格
+
+### 2.1 Kernel 1: flashattn_fwd (Forward)
+
+| 参数 | Shape | dtype | 方向 | 说明 |
+|------|-------|-------|------|------|
+| Q | [B, H, N, D_qk] | float16 | 输入 | Query，BHSD 布局 |
+| K | [B, H_kv, N, D_qk] | float16 | 输入 | Key，BHSD 布局 |
+| V | [B, H_kv, N, D_v] | float16 | 输入 | Value，BHSD 布局 |
+| Output | [B, H, N, D_v] | float16 | 输出 | 注意力输出 |
+| lse | [B, H, N] | float32 | 输出 | Log-sum-exp，backward 使用 |
+
+### 2.2 Kernel 2: flashattn_bwd_preprocess (预处理)
+
+| 参数 | Shape | dtype | 方向 | 说明 |
+|------|-------|-------|------|------|
+| O | [B, H, N, D_v] | float16 | 输入 | Forward 输出 |
+| dO | [B, H, N, D_v] | float16 | 输入 | 输出梯度 |
+| Delta | [B, H, N] | float32 | 输出 | sum(O * dO, dim=-1) |
+
+### 2.3 Kernel 3: flashattn_bwd_postprocess (后处理)
+
+| 参数 | Shape | dtype | 方向 | 说明 |
+|------|-------|-------|------|------|
+| dQ | [B, H, N, D_qk] | float32 | 输入 | dQ fp32 累加器 |
+| dQ_out | [B, H, N, D_qk] | float16 | 输出 | dQ fp16 输出 |
+
+### 2.4 Kernel 4: flashattn_bwd_pipeline (主反向, pipeline)
+
+| 参数 | Shape | dtype | 方向 | 说明 |
+|------|-------|-------|------|------|
+| Q | [B, H, N, D_qk_padded] | float16 | 输入 | D_qk pad 到 128 倍数 |
+| K | [B, H_kv, N, D_qk_padded] | float16 | 输入 | 同上 |
+| V | [B, H_kv, N, D_v] | float16 | 输入 | |
+| dO | [B, H, N, D_v] | float16 | 输入 | |
+| lse | [B, H, N] | float32 | 输入 | Forward 产出 |
+| Delta | [B, H, N] | float32 | 输入 | Kernel 2 产出 |
+| dQ | [B, H, N, D_qk_padded] | float32 | 输出 | 跨 KV 累积（需预清零） |
+| dK | [B, H_kv, N, D_qk_padded] | float32 | 输出 | atomic_add 累加 |
+| dV | [B, H_kv, N, D_v] | float32 | 输出 | atomic_add 累加 |
+| ws_s_dp | [block_num, num_stages, M, N] | float32 | workspace | S/dP 中转 |
+| ws_p_ds | [block_num, num_stages, M, N] | float16 | workspace | P/dS 中转 |
+| ws_dv_dk | [block_num, num_stages, N, max(D_qk_padded, D_v)] | float32 | workspace | dV/dK 中转 |
+
+> **pipeline 版本特性**: 采用 num_stages 批处理 + fine-grained flag sync（set_flag/wait_flag），将每轮 5 对 cross_flag 降低为每批 5 对，显著减少同步开销。dQ 跨 KV 迭代在 L0C 中累积，dK/dV 通过 atomic_add 写入 GM。
+
+### 2.6 动态轴说明
+
+| 符号 | 含义 | 典型范围 |
+|------|------|---------|
+| B | Batch size | 1~8 |
+| H | Q head 数 | 1~32 |
+| H_kv | KV head 数 = H / groups | 1~32 |
+| N | Sequence length | 64~4096 |
+| D_qk | QK head dimension | 64~192 |
+| D_v | V head dimension | 64~128 |
+| groups | GQA 分组数 = H / H_kv | 1~16 |
+
+---
+
+## 3. 编程模式选型
+
+### 3.1 选择: Expert 模式
+
+**理由**:
+
+1. **Flash Attention 是典型的 CV 融合算子**: QK^T 和 PV 是矩阵乘（Cube 核），softmax 是归约+指数（Vector 核），必须显式分离 C/V scope
+2. **需要精细控制 C↔V 数据流**: L0C → workspace(GM) → UB 的搬运路径需要手动管理 workspace 索引和同步
+3. **内存压力大**: Flash Attention 需要大量中间 buffer（acc_s, acc_o, scores_max, scores_scale 等），手动 `T.annotate_address` 可以最大化复用 L1/UB 空间
+4. **参考实现已验证**: `flash_attn_bhsd.py` 和 `fa_opt/flash_attn_bhsd_expert_h16_d128.py` 均为 Expert 模式，已验证可行
+
+### 3.2 pass_configs 配置
+
+```python
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False,
+}
+```
+
+全部关闭，由手动控制同步和内存规划。
+
+### 3.3 Expert 模式要素清单
+
+| 要素 | API | 说明 |
+|------|-----|------|
+| 内存分配 | `T.alloc_L1`, `T.alloc_ub`, `T.alloc_L0C` | 显式指定存储层级 |
+| 地址管理 | `T.annotate_address({...})` | 手动指定 buffer 在 L1/UB 中的偏移 |
+| 计算域 | `T.Scope("C")`, `T.Scope("V")` | Cube/Vector 核代码分离 |
+| 矩阵乘 | `T.gemm_v0(A, B, C, ...)` | 标准 GEMM（L1→L0C） |
+| 元素计算 | `T.tile.xxx(dst, src, ...)` | Buffer 级 SIMD 操作 |
+| 核内同步 | `T.barrier_all()` | 全管线屏障 |
+| 核间同步 | `T.set_cross_flag(pipe, flag)`, `T.wait_cross_flag(flag)` | C↔V 核间握手 |
+| V 核并行 | `vid` (0/1) 切分 block_M // 2 | 两个 V 核各处理一半行 |
+| workspace | `@jit(workspace_idx=[...])` | C↔V 数据中转（GM） |
+
+---
+
+## 4. API 映射表 (GPU → NPU)
+
+### 4.1 Kernel 定义与内存
+
+| GPU API | NPU API | 说明 |
+|---------|---------|------|
+| `T.Kernel(x, y, z, threads=256)` | `T.Kernel(block_num, is_npu=True) as (cid, vid)` | NPU 用 1D grid + cid/vid |
+| `T.alloc_shared(shape, dtype)` | `T.alloc_L1(shape, dtype)` | GPU shared → NPU L1 (Cube) |
+| `T.alloc_fragment(shape, dtype)` | `T.alloc_L0C(shape, dtype)` | GPU fragment → NPU L0C (Cube 输出) |
+| — | `T.alloc_ub(shape, dtype)` | NPU 独有：Vector 核 UB |
+| — | `T.annotate_address({...})` | NPU 独有：手动地址分配 |
+
+### 4.2 计算原语
+
+| GPU API | NPU API | 说明 |
+|---------|---------|------|
+| `T.gemm(A, B, C, transpose_B=True, policy=...)` | `T.gemm_v0(A_L1, B_L1, C_L0C, transpose_B=True, init=True)` | NPU 用 gemm_v0，需显式 init |
+| `T.reduce_max(buf, out, dim=1, clear=False)` | `T.reduce_max(buf_ub, out_ub, dim=-1)` | NPU reduce 在 UB 上执行 |
+| `T.reduce_sum(buf, out, dim=1)` | `T.reduce_sum(buf_ub, out_ub, dim=-1)` | 同上 |
+| `T.fill(buf, val)` | `T.tile.fill(buf_ub, val)` | NPU 用 T.tile.fill |
+| `T.copy(acc_s, acc_s_cast)` (fp32→fp16) | `T.tile.cast(dst, src, "CAST_NONE", count)` 或 `T.copy(fp32_ub, fp16_ub)` | NPU dtype 转换 |
+
+### 4.3 Element-wise 运算
+
+| GPU (T.Parallel + 符号 API) | NPU (T.tile.xxx) | 说明 |
+|---------------------------|-----------------|------|
+| `for i,j in T.Parallel(M,N): c[i,j] = a[i,j] * b[i]` | `T.tile.broadcast(buf_2d, b_1d); T.tile.mul(c, a, buf_2d)` | NPU 需显式广播 |
+| `for i in T.Parallel(M): s[i] = T.exp2(a[i])` | `T.tile.exp(dst, src)` | NPU 用自然指数 exp（非 exp2）|
+| `for i,j in T.Parallel(M,N): c[i,j] = T.exp2(a[i,j]*s - m[i]*s)` | `T.tile.mul → T.tile.sub → T.tile.exp` 多步 | NPU 需分解为多步 T.tile |
+| `for i,j in T.Parallel(M,N): c[i,j] = T.if_then_else(cond, a, b)` | `T.tile.compare(mask, ...); T.tile.select(dst, mask, a, b, "VSEL_CMPMASK_SPR")` | NPU 不支持 T.Parallel 内 if-else |
+| `T.atomic_add(dQ[...], dq[i,j])` | `T.tile.atomic_add(dQ_gm_region, src_ub_or_l0c)` | NPU 原子累加 |
+
+### 4.4 循环与调度
+
+| GPU API | NPU API | 说明 |
+|---------|---------|------|
+| `T.Pipelined(range, num_stages=1)` | `T.serial(range)` | NPU Expert 模式用 T.serial + 手动流水线 |
+| `for i,j in T.Parallel(M,N)` | `T.tile.xxx` 系列 | NPU 用 Buffer 级 SIMD |
+| — | `T.set_cross_flag("FIX"/"MTE3", flag)` | NPU 核间同步 |
+| — | `T.wait_cross_flag(flag)` | NPU 核间等待 |
+| — | `T.barrier_all()` | NPU 核内全管线屏障 |
+
+### 4.5 关键差异总结
+
+| 差异点 | GPU | NPU |
+|--------|-----|-----|
+| 数据布局 | [B, N, H, D] (BSHD) | [B, H, N, D] (BHSD) |
+| 指数函数 | `T.exp2(x * log2e)` | `T.tile.exp(x)` 或 `T.tile.mul + T.tile.exp` |
+| 条件掩码 | `T.if_then_else` in T.Parallel | `T.tile.compare + T.tile.select` |
+| C/V 分离 | 编译器自动 | 手动 `T.Scope("C"/"V")` + workspace |
+| 同步 | 编译器自动 | 手动 `T.barrier_all` + `T.set/wait_cross_flag` |
+| Grid 维度 | 3D (bx, by, bz) | 1D cid + 手动分解 |
+
+---
+
+## 5. 内存层级规划
+
+### 5.1 硬件限制 (Ascend 910B3)
+
+| 存储单元 | 大小上限 | 对齐要求 |
+|---------|---------|---------|
+| L0A | 65536 B (64 KB) | 512 B |
+| L0B | 65536 B (64 KB) | 512 B |
+| L0C | 131072 B (128 KB) | 64 B |
+| L1 | 524288 B (512 KB) | 32 B |
+| UB | 196608 B (192 KB) — 两个 V 核共享 | 32 B |
+
+### 5.2 Kernel 1 (Forward) 内存规划
+
+以 block_M=64, block_N=64, D_qk=128, D_v=128 为例：
+
+**L1 分配 (Cube 核)**:
+
+| Buffer | Shape | dtype | 大小 (B) | 地址偏移 |
+|--------|-------|-------|---------|---------|
+| q_l1 | [64, 128] | fp16 | 16384 | 0 |
+| k_l1 | [64, 128] | fp16 | 16384 | 16384 |
+| acc_s_l1 | [64, 64] | fp16 | 8192 | 32768 |
+| v_l1 | [64, 128] | fp16 | 16384 | 40960 |
+| **合计** | | | **57344** | **< 512KB ✓** |
+
+> 注：k_l1 和 acc_s_l1 可复用地址（不同时使用），v_l1 和 acc_s_l1 也可复用。实际可通过地址复用降至 ~32KB。
+
+**L0C 分配 (Cube 核)**:
+
+| Buffer | Shape | dtype | 大小 (B) | 地址偏移 |
+|--------|-------|-------|---------|---------|
+| acc_s_l0c | [64, 64] | fp32 | 16384 | 0 |
+| acc_o_l0c | [64, 128] | fp32 | 32768 | 0 (与 acc_s_l0c 分时复用) |
+| **合计** | | | **32768** | **< 128KB ✓** |
+
+> acc_s_l0c 和 acc_o_l0c 分时复用同一 L0C 地址（GEMM1 完成后才做 GEMM2）。
+
+**UB 分配 (每个 V 核, half_M = block_M // 2 = 32)**:
+
+| Buffer | Shape | dtype | 大小 (B) | 地址偏移 |
+|--------|-------|-------|---------|---------|
+| acc_o | [32, 128] | fp32 | 16384 | 0 |
+| sumexp | [32] | fp32 | 128 | 16384 |
+| m_i | [32] | fp32 | 128 | 16512 |
+| acc_s_ub | [32, 64] | fp32 | 8192 | 16640 |
+| m_i_prev | [32] | fp32 | 128 | 24832 |
+| acc_s_ub_ | [32, 64] | fp32 | 8192 | 24960 |
+| sumexp_i_ub | [32] | fp32 | 128 | 33152 |
+| acc_s_half | [32, 64] | fp16 | 4096 | 33280 |
+| acc_o_ub | [32, 128] | fp32 | 16384 | 37376 |
+| acc_o_half | [32, 128] | fp16 | 8192 | 53760 |
+| **合计** | | | **~62KB** | **< 96KB (单 V 核) ✓** |
+
+> 部分 buffer 可地址复用（如 acc_s_ub_ 和 sumexp_i_ub 不同时使用，acc_s_half 和 acc_o_half 可复用）。
+
+**Workspace (GM 中转)**:
+
+| Buffer | Shape | dtype | 用途 |
+|--------|-------|-------|------|
+| workspace_1 | [block_num, block_M, block_N] | fp32 | C→V: QK^T 结果 |
+| workspace_2 | [block_num, block_M, block_N] | fp16 | V→C: softmax(P) 结果 |
+| workspace_3 | [block_num, block_M, D_v] | fp32 | C→V: PV 结果 |
+
+### 5.3 Kernel 2 (BWD Preprocess) 内存规划
+
+纯 Vector 核操作，无 Cube 参与。
+
+**UB 分配 (blk=32)**:
+
+| Buffer | Shape | dtype | 大小 (B) |
+|--------|-------|-------|---------|
+| o_ub | [32, 32] | fp16 | 2048 |
+| do_ub | [32, 32] | fp16 | 2048 |
+| acc_ub | [32, 32] | fp32 | 4096 |
+| delta_ub | [32] | fp32 | 128 |
+| **合计** | | | **~8KB ✓** |
+
+### 5.4 Kernel 4 (BWD Main) 内存规划
+
+以 block_M=128, block_N=32, D_qk=128, D_v=128 为例：
+
+**L1 分配 (Cube 核)**:
+
+| Buffer | Shape | dtype | 大小 (B) | 说明 |
+|--------|-------|-------|---------|------|
+| K_l1 | [128, 128] | fp16 | 32768 | K tile |
+| V_l1 | [128, 128] | fp16 | 32768 | V tile |
+| q_l1 | [32, 128] | fp16 | 8192 | Q tile |
+| dsT_l1 | [128, 32] | fp16 | 8192 | dS^T cast 结果 |
+| **合计** | | | **81920** | **< 512KB ✓** |
+
+> K_l1 和 V_l1 在循环内不重叠使用时可地址复用，实际峰值 ~49KB。
+
+**L0C 分配**:
+
+| Buffer | Shape | dtype | 大小 (B) | 说明 |
+|--------|-------|-------|---------|------|
+| qkT_l0c | [128, 32] | fp32 | 16384 | K^T @ Q 结果 |
+| dsT_l0c | [128, 32] | fp32 | 16384 | V^T @ dO 结果 |
+| dv_l0c | [128, 128] | fp32 | 65536 | P^T @ dO 累加器 |
+| dk_l0c | [128, 128] | fp32 | 65536 | dS^T @ Q 累加器 |
+| **合计** | | | **~164KB** | **超 128KB ⚠️** |
+
+> **L0C 容量风险**: dv 和 dk 不能同时驻留 L0C。解决方案：dv/dk 分时计算——先在内循环累加 dv/dk 到 UB，或分两阶段处理。具体策略见 §6 Tiling。
+
+**UB 分配 (每个 V 核, half_M = 64)**:
+
+| Buffer | Shape | dtype | 大小 (B) |
+|--------|-------|-------|---------|
+| qkT_ub | [64, 32] | fp32 | 8192 |
+| dsT_ub | [64, 32] | fp32 | 8192 |
+| lse_ub | [32] | fp32 | 128 |
+| delta_ub | [32] | fp32 | 128 |
+| dq_ub | [32, 128] | fp32 | 16384 |
+| qkT_half | [64, 32] | fp16 | 4096 |
+| dsT_half | [64, 32] | fp16 | 4096 |
+| **合计** | | | **~41KB ✓** |
+
+### 5.5 数据搬运路径总览
+
+```
+Forward Kernel:
+  GM(Q,K,V) → L1 → L0A/L0B → L0C(QK^T) → workspace_1(GM) → UB(softmax) → workspace_2(GM) → L1(P) → L0A/L0B → L0C(PV) → workspace_3(GM) → UB(accumulate) → GM(O)
+
+Backward Kernel:
+  GM(K,V,Q,dO,lse,Delta) → L1/UB
+  Cube: K^T@Q → L0C → workspace → UB(softmax+mask)
+  Cube: V^T@dO → L0C → workspace → UB(dS computation)
+  Cube: P@dO → L0C → UB(dV accumulate) → GM(dV)
+  Cube: dS@Q → L0C → UB(dK accumulate) → GM(dK)
+  Cube: dS^T@K → L0C → UB(dQ) → GM(dQ, atomic_add)
+```
+
+---
+
+## 6. Tiling 策略
+
+### 6.1 Forward Kernel
+
+| 参数 | 值 | 说明 |
+|------|-----|------|
+| block_M | 64 | Q 序列维度 tile 大小 |
+| block_N | 64 | KV 序列维度 tile 大小 |
+| Grid | `(seq_len // block_M) * heads * batch` | 1D grid，cid 分解为 (bx, by, bz) |
+
+**cid 分解**:
+```python
+bx = cid % (seq_len // block_M)          # Q 序列块索引
+by = cid // (seq_len // block_M) % heads  # Q head 索引
+bz = cid // (seq_len // block_M) // heads # batch 索引
+kv_by = by // groups                       # KV head 索引 (GQA)
+```
+
+**内循环**: `for k in T.serial(ceildiv(seq_len, block_N))`
+- 每次迭代处理一个 KV tile
+- Causal 模式下循环范围为 `ceildiv((bx+1)*block_M, block_N)`
+
+### 6.2 Backward Preprocess Kernel
+
+| 参数 | 值 | 说明 |
+|------|-----|------|
+| blk | 32 | 序列维度 tile |
+| Grid | `heads * ceildiv(seq_len, blk) * batch` | 纯 Vector 核 |
+
+**内循环**: `for k in range(ceildiv(D_v, blk))` — 沿 D_v 维度分块累加
+
+### 6.3 Backward Postprocess Kernel
+
+| 参数 | 值 | 说明 |
+|------|-----|------|
+| blk | 64 | 序列维度 tile |
+| Grid | `ceildiv(seq_len, blk) * heads * batch` | 纯 Vector 核 |
+
+### 6.4 Backward Main Kernel
+
+| 参数 | 值 | 说明 |
+|------|-----|------|
+| block_M | 128 | KV 序列维度 tile（外层 grid） |
+| block_N | 32 | Q 序列维度 tile（内循环） |
+| Grid | `heads * ceildiv(seq_len, block_M) * batch` | 按 head 和 KV 块分配 |
+
+**cid 分解**:
+```python
+bx = cid % heads                          # head 索引
+by = cid // heads % ceildiv(seq_len, block_M)  # KV 序列块索引
+bz = cid // heads // ceildiv(seq_len, block_M) # batch 索引
+kv_bx = bx // groups                       # KV head 索引 (GQA)
+```
+
+**内循环**: `for k in T.serial(loop_st, loop_ed)`
+- Non-causal: `loop_st=0, loop_ed=ceildiv(seq_len, block_N)`
+- Causal: `loop_st=floordiv(by*block_M, block_N), loop_ed=ceildiv(seq_len, block_N)`
+
+### 6.5 L0C 容量解决方案 (Backward Kernel)
+
+**问题**: dv [128, 128] fp32 = 64KB + dk [128, 128] fp32 = 64KB = 128KB，恰好等于 L0C 上限。
+
+**方案 A — 分时计算（推荐）**:
+1. 内循环中先计算 dv（GEMM: P^T @ dO → L0C），每轮迭代后将 dv 从 L0C 搬运到 UB 累加
+2. 再计算 dk（GEMM: dS^T @ Q → L0C），每轮迭代后将 dk 从 L0C 搬运到 UB 累加
+3. dv 和 dk 的 L0C 空间分时复用（地址偏移均为 0）
+
+**方案 B — 缩小 block_M**:
+- 将 block_M 从 128 降为 64，dv/dk 各 32KB，总计 64KB < 128KB
+- 代价：grid 翻倍，可能增加 kernel launch 开销
+
+**推荐方案 A**，参考 `flash_attn_bhsd.py` 的分时复用模式。
+
+### 6.6 非整除处理
+
+| 维度 | 策略 |
+|------|------|
+| seq_len % block_M ≠ 0 | L0 测试要求 seq_len 整除 block_M；L1 可扩展动态边界 |
+| seq_len % block_N ≠ 0 | 同上，L0 要求整除 |
+| D_qk / D_v 非整除 | L0 测试使用 2 的幂次；后续可扩展 |
+| Causal 尾块 | 最后一个 KV tile 可能需要掩码处理 |
+
+---
+
+## 7. Cube/Vector 分工
+
+### 7.1 Kernel 1 (Forward)
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Scope("C") — Cube 核                                     │
+│                                                          │
+│  1. GM(Q) → q_l1 (L1)                                   │
+│  for k in serial(num_kv_blocks):                         │
+│    2. GM(K) → k_l1 (L1)                                 │
+│    3. gemm_v0(q_l1, k_l1, acc_s_l0c, transB, init)      │
+│    4. L0C → workspace_1(GM)                              │
+│    5. set_cross_flag("FIX", 0)  ──────── notify V ────►  │
+│    6. wait_cross_flag(1)  ◄──── V done softmax ────      │
+│    7. workspace_2(GM) → acc_s_l1 (L1)                    │
+│    8. GM(V) → v_l1 (L1)                                 │
+│    9. gemm_v0(acc_s_l1, v_l1, acc_o_l0c, init)          │
+│   10. L0C → workspace_3(GM)                              │
+│   11. set_cross_flag("FIX", 2)  ──────── notify V ────►  │
+│   12. wait_cross_flag(3)  ◄──── V done accumulate ────   │
+│                                                          │
+├─────────────────────────────────────────────────────────┤
+│ Scope("V") — Vector 核 (vid=0,1 各处理 block_M//2 行)    │
+│                                                          │
+│  init: fill(acc_o, 0), fill(sumexp, 0), fill(m_i, -inf) │
+│  for k in serial(num_kv_blocks):                         │
+│    1. wait_cross_flag(0)  ◄──── C done QK^T ────        │
+│    2. workspace_1(GM) → acc_s_ub (UB, vid slice)         │
+│    3. scale + reduce_max + exp + reduce_sum (softmax)     │
+│    4. acc_s_half → workspace_2(GM)                       │
+│    5. set_cross_flag("MTE3", 1)  ──── notify C ────►     │
+│    6. wait_cross_flag(2)  ◄──── C done PV ────          │
+│    7. workspace_3(GM) → acc_o_ub (UB, vid slice)         │
+│    8. rescale acc_o + accumulate                          │
+│    9. set_cross_flag("V", 3)  ──── notify C ────►        │
+│  normalize: acc_o /= sumexp                              │
+│  output: UB → GM(Output)                                 │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 7.2 Kernel 2 (BWD Preprocess)
+
+纯 Vector 核，无 Cube 参与。
+
+```
+Scope("V") only:
+  for k in range(ceildiv(D_v, blk)):
+    GM(O slice) → o_ub
+    GM(dO slice) → do_ub
+    acc += o * do (element-wise)
+  reduce_sum(acc, delta, dim=1)
+  UB(delta) → GM(Delta)
+```
+
+### 7.3 Kernel 3 (BWD Postprocess)
+
+纯 Vector 核。
+
+```
+Scope("V") only:
+  GM(dQ fp32) → dQ_ub
+  T.tile.cast(dQ_half_ub, dQ_ub, "CAST_NONE", count)
+  UB(dQ_half) → GM(dQ_out fp16)
+```
+
+### 7.4 Kernel 4 (BWD Main)
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Scope("C") — Cube 核                                     │
+│                                                          │
+│  GM(K) → K_l1, GM(V) → V_l1                             │
+│  for k in serial(num_q_blocks):                          │
+│    GM(Q) → q_l1                                          │
+│    gemm_v0(K_l1, q_l1, qkT_l0c, transB, init)           │
+│    L0C → workspace_1(GM)  ──── notify V ────►            │
+│    ◄──── V done softmax+mask ────                         │
+│    workspace_2(GM) → qkT_l1                              │
+│    GM(dO) → do_l1                                        │
+│    gemm_v0(V_l1, do_l1, dsT_l0c, transB, init)          │
+│    L0C → workspace_4(GM)  ──── notify V ────►            │
+│    ◄──── V done dS computation ────                       │
+│    workspace_5(GM) → dsT_l1                              │
+│    gemm_v0(qkT_l1, do_l1, dv_l0c, init)                 │
+│    L0C → workspace_dv(GM)  ──── notify V ────►           │
+│    gemm_v0(dsT_l1, q_l1, dk_l0c, init)                  │
+│    L0C → workspace_dk(GM)  ──── notify V ────►           │
+│    workspace_dsT(GM) → dsT_l1                            │
+│    gemm_v0(dsT_l1, K_l1, dq_l0c, transA, init)          │
+│    L0C → workspace_dq(GM)  ──── notify V ────►           │
+│                                                          │
+│  end: dv/dk → GM(dV/dK, atomic_add)                      │
+├─────────────────────────────────────────────────────────┤
+│ Scope("V") — Vector 核                                   │
+│                                                          │
+│  for k in serial(num_q_blocks):                          │
+│    ◄──── QK^T from workspace_1 ────                      │
+│    softmax: scale + exp(lse) + causal_mask               │
+│    ──── P to workspace_2 ────►                            │
+│    ◄──── V^T@dO from workspace_4 ────                    │
+│    dS = P * (dS - Delta) * sm_scale                      │
+│    ──── dS to workspace_5 ────►                           │
+│    ◄──── dv from workspace_dv ────                       │
+│    accumulate dv to dv_acc_ub                             │
+│    ◄──── dk from workspace_dk ────                       │
+│    accumulate dk to dk_acc_ub                             │
+│    ◄──── dq from workspace_dq ────                       │
+│    T.tile.atomic_add(dQ_gm, dq_ub)                       │
+│                                                          │
+│  end: T.tile.atomic_add(dV_gm, dv_acc_ub)                │
+│       T.tile.atomic_add(dK_gm, dk_acc_ub)                │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 8. 同步策略
+
+### 8.1 核间同步 (Cross-core Flags)
+
+**Forward Kernel 同步协议**:
+
+| 步骤 | 发起方 | API | 信号 | 含义 |
+|------|--------|-----|------|------|
+| 1 | Cube | `set_cross_flag("FIX", 0)` | 0 | QK^T 结果已写入 workspace_1 |
+| 2 | Vector | `wait_cross_flag(0)` | 0 | 等待 QK^T 就绪 |
+| 3 | Vector | `set_cross_flag("MTE3", 1)` | 1 | softmax(P) 已写入 workspace_2 |
+| 4 | Cube | `wait_cross_flag(1)` | 1 | 等待 P 就绪 |
+| 5 | Cube | `set_cross_flag("FIX", 2)` | 2 | PV 结果已写入 workspace_3 |
+| 6 | Vector | `wait_cross_flag(2)` | 2 | 等待 PV 就绪 |
+| 7 | Vector | `set_cross_flag("V", 3)` | 3 | 累加完成，可进入下一轮 |
+| 8 | Cube | `wait_cross_flag(3)` | 3 | 等待 V 核累加完成 |
+
+**数据通路选择**:
+- Cube 核写 GM: 使用 `"FIX"` 通路（L0C → GM）
+- Vector 核写 GM: 使用 `"MTE3"` 通路（UB → GM）
+- Vector 核通知 Cube: 使用 `"V"` 或 `"MTE3"` 通路
+
+### 8.2 核内同步 (Barrier)
+
+Expert 模式下，每次 `T.copy` 和 `T.gemm_v0` 前后都需要 `T.barrier_all()`:
+
+```python
+# 典型 Cube 核操作序列
+T.copy(GM_src, L1_dst)
+T.barrier_all()                    # 等待搬运完成
+T.gemm_v0(L1_A, L1_B, L0C_C, init=True)
+T.barrier_all()                    # 等待 GEMM 完成
+T.copy(L0C_C, GM_dst)
+T.barrier_all()                    # 等待写出完成
+```
+
+### 8.3 Backward Kernel 同步协议
+
+Backward 更复杂，每轮内循环有 5+ 次 C↔V 交互。信号编号需要仔细规划避免死锁：
+
+| 信号 | 方向 | 含义 |
+|------|------|------|
+| 0 | C→V | QK^T 结果就绪 |
+| 1 | V→C | softmax(P) 就绪 |
+| 2 | C→V | V^T@dO 结果就绪 |
+| 3 | V→C | dS 计算完成 |
+| 4 | C→V | PV (dv 贡献) 就绪 |
+| 5 | C→V | dS@Q (dk 贡献) 就绪 |
+| 6 | C→V | dS^T@K (dq 贡献) 就绪 |
+| 7 | V→C | V 核处理完所有结果 |
+
+---
+
+## 9. GQA 处理
+
+### 9.1 Head 分组映射
+
+```python
+groups = heads_q // heads_kv   # 每个 KV head 对应的 Q head 数
+
+# Forward: Q head by → KV head kv_by
+kv_by = by // groups
+
+# 数据访问:
+Q[bz, by, ...]                 # Q 用完整 head 索引
+K[bz, kv_by, ...]              # K 用 KV head 索引
+V[bz, kv_by, ...]              # V 用 KV head 索引
+```
+
+### 9.2 Forward 中的 GQA
+
+- Grid 按 Q head 数 (`heads`) 分配
+- 每个 Q head tile 读取对应的 KV head tile（`by // groups`）
+- 多个 Q head 共享同一 KV head 的数据
+
+### 9.3 Backward 中的 GQA
+
+**dQ**: 每个 Q head 独立计算，直接 atomic_add 到 `dQ[bz, k*block_N+i, bx, j]`
+
+**dK/dV**: 多个 Q head 的梯度需要累加到同一个 KV head：
+- **atomic_add 方案**: 每个 Q head 的 kernel 实例直接 `T.tile.atomic_add` 到 `dK[bz, kv_by, ...]`，硬件保证原子性
+- **split 方案**: 每个 Q head 写到 `dK[bx % groups, bz, kv_by, ...]` 的独立 slice，host 侧 `dk.sum(0)` 归约
+
+### 9.4 NPU 实现选择
+
+**推荐 atomic_add 方案**（Kernel 4），理由：
+1. 减少 host 侧后处理
+2. `T.tile.atomic_add` 在 V1 版本已支持 UB → GM
+3. 减少 dK/dV 的内存占用（无需 groups 维度）
+
+**dK/dV 的 atomic_add 路径**:
+```python
+# V 核中，内循环结束后
+T.tile.atomic_add(dV[bz, kv_by, by*block_M:(by+1)*block_M, :], dv_acc_ub)
+T.tile.atomic_add(dK[bz, kv_by, by*block_M:(by+1)*block_M, :], dk_acc_ub)
+```
+
+---
+
+## 10. Causal Mask 实现
+
+### 10.1 Forward Causal Mask
+
+**GPU 原始实现** (T.Parallel + if_then_else):
+```python
+for i, j in T.Parallel(block_M, block_N):
+    acc_s[i, j] = T.if_then_else(bx*block_M + i >= k*block_N + j, 0, -inf)
+```
+
+**NPU Expert 实现** (T.tile.compare + T.tile.select):
+
+由于 NPU 的 T.Parallel 不支持 if-else，需要用 compare + select 替代：
+
+```python
+# 方案: 在 softmax 阶段处理 causal mask
+# 1. QK^T 结果写入 workspace_1 后，V 核读取时处理 mask
+# 2. 利用 lse 中的 -inf 值自然处理
+
+# 具体步骤 (V 核内):
+# Step 1: 构建行列索引
+#   row_idx = bx * block_M + vid * half_M + i  (0 <= i < half_M)
+#   col_idx = k * block_N + j                  (0 <= j < block_N)
+# Step 2: causal 条件: row_idx >= col_idx
+#   利用 T.tile.arith_progression 生成索引序列
+#   利用 T.tile.compare 生成 mask
+#   利用 T.tile.select 将不满足条件的位置设为 -inf
+
+# 简化方案 (推荐):
+# 在 QK^T 结果上做 post-mask:
+# 1. 生成 -inf 填充的 buffer
+# 2. T.tile.compare(mask, row_idx_buf, col_idx_buf, "GE")
+# 3. T.tile.select(acc_s_ub, mask, acc_s_ub, neg_inf_buf, "VSEL_CMPMASK_SPR")
+```
+
+**Causal 循环范围优化**:
+```python
+# Non-causal: 遍历所有 KV blocks
+loop_range = ceildiv(seq_len, block_N)
+
+# Causal: 只遍历到当前 Q block 对应的 KV blocks
+loop_range = ceildiv((bx + 1) * block_M, block_N)
+```
+
+### 10.2 Backward Causal Mask
+
+Backward 中的 causal mask 应用在 P 矩阵上：
+```python
+# GPU: qkT[i,j] = if_then_else(by*block_M + i <= k*block_N + j, qkT[i,j], 0)
+# NPU: T.tile.compare + T.tile.select 将不满足条件的位置设为 0
+```
+
+---
+
+## 11. 技术约束检测
+
+### 11.1 三维 Kernel 限制
+
+| 检查项 | 状态 | 说明 |
+|--------|------|------|
+| 三维 grid | ⚠️ 需适配 | GPU 用 3D grid `(bx, by, bz)`，NPU 必须展平为 1D `cid` + 手动分解 |
+| threads 参数 | ✅ 已处理 | GPU `threads=256` 在 NPU 无对应概念，NPU 由 cid/vid 决定并行度 |
+
+### 11.2 动态边界约束
+
+| 检查项 | 状态 | 说明 |
+|--------|------|------|
+| 循环边界 | ⚠️ 需静态化 | Ascend 要求循环边界在编译期可知；`T.ceildiv(seq_len, block_N)` 在 JIT 时已是常量 |
+| Causal loop_range | ✅ 可静态化 | `ceildiv((bx+1)*block_M, block_N)` 中 bx 是运行时变量，但可作为循环内的条件判断 |
+| 尾块处理 | ⚠️ L0 规避 | L0 测试要求 seq_len 整除 block_M/block_N，避免尾块 |
+
+### 11.3 L0C 容量风险
+
+| Kernel | L0C 峰值需求 | L0C 上限 | 状态 |
+|--------|-------------|---------|------|
+| Forward (64×64) | 32KB (acc_o_l0c) | 128KB | ✅ 安全 |
+| BWD Preprocess | 0 (纯 Vector) | 128KB | ✅ 无风险 |
+| BWD Postprocess | 0 (纯 Vector) | 128KB | ✅ 无风险 |
+| BWD Main (128×32) | ~130KB (dv+dk) | 128KB | ⚠️ 需分时复用 |
+
+**BWD Main L0C 解决方案**: 采用分时计算策略（§6.5 方案 A），dv 和 dk 的 GEMM 分时使用 L0C，每轮 GEMM 完成后立即搬运到 UB 累加。
+
+### 11.4 GEMM 分形限制
+
+| 检查项 | 最小要求 (fp16) | 实际值 | 状态 |
+|--------|----------------|--------|------|
+| Forward QK^T: M×K×N | M≥16, K≥16, N≥16 | 64×128×64 | ✅ |
+| Forward PV: M×K×N | M≥16, K≥16, N≥16 | 64×64×128 | ✅ |
+| BWD K^T@Q: M×K×N | M≥16, K≥16, N≥16 | 128×128×32 | ✅ |
+| BWD V^T@dO: M×K×N | M≥16, K≥16, N≥16 | 128×128×32 | ✅ |
+| BWD P@dO: M×K×N | M≥16, K≥16, N≥16 | 128×32×128 | ✅ |
+| BWD dS@Q: M×K×N | M≥16, K≥16, N≥16 | 128×32×128 | ✅ |
+| BWD dS^T@K: M×K×N | M≥16, K≥16, N≥16 | 32×128×128 | ✅ |
+
+### 11.5 UB 容量风险
+
+| Kernel | UB 峰值需求 (单 V 核) | UB 上限 (单 V 核) | 状态 |
+|--------|---------------------|------------------|------|
+| Forward | ~62KB | ~96KB | ✅ 安全 |
+| BWD Preprocess | ~8KB | ~96KB | ✅ 安全 |
+| BWD Main | ~41KB + dv/dk acc | ~96KB | ⚠️ 需精确规划 |
+
+**BWD Main UB 风险**: dv_acc [128, 128] fp32 = 64KB 和 dk_acc [128, 128] fp32 = 64KB 不能同时驻留单 V 核 UB。解决方案：
+- dv_acc 和 dk_acc 分时使用 UB（与 L0C 分时策略配合）
+- 或缩小 block_M 到 64，使 dv_acc/dk_acc 各 16KB
+
+### 11.6 Workspace 内存需求
+
+| Kernel | Workspace 总量 | 说明 |
+|--------|---------------|------|
+| Forward | 3 × block_num × (64×64 + 64×64 + 64×128) | ~block_num × 32KB |
+| BWD Main | 7 × block_num × (128×32 + ...) | 更多 workspace 通道 |
+
+> Workspace 分配在 GM，受设备全局内存限制，通常不是瓶颈。
+
+### 11.7 atomic_add 支持
+
+| 检查项 | 状态 | 说明 |
+|--------|------|------|
+| T.tile.atomic_add UB→GM | ✅ V1 支持 | dQ/dK/dV 的 atomic 累加 |
+| fp32 atomic_add | ✅ 支持 | dQ/dK/dV 均为 fp32 累加器 |
+| 预清零 | ⚠️ 需要 | 调用 kernel 前必须 `torch.zeros_like` 初始化 |
+
+### 11.8 exp2 vs exp 差异
+
+GPU 使用 `T.exp2(x * log2e)` 做指数运算，NPU 使用 `T.tile.exp(x)` 做自然指数。需要调整 scale 因子：
+- GPU: `scale = (1/dim_qk)^0.5 * 1.44269504` (log2(e))，配合 exp2
+- NPU: `scale = (1/dim_qk)^0.5`，配合 exp
+
+---
+
+## 12. 验证方案
+
+### 12.1 Golden 函数 (PyTorch 参考实现)
+
+```python
+import torch
+import torch.nn.functional as F
+
+def ref_program(Q, K, V, is_causal=False, groups=1):
+    """
+    Q: [B, H, N, D_qk] float16
+    K: [B, H_kv, N, D_qk] float16
+    V: [B, H_kv, N, D_v] float16
+    groups = H // H_kv
+    Returns: O [B, H, N, D_v] float16
+    """
+    Q_f = Q.float()
+    K_f = K.float()
+    V_f = V.float()
+
+    # GQA: repeat KV to match Q heads
+    if groups > 1:
+        K_f = K_f.repeat_interleave(groups, dim=1)
+        V_f = V_f.repeat_interleave(groups, dim=1)
+
+    dim_qk = Q_f.shape[-1]
+    scale = 1.0 / (dim_qk ** 0.5)
+
+    # S = Q @ K^T * scale
+    scores = torch.einsum("bqhd,bkhd->bhqk", Q_f, K_f) * scale
+
+    if is_causal:
+        N = Q.shape[2]
+        mask = torch.tril(torch.ones(N, N, device=scores.device, dtype=torch.bool))
+        scores = scores.masked_fill(~mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+
+    P = F.softmax(scores, dim=-1)
+    O = torch.einsum("bhqk,bkhd->bqhd", P, V_f)
+    return O.half()
+
+
+def ref_bwd(Q, K, V, dO, is_causal=False, groups=1):
+    """
+    参考反向实现，返回 dQ, dK, dV
+    """
+    Q_f = Q.float().requires_grad_(True)
+    K_f = K.float().requires_grad_(True)
+    V_f = V.float().requires_grad_(True)
+
+    K_rep = K_f.repeat_interleave(groups, dim=1) if groups > 1 else K_f
+    V_rep = V_f.repeat_interleave(groups, dim=1) if groups > 1 else V_f
+
+    dim_qk = Q_f.shape[-1]
+    scale = 1.0 / (dim_qk ** 0.5)
+    scores = torch.einsum("bqhd,bkhd->bhqk", Q_f, K_rep) * scale
+
+    if is_causal:
+        N = Q.shape[2]
+        mask = torch.tril(torch.ones(N, N, device=scores.device, dtype=torch.bool))
+        scores = scores.masked_fill(~mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+
+    P = F.softmax(scores, dim=-1)
+    O = torch.einsum("bhqk,bkhd->bqhd", P, V_rep)
+    O.backward(dO.float())
+
+    dQ = Q_f.grad.half()
+    # dK/dV 需要归约 groups
+    dK_rep = K_f.grad  # [B, H_kv, N, D_qk]
+    dV_rep = V_f.grad  # [B, H_kv, N, D_v]
+
+    return dQ, dK_rep.half(), dV_rep.half()
+```
+
+### 12.2 L0 门槛测试计划
+
+> 由 `tilelang-op-test-design`（场景 A）生成。L0 只覆盖**规则 shape（block 整除）、标准 dtype、基本精度**。
+
+#### L0 测试用例
+
+| 用例 ID | 场景 | B | H | H_kv | groups | N | D_qk | D_v | causal | block_M | block_N |
+|---------|------|---|---|------|--------|---|------|-----|--------|---------|---------|
+| L0-FWD-01 | Forward MHA | 1 | 1 | 1 | 1 | 128 | 64 | 64 | False | 64 | 64 |
+| L0-FWD-02 | Forward GQA | 1 | 2 | 1 | 2 | 128 | 64 | 64 | False | 64 | 64 |
+| L0-FWD-03 | Forward GQA causal | 1 | 2 | 1 | 2 | 128 | 64 | 64 | True | 64 | 64 |
+| L0-FWD-04 | Forward batch | 2 | 4 | 2 | 2 | 256 | 64 | 64 | False | 64 | 64 |
+| L0-PREP-01 | BWD preprocess | 1 | 1 | — | — | 128 | — | 64 | — | — | — |
+| L0-POST-01 | BWD postprocess | 1 | 1 | — | — | 128 | 64 | — | — | — | — |
+| L0-BWD-01 | BWD MHA | 1 | 1 | 1 | 1 | 128 | 64 | 64 | False | 128 | 32 |
+| L0-BWD-02 | BWD GQA | 1 | 2 | 1 | 2 | 128 | 64 | 64 | False | 128 | 32 |
+| L0-BWD-03 | BWD GQA causal | 1 | 2 | 1 | 2 | 128 | 64 | 64 | True | 128 | 32 |
+
+#### L0 dtype 配置
+
+| 张量 | dtype |
+|------|-------|
+| Q, K, V, O, dO | float16 |
+| lse, Delta, dQ (累加器) | float32 |
+| dK, dV (最终输出) | float16 (从 fp32 转换) |
+
+#### L0 精度标准
+
+| Kernel | 测试类型 | atol | rtol | 说明 |
+|--------|---------|------|------|------|
+| Forward | 输出 O | 1e-2 | 1e-2 | fp16 累积，参考 GPU 版本标准 |
+| Forward | lse | 1e-2 | 1e-2 | fp32 但受 softmax 数值范围影响 |
+| BWD Preprocess | Delta | 1e-3 | 1e-3 | 简单 dot product，精度较高 |
+| BWD Postprocess | dQ_out | 1e-3 | 1e-3 | 纯 dtype 转换 |
+| BWD Main | dQ | 1e-2 | 1e-2 | 多步 GEMM + softmax 反向 |
+| BWD Main | dK | 1e-2 | 1e-2 | 同上 |
+| BWD Main | dV | 1e-2 | 1e-2 | 同上 |
+
+#### L0 验证流程
+
+```python
+# 1. Forward 验证
+O_npu, lse_npu = flashattn_fwd(Q, K, V)
+O_ref = ref_program(Q, K, V, is_causal, groups)
+torch.testing.assert_close(O_npu, O_ref, atol=1e-2, rtol=1e-2)
+
+# 2. BWD Preprocess 验证
+Delta_npu = flashattn_bwd_preprocess(O, dO)
+Delta_ref = (O.float() * dO.float()).sum(dim=-1)
+torch.testing.assert_close(Delta_npu, Delta_ref, atol=1e-3, rtol=1e-3)
+
+# 3. BWD Main 验证 (端到端)
+dQ_npu, dK_npu, dV_npu = flashattn_bwd_pipeline(Q, K, V, dO, lse, Delta)
+dQ_ref, dK_ref, dV_ref = ref_bwd(Q, K, V, dO, is_causal, groups)
+torch.testing.assert_close(dQ_npu, dQ_ref, atol=1e-2, rtol=1e-2)
+torch.testing.assert_close(dK_npu, dK_ref, atol=1e-2, rtol=1e-2)
+torch.testing.assert_close(dV_npu, dV_ref, atol=1e-2, rtol=1e-2)
+```
+
+---
+
+## 13. 同类实现引用
+
+| 文件路径 | 说明 | 参考价值 |
+|---------|------|---------|
+| `examples/flash_attention/flash_attn_bhsd.py` | NPU Expert 模式 forward，手动 Scope/sync/address | **最核心参考**：C/V 分离、workspace 机制、同步协议 |
+| `examples/flash_attention/flash_attn_bhsd_cc_sync.py` | NPU 自动 CV sync 版本 forward | 参考 auto_cv_sync pass_configs 的用法 |
+| `examples/flash_attention/fa_opt/flash_attn_bhsd_expert_h16_d128.py` | NPU 高性能 Expert forward，GQA 支持 | **GQA 处理参考**：`kv_by = by // (heads_q // heads_kv)`、T.mma + double buffering |
+| `examples/flash_attention/paged_flash_attn_bhsd.py` | Paged KV cache flash attention | 参考 auto_cv_combine + workspace 索引模式 |
+| GPU `examples/flash_attention/example_gqa_bwd.py` | GPU GQA forward + backward 完整实现 | **算法逻辑参考**：5 个 kernel 的计算流程 |
+
+---
+
+## 14. 风险点与缓解措施
+
+| 风险 | 严重度 | 缓解措施 |
+|------|--------|---------|
+| BWD Main L0C 溢出 (dv+dk > 128KB) | 高 | 分时计算：dv/dk GEMM 交替使用 L0C，每轮搬出到 UB 累加 |
+| BWD Main UB 溢出 (dv_acc+dk_acc > 96KB) | 高 | 分时累加：dv_acc 和 dk_acc 分时驻留 UB；或缩小 block_M |
+| Causal mask 在 T.tile 中实现复杂 | 中 | 利用 T.tile.compare + T.tile.select；或简化为循环范围限制 + 尾块特殊处理 |
+| 多 workspace 通道增加同步复杂度 | 中 | 严格规划信号编号，避免死锁；参考 flash_attn_bhsd.py 的同步协议 |
+| D_qk=192 非 2 的幂次 | 中 | L0 测试先用 D=64/128；D=192 留到 L1 测试 |
+| exp2 → exp 转换影响数值精度 | 低 | scale 因子调整：去掉 log2(e) 乘数；精度标准放宽到 1e-2 |
+| BWD atomic_add 性能不如 split | 低 | 先实现 atomic_add 版本验证正确性；性能优化阶段可切换 split |
+
+---
+
+## 15. 交付清单
+
+### 15.1 目录结构
+
+```
+example_gqa_bwd/
+├── design.md                # 本设计文档
+├── example_gqa_bwd.py       # 算子实现（Forward v1/v4 + Backward pipeline + Golden Ref + Autograd + __main__ 冒烟测试）
+├── test_gqa_bwd.py          # 分层测试（L0/L1/L2/Boundary + argparse --level）
+└── perf_example_gqa_bwd.py  # 性能测试（正确性检查 + TileLang vs PyTorch 对比）
+```
+
+### 15.2 文件说明
+
+| 文件 | 说明 |
+|------|------|
+| `design.md` | 算子设计文档：I/O 规格、编程模式、API 映射、内存规划、tiling、同步策略、验证方案 |
+| `example_gqa_bwd.py` | 算子实现：全部 kernel + golden reference + autograd wrapper + `__main__` 冒烟测试（输出 "Test Passed!"） |
+| `test_gqa_bwd.py` | 分层测试文件：L0（规则 shape，阻塞）/ L1（不规则 shape，阻塞）/ L2（异常输入，非阻塞）/ Boundary（特殊值，非阻塞）+ `argparse --level` |
+| `perf_example_gqa_bwd.py` | 性能测试：正确性检查 + TileLang Forward v1/v4 + Backward pipeline vs PyTorch baseline + 输出 "Test Passed!" |
+
+### 15.3 函数清单
+
+| 函数名 | 说明 |
+|--------|------|
+| `flashattn_fwd` | Forward 基础版（gemm_v0 + online softmax） |
+| `flashattn_fwd_v4` | Forward 优化版（L0 双缓冲 + Fixed Core + 批处理 + fine-grained sync, num_stages=8） |
+| `flashattn_bwd_preprocess` | Backward 预处理（Delta = sum(O × dO)） |
+| `flashattn_bwd_postprocess` | Backward 后处理（dQ fp32→fp16） |
+| `flashattn_bwd_pipeline` | Backward 主 kernel（5 GEMM + 批处理 + fine-grained sync, num_stages=8） |
+| `ref_program` / `ref_bwd` | PyTorch golden reference |
+| `attention` | autograd wrapper（BSHD↔BHSD 布局转换） |
+
+### 15.4 运行方式
+
+```bash
+# 1. 冒烟测试（CI 直接运行主文件）
+python example_gqa_bwd.py
+# 输出: "Test Passed!"
+
+# 2. 分层精度测试
+python test_gqa_bwd.py --level l0     # L0 门槛测试（阻塞）
+python test_gqa_bwd.py --level all    # 全部层级（L0+L1+L2+Boundary）
+
+# 3. 性能测试
+python perf_example_gqa_bwd.py
+# 输出: 性能表格 + "Test Passed!"
+
+# 4. pytest 兼容
+python -m pytest test_gqa_bwd.py -v
+```

--- a/examples_experiment/example_gqa_bwd/example_gqa_bwd.py
+++ b/examples_experiment/example_gqa_bwd/example_gqa_bwd.py
@@ -1,0 +1,1307 @@
+"""
+GQA Flash Attention Forward + Backward for Ascend NPU (Expert Mode).
+Layout: BHSD (Batch, Heads, SeqLen, Dim).
+Supports D_qk != D_v (separate dimensions for Q/K and V).
+"""
+
+import tilelang
+from tilelang import DataType, language as T
+from tilelang.intrinsics import make_zn_layout, make_nz_layout
+import torch
+import torch.nn.functional as F
+
+# ============================================================================
+# Common pass_configs for Expert mode
+# ============================================================================
+
+_expert_pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False,
+}
+
+NUM_CORES = 24
+
+# Signal IDs for pipeline backward C scope sync
+_SIG_K = 0
+_SIG_MN = 1
+_SIG_V = 2
+_SIG_K5 = 3
+_SIG_L0C_MN = 0
+_SIG_L0C_ND = 1
+
+# ============================================================================
+# Forward (GQA + LSE + causal mask, supports D_qk != D_v)
+# ============================================================================
+
+
+@tilelang.jit(out_idx=[3, 4], workspace_idx=[5, 6, 7], pass_configs=_expert_pass_configs)
+def flashattn_fwd(batch, heads, seq_len, dim_qk, dim_v, is_causal, block_M, block_N, groups=1):
+    """Forward: produces O [B,H,N,dim_v] fp16 and lse [B,H,N] fp32."""
+    assert seq_len % block_M == 0, f"seq_len ({seq_len}) must be divisible by block_M ({block_M})"
+    assert seq_len % block_N == 0, f"seq_len ({seq_len}) must be divisible by block_N ({block_N})"
+    sm_scale = (1.0 / dim_qk) ** 0.5
+    head_kv = heads // groups
+    dtype = "float16"
+    accum_dtype = "float"
+
+    q_shape = [batch, heads, seq_len, dim_qk]
+    k_shape = [batch, head_kv, seq_len, dim_qk]
+    v_shape = [batch, head_kv, seq_len, dim_v]
+    o_shape = [batch, heads, seq_len, dim_v]
+    lse_shape = [batch, heads, seq_len]
+    block_num = (seq_len // block_M) * heads * batch
+
+    @T.prim_func
+    def main(
+        Q: T.Tensor(q_shape, dtype),
+        K: T.Tensor(k_shape, dtype),
+        V: T.Tensor(v_shape, dtype),
+        Output: T.Tensor(o_shape, dtype),
+        lse: T.Tensor(lse_shape, accum_dtype),
+        workspace_1: T.Tensor([block_num, block_M, block_N], accum_dtype),
+        workspace_2: T.Tensor([block_num, block_M, block_N], dtype),
+        workspace_3: T.Tensor([block_num, block_M, dim_v], accum_dtype),
+    ):
+        with T.Kernel(block_num, is_npu=True) as (cid, vid):
+            bx = cid % (seq_len // block_M)
+            by = cid // (seq_len // block_M) % heads
+            bz = cid // (seq_len // block_M) // heads % batch
+            kv_by = by // groups
+
+            q_l1 = T.alloc_L1([block_M, dim_qk], dtype)
+            k_l1 = T.alloc_L1([block_N, dim_qk], dtype)
+            v_l1 = T.alloc_L1([block_N, dim_v], dtype)
+            acc_s_l1 = T.alloc_L1([block_M, block_N], dtype)
+            acc_s_l0c = T.alloc_L0C([block_M, block_N], accum_dtype)
+            acc_o_l0c = T.alloc_L0C([block_M, dim_v], accum_dtype)
+
+            acc_o = T.alloc_ub([block_M // 2, dim_v], accum_dtype)
+            sumexp = T.alloc_ub([block_M // 2], accum_dtype)
+            m_i = T.alloc_ub([block_M // 2], accum_dtype)
+            acc_s_ub = T.alloc_ub([block_M // 2, block_N], accum_dtype)
+            m_i_prev = T.alloc_ub([block_M // 2], accum_dtype)
+            acc_s_ub_ = T.alloc_ub([block_M // 2, block_N], accum_dtype)
+            sumexp_i_ub = T.alloc_ub([block_M // 2], accum_dtype)
+            acc_s_half = T.alloc_ub([block_M // 2, block_N], dtype)
+            acc_o_ub = T.alloc_ub([block_M // 2, dim_v], accum_dtype)
+            acc_o_half = T.alloc_ub([block_M // 2, dim_v], dtype)
+            col_pos = T.alloc_ub([block_N], accum_dtype)
+            cmp_mask = T.alloc_ub([block_N], accum_dtype)
+            m_i_2d = T.alloc_ub([block_M // 2, block_N], accum_dtype)
+            m_prev_2d = T.alloc_ub([block_M // 2, dim_v], accum_dtype)
+            sumexp_2d = T.alloc_ub([block_M // 2, dim_v], accum_dtype)
+
+            T.annotate_address(
+                {
+                    q_l1: 0,
+                    k_l1: block_M * dim_qk * DataType(dtype).bits // 8,
+                    acc_s_l1: block_M * dim_qk * DataType(dtype).bits // 8,
+                    v_l1: block_M * (block_N + dim_qk) * DataType(dtype).bits // 8,
+                    acc_s_l0c: 0,
+                    acc_o_l0c: 0,
+                    acc_o: 0,
+                    sumexp: (block_M // 2) * dim_v * 4,
+                    m_i: (block_M // 2) * dim_v * 4 + (block_M // 2) * 4,
+                    acc_s_ub: (block_M // 2) * dim_v * 4 + (block_M // 2) * 4 + (block_M // 2) * 4,
+                    m_i_prev: (block_M // 2) * dim_v * 4 + (block_M // 2) * 4 + (block_M // 2) * 4 + (block_M // 2) * block_N * 4,
+                    acc_s_ub_: (block_M // 2) * dim_v * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 4
+                    + (block_M // 2) * 4,
+                    sumexp_i_ub: (block_M // 2) * dim_v * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 4,
+                    acc_s_half: (block_M // 2) * dim_v * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 4
+                    + (block_M // 2) * 4,
+                    acc_o_ub: (block_M // 2) * dim_v * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 2,
+                    acc_o_half: (block_M // 2) * dim_v * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 2
+                    + (block_M // 2) * dim_v * 4,
+                    m_i_2d: (block_M // 2) * dim_v * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 4
+                    + (block_M // 2) * 4,
+                    m_prev_2d: (block_M // 2) * dim_v * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 2,
+                    sumexp_2d: (block_M // 2) * dim_v * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 4
+                    + (block_M // 2) * 4
+                    + (block_M // 2) * block_N * 2,
+                }
+            )
+
+            with T.Scope("C"):
+                T.copy(Q[bz, by, bx * block_M : (bx + 1) * block_M, :], q_l1)
+                T.barrier_all()
+                for k in T.serial(T.ceildiv((bx + 1) * block_M, block_N) if is_causal else T.ceildiv(seq_len, block_N)):
+                    T.copy(K[bz, kv_by, k * block_N : (k + 1) * block_N, :], k_l1)
+                    T.barrier_all()
+                    T.gemm_v0(q_l1, k_l1, acc_s_l0c, transpose_B=True, init=True)
+                    T.barrier_all()
+                    T.copy(acc_s_l0c, workspace_1[cid, :, :])
+                    T.barrier_all()
+                    T.set_cross_flag("FIX", 0)
+                    T.wait_cross_flag(1)
+                    T.barrier_all()
+                    T.copy(workspace_2[cid, :, :], acc_s_l1)
+                    T.copy(V[bz, kv_by, k * block_N : (k + 1) * block_N, :], v_l1)
+                    T.barrier_all()
+                    T.gemm_v0(acc_s_l1, v_l1, acc_o_l0c, init=True)
+                    T.barrier_all()
+                    T.copy(acc_o_l0c, workspace_3[cid, :, :])
+                    T.barrier_all()
+                    T.set_cross_flag("FIX", 2)
+                    T.wait_cross_flag(3)
+
+            with T.Scope("V"):
+                T.tile.fill(acc_o, 0.0)
+                T.tile.fill(sumexp, 0.0)
+                T.tile.fill(m_i, -(2**30))
+                T.barrier_all()
+                for _k in T.serial(T.ceildiv((bx + 1) * block_M, block_N) if is_causal else T.ceildiv(seq_len, block_N)):
+                    T.tile.fill(acc_s_ub, 0.0)
+                    T.copy(m_i, m_i_prev)
+                    T.barrier_all()
+                    T.wait_cross_flag(0)
+                    T.copy(workspace_1[cid, vid * block_M // 2 : vid * block_M // 2 + block_M // 2, :], acc_s_ub_)
+                    T.barrier_all()
+                    T.tile.add(acc_s_ub, acc_s_ub, acc_s_ub_)
+                    T.tile.mul(acc_s_ub, acc_s_ub, sm_scale)
+
+                    if is_causal:
+                        T.tile.arith_progression(col_pos, _k * block_N, 1, block_N)
+                        for h_i in range(block_M // 2):
+                            row_pos_val = (bx * block_M + vid * block_M // 2 + h_i) * 1.0
+                            T.tile.compare(cmp_mask, col_pos, row_pos_val, "LE")
+                            T.tile.select(acc_s_ub[h_i, :], cmp_mask, acc_s_ub[h_i, :], -T.infinity(accum_dtype), "VSEL_TENSOR_SCALAR_MODE")
+
+                    T.reduce_max(acc_s_ub, m_i, dim=-1)
+                    T.tile.max(m_i, m_i, m_i_prev)
+                    T.tile.sub(m_i_prev, m_i_prev, m_i)
+                    T.tile.exp(m_i_prev, m_i_prev)
+                    T.tile.broadcast(m_i_2d, m_i, axis=1)
+                    T.tile.sub(acc_s_ub, acc_s_ub, m_i_2d)
+                    T.tile.exp(acc_s_ub, acc_s_ub)
+                    T.reduce_sum(acc_s_ub, sumexp_i_ub, dim=-1)
+                    T.tile.mul(sumexp, sumexp, m_i_prev)
+                    T.tile.add(sumexp, sumexp, sumexp_i_ub)
+                    T.tile.broadcast(m_prev_2d, m_i_prev, axis=1)
+                    T.tile.mul(acc_o, acc_o, m_prev_2d)
+                    T.copy(acc_s_ub, acc_s_half)
+                    T.barrier_all()
+                    T.copy(acc_s_half, workspace_2[cid, vid * block_M // 2 : vid * block_M // 2 + block_M // 2, :])
+                    T.barrier_all()
+                    T.set_cross_flag("MTE3", 1)
+                    T.wait_cross_flag(2)
+                    T.barrier_all()
+                    T.copy(workspace_3[cid, vid * block_M // 2 : vid * block_M // 2 + block_M // 2, :], acc_o_ub)
+                    T.barrier_all()
+                    T.tile.add(acc_o, acc_o, acc_o_ub)
+                    T.barrier_all()
+                    T.set_cross_flag("V", 3)
+                    T.barrier_all()
+                T.tile.broadcast(sumexp_2d, sumexp, axis=1)
+                T.tile.div(acc_o, acc_o, sumexp_2d)
+                T.copy(acc_o, acc_o_half)
+                T.barrier_all()
+                T.copy(acc_o_half, Output[bz, by, bx * block_M + vid * block_M // 2 : bx * block_M + vid * block_M // 2 + block_M // 2, :])
+                T.barrier_all()
+                T.tile.ln(sumexp, sumexp)
+                T.tile.add(sumexp, sumexp, m_i)
+                T.barrier_all()
+                T.copy(sumexp, lse[bz, by, bx * block_M + vid * block_M // 2 : bx * block_M + vid * block_M // 2 + block_M // 2])
+                T.barrier_all()
+
+    return main
+
+
+# ============================================================================
+# Forward v4: L0 double buffer + Fixed Core + batched softmax + fine-grained sync
+# ============================================================================
+
+
+@tilelang.jit(out_idx=[3, 4], workspace_idx=[5, 6, 7], pass_configs=_expert_pass_configs)
+def flashattn_fwd_v4(
+    batch,
+    heads,
+    seq_len,
+    dim_qk,
+    dim_v,
+    is_causal,
+    block_M=32,
+    block_N=64,
+    groups=1,
+    num_stages=8,
+    cross_interval=2,
+):
+    """Forward v4: block_M=32 enables L0 double buffering.
+
+    Key changes from v3:
+    - block_M=32 (was 64) → L0 fits double buffer for both GEMMs
+    - L0 double buffering with [2, ...] syntax for GEMM1 and GEMM2
+    - Batched iterations (num_stages per batch)
+    - Fine-grained flag sync (set_flag/wait_flag) within C and V scopes
+    - Batched softmax (r_factors + sumexp_is, decoupled from O accumulation)
+    """
+    assert heads % groups == 0
+    assert num_stages % 2 == 0, "num_stages must be even for double buffering"
+    assert seq_len % block_M == 0, f"seq_len ({seq_len}) must be divisible by block_M ({block_M})"
+    assert seq_len % block_N == 0, f"seq_len ({seq_len}) must be divisible by block_N ({block_N})"
+
+    head_kv = heads // groups
+    dtype = "float16"
+    accum_dtype = "float"
+    sm_scale = (1.0 / dim_qk) ** 0.5
+
+    q_shape = [batch, heads, seq_len, dim_qk]
+    k_shape = [batch, head_kv, seq_len, dim_qk]
+    v_shape = [batch, head_kv, seq_len, dim_v]
+    o_shape = [batch, heads, seq_len, dim_v]
+    lse_shape = [batch, heads, seq_len]
+
+    num_seq_blocks = seq_len // block_M
+    block_num = num_seq_blocks * heads * batch
+    num_iters = T.ceildiv(seq_len, block_N)
+    half_M = block_M // 2
+
+    q_tasks = block_num // NUM_CORES
+    r_tasks = block_num % NUM_CORES
+
+    # Cross-core semaphore IDs
+    SEM_WS1_C2V = 0
+    SEM_WS1_V2C = 1
+    SEM_WS2_V2C = 2
+    SEM_WS2_C2V = 3
+    SEM_WS3_C2V = 4
+    SEM_WS3_V2C = 5
+
+    # Intra-core signal IDs (C Scope)
+    SIG_K_L1 = 0
+    SIG_P_L1 = 1
+    SIG_V_L1 = 2
+    SIG_L0AB = 3  # double-buffer base: slot 0 = SIG_L0AB, slot 1 = SIG_L0AB+1
+    SIG_L0C = 5  # double-buffer base: slot 0 = SIG_L0C,  slot 1 = SIG_L0C+1
+
+    # Intra-core signal IDs (V Scope)
+    SIG_IO_UB = 0
+    SIG_S_HALF = 1
+
+    def task_range(cid_val):
+        start = cid_val * q_tasks + T.if_then_else(cid_val < r_tasks, cid_val, r_tasks)
+        count = q_tasks + T.if_then_else(cid_val < r_tasks, 1, 0)
+        return start, count
+
+    @T.prim_func
+    def main(
+        Q: T.Tensor(q_shape, dtype),
+        K: T.Tensor(k_shape, dtype),
+        V: T.Tensor(v_shape, dtype),
+        Output: T.Tensor(o_shape, dtype),
+        lse: T.Tensor(lse_shape, accum_dtype),
+        workspace_1: T.Tensor([NUM_CORES, num_stages, block_M, block_N], accum_dtype),
+        workspace_2: T.Tensor([NUM_CORES, num_stages, block_M, block_N], dtype),
+        workspace_3: T.Tensor([NUM_CORES, num_stages, block_M, dim_v], accum_dtype),
+    ):
+        with T.Kernel(NUM_CORES, is_npu=True) as (cid, vid):
+            # --- L1 buffers ---
+            q_l1 = T.alloc_L1([block_M, dim_qk], dtype)
+            k_l1 = T.alloc_L1([block_N, dim_qk], dtype)
+            v_l1 = T.alloc_L1([block_N, dim_v], dtype)
+            p_l1 = T.alloc_L1([block_M, block_N], dtype)
+
+            T.annotate_layout(
+                {
+                    q_l1: make_zn_layout(q_l1),
+                    k_l1: make_nz_layout(k_l1),
+                    p_l1: make_zn_layout(p_l1),
+                    v_l1: make_zn_layout(v_l1),
+                }
+            )
+
+            # --- GEMM1 L0 double buffer (Q @ K^T) ---
+            g1_l0a = T.alloc_L0A([2, block_M, dim_qk], dtype)
+            g1_l0b = T.alloc_L0B([2, dim_qk, block_N], dtype)
+            g1_l0c = T.alloc_L0C([2, block_M, block_N], accum_dtype)
+
+            # --- GEMM2 L0 double buffer (P @ V) ---
+            g2_l0a = T.alloc_L0A([2, block_M, block_N], dtype)
+            g2_l0b = T.alloc_L0B([2, block_N, dim_v], dtype)
+            g2_l0c = T.alloc_L0C([2, block_M, dim_v], accum_dtype)
+
+            # Separate L0A and L0C to avoid double-buffer read/write conflicts
+            # L0B can overlap (80KB > 64KB limit, but GEMM1/GEMM2 use L0B serially)
+            T.annotate_address(
+                {
+                    g1_l0a: 0,
+                    g2_l0a: 24576,  # 24KB offset, no overlap with g1_l0a
+                    g1_l0b: 0,
+                    g2_l0b: 0,  # overlaps g1_l0b (L0B total 80KB > 64KB)
+                    g1_l0c: 0,
+                    g2_l0c: 16384,  # 16KB offset, no overlap with g1_l0c
+                }
+            )
+
+            # --- UB buffers ---
+            # I/O intermediate buffers (for two-step workspace loads, fp32 to match workspace)
+            io_buf = T.alloc_ub([half_M, block_N], accum_dtype)  # for S loads (fp32)
+            io_buf_o = T.alloc_ub([half_M, dim_v], accum_dtype)  # for O loads (fp32)
+
+            # Softmax computation
+            work_ub = T.alloc_ub([half_M, block_N], accum_dtype)
+            buf_2d = T.alloc_ub([half_M, block_N], accum_dtype)
+            acc_s_half = T.alloc_ub([half_M, block_N], dtype)
+
+            # O accumulation
+            acc_o = T.alloc_ub([half_M, dim_v], accum_dtype)
+            acc_o_ub = T.alloc_ub([half_M, dim_v], accum_dtype)
+            broadcast_buf = T.alloc_ub([half_M, dim_v], accum_dtype)
+            acc_o_half = T.alloc_ub([half_M, dim_v], dtype)
+
+            # Batched softmax state
+            r_factors = T.alloc_ub([num_stages, half_M, 1], accum_dtype)
+            sumexp_is = T.alloc_ub([num_stages, half_M, 1], accum_dtype)
+            sumexp = T.alloc_ub([half_M, 1], accum_dtype)
+            neg_sm = T.alloc_ub([2, half_M, 1], accum_dtype)
+
+            # LSE
+            lse_buf = T.alloc_ub([half_M, 1], accum_dtype)
+
+            # Causal mask (defined unconditionally so V scope can access them;
+            # v1 defines them outside `if is_causal:` too — see line 90-91)
+            col_pos = T.alloc_ub([block_N], accum_dtype)
+            cmp_mask = T.alloc_ub([block_N], accum_dtype)
+
+            my_start, my_count = task_range(cid)
+
+            # ================================================================
+            # C Scope — GEMM1 + GEMM2 with L0 double buffering
+            # ================================================================
+            with T.Scope("C"):
+                # Init flags — pretend all buffers are free
+                T.set_cross_flag("MTE2", SEM_WS2_C2V)
+                T.set_flag("MTE1", "MTE2", SIG_K_L1)
+                T.set_flag("MTE1", "MTE2", SIG_P_L1)
+                T.set_flag("MTE1", "MTE2", SIG_V_L1)
+                T.set_flag("M", "MTE1", SIG_L0AB)
+                T.set_flag("M", "MTE1", SIG_L0AB + 1)
+                T.set_flag("FIX", "M", SIG_L0C)
+                T.set_flag("FIX", "M", SIG_L0C + 1)
+
+                for t in T.serial(my_count):
+                    task_id = my_start + t
+                    bx = task_id % num_seq_blocks
+                    by = (task_id // num_seq_blocks) % heads
+                    bz = task_id // (num_seq_blocks * heads)
+                    kv_by = by // groups
+
+                    T.copy(Q[bz, by, bx * block_M : (bx + 1) * block_M, :], q_l1)
+                    T.barrier_all()
+
+                    _task_iters = T.ceildiv((bx + 1) * block_M, block_N) if is_causal else num_iters
+                    _task_outer = T.ceildiv(_task_iters, num_stages)
+                    for k in T.serial(_task_outer):
+                        _remaining = _task_iters - k * num_stages
+                        batch_iters = T.if_then_else(_remaining < num_stages, _remaining, num_stages)
+
+                        # --- GEMM1 batch: Q @ K^T → workspace_1 ---
+                        T.wait_cross_flag(SEM_WS1_V2C)
+                        for i in T.serial(batch_iters):
+                            side = i % 2
+                            idx = k * num_stages + i
+
+                            # Load K to L1
+                            T.wait_flag("MTE1", "MTE2", SIG_K_L1)
+                            T.copy(K[bz, kv_by, idx * block_N : (idx + 1) * block_N, :], k_l1)
+                            T.set_flag("MTE2", "MTE1", SIG_K_L1)
+
+                            # Copy Q to L0A (only first 2 iters — Q is constant)
+                            T.wait_flag("M", "MTE1", SIG_L0AB + side)
+                            if i < 2:
+                                T.copy(q_l1, g1_l0a[side, :, :])
+
+                            # Copy K to L0B (transposed)
+                            T.wait_flag("MTE2", "MTE1", SIG_K_L1)
+                            T.copy(k_l1, g1_l0b[side, :, :], transpose=True)
+                            T.set_flag("MTE1", "MTE2", SIG_K_L1)
+                            T.set_flag("MTE1", "M", SIG_L0AB + side)
+
+                            # MMA
+                            T.wait_flag("MTE1", "M", SIG_L0AB + side)
+                            T.wait_flag("FIX", "M", SIG_L0C + side)
+                            T.mma(g1_l0a[side, :, :], g1_l0b[side, :, :], g1_l0c[side, :, :], init=True)
+                            T.set_flag("M", "MTE1", SIG_L0AB + side)
+                            T.set_flag("M", "FIX", SIG_L0C + side)
+
+                            # Copy result to workspace
+                            T.wait_flag("M", "FIX", SIG_L0C + side)
+                            T.copy(g1_l0c[side, :, :], workspace_1[cid, i, :, :])
+                            T.set_flag("FIX", "M", SIG_L0C + side)
+                            if (i + 1) % cross_interval == 0 or i == batch_iters - 1:
+                                T.set_cross_flag("FIX", SEM_WS1_C2V)
+
+                        # --- GEMM2 batch: P @ V → workspace_3 ---
+                        T.wait_cross_flag(SEM_WS3_V2C)
+                        for i in T.serial(batch_iters):
+                            side = i % 2
+                            idx = k * num_stages + i
+
+                            # Load V to L1
+                            T.wait_flag("MTE1", "MTE2", SIG_V_L1)
+                            T.copy(V[bz, kv_by, idx * block_N : (idx + 1) * block_N, :], v_l1)
+                            T.set_flag("MTE2", "MTE1", SIG_V_L1)
+
+                            # Load P from workspace_2 to L1
+                            T.wait_flag("MTE1", "MTE2", SIG_P_L1)
+                            if i % cross_interval == 0:
+                                T.wait_cross_flag(SEM_WS2_V2C)
+                            T.copy(workspace_2[cid, i, :, :], p_l1)
+                            T.set_flag("MTE2", "MTE1", SIG_P_L1)
+
+                            # Copy V to L0B
+                            T.wait_flag("MTE2", "MTE1", SIG_V_L1)
+                            T.wait_flag("M", "MTE1", SIG_L0AB + side)
+                            T.copy(v_l1, g2_l0b[side, :, :])
+                            T.set_flag("MTE1", "MTE2", SIG_V_L1)
+
+                            # Copy P to L0A
+                            T.wait_flag("MTE2", "MTE1", SIG_P_L1)
+                            T.copy(p_l1, g2_l0a[side, :, :])
+                            T.set_flag("MTE1", "MTE2", SIG_P_L1)
+                            T.set_flag("MTE1", "M", SIG_L0AB + side)
+
+                            # MMA
+                            T.wait_flag("MTE1", "M", SIG_L0AB + side)
+                            T.wait_flag("FIX", "M", SIG_L0C + side)
+                            T.mma(g2_l0a[side, :, :], g2_l0b[side, :, :], g2_l0c[side, :, :], init=True)
+                            T.set_flag("M", "MTE1", SIG_L0AB + side)
+                            T.set_flag("M", "FIX", SIG_L0C + side)
+
+                            # Copy result to workspace
+                            T.wait_flag("M", "FIX", SIG_L0C + side)
+                            T.copy(g2_l0c[side, :, :], workspace_3[cid, i, :, :])
+                            T.set_flag("FIX", "M", SIG_L0C + side)
+                            if (i + 1) % cross_interval == 0 or i == batch_iters - 1:
+                                T.set_cross_flag("FIX", SEM_WS3_C2V)
+
+                        T.set_cross_flag("MTE2", SEM_WS2_C2V)
+
+                # Destroy: consume outstanding init-direction flags
+                T.wait_flag("MTE1", "MTE2", SIG_K_L1)
+                T.wait_flag("MTE1", "MTE2", SIG_P_L1)
+                T.wait_flag("MTE1", "MTE2", SIG_V_L1)
+                T.wait_flag("M", "MTE1", SIG_L0AB)
+                T.wait_flag("M", "MTE1", SIG_L0AB + 1)
+                T.wait_flag("FIX", "M", SIG_L0C)
+                T.wait_flag("FIX", "M", SIG_L0C + 1)
+
+            # ================================================================
+            # V Scope — Batched softmax + O accumulation
+            # ================================================================
+            with T.Scope("V"):
+                # Init flags
+                T.set_cross_flag("MTE2", SEM_WS1_V2C)
+                T.set_cross_flag("MTE2", SEM_WS3_V2C)
+                T.set_flag("V", "MTE2", SIG_IO_UB)
+                T.set_flag("MTE3", "V", SIG_S_HALF)
+
+                for t in T.serial(my_count):
+                    task_id = my_start + t
+                    bx = task_id % num_seq_blocks
+                    by = (task_id // num_seq_blocks) % heads
+                    bz = task_id // (num_seq_blocks * heads)
+
+                    T.tile.fill(acc_o, 0.0)
+                    T.tile.fill(sumexp, 0.0)
+                    T.tile.fill(neg_sm, 2**30)
+
+                    _task_iters = T.ceildiv((bx + 1) * block_M, block_N) if is_causal else num_iters
+                    _task_outer = T.ceildiv(_task_iters, num_stages)
+                    for k in T.serial(_task_outer):
+                        _remaining = _task_iters - k * num_stages
+                        batch_iters = T.if_then_else(_remaining < num_stages, _remaining, num_stages)
+
+                        # --- Softmax batch (reference two-step pattern) ---
+                        T.wait_cross_flag(SEM_WS2_C2V)
+                        for i in T.serial(batch_iters):
+                            cur = i % 2
+                            prv = 1 - cur
+
+                            # Step 1: MTE2 loads S from workspace_1 → io_buf
+                            T.wait_flag("V", "MTE2", SIG_IO_UB)
+                            if i % cross_interval == 0:
+                                T.wait_cross_flag(SEM_WS1_C2V)
+                            T.copy(workspace_1[cid, i, vid * half_M : vid * half_M + half_M, :], io_buf)
+                            T.set_flag("MTE2", "V", SIG_IO_UB)
+
+                            # Step 2: V copies io_buf → work_ub (fp16→fp32)
+                            T.wait_flag("MTE2", "V", SIG_IO_UB)
+                            T.copy(io_buf, work_ub)
+                            T.set_flag("V", "MTE2", SIG_IO_UB)
+
+                            # Causal mask (V unit, operates on work_ub)
+                            if is_causal:
+                                idx = k * num_stages + i
+                                T.tile.arith_progression(col_pos, idx * block_N, 1, block_N)
+                                for h_i in range(half_M):
+                                    row_pos_val = (bx * block_M + vid * half_M + h_i) * 1.0
+                                    T.tile.compare(cmp_mask, col_pos, row_pos_val, "LE")
+                                    T.tile.select(
+                                        work_ub[h_i, :], cmp_mask, work_ub[h_i, :], -T.infinity(accum_dtype), "VSEL_TENSOR_SCALAR_MODE"
+                                    )
+
+                            # Batched softmax computation (V unit, on work_ub)
+                            T.reduce_max(work_ub, neg_sm[cur, :, :], dim=-1)
+                            T.tile.mul(neg_sm[cur, :, :], neg_sm[cur, :, :], -sm_scale)
+                            T.tile.min(neg_sm[cur, :, :], neg_sm[cur, :, :], neg_sm[prv, :, :])
+                            T.tile.broadcast(buf_2d, neg_sm[cur, :, :])
+                            T.tile.axpy(buf_2d, work_ub, sm_scale)
+                            T.tile.exp(work_ub, buf_2d)
+
+                            # Store P: work_ub (fp32) → acc_s_half (fp16)
+                            T.wait_flag("MTE3", "V", SIG_S_HALF)
+                            T.copy(work_ub, acc_s_half)
+                            T.set_flag("V", "MTE3", SIG_S_HALF)
+
+                            # MTE3: acc_s_half → workspace_2 (GM)
+                            T.wait_flag("V", "MTE3", SIG_S_HALF)
+                            T.copy(acc_s_half, workspace_2[cid, i, vid * half_M : vid * half_M + half_M, :])
+                            T.set_flag("MTE3", "V", SIG_S_HALF)
+                            if (i + 1) % cross_interval == 0 or i == batch_iters - 1:
+                                T.set_cross_flag("MTE3", SEM_WS2_V2C)
+
+                            # sumexp_i and r_factor (V unit, reads work_ub)
+                            T.reduce_sum(work_ub, sumexp_is[i, :, :], dim=-1)
+                            T.tile.sub(r_factors[i, :, :], neg_sm[cur, :, :], neg_sm[prv, :, :])
+
+                        T.set_cross_flag("MTE2", SEM_WS1_V2C)
+
+                        # --- O accumulation batch (reference pattern) ---
+                        for i in T.serial(batch_iters):
+                            # Rescale acc_o with r_factor
+                            T.tile.exp(r_factors[i, :, :], r_factors[i, :, :])
+                            T.tile.mul(sumexp, sumexp, r_factors[i, :, :])
+                            T.tile.add(sumexp, sumexp, sumexp_is[i, :, :])
+                            T.tile.broadcast(broadcast_buf, r_factors[i, :, :])
+                            T.tile.mul(acc_o, acc_o, broadcast_buf)
+
+                            # Step 1: MTE2 loads O from workspace_3 → io_buf_o
+                            T.wait_flag("V", "MTE2", SIG_IO_UB)
+                            if i % cross_interval == 0:
+                                T.wait_cross_flag(SEM_WS3_C2V)
+                            T.copy(workspace_3[cid, i, vid * half_M : vid * half_M + half_M, :], io_buf_o)
+                            T.set_flag("MTE2", "V", SIG_IO_UB)
+
+                            # Step 2: V copies io_buf_o → acc_o_ub (fp16→fp32)
+                            T.wait_flag("MTE2", "V", SIG_IO_UB)
+                            T.copy(io_buf_o, acc_o_ub)
+                            T.set_flag("V", "MTE2", SIG_IO_UB)
+
+                            T.tile.add(acc_o, acc_o, acc_o_ub)
+
+                        T.set_cross_flag("MTE2", SEM_WS3_V2C)
+
+                    # Final normalization: acc_o /= sumexp
+                    T.tile.broadcast(broadcast_buf, sumexp)
+                    T.tile.div(acc_o, acc_o, broadcast_buf)
+
+                    # Write output (fp32 → fp16 → GM)
+                    T.copy(acc_o, acc_o_half)
+                    T.barrier_all()
+                    T.copy(acc_o_half, Output[bz, by, bx * block_M + vid * half_M : bx * block_M + vid * half_M + half_M, :])
+
+                    # LSE = ln(sumexp) - neg_sm[0]
+                    # neg_sm[0] = -sm_scale * global_max after min merge
+                    T.tile.min(neg_sm[0, :, :], neg_sm[0, :, :], neg_sm[1, :, :])
+                    T.tile.ln(lse_buf, sumexp)
+                    T.tile.sub(lse_buf, lse_buf, neg_sm[0, :, :])
+                    T.barrier_all()
+                    T.copy(lse_buf, lse[bz, by, bx * block_M + vid * half_M : bx * block_M + vid * half_M + half_M])
+                    T.barrier_all()
+
+                # Destroy: consume outstanding init-direction flags
+                T.wait_flag("V", "MTE2", SIG_IO_UB)
+                T.wait_flag("MTE3", "V", SIG_S_HALF)
+
+    return main
+
+
+# ============================================================================
+# Backward Preprocess — Delta = sum(O * dO, dim=-1)
+# ============================================================================
+
+
+@tilelang.jit(out_idx=[2], pass_configs=_expert_pass_configs)
+def flashattn_bwd_preprocess(batch, heads, seq_len, dim_v, blk=32):
+    dtype = "float16"
+    accum_dtype = "float"
+    shape = [batch, heads, seq_len, dim_v]
+    block_num = heads * (seq_len // blk) * batch
+
+    @T.prim_func
+    def main(
+        O: T.Tensor(shape, dtype),
+        dO: T.Tensor(shape, dtype),
+        Delta: T.Tensor([batch, heads, seq_len], accum_dtype),
+    ):
+        with T.Kernel(block_num, is_npu=True) as (cid, vid):
+            by = cid % (seq_len // blk)
+            bx = cid // (seq_len // blk) % heads
+            bz = cid // (seq_len // blk) // heads % batch
+
+            o_ub = T.alloc_ub([blk // 2, dim_v], dtype)
+            do_ub = T.alloc_ub([blk // 2, dim_v], dtype)
+            sum_ub = T.alloc_ub([blk // 2, dim_v], accum_dtype)
+            prod_ub = T.alloc_ub([blk // 2, dim_v], accum_dtype)
+            do_fp32 = T.alloc_ub([blk // 2, dim_v], accum_dtype)
+            delta_ub = T.alloc_ub([blk // 2], accum_dtype)
+
+            T.annotate_address(
+                {
+                    o_ub: 0,
+                    do_ub: blk // 2 * dim_v * DataType(dtype).bits // 8,
+                    sum_ub: blk // 2 * dim_v * 2 * DataType(dtype).bits // 8,
+                    prod_ub: blk // 2 * dim_v * 2 * DataType(dtype).bits // 8 + blk // 2 * dim_v * DataType(accum_dtype).bits // 8,
+                    do_fp32: blk // 2 * dim_v * 2 * DataType(dtype).bits // 8 + 2 * blk // 2 * dim_v * DataType(accum_dtype).bits // 8,
+                    delta_ub: blk // 2 * dim_v * 2 * DataType(dtype).bits // 8 + 3 * blk // 2 * dim_v * DataType(accum_dtype).bits // 8,
+                }
+            )
+
+            with T.Scope("V"):
+                T.tile.fill(sum_ub, 0.0)
+                T.barrier_all()
+                for _k in T.serial(T.ceildiv(dim_v, dim_v)):
+                    T.copy(O[bz, bx, by * blk + vid * blk // 2 : by * blk + vid * blk // 2 + blk // 2, :], o_ub)
+                    T.copy(dO[bz, bx, by * blk + vid * blk // 2 : by * blk + vid * blk // 2 + blk // 2, :], do_ub)
+                    T.barrier_all()
+                    T.copy(o_ub, prod_ub)
+                    T.copy(do_ub, do_fp32)
+                    T.barrier_all()
+                    T.tile.mul(prod_ub, prod_ub, do_fp32)
+                    T.barrier_all()
+                    T.tile.add(sum_ub, sum_ub, prod_ub)
+                    T.barrier_all()
+                T.reduce_sum(sum_ub, delta_ub, dim=-1)
+                T.barrier_all()
+                T.copy(delta_ub, Delta[bz, bx, by * blk + vid * blk // 2 : by * blk + vid * blk // 2 + blk // 2])
+                T.barrier_all()
+
+    return main
+
+
+# ============================================================================
+# Backward Postprocess — dQ fp32 -> fp16
+# ============================================================================
+
+
+@tilelang.jit(out_idx=[1], pass_configs=_expert_pass_configs)
+def flashattn_bwd_postprocess(batch, heads, seq_len, dim_qk, blk=64):
+    dtype = "float16"
+    accum_dtype = "float"
+    shape = [batch, heads, seq_len, dim_qk]
+    block_num = (seq_len // blk) * heads * batch
+
+    @T.prim_func
+    def main(
+        dQ: T.Tensor(shape, accum_dtype),
+        dQ_out: T.Tensor(shape, dtype),
+    ):
+        with T.Kernel(block_num, is_npu=True) as (cid, vid):
+            bx = cid % (seq_len // blk)
+            by = cid // (seq_len // blk) % heads
+            bz = cid // (seq_len // blk) // heads % batch
+
+            dq_ub = T.alloc_ub([blk // 2, dim_qk], accum_dtype)
+            dq_half = T.alloc_ub([blk // 2, dim_qk], dtype)
+
+            T.annotate_address(
+                {
+                    dq_ub: 0,
+                    dq_half: blk // 2 * dim_qk * DataType(accum_dtype).bits // 8,
+                }
+            )
+
+            with T.Scope("V"):
+                T.copy(dQ[bz, by, bx * blk + vid * blk // 2 : bx * blk + vid * blk // 2 + blk // 2, :], dq_ub)
+                T.barrier_all()
+                T.copy(dq_ub, dq_half)
+                T.barrier_all()
+                T.copy(dq_half, dQ_out[bz, by, bx * blk + vid * blk // 2 : bx * blk + vid * blk // 2 + blk // 2, :])
+                T.barrier_all()
+
+    return main
+
+
+# ============================================================================
+# Backward Pipeline: fine-grained set_flag/wait_flag sync in C scope
+# ============================================================================
+
+
+@tilelang.jit(pass_configs=_expert_pass_configs)
+def flashattn_bwd_pipeline(
+    batch,
+    heads,
+    seq_len,
+    dim_qk,
+    dim_v,
+    is_causal,
+    block_M,
+    block_N,
+    groups=1,
+    num_stages=8,
+):
+    """Backward kernel with fine-grained pipeline sync in C scope.
+
+    Replaces barrier_all() with set_flag/wait_flag within C scope phases
+    to overlap MTE2 (GM->L1 data loading), M (MMA compute via gemm_v0),
+    and FIX (L0C->GM result writing).
+
+    Phase structure per batch:
+      Phase 1 (C): GEMM1 for all iters -> ws_s_dp[cid, i, :, :]
+      Phase 2 (V): softmax for all iters -> ws_p_ds[cid, i, :, :]
+      Phase 3 (C): GEMM2+GEMM3 for all iters
+      Phase 4 (V): atomic_add dV, compute dS -> ws_p_ds[cid, i, :, :]
+      Phase 5 (C): GEMM4+GEMM5 for all iters
+
+    cross_flag: kept between phases for C-V synchronization.
+    set_flag/wait_flag: used within phases for C-internal pipeline overlap.
+    """
+    assert seq_len % block_M == 0, f"seq_len ({seq_len}) must be divisible by block_M ({block_M})"
+    assert seq_len % block_N == 0, f"seq_len ({seq_len}) must be divisible by block_N ({block_N})"
+    sm_scale = (1.0 / dim_qk) ** 0.5
+    head_kv = heads // groups
+    dtype = "float16"
+    accum_dtype = "float"
+    dim_qk_padded = ((dim_qk + 127) // 128) * 128
+
+    q_shape = [batch, heads, seq_len, dim_qk_padded]
+    k_shape = [batch, head_kv, seq_len, dim_qk_padded]
+    v_shape = [batch, head_kv, seq_len, dim_v]
+    do_shape = [batch, heads, seq_len, dim_v]
+    dq_shape_padded = [batch, heads, seq_len, dim_qk_padded]
+    dk_shape_padded = [batch, head_kv, seq_len, dim_qk_padded]
+    bwd_block_num = (seq_len // block_M) * heads * batch
+
+    num_iters = seq_len // block_N
+    eff_stages = num_stages if num_stages <= num_iters else num_iters
+    # Use ceildiv to ensure all iterations are processed
+    num_outer = (num_iters + eff_stages - 1) // eff_stages
+
+    @T.prim_func
+    def main(
+        Q: T.Tensor(q_shape, dtype),
+        K: T.Tensor(k_shape, dtype),
+        V: T.Tensor(v_shape, dtype),
+        dO: T.Tensor(do_shape, dtype),
+        lse: T.Tensor([batch, heads, seq_len], accum_dtype),
+        Delta: T.Tensor([batch, heads, seq_len], accum_dtype),
+        dQ: T.Tensor(dq_shape_padded, accum_dtype),
+        dK: T.Tensor(dk_shape_padded, accum_dtype),
+        dV: T.Tensor(v_shape, accum_dtype),
+        ws_s_dp: T.Tensor([bwd_block_num, num_stages, block_M, block_N], accum_dtype),
+        ws_p_ds: T.Tensor([bwd_block_num, num_stages, block_M, block_N], dtype),
+        ws_dv_dk: T.Tensor([bwd_block_num, num_stages, block_N, max(dim_qk_padded, dim_v)], accum_dtype),
+    ):
+        with T.Kernel(bwd_block_num, is_npu=True) as (cid, vid):
+            bx = cid % (seq_len // block_M)
+            by = cid // (seq_len // block_M) % heads
+            bz = cid // (seq_len // block_M) // heads % batch
+            kv_by = by // groups
+
+            q_l1 = T.alloc_L1([block_M, dim_qk_padded], dtype)
+            do_l1 = T.alloc_L1([block_M, dim_v], dtype)
+            k_l1 = T.alloc_L1([block_N, dim_qk_padded], dtype)
+            v_l1 = T.alloc_L1([block_N, dim_v], dtype)
+            mn_l1 = T.alloc_L1([block_M, block_N], dtype)
+            k5_l1 = T.alloc_L1([block_N, dim_qk_padded], dtype)
+
+            l0c_mn = T.alloc_L0C([block_M, block_N], accum_dtype)
+            l0c_nd_v = T.alloc_L0C([block_N, dim_v], accum_dtype)
+            l0c_nd_qk = T.alloc_L0C([block_N, dim_qk_padded], accum_dtype)
+            l0c_dq = T.alloc_L0C([block_M, dim_qk_padded], accum_dtype)
+
+            work_ub = T.alloc_ub([block_M // 2, block_N], accum_dtype)
+            dp_ub = T.alloc_ub([block_M // 2, block_N], accum_dtype)
+            p_half = T.alloc_ub([block_M // 2, block_N], dtype)
+            lse_ub = T.alloc_ub([block_M // 2], accum_dtype)
+            delta_ub = T.alloc_ub([block_M // 2], accum_dtype)
+            dv_tmp = T.alloc_ub([block_N // 2, max(dim_qk_padded, dim_v)], accum_dtype)
+            col_pos = T.alloc_ub([block_N], accum_dtype)
+            cmp_mask = T.alloc_ub([block_N], accum_dtype)
+
+            T.annotate_address(
+                {
+                    q_l1: 0,
+                    do_l1: block_M * dim_qk_padded * DataType(dtype).bits // 8,
+                    k_l1: (block_M * dim_qk_padded * DataType(dtype).bits // 8 + block_M * dim_v * DataType(dtype).bits // 8),
+                    v_l1: (
+                        block_M * dim_qk_padded * DataType(dtype).bits // 8
+                        + block_M * dim_v * DataType(dtype).bits // 8
+                        + block_N * dim_qk_padded * DataType(dtype).bits // 8
+                    ),
+                    mn_l1: (
+                        block_M * dim_qk_padded * DataType(dtype).bits // 8
+                        + block_M * dim_v * DataType(dtype).bits // 8
+                        + block_N * dim_qk_padded * DataType(dtype).bits // 8
+                        + block_N * dim_v * DataType(dtype).bits // 8
+                    ),
+                    k5_l1: (
+                        block_M * dim_qk_padded * DataType(dtype).bits // 8
+                        + block_M * dim_v * DataType(dtype).bits // 8
+                        + block_N * dim_qk_padded * DataType(dtype).bits // 8
+                        + block_N * dim_v * DataType(dtype).bits // 8
+                        + block_M * block_N * DataType(dtype).bits // 8
+                    ),
+                    l0c_mn: 0,
+                    l0c_nd_v: block_M * block_N * DataType(accum_dtype).bits // 8,
+                    l0c_nd_qk: block_M * block_N * DataType(accum_dtype).bits // 8,
+                    l0c_dq: (block_M * block_N + block_N * max(dim_v, dim_qk_padded)) * DataType(accum_dtype).bits // 8,
+                    work_ub: 0,
+                    dp_ub: block_M // 2 * block_N * DataType(accum_dtype).bits // 8,
+                    p_half: 2 * block_M // 2 * block_N * DataType(accum_dtype).bits // 8,
+                    lse_ub: (
+                        2 * block_M // 2 * block_N * DataType(accum_dtype).bits // 8 + block_M // 2 * block_N * DataType(dtype).bits // 8
+                    ),
+                    delta_ub: (
+                        2 * block_M // 2 * block_N * DataType(accum_dtype).bits // 8
+                        + block_M // 2 * block_N * DataType(dtype).bits // 8
+                        + block_M // 2 * DataType(accum_dtype).bits // 8
+                    ),
+                    dv_tmp: (
+                        2 * block_M // 2 * block_N * DataType(accum_dtype).bits // 8
+                        + block_M // 2 * block_N * DataType(dtype).bits // 8
+                        + 2 * block_M // 2 * DataType(accum_dtype).bits // 8
+                    ),
+                    col_pos: (
+                        2 * block_M // 2 * block_N * DataType(accum_dtype).bits // 8
+                        + block_M // 2 * block_N * DataType(dtype).bits // 8
+                        + 2 * block_M // 2 * DataType(accum_dtype).bits // 8
+                        + block_N // 2 * max(dim_qk_padded, dim_v) * DataType(accum_dtype).bits // 8
+                    ),
+                    cmp_mask: (
+                        2 * block_M // 2 * block_N * DataType(accum_dtype).bits // 8
+                        + block_M // 2 * block_N * DataType(dtype).bits // 8
+                        + 2 * block_M // 2 * DataType(accum_dtype).bits // 8
+                        + block_N // 2 * max(dim_qk_padded, dim_v) * DataType(accum_dtype).bits // 8
+                        + block_N * DataType(accum_dtype).bits // 8
+                    ),
+                }
+            )
+
+            with T.Scope("C"):
+                T.copy(Q[bz, by, bx * block_M : (bx + 1) * block_M, :], q_l1)
+                T.copy(dO[bz, by, bx * block_M : (bx + 1) * block_M, :], do_l1)
+                T.barrier_all()
+
+                T.set_flag("M", "MTE2", _SIG_K)
+                T.set_flag("M", "MTE2", _SIG_MN)
+                T.set_flag("M", "MTE2", _SIG_V)
+                T.set_flag("M", "MTE2", _SIG_K5)
+                T.set_flag("FIX", "M", _SIG_L0C_MN)
+                T.set_flag("FIX", "M", _SIG_L0C_ND)
+
+                for k_outer in range(num_outer):
+                    batch_iters = eff_stages
+
+                    for i in range(batch_iters):
+                        idx = k_outer * num_stages + i
+
+                        T.wait_flag("M", "MTE2", _SIG_K)
+                        T.copy(K[bz, kv_by, idx * block_N : (idx + 1) * block_N, :], k_l1)
+                        T.set_flag("MTE2", "M", _SIG_K)
+
+                        T.wait_flag("MTE2", "M", _SIG_K)
+                        T.wait_flag("FIX", "M", _SIG_L0C_MN)
+                        T.gemm_v0(q_l1, k_l1, l0c_mn, transpose_B=True, init=True)
+                        T.set_flag("M", "FIX", _SIG_L0C_MN)
+                        T.set_flag("M", "MTE2", _SIG_K)
+
+                        T.wait_flag("M", "FIX", _SIG_L0C_MN)
+                        T.copy(l0c_mn, ws_s_dp[cid, i, :, :])
+                        T.set_flag("FIX", "M", _SIG_L0C_MN)
+
+                    T.set_cross_flag("FIX", 0)
+
+                    for i in range(batch_iters):
+                        idx = k_outer * num_stages + i
+
+                        T.wait_cross_flag(1)
+                        T.barrier_all()
+
+                        T.wait_flag("M", "MTE2", _SIG_MN)
+                        T.copy(ws_p_ds[cid, i, :, :], mn_l1)
+                        T.set_flag("MTE2", "M", _SIG_MN)
+
+                        T.wait_flag("MTE2", "M", _SIG_MN)
+                        T.wait_flag("FIX", "M", _SIG_L0C_ND)
+                        T.gemm_v0(mn_l1, do_l1, l0c_nd_v, transpose_A=True, init=True)
+                        T.set_flag("M", "FIX", _SIG_L0C_ND)
+                        T.set_flag("M", "MTE2", _SIG_MN)
+
+                        T.wait_flag("M", "FIX", _SIG_L0C_ND)
+                        T.copy(l0c_nd_v, ws_dv_dk[cid, i, :, :])
+                        T.set_flag("FIX", "M", _SIG_L0C_ND)
+
+                        T.wait_flag("M", "MTE2", _SIG_V)
+                        T.copy(V[bz, kv_by, idx * block_N : (idx + 1) * block_N, :], v_l1)
+                        T.set_flag("MTE2", "M", _SIG_V)
+
+                        T.wait_flag("MTE2", "M", _SIG_V)
+                        T.wait_flag("FIX", "M", _SIG_L0C_MN)
+                        T.gemm_v0(do_l1, v_l1, l0c_mn, transpose_B=True, init=True)
+                        T.set_flag("M", "FIX", _SIG_L0C_MN)
+                        T.set_flag("M", "MTE2", _SIG_V)
+
+                        T.wait_flag("M", "FIX", _SIG_L0C_MN)
+                        T.copy(l0c_mn, ws_s_dp[cid, i, :, :])
+                        T.set_flag("FIX", "M", _SIG_L0C_MN)
+
+                    T.set_cross_flag("FIX", 2)
+
+                    for i in range(batch_iters):
+                        idx = k_outer * num_stages + i
+
+                        T.wait_cross_flag(3)
+                        T.barrier_all()
+
+                        T.wait_flag("M", "MTE2", _SIG_MN)
+                        T.copy(ws_p_ds[cid, i, :, :], mn_l1)
+                        T.set_flag("MTE2", "M", _SIG_MN)
+
+                        T.wait_flag("MTE2", "M", _SIG_MN)
+                        T.wait_flag("FIX", "M", _SIG_L0C_ND)
+                        T.gemm_v0(mn_l1, q_l1, l0c_nd_qk, transpose_A=True, init=True)
+                        T.set_flag("M", "FIX", _SIG_L0C_ND)
+
+                        T.wait_flag("M", "FIX", _SIG_L0C_ND)
+                        T.copy(l0c_nd_qk, ws_dv_dk[cid, i, :, :])
+                        T.set_flag("FIX", "M", _SIG_L0C_ND)
+
+                        T.set_cross_flag("FIX", 4)
+                        T.barrier_all()
+
+                        T.wait_flag("M", "MTE2", _SIG_K5)
+                        T.copy(K[bz, kv_by, idx * block_N : (idx + 1) * block_N, :], k5_l1)
+                        T.set_flag("MTE2", "M", _SIG_K5)
+
+                        T.wait_flag("MTE2", "M", _SIG_K5)
+                        if k_outer == 0 and i == 0:
+                            T.gemm_v0(mn_l1, k5_l1, l0c_dq, init=True)
+                        else:
+                            T.gemm_v0(mn_l1, k5_l1, l0c_dq, init=False)
+                        T.set_flag("M", "MTE2", _SIG_MN)
+                        T.set_flag("M", "MTE2", _SIG_K5)
+
+                T.barrier_all()
+                T.copy(l0c_dq, dQ[bz, by, bx * block_M : (bx + 1) * block_M, :])
+                T.barrier_all()
+
+                T.wait_flag("M", "MTE2", _SIG_K)
+                T.wait_flag("M", "MTE2", _SIG_MN)
+                T.wait_flag("M", "MTE2", _SIG_V)
+                T.wait_flag("M", "MTE2", _SIG_K5)
+                T.wait_flag("FIX", "M", _SIG_L0C_MN)
+                T.wait_flag("FIX", "M", _SIG_L0C_ND)
+
+            with T.Scope("V"):
+                for _k_outer in range(num_outer):
+                    batch_iters = eff_stages
+
+                    T.wait_cross_flag(0)
+                    T.barrier_all()
+
+                    for i in range(batch_iters):
+                        idx = _k_outer * num_stages + i
+
+                        T.copy(ws_s_dp[cid, i, vid * block_M // 2 : vid * block_M // 2 + block_M // 2, :], work_ub)
+                        T.barrier_all()
+
+                        T.tile.mul(work_ub, work_ub, sm_scale)
+
+                        T.copy(lse[bz, by, bx * block_M + vid * block_M // 2 : bx * block_M + vid * block_M // 2 + block_M // 2], lse_ub)
+                        T.barrier_all()
+                        for h_i in range(block_M // 2):
+                            T.tile.sub(work_ub[h_i, :], work_ub[h_i, :], lse_ub[h_i])
+                        T.tile.exp(work_ub, work_ub)
+
+                        if is_causal and block_N >= 64:
+                            T.tile.arith_progression(col_pos, idx * block_N, 1, block_N)
+                            for h_i in range(block_M // 2):
+                                row_pos_val = (bx * block_M + vid * block_M // 2 + h_i) * 1.0
+                                T.tile.compare(cmp_mask, col_pos, row_pos_val, "LE")
+                                T.tile.select(work_ub[h_i, :], cmp_mask, work_ub[h_i, :], 0.0, "VSEL_TENSOR_SCALAR_MODE")
+
+                        T.copy(work_ub, p_half)
+                        T.barrier_all()
+                        T.copy(p_half, ws_p_ds[cid, i, vid * block_M // 2 : vid * block_M // 2 + block_M // 2, :])
+                        T.barrier_all()
+                        T.set_cross_flag("MTE3", 1)
+
+                    T.wait_cross_flag(2)
+                    T.barrier_all()
+
+                    for i in range(batch_iters):
+                        idx = _k_outer * num_stages + i
+
+                        T.copy(ws_dv_dk[cid, i, vid * block_N // 2 : vid * block_N // 2 + block_N // 2, :dim_v], dv_tmp)
+                        T.barrier_all()
+                        T.tile.atomic_add(
+                            dV[bz, kv_by, idx * block_N + vid * block_N // 2 : idx * block_N + vid * block_N // 2 + block_N // 2, :], dv_tmp
+                        )
+
+                        T.copy(ws_s_dp[cid, i, vid * block_M // 2 : vid * block_M // 2 + block_M // 2, :], dp_ub)
+                        T.barrier_all()
+
+                        T.copy(ws_p_ds[cid, i, vid * block_M // 2 : vid * block_M // 2 + block_M // 2, :], p_half)
+                        T.barrier_all()
+                        T.copy(p_half, work_ub)
+
+                        T.copy(
+                            Delta[bz, by, bx * block_M + vid * block_M // 2 : bx * block_M + vid * block_M // 2 + block_M // 2], delta_ub
+                        )
+                        T.barrier_all()
+
+                        for h_i in range(block_M // 2):
+                            T.tile.sub(dp_ub[h_i, :], dp_ub[h_i, :], delta_ub[h_i])
+                        T.tile.mul(work_ub, work_ub, dp_ub)
+                        T.tile.mul(work_ub, work_ub, sm_scale)
+
+                        T.copy(work_ub, p_half)
+                        T.barrier_all()
+                        T.copy(p_half, ws_p_ds[cid, i, vid * block_M // 2 : vid * block_M // 2 + block_M // 2, :])
+                        T.barrier_all()
+                        T.set_cross_flag("V", 3)
+
+                    for i in range(batch_iters):
+                        idx = _k_outer * num_stages + i
+                        T.wait_cross_flag(4)
+                        T.barrier_all()
+                        T.copy(ws_dv_dk[cid, i, vid * block_N // 2 : vid * block_N // 2 + block_N // 2, :dim_qk_padded], dv_tmp)
+                        T.barrier_all()
+                        T.tile.atomic_add(
+                            dK[bz, kv_by, idx * block_N + vid * block_N // 2 : idx * block_N + vid * block_N // 2 + block_N // 2, :], dv_tmp
+                        )
+                        T.barrier_all()
+
+    return main
+
+
+# ============================================================================
+# Golden Reference
+# ============================================================================
+
+
+def ref_program(Q, K, V, is_causal, groups=1):
+    Q_f = Q.float()
+    K_f = K.float().repeat_interleave(groups, dim=1) if groups > 1 else K.float()
+    V_f = V.float().repeat_interleave(groups, dim=1) if groups > 1 else V.float()
+    dim_qk = Q_f.shape[-1]
+    scale = 1.0 / (dim_qk**0.5)
+    scores = torch.matmul(Q_f, K_f.transpose(-2, -1)) * scale
+    if is_causal:
+        N = Q.shape[2]
+        mask = torch.tril(torch.ones(N, N, device=scores.device, dtype=torch.bool))
+        scores = scores.masked_fill(~mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+    P = F.softmax(scores, dim=-1)
+    O = torch.matmul(P, V_f)
+    return O.half()
+
+
+def ref_bwd(Q, K, V, dO, is_causal, groups=1):
+    Q_f = Q.float().requires_grad_(True)
+    K_f = K.float().requires_grad_(True)
+    V_f = V.float().requires_grad_(True)
+    K_rep = K_f.repeat_interleave(groups, dim=1) if groups > 1 else K_f
+    V_rep = V_f.repeat_interleave(groups, dim=1) if groups > 1 else V_f
+    dim_qk = Q_f.shape[-1]
+    scale = 1.0 / (dim_qk**0.5)
+    scores = torch.matmul(Q_f, K_rep.transpose(-2, -1)) * scale
+    if is_causal:
+        N = Q.shape[2]
+        mask = torch.tril(torch.ones(N, N, device=scores.device, dtype=torch.bool))
+        scores = scores.masked_fill(~mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+    P = F.softmax(scores, dim=-1)
+    O = torch.matmul(P, V_rep)
+    O.backward(dO.float())
+    return Q_f.grad.half(), K_f.grad.half(), V_f.grad.half()
+
+
+# ============================================================================
+# Autograd Function (BSHD <-> BHSD layout conversion)
+# ============================================================================
+
+
+class _attention(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, q, k, v, causal, groups=1):
+        B, N, H, D_qk = q.shape
+        D_v = v.shape[-1]
+        q_bhsd = q.permute(0, 2, 1, 3).contiguous()
+        k_bhsd = k.permute(0, 2, 1, 3).contiguous()
+        v_bhsd = v.permute(0, 2, 1, 3).contiguous()
+
+        block_M = 64
+        mod = flashattn_fwd(B, H, N, D_qk, D_v, causal, block_M, block_M, groups)
+        o_bhsd, lse = mod(q_bhsd, k_bhsd, v_bhsd)
+
+        o = o_bhsd.permute(0, 2, 1, 3).contiguous()
+
+        ctx.save_for_backward(q_bhsd, k_bhsd, v_bhsd, o_bhsd, lse)
+        ctx.causal = causal
+        ctx.groups = groups
+        return o
+
+    @staticmethod
+    def backward(ctx, do):
+        q, k, v, o, lse = ctx.saved_tensors
+        B, H, N, D_qk = q.shape
+        D_v = v.shape[-1]
+        H_kv = k.shape[1]
+        groups = ctx.groups
+
+        do_bhsd = do.permute(0, 2, 1, 3).contiguous()
+
+        prep_mod = flashattn_bwd_preprocess(B, H, N, D_v, blk=32)
+        delta = prep_mod(o, do_bhsd)
+
+        block_M, block_N = 64, 32
+        if ctx.causal:
+            block_N = 64
+
+        dim_qk_padded = ((D_qk + 127) // 128) * 128
+        num_stages = 8
+
+        dQ = torch.zeros(B, H, N, dim_qk_padded, dtype=torch.float32, device="npu")
+        dK = torch.zeros(B, H_kv, N, dim_qk_padded, dtype=torch.float32, device="npu")
+        dV = torch.zeros(B, H_kv, N, D_v, dtype=torch.float32, device="npu")
+
+        Q_padded = torch.zeros(B, H, N, dim_qk_padded, dtype=torch.float16, device="npu")
+        Q_padded[:, :, :, :D_qk] = q
+        K_padded = torch.zeros(B, H_kv, N, dim_qk_padded, dtype=torch.float16, device="npu")
+        K_padded[:, :, :, :D_qk] = k
+
+        bwd_block_num = (N // block_M) * H * B
+        ws_s_dp = torch.empty(bwd_block_num, num_stages, block_M, block_N, dtype=torch.float32, device="npu")
+        ws_p_ds = torch.empty(bwd_block_num, num_stages, block_M, block_N, dtype=torch.float16, device="npu")
+        ws_dv_dk = torch.empty(bwd_block_num, num_stages, block_N, max(dim_qk_padded, D_v), dtype=torch.float32, device="npu")
+
+        kernel = flashattn_bwd_pipeline(B, H, N, D_qk, D_v, ctx.causal, block_M, block_N, groups, num_stages)
+        kernel(Q_padded, K_padded, v, do_bhsd, lse, delta, dQ, dK, dV, ws_s_dp, ws_p_ds, ws_dv_dk)
+
+        dQ = dQ[:, :, :, :D_qk].half()
+        dK = dK[:, :, :, :D_qk].half()
+        dV = dV.half()
+
+        dQ = dQ.permute(0, 2, 1, 3).contiguous()
+        dK = dK.permute(0, 2, 1, 3).contiguous()
+        dV = dV.permute(0, 2, 1, 3).contiguous()
+
+        return dQ, dK, dV, None, None
+
+
+attention = _attention.apply
+
+
+# ===========================================================================
+# __main__: minimal L0 smoke test (CI bench_test.sh runs this directly).
+# stdout must contain "Test Passed!" for CI to mark the script PASSED.
+# Matches L0 "FWD-GQA-causal + BWD-GQA-causal" minimal config:
+#   B=1, H=2, H_kv=1, N=128, D_qk=D_v=64, groups=2, causal=True.
+# ===========================================================================
+
+
+if __name__ == "__main__":
+    tilelang.disable_cache()
+    torch.set_default_device("npu")
+    torch.manual_seed(42)
+
+    # Minimal L0 config (causal GQA, D_qk=D_v=64)
+    B, H, N, D_qk, D_v, groups = 1, 2, 128, 64, 64, 2
+    H_kv = H // groups
+    causal = True
+    atol = 1e-2
+
+    Q = torch.randn(B, H, N, D_qk, dtype=torch.float16, device="npu")
+    K = torch.randn(B, H_kv, N, D_qk, dtype=torch.float16, device="npu")
+    V = torch.randn(B, H_kv, N, D_v, dtype=torch.float16, device="npu")
+    dO = torch.randn(B, H, N, D_v, dtype=torch.float16, device="npu")
+
+    # --- Forward smoke test (flashattn_fwd v1, causal) ---
+    bM, bN = 64, 64
+    fwd_mod = flashattn_fwd(B, H, N, D_qk, D_v, causal, bM, bN, groups)
+    O_npu, lse_npu = fwd_mod(Q, K, V)
+    torch.npu.synchronize()
+
+    O_ref = ref_program(Q, K, V, causal, groups)
+    fwd_max_diff = (O_npu.float() - O_ref.float()).abs().max().item()
+    assert fwd_max_diff < atol, f"Forward precision check failed: max_diff={fwd_max_diff} >= atol={atol}"
+
+    # --- Backward smoke test (flashattn_bwd_pipeline, causal) ---
+    prep_mod = flashattn_bwd_preprocess(B, H, N, D_v, blk=32)
+    Delta_npu = prep_mod(O_npu, dO)
+    torch.npu.synchronize()
+
+    D_qk_padded = ((D_qk + 127) // 128) * 128
+    num_stages = 8
+    dQ = torch.zeros(B, H, N, D_qk_padded, dtype=torch.float32, device="npu")
+    dK = torch.zeros(B, H_kv, N, D_qk_padded, dtype=torch.float32, device="npu")
+    dV = torch.zeros(B, H_kv, N, D_v, dtype=torch.float32, device="npu")
+
+    Q_padded = torch.zeros(B, H, N, D_qk_padded, dtype=torch.float16, device="npu")
+    Q_padded[:, :, :, :D_qk] = Q
+    K_padded = torch.zeros(B, H_kv, N, D_qk_padded, dtype=torch.float16, device="npu")
+    K_padded[:, :, :, :D_qk] = K
+
+    bwd_block_num = (N // bM) * H * B
+    ws_s_dp = torch.empty(bwd_block_num, num_stages, bM, bN, dtype=torch.float32, device="npu")
+    ws_p_ds = torch.empty(bwd_block_num, num_stages, bM, bN, dtype=torch.float16, device="npu")
+    ws_dv_dk = torch.empty(bwd_block_num, num_stages, bN, max(D_qk_padded, D_v), dtype=torch.float32, device="npu")
+
+    bwd_mod = flashattn_bwd_pipeline(B, H, N, D_qk, D_v, causal, bM, bN, groups, num_stages)
+    bwd_mod(Q_padded, K_padded, V, dO, lse_npu, Delta_npu, dQ, dK, dV, ws_s_dp, ws_p_ds, ws_dv_dk)
+    torch.npu.synchronize()
+
+    dQ_ref, dK_ref, dV_ref = ref_bwd(Q, K, V, dO, causal, groups)
+    bwd_max_diff = max(
+        (dV.half().float() - dV_ref.float()).abs().max().item(),
+        (dK[:, :, :, :D_qk].half().float() - dK_ref.float()).abs().max().item(),
+        (dQ[:, :, :, :D_qk].half().float() - dQ_ref.float()).abs().max().item(),
+    )
+    assert bwd_max_diff < atol, f"Backward precision check failed: max_diff={bwd_max_diff} >= atol={atol}"
+
+    print(f"max_diff: fwd={fwd_max_diff:.6e} bwd={bwd_max_diff:.6e}")
+    print("Test Passed!")

--- a/examples_experiment/example_gqa_bwd/perf_example_gqa_bwd.py
+++ b/examples_experiment/example_gqa_bwd/perf_example_gqa_bwd.py
@@ -1,0 +1,260 @@
+"""
+Performance benchmark for GQA Flash Attention (github version).
+
+Tests:
+  1. TileLang Forward v1 (flashattn_fwd)
+  2. TileLang Forward v4 (flashattn_fwd_v4, L0 double buffer)
+  3. TileLang Backward pipeline (flashattn_bwd_pipeline)
+  4. PyTorch baseline (forward + backward)
+
+Usage:
+  python perf_example_gqa_bwd.py
+  python perf_example_gqa_bwd.py --causal
+  python perf_example_gqa_bwd.py --batch 4 --n_ctx 2048
+"""
+
+import sys
+import os
+import time
+import argparse
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import tilelang
+import torch
+import torch.nn.functional as F
+
+from example_gqa_bwd import (
+    flashattn_fwd,
+    flashattn_fwd_v4,
+    flashattn_bwd_preprocess,
+    flashattn_bwd_pipeline,
+    ref_program,
+    ref_bwd,
+    NUM_CORES,
+)
+
+
+def _bench(fn, warmup=50, iters=200):
+    """Manual bench with explicit sync."""
+    for _ in range(warmup):
+        fn()
+    torch.npu.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    torch.npu.synchronize()
+    t1 = time.perf_counter()
+    return (t1 - t0) / iters * 1000  # ms
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch", type=int, default=8)
+    parser.add_argument("--h", type=int, default=32)
+    parser.add_argument("--n_ctx", type=int, default=1024)
+    parser.add_argument("--d_head_qk", type=int, default=192)
+    parser.add_argument("--d_head_v", type=int, default=128)
+    parser.add_argument("--groups", type=int, default=16)
+    parser.add_argument("--causal", action="store_true")
+    args = parser.parse_args()
+
+    tilelang.disable_cache()
+    torch.set_default_device("npu")
+    torch.manual_seed(42)
+
+    B = args.batch
+    H = args.h
+    N = args.n_ctx
+    D_qk = args.d_head_qk
+    D_v = args.d_head_v
+    groups = args.groups
+    causal = args.causal
+    H_kv = H // groups
+
+    # FLOPS calculation
+    fwd_flops = 2.0 * B * H * N * N * (D_qk + D_v)
+    bwd_flops = 2.0 * B * H * N * N * (3 * D_qk + 2 * D_v)
+    total_flops = fwd_flops + bwd_flops
+    if causal:
+        fwd_flops *= 0.5
+        bwd_flops *= 0.5
+        total_flops *= 0.5
+
+    # ---- Allocate tensors (BHSD layout) ----
+    Q = torch.randn(B, H, N, D_qk, dtype=torch.float16, device="npu")
+    K = torch.randn(B, H_kv, N, D_qk, dtype=torch.float16, device="npu")
+    V = torch.randn(B, H_kv, N, D_v, dtype=torch.float16, device="npu")
+    dO = torch.randn(B, H, N, D_v, dtype=torch.float16, device="npu")
+
+    print()
+    print("=" * 70)
+    print(f"  Config: B={B} H={H} H_kv={H_kv} N={N} D_qk={D_qk} D_v={D_v}")
+    print(f"          groups={groups} causal={causal} dtype=fp16")
+    print("=" * 70)
+
+    # ============================================================
+    # 0. Correctness check before bench (so we don't bench a broken kernel)
+    #    Forward v4 vs PyTorch golden + Backward pipeline vs PyTorch golden.
+    # ============================================================
+    atol = 1e-2
+    bM_v4, bN_v4 = 32, 64
+    num_stages_fwd = 8
+    cross_interval_fwd = 2
+    fwd_v4_mod = flashattn_fwd_v4(
+        B,
+        H,
+        N,
+        D_qk,
+        D_v,
+        causal,
+        bM_v4,
+        bN_v4,
+        groups,
+        num_stages_fwd,
+        cross_interval_fwd,
+    )
+    ws1_fwd = torch.empty(NUM_CORES, num_stages_fwd, bM_v4, bN_v4, dtype=torch.float32, device="npu")
+    ws2_fwd = torch.empty(NUM_CORES, num_stages_fwd, bM_v4, bN_v4, dtype=torch.float16, device="npu")
+    ws3_fwd = torch.empty(NUM_CORES, num_stages_fwd, bM_v4, D_v, dtype=torch.float32, device="npu")
+    O_npu, lse_npu = fwd_v4_mod(Q, K, V, ws1_fwd, ws2_fwd, ws3_fwd)
+    torch.npu.synchronize()
+
+    O_ref = ref_program(Q, K, V, causal, groups)
+    fwd_max_diff = (O_npu.float() - O_ref.float()).abs().max().item()
+    print(f"  correctness: fwd_max_diff={fwd_max_diff:.6e} (atol={atol})")
+    if fwd_max_diff >= atol:
+        print(f"  [ERROR] forward correctness check failed: max_diff={fwd_max_diff} >= atol={atol}")
+        sys.exit(1)
+
+    # Backward correctness
+    prep_mod = flashattn_bwd_preprocess(B, H, N, D_v, blk=32)
+    Delta_npu = prep_mod(O_npu, dO)
+    torch.npu.synchronize()
+
+    D_qk_padded = ((D_qk + 127) // 128) * 128
+    bM_bwd, bN_bwd = 64, 64 if causal else 32
+    num_stages_bwd = 8
+    dQ_raw = torch.zeros(B, H, N, D_qk_padded, dtype=torch.float32, device="npu")
+    dK_raw = torch.zeros(B, H_kv, N, D_qk_padded, dtype=torch.float32, device="npu")
+    dV_raw = torch.zeros(B, H_kv, N, D_v, dtype=torch.float32, device="npu")
+    bwd_block_num = (N // bM_bwd) * H * B
+    ws1_bwd = torch.empty(bwd_block_num, num_stages_bwd, bM_bwd, bN_bwd, dtype=torch.float32, device="npu")
+    ws2_bwd = torch.empty(bwd_block_num, num_stages_bwd, bM_bwd, bN_bwd, dtype=torch.float16, device="npu")
+    ws3_bwd = torch.empty(bwd_block_num, num_stages_bwd, bN_bwd, max(D_qk_padded, D_v), dtype=torch.float32, device="npu")
+    bwd_mod = flashattn_bwd_pipeline(B, H, N, D_qk, D_v, causal, bM_bwd, bN_bwd, groups, num_stages_bwd)
+
+    Q_padded = torch.zeros(B, H, N, D_qk_padded, dtype=torch.float16, device="npu")
+    Q_padded[:, :, :, :D_qk] = Q
+    K_padded = torch.zeros(B, H_kv, N, D_qk_padded, dtype=torch.float16, device="npu")
+    K_padded[:, :, :, :D_qk] = K
+    bwd_mod(Q_padded, K_padded, V, dO, lse_npu, Delta_npu, dQ_raw, dK_raw, dV_raw, ws1_bwd, ws2_bwd, ws3_bwd)
+    torch.npu.synchronize()
+
+    dQ_ref, dK_ref, dV_ref = ref_bwd(Q, K, V, dO, causal, groups)
+    bwd_max_diff = max(
+        (dV_raw.half().float() - dV_ref.float()).abs().max().item(),
+        (dK_raw[:, :, :, :D_qk].half().float() - dK_ref.float()).abs().max().item(),
+        (dQ_raw[:, :, :, :D_qk].half().float() - dQ_ref.float()).abs().max().item(),
+    )
+    print(f"  correctness: bwd_max_diff={bwd_max_diff:.6e} (atol={atol})")
+    if bwd_max_diff >= atol:
+        print(f"  [ERROR] backward correctness check failed: max_diff={bwd_max_diff} >= atol={atol}")
+        sys.exit(1)
+    print(f"  correctness: PASS (fwd={fwd_max_diff:.6e}, bwd={bwd_max_diff:.6e})")
+
+    # ============================================================
+    # 1. TileLang Forward v1
+    #    Note: v1 has a known limitation — causal + D_qk_padded>128
+    #    causes L0C overflow (see 算子bug总结.md §3.1). Skip v1 in
+    #    that case and rely on v4.
+    # ============================================================
+    D_qk_padded_check = ((D_qk + 127) // 128) * 128
+    skip_v1 = causal and D_qk_padded_check > 128
+    if skip_v1:
+        lat_fwd_v1 = float("nan")
+        print(f"  [INFO] Skipping Forward v1 (causal + D_qk_padded={D_qk_padded_check} > 128, known limitation §3.1)")
+    else:
+        bM_v1, bN_v1 = 64, 64
+        fwd_v1_mod = flashattn_fwd(B, H, N, D_qk, D_v, causal, bM_v1, bN_v1, groups)
+        lat_fwd_v1 = _bench(lambda: fwd_v1_mod(Q, K, V))
+
+    # ============================================================
+    # 2. TileLang Forward v4 (L0 double buffer + batched softmax)
+    #    Reuse fwd_v4_mod and workspace from correctness check above.
+    # ============================================================
+    lat_fwd_v4 = _bench(lambda: fwd_v4_mod(Q, K, V, ws1_fwd, ws2_fwd, ws3_fwd))
+
+    # ============================================================
+    # 3. TileLang Backward (pipeline)
+    #    Reuse bwd_mod and workspace from correctness check above.
+    # ============================================================
+    def _run_bwd():
+        bwd_mod(Q_padded, K_padded, V, dO, lse_npu, Delta_npu, dQ_raw, dK_raw, dV_raw, ws1_bwd, ws2_bwd, ws3_bwd)
+
+    lat_bwd = _bench(_run_bwd)
+
+    # ============================================================
+    # 4. PyTorch baseline
+    # ============================================================
+    q_r = Q.float()
+    k_r = K.float().repeat_interleave(groups, dim=1)
+    v_r = V.float().repeat_interleave(groups, dim=1)
+
+    def _run_ref_fwd():
+        scores = torch.matmul(q_r, k_r.transpose(-2, -1)) * (1.0 / D_qk**0.5)
+        if causal:
+            mask = torch.tril(torch.ones(N, N, device=scores.device, dtype=torch.bool))
+            scores = scores.masked_fill(~mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+        P = F.softmax(scores, dim=-1)
+        torch.matmul(P, v_r)
+
+    lat_ref_fwd = _bench(_run_ref_fwd)
+
+    def _run_ref_fwd_bwd():
+        q2 = Q.float().requires_grad_(True)
+        k2 = K.float().repeat_interleave(groups, dim=1).requires_grad_(True)
+        v2 = V.float().repeat_interleave(groups, dim=1).requires_grad_(True)
+        scores = torch.matmul(q2, k2.transpose(-2, -1)) * (1.0 / D_qk**0.5)
+        if causal:
+            mask = torch.tril(torch.ones(N, N, device=scores.device, dtype=torch.bool))
+            scores = scores.masked_fill(~mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+        P = F.softmax(scores, dim=-1)
+        O2 = torch.matmul(P, v2)
+        O2.backward(dO.float())
+
+    lat_ref_e2e = _bench(_run_ref_fwd_bwd, warmup=20, iters=50)
+
+    # ============================================================
+    # Print results
+    # ============================================================
+    print()
+    print(f"  {'Kernel':<32} {'Latency':>10} {'TFlops':>10}")
+    print(f"  {'-' * 55}")
+    if skip_v1:
+        print(f"  {'TileLang Forward v1':<32} {'SKIPPED':>10}         -")
+    else:
+        print(f"  {'TileLang Forward v1':<32} {lat_fwd_v1:>8.2f} ms  {fwd_flops / lat_fwd_v1 * 1e-9:>8.2f}")
+    print(f"  {'TileLang Forward v4':<32} {lat_fwd_v4:>8.2f} ms  {fwd_flops / lat_fwd_v4 * 1e-9:>8.2f}")
+    print(f"  {'TileLang Backward (pipeline)':<32} {lat_bwd:>8.2f} ms  {bwd_flops / lat_bwd * 1e-9:>8.2f}")
+    print(f"  {'TileLang Fwd(v4)+Bwd (raw)':<32} {lat_fwd_v4 + lat_bwd:>8.2f} ms  {total_flops / (lat_fwd_v4 + lat_bwd) * 1e-9:>8.2f}")
+    print(f"  {'-' * 55}")
+    print(f"  {'PyTorch Forward only':<32} {lat_ref_fwd:>8.2f} ms  {fwd_flops / lat_ref_fwd * 1e-9:>8.2f}")
+    print(f"  {'PyTorch Fwd+Bwd (e2e)':<32} {lat_ref_e2e:>8.2f} ms  {total_flops / lat_ref_e2e * 1e-9:>8.2f}")
+    print(f"  {'-' * 55}")
+    sp_fwd_v4 = lat_ref_fwd / lat_fwd_v4
+    sp_e2e_v4 = lat_ref_e2e / (lat_fwd_v4 + lat_bwd)
+    print(f"  Speedup (v4 forward vs PyTorch fwd):  {sp_fwd_v4:.2f}x")
+    print(f"  Speedup (v4 fwd+bwd vs PyTorch e2e):  {sp_e2e_v4:.2f}x")
+    if not skip_v1:
+        print(f"  v4 vs v1 forward speedup:             {lat_fwd_v1 / lat_fwd_v4:.2f}x")
+    print("=" * 70)
+
+    # CI compatibility: bench_test.sh marks a script PASSED only if stdout
+    # contains "Test Passed!" / "Kernel Output Match!". Correctness was
+    # already verified above (fwd_max_diff < atol and bwd_max_diff < atol).
+    print("Test Passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples_experiment/example_gqa_bwd/perf_example_gqa_bwd.py
+++ b/examples_experiment/example_gqa_bwd/perf_example_gqa_bwd.py
@@ -15,7 +15,6 @@ Usage:
 
 import sys
 import os
-import time
 import argparse
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -23,8 +22,9 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import tilelang
 import torch
 import torch.nn.functional as F
+from tilelang.profiler import do_bench  # noqa: E402
 
-from example_gqa_bwd import (
+from example_gqa_bwd import (  # noqa: E402
     flashattn_fwd,
     flashattn_fwd_v4,
     flashattn_bwd_preprocess,
@@ -33,19 +33,6 @@ from example_gqa_bwd import (
     ref_bwd,
     NUM_CORES,
 )
-
-
-def _bench(fn, warmup=50, iters=200):
-    """Manual bench with explicit sync."""
-    for _ in range(warmup):
-        fn()
-    torch.npu.synchronize()
-    t0 = time.perf_counter()
-    for _ in range(iters):
-        fn()
-    torch.npu.synchronize()
-    t1 = time.perf_counter()
-    return (t1 - t0) / iters * 1000  # ms
 
 
 def main():
@@ -164,46 +151,42 @@ def main():
     print(f"  correctness: PASS (fwd={fwd_max_diff:.6e}, bwd={bwd_max_diff:.6e})")
 
     # ============================================================
-    # 1. TileLang Forward v1
-    #    Note: v1 has a known limitation — causal + D_qk_padded>128
-    #    causes L0C overflow (see 算子bug总结.md §3.1). Skip v1 in
-    #    that case and rely on v4.
+    # Benchmark using tilelang.profiler.do_bench (standard NPU profiler).
+    # Uses _n_warmup=5, _n_repeat=5 (same as perf_gqa_fwd_varlen.py).
+    # do_bench handles NPU synchronization properly between iterations,
+    # avoiding aicore timeout from tight 250-iter loops.
     # ============================================================
+
+    # 1. TileLang Forward v1
     D_qk_padded_check = ((D_qk + 127) // 128) * 128
     skip_v1 = causal and D_qk_padded_check > 128
     if skip_v1:
         lat_fwd_v1 = float("nan")
-        print(f"  [INFO] Skipping Forward v1 (causal + D_qk_padded={D_qk_padded_check} > 128, known limitation §3.1)")
+        print(f"  [INFO] Skipping Forward v1 (causal + D_qk_padded={D_qk_padded_check} > 128, known limitation)")
     else:
         bM_v1, bN_v1 = 64, 64
         fwd_v1_mod = flashattn_fwd(B, H, N, D_qk, D_v, causal, bM_v1, bN_v1, groups)
-        lat_fwd_v1 = _bench(lambda: fwd_v1_mod(Q, K, V))
+        lat_fwd_v1 = do_bench(lambda: fwd_v1_mod(Q, K, V), _n_warmup=5, _n_repeat=5, return_mode="mean")
 
-    # ============================================================
-    # 2. TileLang Forward v4 (L0 double buffer + batched softmax)
-    #    Reuse fwd_v4_mod and workspace from correctness check above.
-    # ============================================================
-    lat_fwd_v4 = _bench(lambda: fwd_v4_mod(Q, K, V, ws1_fwd, ws2_fwd, ws3_fwd))
+    # 2. TileLang Forward v4
+    lat_fwd_v4 = do_bench(
+        lambda: fwd_v4_mod(Q, K, V, ws1_fwd, ws2_fwd, ws3_fwd),
+        _n_warmup=5,
+        _n_repeat=5,
+        return_mode="mean",
+    )
 
-    # ============================================================
     # 3. TileLang Backward (pipeline)
-    #    Reuse bwd_mod and workspace from correctness check above.
-    #    IMPORTANT: dK/dV use atomic_add to GM, so they accumulate across
-    #    calls. Must zero dQ/dK/dV before each call to prevent (a) numerical
-    #    overflow after 250 iters and (b) sustained atomic_add contention
-    #    on the same GM addresses causing aicore timeout.
-    # ============================================================
+    #    dK/dV use atomic_add to GM — must zero before each call to prevent
+    #    accumulation across bench iterations.
     def _run_bwd():
-        dQ_raw.zero_()
         dK_raw.zero_()
         dV_raw.zero_()
         bwd_mod(Q_padded, K_padded, V, dO, lse_npu, Delta_npu, dQ_raw, dK_raw, dV_raw, ws1_bwd, ws2_bwd, ws3_bwd)
 
-    lat_bwd = _bench(_run_bwd)
+    lat_bwd = do_bench(_run_bwd, _n_warmup=5, _n_repeat=5, return_mode="mean")
 
-    # ============================================================
     # 4. PyTorch baseline
-    # ============================================================
     q_r = Q.float()
     k_r = K.float().repeat_interleave(groups, dim=1)
     v_r = V.float().repeat_interleave(groups, dim=1)
@@ -216,7 +199,7 @@ def main():
         P = F.softmax(scores, dim=-1)
         torch.matmul(P, v_r)
 
-    lat_ref_fwd = _bench(_run_ref_fwd)
+    lat_ref_fwd = do_bench(_run_ref_fwd, _n_warmup=5, _n_repeat=5, return_mode="mean")
 
     def _run_ref_fwd_bwd():
         q2 = Q.float().requires_grad_(True)
@@ -230,7 +213,7 @@ def main():
         O2 = torch.matmul(P, v2)
         O2.backward(dO.float())
 
-    lat_ref_e2e = _bench(_run_ref_fwd_bwd, warmup=20, iters=50)
+    lat_ref_e2e = do_bench(_run_ref_fwd_bwd, _n_warmup=3, _n_repeat=3, return_mode="mean")
 
     # ============================================================
     # Print results

--- a/examples_experiment/example_gqa_bwd/perf_example_gqa_bwd.py
+++ b/examples_experiment/example_gqa_bwd/perf_example_gqa_bwd.py
@@ -188,8 +188,15 @@ def main():
     # ============================================================
     # 3. TileLang Backward (pipeline)
     #    Reuse bwd_mod and workspace from correctness check above.
+    #    IMPORTANT: dK/dV use atomic_add to GM, so they accumulate across
+    #    calls. Must zero dQ/dK/dV before each call to prevent (a) numerical
+    #    overflow after 250 iters and (b) sustained atomic_add contention
+    #    on the same GM addresses causing aicore timeout.
     # ============================================================
     def _run_bwd():
+        dQ_raw.zero_()
+        dK_raw.zero_()
+        dV_raw.zero_()
         bwd_mod(Q_padded, K_padded, V, dO, lse_npu, Delta_npu, dQ_raw, dK_raw, dV_raw, ws1_bwd, ws2_bwd, ws3_bwd)
 
     lat_bwd = _bench(_run_bwd)

--- a/examples_experiment/example_gqa_bwd/test_gqa_bwd.py
+++ b/examples_experiment/example_gqa_bwd/test_gqa_bwd.py
@@ -1,0 +1,375 @@
+"""
+Test suite for GQA Flash Attention (Forward + Backward).
+Imports kernels from example_gqa_bwd.py.
+
+Layered test structure (matches gqa_fwd_varlen convention):
+  - L0: regular shapes (block-aligned), precision convergence gate (blocking)
+  - L1: irregular shapes, D_qk != D_v, causal variants (blocking)
+  - L2: abnormal inputs (single token, min seqlen) (non-blocking)
+  - Boundary: special values (zero input, large input) (non-blocking)
+
+Usage:
+  python test_gqa_bwd.py                # default: run L0 only
+  python test_gqa_bwd.py --level l0
+  python test_gqa_bwd.py --level all
+"""
+
+import argparse
+import os
+import sys
+import traceback
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import tilelang
+import torch
+
+from example_gqa_bwd import (  # noqa: E402
+    flashattn_fwd,
+    flashattn_bwd_preprocess,
+    flashattn_bwd_pipeline,
+    ref_program,
+    ref_bwd,
+    attention,
+)
+
+ATOL = 1e-2
+RTOL = 1e-2
+
+
+def _setup():
+    tilelang.disable_cache()
+    torch.set_default_device("npu")
+
+
+# ===========================================================================
+# Test helpers
+# ===========================================================================
+
+
+def _run_forward(B, H, H_kv, groups, N, D_qk, D_v, causal, name, level):
+    """Run one forward case, print [PRECISION_PASS/FAIL] or [BOUNDARY_PASS/WARN]."""
+    tag = "PRECISION" if level in ("l0", "l1") else "BOUNDARY"
+    try:
+        torch.manual_seed(42)
+        Q = torch.randn(B, H, N, D_qk, dtype=torch.float16, device="npu")
+        K = torch.randn(B, H_kv, N, D_qk, dtype=torch.float16, device="npu")
+        V = torch.randn(B, H_kv, N, D_v, dtype=torch.float16, device="npu")
+
+        bM, bN = 64, 64
+        mod = flashattn_fwd(B, H, N, D_qk, D_v, causal, bM, bN, groups)
+        O_npu, _ = mod(Q, K, V)
+        torch.npu.synchronize()
+
+        O_ref = ref_program(Q, K, V, causal, groups)
+        max_diff = (O_npu.float() - O_ref.float()).abs().max().item()
+        torch.testing.assert_close(O_npu.cpu(), O_ref.cpu(), rtol=RTOL, atol=ATOL)
+
+        print(f"[{tag}_PASS] {level} {name} fwd B={B} H={H} N={N} D_qk={D_qk} D_v={D_v} causal={causal} max_diff={max_diff:.6e}")
+        return True
+    except Exception as e:
+        print(f"[{tag}_FAIL] {level} {name} fwd B={B} H={H} N={N} D_qk={D_qk} D_v={D_v} causal={causal}: {e}")
+        if tag == "BOUNDARY":
+            traceback.print_exc()
+        return False
+
+
+def _run_backward(B, H, H_kv, groups, N, D_qk, D_v, causal, name, level):
+    """Run one backward case (fwd + prep + bwd_pipeline), print result tag."""
+    tag = "PRECISION" if level in ("l0", "l1") else "BOUNDARY"
+    try:
+        torch.manual_seed(42)
+        bM, bN = 64, (64 if causal else 32)
+        D_qk_padded = ((D_qk + 127) // 128) * 128
+        if causal and D_qk_padded > 128:
+            bM = 32
+
+        Q = torch.randn(B, H, N, D_qk, dtype=torch.float16, device="npu")
+        K = torch.randn(B, H_kv, N, D_qk, dtype=torch.float16, device="npu")
+        V = torch.randn(B, H_kv, N, D_v, dtype=torch.float16, device="npu")
+        dO = torch.randn(B, H, N, D_v, dtype=torch.float16, device="npu")
+
+        fwd_mod = flashattn_fwd(B, H, N, D_qk, D_v, causal, bM, bM, groups)
+        O_npu, lse_npu = fwd_mod(Q, K, V)
+        torch.npu.synchronize()
+
+        prep_mod = flashattn_bwd_preprocess(B, H, N, D_v, blk=32)
+        Delta_npu = prep_mod(O_npu, dO)
+        torch.npu.synchronize()
+
+        num_stages = 8
+        dQ = torch.zeros(B, H, N, D_qk_padded, dtype=torch.float32, device="npu")
+        dK = torch.zeros(B, H_kv, N, D_qk_padded, dtype=torch.float32, device="npu")
+        dV = torch.zeros(B, H_kv, N, D_v, dtype=torch.float32, device="npu")
+
+        Q_padded = torch.zeros(B, H, N, D_qk_padded, dtype=torch.float16, device="npu")
+        Q_padded[:, :, :, :D_qk] = Q
+        K_padded = torch.zeros(B, H_kv, N, D_qk_padded, dtype=torch.float16, device="npu")
+        K_padded[:, :, :, :D_qk] = K
+
+        bwd_block_num = (N // bM) * H * B
+        ws_s_dp = torch.empty(bwd_block_num, num_stages, bM, bN, dtype=torch.float32, device="npu")
+        ws_p_ds = torch.empty(bwd_block_num, num_stages, bM, bN, dtype=torch.float16, device="npu")
+        ws_dv_dk = torch.empty(bwd_block_num, num_stages, bN, max(D_qk_padded, D_v), dtype=torch.float32, device="npu")
+
+        bwd_mod = flashattn_bwd_pipeline(B, H, N, D_qk, D_v, causal, bM, bN, groups, num_stages)
+        bwd_mod(Q_padded, K_padded, V, dO, lse_npu, Delta_npu, dQ, dK, dV, ws_s_dp, ws_p_ds, ws_dv_dk)
+        torch.npu.synchronize()
+
+        dQ_ref, dK_ref, dV_ref = ref_bwd(Q, K, V, dO, causal, groups)
+        max_diff = max(
+            (dV.half().float() - dV_ref.float()).abs().max().item(),
+            (dK[:, :, :, :D_qk].half().float() - dK_ref.float()).abs().max().item(),
+            (dQ[:, :, :, :D_qk].half().float() - dQ_ref.float()).abs().max().item(),
+        )
+        torch.testing.assert_close(dV.half().cpu(), dV_ref.cpu(), rtol=RTOL, atol=ATOL)
+        torch.testing.assert_close(dK[:, :, :, :D_qk].half().cpu(), dK_ref.cpu(), rtol=RTOL, atol=ATOL)
+        torch.testing.assert_close(dQ[:, :, :, :D_qk].half().cpu(), dQ_ref.cpu(), rtol=RTOL, atol=ATOL)
+
+        print(f"[{tag}_PASS] {level} {name} bwd B={B} H={H} N={N} D_qk={D_qk} D_v={D_v} causal={causal} max_diff={max_diff:.6e}")
+        return True
+    except Exception as e:
+        print(f"[{tag}_FAIL] {level} {name} bwd B={B} H={H} N={N} D_qk={D_qk} D_v={D_v} causal={causal}: {e}")
+        if tag == "BOUNDARY":
+            traceback.print_exc()
+        return False
+
+
+def _run_autograd(B, N, H, D_qk, D_v, groups, name, level):
+    """End-to-end autograd test (BSHD layout)."""
+    tag = "PRECISION" if level in ("l0", "l1") else "BOUNDARY"
+    try:
+        torch.manual_seed(42)
+        H_kv = H // groups
+        q = torch.randn(B, N, H, D_qk, dtype=torch.float16, device="npu", requires_grad=True)
+        k = torch.randn(B, N, H_kv, D_qk, dtype=torch.float16, device="npu", requires_grad=True)
+        v = torch.randn(B, N, H_kv, D_v, dtype=torch.float16, device="npu", requires_grad=True)
+        dO = torch.randn(B, N, H, D_v, dtype=torch.float16, device="npu")
+
+        O = attention(q, k, v, False, groups)
+        O.backward(dO)
+
+        q_bhsd = q.detach().permute(0, 2, 1, 3)
+        k_bhsd = k.detach().permute(0, 2, 1, 3)
+        v_bhsd = v.detach().permute(0, 2, 1, 3)
+        dO_bhsd = dO.permute(0, 2, 1, 3)
+        dQ_ref, dK_ref, dV_ref = ref_bwd(q_bhsd, k_bhsd, v_bhsd, dO_bhsd, False, groups)
+
+        torch.testing.assert_close(q.grad.permute(0, 2, 1, 3).cpu(), dQ_ref.cpu(), rtol=RTOL, atol=ATOL)
+        torch.testing.assert_close(k.grad.permute(0, 2, 1, 3).cpu(), dK_ref.cpu(), rtol=RTOL, atol=ATOL)
+        torch.testing.assert_close(v.grad.permute(0, 2, 1, 3).cpu(), dV_ref.cpu(), rtol=RTOL, atol=ATOL)
+
+        print(f"[{tag}_PASS] {level} {name} autograd B={B} H={H} N={N} groups={groups}")
+        return True
+    except Exception as e:
+        print(f"[{tag}_FAIL] {level} {name} autograd B={B} H={H} N={N} groups={groups}: {e}")
+        if tag == "BOUNDARY":
+            traceback.print_exc()
+        return False
+
+
+# ===========================================================================
+# L0 gate tests — regular shapes (block-aligned), precision convergence.
+# ===========================================================================
+
+
+def test_gqa_bwd_l0():
+    """L0 gate tests: regular shapes (block-aligned), for precision convergence.
+
+    Raises AssertionError on failure (pytest-discoverable, returns None).
+    """
+    _setup()
+    # (name, B, H, H_kv, groups, N, D_qk, D_v, causal)
+    fwd_configs = [
+        ("fwd_mha", 1, 1, 1, 1, 128, 64, 64, False),
+        ("fwd_gqa", 1, 2, 1, 2, 128, 64, 64, False),
+        ("fwd_gqa_causal", 1, 2, 1, 2, 128, 64, 64, True),
+        ("fwd_gqa_dqk64_dv128", 1, 2, 1, 2, 128, 64, 128, False),
+        ("fwd_gqa_golden", 8, 32, 2, 16, 1024, 192, 128, False),
+    ]
+    bwd_configs = [
+        ("bwd_mha", 1, 1, 1, 1, 128, 64, 64, False),
+        ("bwd_gqa", 1, 2, 1, 2, 128, 64, 64, False),
+        ("bwd_gqa_dqk64_dv128", 1, 2, 1, 2, 128, 64, 128, False),
+        ("bwd_gqa_causal", 1, 2, 1, 2, 128, 64, 64, True),
+        ("bwd_gqa_golden", 1, 32, 2, 16, 256, 192, 128, False),
+    ]
+    autograd_configs = [
+        ("autograd_mha", 1, 128, 1, 64, 64, 1),
+        ("autograd_gqa", 1, 128, 2, 64, 64, 2),
+    ]
+
+    for name, B, H, H_kv, groups, N, D_qk, D_v, causal in fwd_configs:
+        assert _run_forward(B, H, H_kv, groups, N, D_qk, D_v, causal, name, "l0"), f"L0 forward case '{name}' failed"
+    for name, B, H, H_kv, groups, N, D_qk, D_v, causal in bwd_configs:
+        assert _run_backward(B, H, H_kv, groups, N, D_qk, D_v, causal, name, "l0"), f"L0 backward case '{name}' failed"
+    for name, B, N, H, D_qk, D_v, groups in autograd_configs:
+        assert _run_autograd(B, N, H, D_qk, D_v, groups, name, "l0"), f"L0 autograd case '{name}' failed"
+
+
+# ===========================================================================
+# L1 functional tests — irregular shapes, causal variants, GQA edge cases.
+# ===========================================================================
+
+
+def test_gqa_bwd_l1():
+    """L1 functional tests: irregular shapes, causal variants, GQA edge cases.
+
+    Raises AssertionError on failure (pytest-discoverable, returns None).
+    """
+    _setup()
+    # (name, B, H, H_kv, groups, N, D_qk, D_v, causal)
+    fwd_configs = [
+        ("fwd_batch_causal", 2, 4, 2, 2, 256, 64, 64, True),
+        ("fwd_gqa_dqk128_dv64", 1, 2, 1, 2, 256, 128, 64, False),
+        ("fwd_gqa_groups4", 1, 8, 2, 4, 256, 128, 128, False),
+    ]
+    bwd_configs = [
+        ("bwd_gqa_causal_dqk128", 1, 2, 1, 2, 128, 128, 64, True),
+        ("bwd_gqa_groups4", 1, 8, 2, 4, 256, 128, 128, False),
+        ("bwd_batch_causal", 2, 4, 2, 2, 256, 64, 64, True),
+    ]
+
+    for name, B, H, H_kv, groups, N, D_qk, D_v, causal in fwd_configs:
+        assert _run_forward(B, H, H_kv, groups, N, D_qk, D_v, causal, name, "l1"), f"L1 forward case '{name}' failed"
+    for name, B, H, H_kv, groups, N, D_qk, D_v, causal in bwd_configs:
+        assert _run_backward(B, H, H_kv, groups, N, D_qk, D_v, causal, name, "l1"), f"L1 backward case '{name}' failed"
+
+
+# ===========================================================================
+# L2 abnormal input tests. Non-blocking: prints [BOUNDARY_PASS/WARN].
+# ===========================================================================
+
+
+def test_gqa_bwd_l2():
+    """L2 abnormal input tests. Non-blocking: prints [BOUNDARY_PASS/WARN]."""
+    _setup()
+    # (name, B, H, H_kv, groups, N, D_qk, D_v, causal)
+    fwd_configs = [
+        ("fwd_single_token", 1, 1, 1, 1, 64, 64, 64, False),
+        ("fwd_min_seqlen", 1, 1, 1, 1, 64, 64, 64, True),
+        ("fwd_batch1_head1", 1, 1, 1, 1, 128, 64, 64, False),
+    ]
+    bwd_configs = [
+        ("bwd_single_token", 1, 1, 1, 1, 64, 64, 64, False),
+        ("bwd_min_seqlen", 1, 1, 1, 1, 64, 64, 64, True),
+    ]
+
+    for name, B, H, H_kv, groups, N, D_qk, D_v, causal in fwd_configs:
+        _run_forward(B, H, H_kv, groups, N, D_qk, D_v, causal, name, "l2")
+    for name, B, H, H_kv, groups, N, D_qk, D_v, causal in bwd_configs:
+        _run_backward(B, H, H_kv, groups, N, D_qk, D_v, causal, name, "l2")
+
+
+# ===========================================================================
+# Boundary / special value tests. Non-blocking.
+# ===========================================================================
+
+
+def test_gqa_bwd_boundary():
+    """Boundary / special value tests. Non-blocking: prints [BOUNDARY_PASS/WARN]."""
+    _setup()
+    # (name, B, H, H_kv, groups, N, D_qk, D_v, causal, input_scale)
+    boundary_configs = [
+        ("zero_input", 1, 2, 1, 2, 128, 64, 64, False, 0.0),
+        ("large_input", 1, 2, 1, 2, 128, 64, 64, False, 10.0),
+    ]
+
+    for name, B, H, H_kv, groups, N, D_qk, D_v, causal, scale in boundary_configs:
+        try:
+            torch.manual_seed(42)
+            Q = torch.randn(B, H, N, D_qk, dtype=torch.float16, device="npu") * scale
+            K = torch.randn(B, H_kv, N, D_qk, dtype=torch.float16, device="npu") * scale
+            V = torch.randn(B, H_kv, N, D_v, dtype=torch.float16, device="npu") * scale
+
+            bM, bN = 64, 64
+            mod = flashattn_fwd(B, H, N, D_qk, D_v, causal, bM, bN, groups)
+            O_npu, _ = mod(Q, K, V)
+            torch.npu.synchronize()
+
+            O_ref = ref_program(Q, K, V, causal, groups)
+            max_diff = (O_npu.float() - O_ref.float()).abs().max().item()
+            if torch.isnan(O_npu).any():
+                print(f"[BOUNDARY_WARN] boundary {name}: NaN in output")
+                continue
+            torch.testing.assert_close(O_npu.cpu(), O_ref.cpu(), rtol=RTOL, atol=ATOL)
+            print(f"[BOUNDARY_PASS] boundary {name} max_diff={max_diff:.6e}")
+        except Exception as e:
+            print(f"[BOUNDARY_WARN] boundary {name}: {e}")
+
+
+# ===========================================================================
+# Main entrypoint with argparse --level
+# ===========================================================================
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GQA Flash Attention (Forward + Backward) test suite")
+    parser.add_argument(
+        "--level",
+        default="l0",
+        choices=["l0", "l1", "l2", "boundary", "all"],
+        help="Test level to run",
+    )
+    args = parser.parse_args()
+
+    _setup()
+
+    blocking_ok = True  # Only L0/L1 count toward blocking
+
+    try:
+        if args.level in ("l0", "all"):
+            test_gqa_bwd_l0()
+        if args.level in ("l1", "all"):
+            test_gqa_bwd_l1()
+    except AssertionError:
+        blocking_ok = False
+
+    if args.level in ("l2", "all"):
+        test_gqa_bwd_l2()
+    if args.level in ("boundary", "all"):
+        test_gqa_bwd_boundary()
+
+    if blocking_ok:
+        print("Test Passed!")
+        sys.exit(0)
+    sys.exit(1)
+
+
+# pytest-discoverable aliases (so `pytest test_gqa_bwd.py` still works)
+def test_forward():
+    """Pytest alias: run L0 forward cases."""
+    _setup()
+    configs = [
+        (1, 1, 1, 1, 128, 64, 64, False, "FWD-MHA"),
+        (1, 2, 1, 2, 128, 64, 64, False, "FWD-GQA"),
+        (1, 2, 1, 2, 128, 64, 64, True, "FWD-GQA-causal"),
+        (1, 2, 1, 2, 128, 64, 128, False, "FWD-GQA-Dqk64-Dv128"),
+        (8, 32, 2, 16, 1024, 192, 128, False, "FWD-GQA-golden"),
+    ]
+    for B, H, H_kv, groups, N, D_qk, D_v, causal, _desc in configs:
+        assert _run_forward(B, H, H_kv, groups, N, D_qk, D_v, causal, _desc, "l0")
+
+
+def test_backward():
+    """Pytest alias: run L0 backward cases."""
+    _setup()
+    configs = [
+        (1, 1, 1, 1, 128, 64, 64, False, "BWD-MHA"),
+        (1, 2, 1, 2, 128, 64, 64, False, "BWD-GQA"),
+        (1, 2, 1, 2, 128, 64, 128, False, "BWD-GQA-Dqk64-Dv128"),
+        (1, 2, 1, 2, 128, 64, 64, True, "BWD-GQA-causal"),
+        (1, 32, 2, 16, 256, 192, 128, False, "BWD-GQA-golden"),
+    ]
+    for B, H, H_kv, groups, N, D_qk, D_v, causal, _desc in configs:
+        assert _run_backward(B, H, H_kv, groups, N, D_qk, D_v, causal, _desc, "l0")
+
+
+def test_autograd():
+    """Pytest alias: end-to-end autograd test (BSHD layout)."""
+    _setup()
+    assert _run_autograd(1, 128, 2, 64, 64, 2, "AUTOGRAD-GQA", "l0")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
Migrate GQA backward kernel, implemented in `example_gqa_bwd.py` based on TileLang + AscendC.
Add design document for implementation.

Tested on Ascend NPU, fp16, B=8 H=32 H_kv=2 groups=16. Precision verified against PyTorch golden (atol=1e-2, rtol=1e-2).

## Non-causal (D_qk=192, D_v=128 -- golden config)
| Kernel                      | Q 序列长度 | K/V 序列长度 | 延迟 (ms) | 算力 (TFlops) | 精度 (max_diff) |
| --------------------------- | ---------- | ------------ | --------- | ------------- | --------------- |
| TileLang Forward v1         | 1024       | 1024         | 14.61     | 11.76         | 2.44e-04        |
| TileLang Forward v4         | 1024       | 1024         | 10.10     | 17.01         | 2.44e-04        |
| TileLang Backward (pipeline)| 1024       | 1024         | 34.44     | 12.97         | 9.77e-04        |
| TileLang Fwd(v4)+Bwd        | 1024       | 1024         | 44.55     | 13.88         | —               |
| PyTorch Forward only        | 1024       | 1024         | 7.30      | 23.54         | —               |
| PyTorch Fwd+Bwd (e2e)       | 1024       | 1024         | 20.02     | 30.89         | —               |

- v4 vs v1 forward: 1.45x speedup
- v4 forward vs PyTorch forward: 0.72x

## Causal (D_qk=128, D_v=128)
| Kernel                      | Q 序列长度 | K/V 序列长度 | 延迟 (ms) | 算力 (TFlops) | 精度 (max_diff) |
| --------------------------- | ---------- | ------------ | --------- | ------------- | --------------- |
| TileLang Forward v1         | 1024       | 1024         | 10.17     | 6.76          | 1.95e-03        |
| TileLang Forward v4         | 1024       | 1024         | 9.45      | 7.27          | 1.95e-03        |
| TileLang Backward (pipeline)| 1024       | 1024         | 22.53     | 7.62          | 7.81e-03        |
| TileLang Fwd(v4)+Bwd        | 1024       | 1024         | 31.98     | 7.52          | —               |
| PyTorch Forward only        | 1024       | 1024         | 10.57     | 6.50          | —               |
| PyTorch Fwd+Bwd (e2e)       | 1024       | 1024         | 24.72     | 9.73          | —               |

- v4 forward vs PyTorch forward: 1.12x speedup (causal mode beats PyTorch)

## Notes
- Forward v4: L0 double buffering + batched softmax + Fixed Core + causal loop range optimization (num_stages=8).
- Backward: pipeline kernel with fine-grained set_flag/wait_flag sync in C scope (num_stages=8).
- v1 is skipped in causal + D_qk > 128 due to L0C overflow (known architecture limitation).
- End-to-end ~2.4x gap vs PyTorch is an architecture-level limitation (C/V physical separation forces workspace GM round-trip).

## Checklist
- [x] GQA backward kernel implementation
- [x] Basic function verification passed