### PR TITLE
[Test] Run migrated operator tests through Pytest

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -202,6 +202,18 @@ jobs:
           pytest_files_array=()
           pytest_dirs_array=()
 
+          # A migrated operator is covered by its Pytest test, so a change to either
+          # one only needs that test; there is no reason to run the whole directory.
+          declare -A source_to_test=()
+          declare -A test_to_test=()
+          if [ -f scripts/ci/resolve_operator_tests.py ]; then
+            while IFS=$'\t' read -r source test; do
+              [[ -n "$source" && -n "$test" ]] || continue
+              source_to_test["$source"]="$test"
+              test_to_test["$test"]="$test"
+            done < <(python scripts/ci/resolve_operator_tests.py list --format tsv)
+          fi
+
           for file in $changed_files; do
             # 排除 .agents 目录（skill 配置，无需测试）
             if [[ "$file" =~ ^\.agents/ ]]; then
@@ -254,6 +266,25 @@ jobs:
               break
             fi
             
+            if [[ -n "${source_to_test[$file]:-}" ]]; then
+              mapped_test="${source_to_test[$file]}"
+              pytest_files_array+=("$mapped_test")
+              run_examples=false
+              run_pytest_only=true
+              should_skip=false
+              echo "Mapped migrated operator $file -> $mapped_test"
+              continue
+            fi
+
+            if [[ -n "${test_to_test[$file]:-}" ]]; then
+              pytest_files_array+=("$file")
+              run_examples=false
+              run_pytest_only=true
+              should_skip=false
+              echo "Mapped migrated test: $file"
+              continue
+            fi
+
             # examples 文件 → 增量 examples + pytest
             if [[ "$file" =~ ^examples/([^/]+)/ ]]; then
               test_dir="${BASH_REMATCH[1]}"
@@ -614,6 +645,23 @@ jobs:
                   fi
                 fi
                 TEST_EXIT_CODE=\${PIPESTATUS[0]}
+
+                # Operator tests were moved out of the legacy runner, so run them here:
+                # one Pytest invocation gets xdist scheduling, the marker filter and the
+                # full failure output. Entries reserved but not migrated yet are absent
+                # from list-tests, so nothing points at a file that does not exist.
+                OPERATOR_TESTS=()
+                while IFS= read -r operator_test; do
+                  [ -n \"\$operator_test\" ] && OPERATOR_TESTS+=(\"../\$operator_test\")
+                done < <(python ../scripts/ci/resolve_operator_tests.py list-tests)
+                if [ \${#OPERATOR_TESTS[@]} -gt 0 ]; then
+                  echo 'Running operator tests: '\${OPERATOR_TESTS[*]}
+                  pytest --forked \"\${OPERATOR_TESTS[@]}\" -v -n 8 \"\${PYTEST_MARKER_ARGS[@]}\" 2>&1 | tee -a test_output.log
+                  OPERATOR_EXIT_CODE=\${PIPESTATUS[0]}
+                  if [ \"\$TEST_EXIT_CODE\" -eq 0 ]; then
+                    TEST_EXIT_CODE=\$OPERATOR_EXIT_CODE
+                  fi
+                fi
                 set -e
               fi
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -269,8 +269,11 @@ jobs:
             if [[ -n "${source_to_test[$file]:-}" ]]; then
               mapped_test="${source_to_test[$file]}"
               pytest_files_array+=("$mapped_test")
-              run_examples=false
-              run_pytest_only=true
+              # Only claim the pytest-only path while nothing else has asked for
+              # examples: otherwise this would drop the directories they collected.
+              if [[ "$run_examples" == false ]]; then
+                run_pytest_only=true
+              fi
               should_skip=false
               echo "Mapped migrated operator $file -> $mapped_test"
               continue
@@ -278,8 +281,9 @@ jobs:
 
             if [[ -n "${test_to_test[$file]:-}" ]]; then
               pytest_files_array+=("$file")
-              run_examples=false
-              run_pytest_only=true
+              if [[ "$run_examples" == false ]]; then
+                run_pytest_only=true
+              fi
               should_skip=false
               echo "Mapped migrated test: $file"
               continue

--- a/ci/operator_test_manifest.yaml
+++ b/ci/operator_test_manifest.yaml
@@ -1,0 +1,60 @@
+# 算子源文件 -> 它的 Pytest 测试。
+# 一条登记只有在测试文件真实存在时才生效；否则算子照常由
+# examples/bench_test.sh 执行。
+version: 1
+mappings:
+
+  # examples/batch_gemm
+    examples/batch_gemm/batch_gemm.py: examples/batch_gemm/test_batch_gemm.py
+
+  # examples/flash_attention
+    examples/flash_attention/flash_attn_bhsd.py: examples/flash_attention/test_flash_attn_bhsd.py
+    examples/flash_attention/flash_attn_bhsd_cc_sync.py: examples/flash_attention/test_flash_attn_bhsd_cc_sync.py
+    examples/flash_attention/paged_flash_attn_bhsd.py: examples/flash_attention/test_paged_flash_attn_bhsd.py
+
+  # examples/gqa_fwd_varlen
+    examples/gqa_fwd_varlen/gqa_fwd_varlen.py: examples/gqa_fwd_varlen/test_gqa_fwd_varlen.py
+
+  # examples/HISA
+    examples/HISA/paged_block_sparse_mqa_attn_expert.py: examples/HISA/test_paged_block_sparse_mqa_attn_expert.py
+
+  # examples/xattention
+    examples/xattention/xattention.py: examples/xattention/test_xattention.py
+    examples/xattention/xattention_paged.py: examples/xattention/test_xattention_paged.py
+
+  # examples/sparse_flash_attention
+    examples/sparse_flash_attention/example_sparse_flash_attn.py: examples/sparse_flash_attention/test_example_sparse_flash_attn.py
+    examples/sparse_flash_attention/example_sparse_flash_attn_dynamic_shape.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_dynamic_shape.py
+    examples/sparse_flash_attention/example_sparse_flash_attn_gqa.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa.py
+    examples/sparse_flash_attention/example_sparse_flash_attn_gqa_pto.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa_pto.py
+    examples/sparse_flash_attention/example_sparse_flash_attn_gqa_pto_developer.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa_pto_developer.py
+    examples/sparse_flash_attention/example_sparse_flash_attn_mask.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_mask.py
+    examples/sparse_flash_attention/example_sparse_flash_attn_mask_pa.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_mask_pa.py
+
+  # examples/linear_attention_and_rnn
+    examples/linear_attention_and_rnn/gdn_full.py: examples/linear_attention_and_rnn/test_gdn_full.py
+    examples/linear_attention_and_rnn/linear_attention_causal.py: examples/linear_attention_and_rnn/test_linear_attention_causal.py
+    examples/linear_attention_and_rnn/linear_attention_normalize.py: examples/linear_attention_and_rnn/test_linear_attention_normalize.py
+    examples/linear_attention_and_rnn/opt_gdn_full.py: examples/linear_attention_and_rnn/test_opt_gdn_full.py
+
+  # examples/moe_token_permute
+    examples/moe_token_permute/moe_token_permute.py: examples/moe_token_permute/test_moe_token_permute.py
+    examples/moe_token_permute/moe_token_permute_grad.py: examples/moe_token_permute/test_moe_token_permute_grad.py
+    examples/moe_token_permute/moe_token_unpermute.py: examples/moe_token_permute/test_moe_token_unpermute.py
+    examples/moe_token_permute/moe_token_unpermute_grad.py: examples/moe_token_permute/test_moe_token_unpermute_grad.py
+
+  # examples/tile_kernels/moe
+    examples/tile_kernels/moe/moe_topk_gate.py: examples/tile_kernels/moe/test_moe_topk_gate.py
+
+  # examples/fused_sigmoid_gating_delta_rule
+    examples/fused_sigmoid_gating_delta_rule/fused_sigmoid_gating_delta_rule_varlen.py: examples/fused_sigmoid_gating_delta_rule/test_fused_sigmoid_gating_delta_rule_varlen.py
+
+  # examples_experiment/seer_attention
+    examples_experiment/seer_attention/block_sparse_attn.py: examples_experiment/seer_attention/test_block_sparse_attn.py
+
+  # examples_experiment/chunk_gated_delta_rule
+    examples_experiment/chunk_gated_delta_rule/chunk_gated_delta_rule.py: examples_experiment/chunk_gated_delta_rule/test_chunk_gated_delta_rule.py
+    examples_experiment/chunk_gated_delta_rule/expert_chunk_gated_delta_rule.py: examples_experiment/chunk_gated_delta_rule/test_expert_chunk_gated_delta_rule.py
+
+  # examples_experiment/cumsum_gdn
+    examples_experiment/cumsum_gdn/example_cumsum.py: examples_experiment/cumsum_gdn/test_example_cumsum.py

--- a/examples/batch_gemm/test_batch_gemm.py
+++ b/examples/batch_gemm/test_batch_gemm.py
@@ -1,0 +1,53 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_batch_gemm_example() -> ModuleType:
+    source = Path(__file__).with_name("batch_gemm.py")
+    spec = importlib.util.spec_from_file_location("_batch_gemm_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        # batch_gemm.py parses arguments at import time. Hide Pytest arguments
+        # while loading it without changing the original Example.
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_batch_gemm_accuracy() -> None:
+    import torch
+
+    example = _load_batch_gemm_example()
+
+    batch = 8
+    m = 1024
+    n = 1024
+    k = 1024
+
+    kernel = example.batch_matmul(
+        batch,
+        m,
+        n,
+        k,
+        block_M=128,
+        block_N=256,
+        K_L1=64,
+    )
+
+    torch.manual_seed(0)
+    lhs = torch.randn(batch, m, k).half().npu()
+    rhs = torch.randn(batch, k, n).half().npu()
+
+    actual = kernel(lhs, rhs)
+    expected = torch.matmul(lhs, rhs)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)

--- a/examples/bench_test.sh
+++ b/examples/bench_test.sh
@@ -61,6 +61,28 @@ done
 # ================= 全局环境变量设置 =================
 PROJECT_ROOT="$(cd .. && pwd)"
 
+# An operator listed here is covered by its Pytest test, which the workflow
+# runs separately; executing it here as well would compile and run the same
+# kernel twice.
+declare -A MIGRATED_SOURCES=()
+OPERATOR_TEST_RESOLVER="${PROJECT_ROOT}/scripts/ci/resolve_operator_tests.py"
+if [ -f "$OPERATOR_TEST_RESOLVER" ]; then
+    # This script has no `set -e`, so a failure here would otherwise leave the
+    # skip list empty and let every migrated operator run twice unnoticed.
+    if ! python "$OPERATOR_TEST_RESOLVER" validate; then
+        echo "Operator test manifest is invalid" >&2
+        exit 1
+    fi
+    if ! python "$OPERATOR_TEST_RESOLVER" check-orphans; then
+        echo "Operator test names do not match the manifest" >&2
+        exit 1
+    fi
+    while IFS=$'\t' read -r source test; do
+        [ -n "$source" ] || continue
+        MIGRATED_SOURCES["$source"]=1
+    done < <(python "$OPERATOR_TEST_RESOLVER" list --format tsv)
+fi
+
 # experiment 算子根目录（相对 examples 工作目录）
 EXPERIMENT_ROOT="../examples_experiment"
 
@@ -148,6 +170,19 @@ total_scripts=0
 passed_scripts=0
 all_scripts=()
 
+should_skip_python_script() {
+    local candidate="$1"
+    local repo_relative
+
+    repo_relative=$(realpath --relative-to="$PROJECT_ROOT" "$candidate")
+    if [[ -n "${MIGRATED_SOURCES[$repo_relative]:-}" ]]; then
+        echo "Skip migrated operator in legacy runner: $candidate" >&2
+        return 0
+    fi
+
+    return 1
+}
+
 # 函数：收集单个目录下的测试脚本
 collect_test_scripts() {
     local dir="$1"
@@ -169,9 +204,12 @@ collect_test_scripts() {
             # 收集主目录的 py 文件（排除 fa_opt）
             local py_files=$(find "$dir" -maxdepth 1 -name "*.py" \
                 -not -name "__init__.py" \
+                -not -name "test_*.py" \
                 -not -name "*_golden.py" \
                 | sort)
-            for f in $py_files; do scripts+=("$f"); done
+            for f in $py_files; do
+                should_skip_python_script "$f" || scripts+=("$f")
+            done
             
             echo "${scripts[@]}"
             return
@@ -181,6 +219,7 @@ collect_test_scripts() {
     # 搜索 maxdepth 2 的 py 文件（排除特殊文件和 bench_sfa 子目录）
     local py_files=$(find "$dir" -maxdepth 2 -name "*.py" \
         -not -name "__init__.py" \
+        -not -name "test_*.py" \
         -not -name "*_golden.py" \
         -not -name "sfa_golden.py" \
         -not -name "utils.py" \
@@ -188,7 +227,9 @@ collect_test_scripts() {
         -not -path "*/generative_recommendation/golden.py" \
         -not -path "*/generative_recommendation/testcase.py" \
         | sort)
-    for f in $py_files; do scripts+=("$f"); done
+    for f in $py_files; do
+        should_skip_python_script "$f" || scripts+=("$f")
+    done
     
     # 搜索 bash 脚本（特定命名模式）
     local sh_files=$(find "$dir" -maxdepth 2 \( -name "run_*.sh" -o -name "test_*.sh" \) | sort)
@@ -250,7 +291,9 @@ if [ -n "$TEST_DIRS" ] || [ -n "$EXPERIMENT_DIRS" ]; then
         if [ -d "$fa_dir" ]; then
             fa_python_files=$(find "$fa_dir" -maxdepth 1 -name "flash_*.py" | sort)
             if [ -n "$fa_python_files" ]; then
-                for file in $fa_python_files; do all_scripts+=("$file"); done
+                for file in $fa_python_files; do
+                    should_skip_python_script "$file" || all_scripts+=("$file")
+                done
             fi
         fi
     fi
@@ -280,7 +323,9 @@ else
     if [ -d "$fa_dir" ]; then
         fa_python_files=$(find "$fa_dir" -maxdepth 1 -name "flash_*.py" | sort)
         if [ -n "$fa_python_files" ]; then
-            for file in $fa_python_files; do all_scripts+=("$file"); done
+            for file in $fa_python_files; do
+                should_skip_python_script "$file" || all_scripts+=("$file")
+            done
         fi
     fi
 

--- a/examples/flash_attention/test_flash_attn_bhsd.py
+++ b/examples/flash_attention/test_flash_attn_bhsd.py
@@ -1,0 +1,67 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_flash_attn_example() -> ModuleType:
+    source = Path(__file__).with_name("flash_attn_bhsd.py")
+    spec = importlib.util.spec_from_file_location("_flash_attn_bhsd_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        # flash_attn_bhsd.py parses arguments in its __main__ block. Hide Pytest
+        # arguments while loading it without changing the original Example.
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def _reference_flash_attn(query, key, value):
+    # Mirrors ref_flash_attn defined inside the example's __main__ block, which
+    # is not reachable after importing the module.
+    import torch
+
+    query = query.float()
+    key = key.float()
+    value = value.float()
+
+    scores = torch.einsum("bhsd,bhkd->bhsk", query, key) * (1.0 / query.shape[-1]) ** 0.5
+    scores = scores.softmax(dim=-1)
+    out = torch.einsum("bhsk,bhkd->bhsd", scores, value)
+    return out.to(torch.float16)
+
+
+def test_flash_attn_bhsd_accuracy() -> None:
+    import torch
+
+    example = _load_flash_attn_example()
+
+    batch = 1
+    seq_len = 128
+    heads = 1
+    dim = 512
+
+    kernel = example.flash_attention_fwd(
+        batch=batch,
+        seq_len=seq_len,
+        heads=heads,
+        dim=dim,
+    )
+
+    torch.manual_seed(0)
+    query = torch.randn((batch, heads, seq_len, dim), dtype=torch.float16, device="npu")
+    key = torch.randn((batch, heads, seq_len, dim), dtype=torch.float16, device="npu")
+    value = torch.randn((batch, heads, seq_len, dim), dtype=torch.float16, device="npu")
+
+    actual = kernel(query, key, value)
+    expected = _reference_flash_attn(query, key, value)
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)

--- a/scripts/ci/resolve_operator_tests.py
+++ b/scripts/ci/resolve_operator_tests.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Validate and query the operator-to-Pytest migration manifest."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path, PurePosixPath
+
+
+DEFAULT_MANIFEST = Path("ci/operator_test_manifest.yaml")
+VERSION_PATTERN = re.compile(r"^version:\s*(\d+)\s*$")
+EXAMPLE_ROOTS = ("examples", "examples_experiment")
+RUNNER_PATTERN = re.compile(r"\b(?:python[0-9.]*|pytest)\b")
+PY_FILE_PATTERN = re.compile(r"[\w./-]+\.py\b")
+
+
+class ManifestError(ValueError):
+    """Raised when the operator test manifest is invalid."""
+
+
+def _parse_manifest(manifest_path: Path) -> list[tuple[str, str]]:
+    version: int | None = None
+    in_mappings = False
+    mappings: list[tuple[str, str]] = []
+
+    for line_number, raw_line in enumerate(
+        manifest_path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        version_match = VERSION_PATTERN.fullmatch(stripped)
+        if version_match:
+            if version is not None:
+                raise ManifestError(f"{manifest_path}:{line_number}: duplicate version")
+            version = int(version_match.group(1))
+            continue
+
+        if stripped == "mappings:":
+            if in_mappings:
+                raise ManifestError(f"{manifest_path}:{line_number}: duplicate mappings section")
+            in_mappings = True
+            continue
+
+        if not in_mappings or not raw_line.startswith("  ") or ":" not in stripped:
+            raise ManifestError(f"{manifest_path}:{line_number}: expected an indented source: test mapping")
+
+        source, test = (part.strip() for part in stripped.split(":", maxsplit=1))
+        if not source or not test:
+            raise ManifestError(f"{manifest_path}:{line_number}: source and test are required")
+        mappings.append((source, test))
+
+    if version != 1:
+        raise ManifestError(f"{manifest_path}: unsupported or missing version: {version}")
+    if not in_mappings:
+        raise ManifestError(f"{manifest_path}: missing mappings section")
+    if not mappings:
+        raise ManifestError(f"{manifest_path}: mappings must not be empty")
+    return mappings
+
+
+def _validate_relative_path(value: str, field: str) -> PurePosixPath:
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or str(path) != value:
+        raise ManifestError(f"{field} must be a normalized repo-relative POSIX path: {value}")
+    return path
+
+
+def load_mappings(repo_root: Path, manifest_path: Path) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """Return the mappings that are live, and those still waiting on their test.
+
+    Registering a source excludes it from the legacy runner, so a mapping whose
+    test has not landed yet must not take effect: it is a plan, not a migration.
+    Holding it back keeps the example running and keeps Pytest from being
+    pointed at a file that does not exist.
+    """
+    if not manifest_path.is_absolute():
+        manifest_path = repo_root / manifest_path
+    if not manifest_path.is_file():
+        raise ManifestError(f"manifest does not exist: {manifest_path}")
+
+    mappings = _parse_manifest(manifest_path)
+    seen_sources: set[str] = set()
+    seen_tests: set[str] = set()
+    active: list[tuple[str, str]] = []
+    pending: list[tuple[str, str]] = []
+
+    for source, test in mappings:
+        source_path = _validate_relative_path(source, "source")
+        test_path = _validate_relative_path(test, "test")
+
+        if source in seen_sources:
+            raise ManifestError(f"duplicate source: {source}")
+        if test in seen_tests:
+            raise ManifestError(f"duplicate test: {test}")
+        if source == test:
+            raise ManifestError(f"source and test must be different: {source}")
+        if source_path.suffix != ".py":
+            raise ManifestError(f"source must be a Python file: {source}")
+        if test_path.suffix != ".py" or not test_path.name.startswith("test_"):
+            raise ManifestError(f"test must be named test_*.py: {test}")
+        if not (repo_root / Path(*source_path.parts)).is_file():
+            raise ManifestError(f"source does not exist: {source}")
+        seen_sources.add(source)
+        seen_tests.add(test)
+
+        if (repo_root / Path(*test_path.parts)).is_file():
+            active.append((source, test))
+        else:
+            pending.append((source, test))
+
+    return active, pending
+
+
+def _shell_invoked_tests(repo_root: Path) -> set[str]:
+    """Collect tests that a shell script under the example roots runs directly.
+
+    Those do not go through the manifest at all, so an unregistered name there
+    is not a mistake. Paths resolve against the script directory because these
+    scripts cd into their own directory first.
+    """
+    invoked: set[str] = set()
+    for root in EXAMPLE_ROOTS:
+        root_path = repo_root / root
+        if not root_path.is_dir():
+            continue
+        for script in root_path.rglob("*.sh"):
+            try:
+                text = script.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            for line in text.splitlines():
+                if line.lstrip().startswith("#") or not RUNNER_PATTERN.search(line):
+                    continue
+                for token in PY_FILE_PATTERN.findall(line):
+                    target = (script.parent / token).resolve()
+                    if target.is_file():
+                        invoked.add(target.as_posix())
+    return invoked
+
+
+def find_unregistered_tests(repo_root: Path, active: list[tuple[str, str]], pending: list[tuple[str, str]]) -> list[str]:
+    """List example tests that match no manifest entry, live or reserved.
+
+    With every operator reserved up front, a test file that matches nothing is
+    almost always a misspelt name: its reservation stays pending, the operator
+    keeps running in the legacy runner, and CI passes without anyone noticing.
+    """
+    expected = {test for _, test in active} | {test for _, test in pending}
+    invoked = _shell_invoked_tests(repo_root)
+    unregistered: list[str] = []
+    for root in EXAMPLE_ROOTS:
+        root_path = repo_root / root
+        if not root_path.is_dir():
+            continue
+        for path in sorted(root_path.rglob("test_*.py")):
+            relative = path.relative_to(repo_root).as_posix()
+            if relative in expected or path.resolve().as_posix() in invoked:
+                continue
+            unregistered.append(relative)
+    return unregistered
+
+
+def _print_lines(values: Iterable[str]) -> None:
+    for value in values:
+        print(value)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="repository root (defaults to the resolver's repository)",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help="manifest path, relative to the repository root by default",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("validate", help="validate the manifest and referenced files")
+
+    list_parser = subparsers.add_parser("list", help="list source-to-test mappings")
+    list_parser.add_argument("--format", choices=("tsv",), default="tsv")
+
+    subparsers.add_parser("list-tests", help="list all migrated Pytest files")
+    subparsers.add_parser("list-sources", help="list all sources excluded from the legacy runner")
+    subparsers.add_parser(
+        "check-orphans",
+        help="fail if an example test matches no manifest entry, live or reserved",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        mappings, pending = load_mappings(args.repo_root.resolve(), args.manifest)
+    except (ManifestError, OSError) as error:
+        print(f"operator test manifest error: {error}", file=sys.stderr)
+        return 1
+
+    if args.command == "validate":
+        print(f"Validated {len(mappings)} operator test mapping(s)")
+        if pending:
+            print(
+                f"{len(pending)} mapping(s) reserved but not migrated yet; the "
+                "example keeps running in the legacy runner until its test lands:"
+            )
+            for source, test in pending:
+                print(f"  {source} -> {test}")
+    elif args.command == "list":
+        _print_lines(f"{source}\t{test}" for source, test in mappings)
+    elif args.command == "list-tests":
+        _print_lines(test for _, test in mappings)
+    elif args.command == "list-sources":
+        _print_lines(source for source, _ in mappings)
+    elif args.command == "check-orphans":
+        unregistered = find_unregistered_tests(args.repo_root.resolve(), mappings, pending)
+        if unregistered:
+            print("operator tests matching no manifest entry:", file=sys.stderr)
+            for item in unregistered:
+                print(f"  {item}", file=sys.stderr)
+            print(
+                "the legacy runner skips every test_*.py, so a test that matches no "
+                "entry runs nowhere: add it to ci/operator_test_manifest.yaml, or "
+                "check its name against the entry meant to cover it",
+                file=sys.stderr,
+            )
+            return 1
+        print("All operator tests match a manifest entry")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The manifest was generated for every operator under examples/, deriving each test name as test_<operator>.py. examples/gemm_aot/example_gemm.py derives test_example_gemm.py, which is already taken by a standalone script that run_example_gemm_aot.sh runs as `python test_example_gemm.py` from its own directory. It defines no test function; handing it to Pytest runs its module level in every xdist worker while collecting -- allocating device memory, loading ./kernel_lib.so and launching a kernel -- and collects nothing.