### PR TITLE
[Test] Run migrated operator tests through Pytest

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -202,6 +202,18 @@ jobs:
           pytest_files_array=()
           pytest_dirs_array=()
 
+          # A migrated operator is covered by its Pytest test, so a change to either
+          # one only needs that test; there is no reason to run the whole directory.
+          declare -A source_to_test=()
+          declare -A test_to_test=()
+          if [ -f scripts/ci/resolve_operator_tests.py ]; then
+            while IFS=$'\t' read -r source test; do
+              [[ -n "$source" && -n "$test" ]] || continue
+              source_to_test["$source"]="$test"
+              test_to_test["$test"]="$test"
+            done < <(python scripts/ci/resolve_operator_tests.py list --format tsv)
+          fi
+
           for file in $changed_files; do
             # 排除 .agents 目录（skill 配置，无需测试）
             if [[ "$file" =~ ^\.agents/ ]]; then
@@ -254,6 +266,25 @@ jobs:
               break
             fi
             
+            if [[ -n "${source_to_test[$file]:-}" ]]; then
+              mapped_test="${source_to_test[$file]}"
+              pytest_files_array+=("$mapped_test")
+              run_examples=false
+              run_pytest_only=true
+              should_skip=false
+              echo "Mapped migrated operator $file -> $mapped_test"
+              continue
+            fi
+
+            if [[ -n "${test_to_test[$file]:-}" ]]; then
+              pytest_files_array+=("$file")
+              run_examples=false
+              run_pytest_only=true
+              should_skip=false
+              echo "Mapped migrated test: $file"
+              continue
+            fi
+
             # examples 文件 → 增量 examples + pytest
             if [[ "$file" =~ ^examples/([^/]+)/ ]]; then
               test_dir="${BASH_REMATCH[1]}"
@@ -614,6 +645,23 @@ jobs:
                   fi
                 fi
                 TEST_EXIT_CODE=\${PIPESTATUS[0]}
+
+                # Operator tests were moved out of the legacy runner, so run them here:
+                # one Pytest invocation gets xdist scheduling, the marker filter and the
+                # full failure output. Entries reserved but not migrated yet are absent
+                # from list-tests, so nothing points at a file that does not exist.
+                OPERATOR_TESTS=()
+                while IFS= read -r operator_test; do
+                  [ -n \"\$operator_test\" ] && OPERATOR_TESTS+=(\"../\$operator_test\")
+                done < <(python ../scripts/ci/resolve_operator_tests.py list-tests)
+                if [ \${#OPERATOR_TESTS[@]} -gt 0 ]; then
+                  echo 'Running operator tests: '\${OPERATOR_TESTS[*]}
+                  pytest --forked \"\${OPERATOR_TESTS[@]}\" -v -n 8 \"\${PYTEST_MARKER_ARGS[@]}\" 2>&1 | tee -a test_output.log
+                  OPERATOR_EXIT_CODE=\${PIPESTATUS[0]}
+                  if [ \"\$TEST_EXIT_CODE\" -eq 0 ]; then
+                    TEST_EXIT_CODE=\$OPERATOR_EXIT_CODE
+                  fi
+                fi
                 set -e
               fi
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - ascendc_pto*
+      - example_test*
     paths-ignore:
       - '**.md'
       - '**.png'

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -206,6 +206,11 @@ jobs:
           # one only needs that test; there is no reason to run the whole directory.
           declare -A source_to_test=()
           declare -A test_to_test=()
+          # Collected separately from pytest_files_array: that one is for
+          # testing/python/ and gets collapsed by rules further down.
+          declare -A routed_tests=()
+          routed_example_dirs=()
+          routed_experiment_dirs=()
           if [ -f scripts/ci/resolve_operator_tests.py ]; then
             while IFS=$'\t' read -r source test; do
               [[ -n "$source" && -n "$test" ]] || continue
@@ -268,11 +273,11 @@ jobs:
             
             if [[ -n "${source_to_test[$file]:-}" ]]; then
               mapped_test="${source_to_test[$file]}"
-              pytest_files_array+=("$mapped_test")
-              # Only claim the pytest-only path while nothing else has asked for
-              # examples: otherwise this would drop the directories they collected.
-              if [[ "$run_examples" == false ]]; then
-                run_pytest_only=true
+              routed_tests["$mapped_test"]=1
+              if [[ "$file" =~ ^examples/([^/]+)/ ]]; then
+                routed_example_dirs+=("${BASH_REMATCH[1]}")
+              elif [[ "$file" =~ ^examples_experiment/([^/]+)/ ]]; then
+                routed_experiment_dirs+=("${BASH_REMATCH[1]}")
               fi
               should_skip=false
               echo "Mapped migrated operator $file -> $mapped_test"
@@ -280,9 +285,11 @@ jobs:
             fi
 
             if [[ -n "${test_to_test[$file]:-}" ]]; then
-              pytest_files_array+=("$file")
-              if [[ "$run_examples" == false ]]; then
-                run_pytest_only=true
+              routed_tests["$file"]=1
+              if [[ "$file" =~ ^examples/([^/]+)/ ]]; then
+                routed_example_dirs+=("${BASH_REMATCH[1]}")
+              elif [[ "$file" =~ ^examples_experiment/([^/]+)/ ]]; then
+                routed_experiment_dirs+=("${BASH_REMATCH[1]}")
               fi
               should_skip=false
               echo "Mapped migrated test: $file"
@@ -374,6 +381,36 @@ jobs:
             fi
           done
           
+          # A single routed test and nothing else is the only shape that fits
+          # `pytest --forked ../$PYTEST_FILES_ARG`: that command prefixes ../ onto
+          # the first path only, so every extra path would resolve against examples/
+          # and fail to open. Anything wider goes through the examples branch, where
+          # the fallback prefixes each entry on its own.
+          if [[ ${#routed_tests[@]} -eq 1 ]] \
+             && [[ ${#pytest_files_array[@]} -eq 0 ]] \
+             && [[ ${#pytest_dirs_array[@]} -eq 0 ]] \
+             && [[ ${#test_dirs_array[@]} -eq 0 ]] \
+             && [[ ${#experiment_dirs_array[@]} -eq 0 ]] \
+             && [[ "$run_examples" == false ]]; then
+            pytest_files_array=("${!routed_tests[@]}")
+            run_pytest_only=true
+            echo "Only migrated tests changed: ${pytest_files_array[*]}"
+          elif [[ ${#routed_tests[@]} -gt 0 ]]; then
+            run_examples=true
+            run_pytest_only=false
+            for routed_dir in "${routed_example_dirs[@]}"; do
+              if [[ ! " ${test_dirs_array[*]} " =~ " $routed_dir " ]]; then
+                test_dirs_array+=("$routed_dir")
+              fi
+            done
+            for routed_dir in "${routed_experiment_dirs[@]}"; do
+              if [[ ! " ${experiment_dirs_array[*]} " =~ " $routed_dir " ]]; then
+                experiment_dirs_array+=("$routed_dir")
+              fi
+            done
+            echo "Migrated tests alongside other changes: running examples plus every registered test"
+          fi
+
           # 决定 pytest 测试范围
           pytest_files=""
           if [[ ${#pytest_files_array[@]} -gt 0 ]]; then

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -269,8 +269,11 @@ jobs:
             if [[ -n "${source_to_test[$file]:-}" ]]; then
               mapped_test="${source_to_test[$file]}"
               pytest_files_array+=("$mapped_test")
-              run_examples=false
-              run_pytest_only=true
+              # Only claim the pytest-only path while nothing else has asked for
+              # examples: otherwise this would drop the directories they collected.
+              if [[ "$run_examples" == false ]]; then
+                run_pytest_only=true
+              fi
               should_skip=false
               echo "Mapped migrated operator $file -> $mapped_test"
               continue
@@ -278,8 +281,9 @@ jobs:
 
             if [[ -n "${test_to_test[$file]:-}" ]]; then
               pytest_files_array+=("$file")
-              run_examples=false
-              run_pytest_only=true
+              if [[ "$run_examples" == false ]]; then
+                run_pytest_only=true
+              fi
               should_skip=false
               echo "Mapped migrated test: $file"
               continue

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -382,36 +382,6 @@ jobs:
             fi
           done
           
-          # A single routed test and nothing else is the only shape that fits
-          # `pytest --forked ../$PYTEST_FILES_ARG`: that command prefixes ../ onto
-          # the first path only, so every extra path would resolve against examples/
-          # and fail to open. Anything wider goes through the examples branch, where
-          # the fallback prefixes each entry on its own.
-          if [[ ${#routed_tests[@]} -eq 1 ]] \
-             && [[ ${#pytest_files_array[@]} -eq 0 ]] \
-             && [[ ${#pytest_dirs_array[@]} -eq 0 ]] \
-             && [[ ${#test_dirs_array[@]} -eq 0 ]] \
-             && [[ ${#experiment_dirs_array[@]} -eq 0 ]] \
-             && [[ "$run_examples" == false ]]; then
-            pytest_files_array=("${!routed_tests[@]}")
-            run_pytest_only=true
-            echo "Only migrated tests changed: ${pytest_files_array[*]}"
-          elif [[ ${#routed_tests[@]} -gt 0 ]]; then
-            run_examples=true
-            run_pytest_only=false
-            for routed_dir in "${routed_example_dirs[@]}"; do
-              if [[ ! " ${test_dirs_array[*]} " =~ " $routed_dir " ]]; then
-                test_dirs_array+=("$routed_dir")
-              fi
-            done
-            for routed_dir in "${routed_experiment_dirs[@]}"; do
-              if [[ ! " ${experiment_dirs_array[*]} " =~ " $routed_dir " ]]; then
-                experiment_dirs_array+=("$routed_dir")
-              fi
-            done
-            echo "Migrated tests alongside other changes: running examples plus every registered test"
-          fi
-
           # 决定 pytest 测试范围
           pytest_files=""
           if [[ ${#pytest_files_array[@]} -gt 0 ]]; then
@@ -432,6 +402,39 @@ jobs:
           
           test_dirs="${test_dirs_array[*]}"
           experiment_dirs="${experiment_dirs_array[*]}"
+          # Decided after the collapsing above, and overriding it: those two rules
+          # (one subdirectory replaces the list, more than three empties it) exist
+          # for testing/python/ and would drop these entries. Nothing else queued
+          # means the whole change is migrated tests, so run exactly those.
+          if [[ ${#routed_tests[@]} -gt 0 ]]; then
+            if [[ ${#pytest_files_array[@]} -eq 0 ]] \
+               && [[ ${#pytest_dirs_array[@]} -eq 0 ]] \
+               && [[ ${#test_dirs_array[@]} -eq 0 ]] \
+               && [[ ${#experiment_dirs_array[@]} -eq 0 ]] \
+               && [[ "$run_examples" == false ]]; then
+              pytest_files="${!routed_tests[*]}"
+              run_pytest_only=true
+              echo "Only migrated tests changed: ${pytest_files}"
+            else
+              run_examples=true
+              run_pytest_only=false
+              pytest_files=""
+              for routed_dir in "${routed_example_dirs[@]}"; do
+                if [[ ! " ${test_dirs_array[*]} " =~ " $routed_dir " ]]; then
+                  test_dirs_array+=("$routed_dir")
+                fi
+              done
+              for routed_dir in "${routed_experiment_dirs[@]}"; do
+                if [[ ! " ${experiment_dirs_array[*]} " =~ " $routed_dir " ]]; then
+                  experiment_dirs_array+=("$routed_dir")
+                fi
+              done
+              test_dirs="${test_dirs_array[*]}"
+              experiment_dirs="${experiment_dirs_array[*]}"
+              echo "Migrated tests alongside other changes: running examples plus every registered test"
+            fi
+          fi
+
           echo "run_examples=${run_examples}" >> $GITHUB_OUTPUT
           echo "run_pytest_only=${run_pytest_only}" >> $GITHUB_OUTPUT
           echo "test_dirs=${test_dirs}" >> $GITHUB_OUTPUT
@@ -664,8 +667,14 @@ jobs:
                 # 只跑 pytest（testing/ 修改）
                 if [ -n \"\$PYTEST_FILES_ARG\" ]; then
                   echo 'Running incremental pytest for: '\$PYTEST_FILES_ARG
+                  # Prefix every path, not just the first: the value can hold several
+                  # files and the rest would otherwise resolve against examples/.
+                  PYTEST_TARGETS=()
+                  for pytest_target in \$PYTEST_FILES_ARG; do
+                    PYTEST_TARGETS+=(\"../\$pytest_target\")
+                  done
                   set +e
-                  pytest --forked ../\$PYTEST_FILES_ARG -v -n 4 \"\${PYTEST_MARKER_ARGS[@]}\" 2>&1 | tee test_output.log
+                  pytest --forked \"\${PYTEST_TARGETS[@]}\" -v -n 4 \"\${PYTEST_MARKER_ARGS[@]}\" 2>&1 | tee test_output.log
                 else
                   echo 'Running full pytest (testing/ modified)'
                   set +e

--- a/ci/operator_test_manifest.yaml
+++ b/ci/operator_test_manifest.yaml
@@ -1,0 +1,60 @@
+# 算子源文件 -> 它的 Pytest 测试。
+# 一条登记只有在测试文件真实存在时才生效；否则算子照常由
+# examples/bench_test.sh 执行。
+version: 1
+mappings:
+
+  # examples/batch_gemm
+    examples/batch_gemm/batch_gemm.py: examples/batch_gemm/test_batch_gemm.py
+
+  # examples/flash_attention
+    examples/flash_attention/flash_attn_bhsd.py: examples/flash_attention/test_flash_attn_bhsd.py
+    examples/flash_attention/flash_attn_bhsd_cc_sync.py: examples/flash_attention/test_flash_attn_bhsd_cc_sync.py
+    examples/flash_attention/paged_flash_attn_bhsd.py: examples/flash_attention/test_paged_flash_attn_bhsd.py
+
+  # examples/gqa_fwd_varlen
+    examples/gqa_fwd_varlen/gqa_fwd_varlen.py: examples/gqa_fwd_varlen/test_gqa_fwd_varlen.py
+
+  # examples/HISA
+    examples/HISA/paged_block_sparse_mqa_attn_expert.py: examples/HISA/test_paged_block_sparse_mqa_attn_expert.py
+
+  # examples/xattention
+    examples/xattention/xattention.py: examples/xattention/test_xattention.py
+    examples/xattention/xattention_paged.py: examples/xattention/test_xattention_paged.py
+
+  # examples/sparse_flash_attention
+    examples/sparse_flash_attention/example_sparse_flash_attn.py: examples/sparse_flash_attention/test_example_sparse_flash_attn.py
+    examples/sparse_flash_attention/example_sparse_flash_attn_dynamic_shape.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_dynamic_shape.py
+    examples/sparse_flash_attention/example_sparse_flash_attn_gqa.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa.py
+    examples/sparse_flash_attention/example_sparse_flash_attn_gqa_pto.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa_pto.py
+    examples/sparse_flash_attention/example_sparse_flash_attn_gqa_pto_developer.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa_pto_developer.py
+    examples/sparse_flash_attention/example_sparse_flash_attn_mask.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_mask.py
+    examples/sparse_flash_attention/example_sparse_flash_attn_mask_pa.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_mask_pa.py
+
+  # examples/linear_attention_and_rnn
+    examples/linear_attention_and_rnn/gdn_full.py: examples/linear_attention_and_rnn/test_gdn_full.py
+    examples/linear_attention_and_rnn/linear_attention_causal.py: examples/linear_attention_and_rnn/test_linear_attention_causal.py
+    examples/linear_attention_and_rnn/linear_attention_normalize.py: examples/linear_attention_and_rnn/test_linear_attention_normalize.py
+    examples/linear_attention_and_rnn/opt_gdn_full.py: examples/linear_attention_and_rnn/test_opt_gdn_full.py
+
+  # examples/moe_token_permute
+    examples/moe_token_permute/moe_token_permute.py: examples/moe_token_permute/test_moe_token_permute.py
+    examples/moe_token_permute/moe_token_permute_grad.py: examples/moe_token_permute/test_moe_token_permute_grad.py
+    examples/moe_token_permute/moe_token_unpermute.py: examples/moe_token_permute/test_moe_token_unpermute.py
+    examples/moe_token_permute/moe_token_unpermute_grad.py: examples/moe_token_permute/test_moe_token_unpermute_grad.py
+
+  # examples/tile_kernels/moe
+    examples/tile_kernels/moe/moe_topk_gate.py: examples/tile_kernels/moe/test_moe_topk_gate.py
+
+  # examples/fused_sigmoid_gating_delta_rule
+    examples/fused_sigmoid_gating_delta_rule/fused_sigmoid_gating_delta_rule_varlen.py: examples/fused_sigmoid_gating_delta_rule/test_fused_sigmoid_gating_delta_rule_varlen.py
+
+  # examples_experiment/seer_attention
+    examples_experiment/seer_attention/block_sparse_attn.py: examples_experiment/seer_attention/test_block_sparse_attn.py
+
+  # examples_experiment/chunk_gated_delta_rule
+    examples_experiment/chunk_gated_delta_rule/chunk_gated_delta_rule.py: examples_experiment/chunk_gated_delta_rule/test_chunk_gated_delta_rule.py
+    examples_experiment/chunk_gated_delta_rule/expert_chunk_gated_delta_rule.py: examples_experiment/chunk_gated_delta_rule/test_expert_chunk_gated_delta_rule.py
+
+  # examples_experiment/cumsum_gdn
+    examples_experiment/cumsum_gdn/example_cumsum.py: examples_experiment/cumsum_gdn/test_example_cumsum.py

--- a/ci/operator_test_manifest.yaml
+++ b/ci/operator_test_manifest.yaml
@@ -1,26 +1,195 @@
 # 算子源文件 -> 它的 Pytest 测试。
 # 一条登记只有在测试文件真实存在时才生效；否则算子照常由
 # examples/bench_test.sh 执行。
+#
+# 覆盖 bench_test.sh 会收集到的全部算子。以下不在此表：
+#   examples/gemm_aot/example_gemm.py —— 拼出的名字与已有的独立脚本
+#     test_example_gemm.py 相同，那个脚本由 run_example_gemm_aot.sh 直接执行。
+#   dispatch_combine/ 与 shmem/ —— bench_test.sh 全量扫描时就排除了。
+#   sparse_flash_attention/bench_sfa/ —— 由 CUSTOM_TASK 按名字驱动，
+#     不按路径收集，跳过逻辑碰不到。
+#   torch_tl_ascend/ 的包内部与 build/ 产物 —— 不是独立算子。
 version: 1
 mappings:
 
+  # examples/HISA
+  examples/HISA/block_sparse_mqa_attn_expert_test.py: examples/HISA/test_block_sparse_mqa_attn_expert_test.py
+  examples/HISA/paged_block_sparse_mqa_attn_expert.py: examples/HISA/test_paged_block_sparse_mqa_attn_expert.py
+
+  # examples/aclgraph
+  examples/aclgraph/rms_rope_aclgraph.py: examples/aclgraph/test_rms_rope_aclgraph.py
+
+  # examples/activation
+  examples/activation/gelu_grad.py: examples/activation/test_gelu_grad.py
+  examples/activation/gelu_mul.py: examples/activation/test_gelu_mul.py
+  examples/activation/sigmoid.py: examples/activation/test_sigmoid.py
+  examples/activation/sigmoidv2.py: examples/activation/test_sigmoidv2.py
+  examples/activation/sigmoidv2_slice.py: examples/activation/test_sigmoidv2_slice.py
+  examples/activation/silu.py: examples/activation/test_silu.py
+  examples/activation/swi_glu.py: examples/activation/test_swi_glu.py
+  examples/activation/swi_glu_grad.py: examples/activation/test_swi_glu_grad.py
+  examples/activation/swi_glu_v2.py: examples/activation/test_swi_glu_v2.py
+  examples/activation/tanh.py: examples/activation/test_tanh.py
+
+  # examples/autotune
+  examples/autotune/example_gemm_autotune.py: examples/autotune/test_example_gemm_autotune.py
+  examples/autotune/example_gemm_carver.py: examples/autotune/test_example_gemm_carver.py
+
   # examples/batch_gemm
   examples/batch_gemm/batch_gemm.py: examples/batch_gemm/test_batch_gemm.py
+
+  # examples/causal_conv1d
+  examples/causal_conv1d/causal_conv1d.py: examples/causal_conv1d/test_causal_conv1d.py
+  examples/causal_conv1d/causal_conv1d_pto.py: examples/causal_conv1d/test_causal_conv1d_pto.py
+
+  # examples/compile_flags
+  examples/compile_flags/compile_flags_example.py: examples/compile_flags/test_compile_flags_example.py
+
+  # examples/cross_entropy_loss
+  examples/cross_entropy_loss/example_cross_entro.py: examples/cross_entropy_loss/test_example_cross_entro.py
+
+  # examples/cummin
+  examples/cummin/example_cummin.py: examples/cummin/test_example_cummin.py
+
+  # examples/deepseek_v4
+  examples/deepseek_v4/act_quant.py: examples/deepseek_v4/test_act_quant.py
+  examples/deepseek_v4/hc_split_sinkhorn.py: examples/deepseek_v4/test_hc_split_sinkhorn.py
+  examples/deepseek_v4/int8_gemm.py: examples/deepseek_v4/test_int8_gemm.py
+  examples/deepseek_v4/sparse_attention.py: examples/deepseek_v4/test_sparse_attention.py
+
+  # examples/developer_mode
+  examples/developer_mode/flash_attn_bshd_developer.py: examples/developer_mode/test_flash_attn_bshd_developer.py
+  examples/developer_mode/gelu_mul_developer.py: examples/developer_mode/test_gelu_mul_developer.py
+  examples/developer_mode/gemm_developer.py: examples/developer_mode/test_gemm_developer.py
+  examples/developer_mode/matmul_add_developer.py: examples/developer_mode/test_matmul_add_developer.py
+  examples/developer_mode/matmul_add_developer_vec_cast.py: examples/developer_mode/test_matmul_add_developer_vec_cast.py
+  examples/developer_mode/sparse_flash_attn_developer.py: examples/developer_mode/test_sparse_flash_attn_developer.py
+  examples/developer_mode/sparse_flash_attn_developer_vid_reduce.py: examples/developer_mode/test_sparse_flash_attn_developer_vid_reduce.py
+
+  # examples/elementwise
+  examples/elementwise/elementwise_add.py: examples/elementwise/test_elementwise_add.py
+  examples/elementwise/elementwise_add_pipeline.py: examples/elementwise/test_elementwise_add_pipeline.py
+  examples/elementwise/setvalue_example.py: examples/elementwise/test_setvalue_example.py
+
+  # examples/flash_attention/fa_opt
+  examples/flash_attention/fa_opt/flash_attn_bhsd_ascendc.py: examples/flash_attention/fa_opt/test_flash_attn_bhsd_ascendc.py
+  examples/flash_attention/fa_opt/flash_attn_bhsd_auto_pipeline_h16_d128.py: examples/flash_attention/fa_opt/test_flash_attn_bhsd_auto_pipeline_h16_d128.py
+  examples/flash_attention/fa_opt/flash_attn_bhsd_auto_pipeline_h32_d512.py: examples/flash_attention/fa_opt/test_flash_attn_bhsd_auto_pipeline_h32_d512.py
+  examples/flash_attention/fa_opt/flash_attn_bhsd_expert_h16_d128.py: examples/flash_attention/fa_opt/test_flash_attn_bhsd_expert_h16_d128.py
 
   # examples/flash_attention
   examples/flash_attention/flash_attn_bhsd.py: examples/flash_attention/test_flash_attn_bhsd.py
   examples/flash_attention/flash_attn_bhsd_cc_sync.py: examples/flash_attention/test_flash_attn_bhsd_cc_sync.py
   examples/flash_attention/paged_flash_attn_bhsd.py: examples/flash_attention/test_paged_flash_attn_bhsd.py
 
+  # examples/fused_sigmoid_gating_delta_rule
+  examples/fused_sigmoid_gating_delta_rule/fused_sigmoid_gating_delta_rule_varlen.py: examples/fused_sigmoid_gating_delta_rule/test_fused_sigmoid_gating_delta_rule_varlen.py
+
+  # examples/gemm
+  examples/gemm/example_gemm.py: examples/gemm/test_example_gemm.py
+  examples/gemm/example_gemm_fp8_pto.py: examples/gemm/test_example_gemm_fp8_pto.py
+  examples/gemm/example_gemm_infer_scope.py: examples/gemm/test_example_gemm_infer_scope.py
+  examples/gemm/example_gemm_intrinsic.py: examples/gemm/test_example_gemm_intrinsic.py
+  examples/gemm/example_gemm_intrinsic_persistent.py: examples/gemm/test_example_gemm_intrinsic_persistent.py
+  examples/gemm/example_gemm_persistent.py: examples/gemm/test_example_gemm_persistent.py
+  examples/gemm/example_gemm_pto_developer.py: examples/gemm/test_example_gemm_pto_developer.py
+  examples/gemm/example_gemm_tail_block_developer.py: examples/gemm/test_example_gemm_tail_block_developer.py
+  examples/gemm/example_gemm_transpose_l1.py: examples/gemm/test_example_gemm_transpose_l1.py
+
+  # examples/gemv
+  examples/gemv/example_gemv_c.py: examples/gemv/test_example_gemv_c.py
+  examples/gemv/example_gemv_v.py: examples/gemv/test_example_gemv_v.py
+
+  # examples/generative_recommendation
+  examples/generative_recommendation/mtgr_ragged_segment_attention.py: examples/generative_recommendation/test_mtgr_ragged_segment_attention.py
+
   # examples/gqa_fwd_varlen
   examples/gqa_fwd_varlen/gqa_fwd_varlen.py: examples/gqa_fwd_varlen/test_gqa_fwd_varlen.py
+  examples/gqa_fwd_varlen/perf_gqa_fwd_varlen.py: examples/gqa_fwd_varlen/test_perf_gqa_fwd_varlen.py
 
-  # examples/HISA
-  examples/HISA/paged_block_sparse_mqa_attn_expert.py: examples/HISA/test_paged_block_sparse_mqa_attn_expert.py
+  # examples/group_norm
+  examples/group_norm/example_group_norm.py: examples/group_norm/test_example_group_norm.py
 
-  # examples/xattention
-  examples/xattention/xattention.py: examples/xattention/test_xattention.py
-  examples/xattention/xattention_paged.py: examples/xattention/test_xattention_paged.py
+  # examples/lightning_indexer
+  examples/lightning_indexer/example_lightning_indexer.py: examples/lightning_indexer/test_example_lightning_indexer.py
+  examples/lightning_indexer/example_lightning_indexer_dynamic_shape.py: examples/lightning_indexer/test_example_lightning_indexer_dynamic_shape.py
+
+  # examples/linear_attention_and_rnn/gdn
+  examples/linear_attention_and_rnn/gdn/gdn_chunk_cumsum.py: examples/linear_attention_and_rnn/gdn/test_gdn_chunk_cumsum.py
+  examples/linear_attention_and_rnn/gdn/gdn_chunk_h.py: examples/linear_attention_and_rnn/gdn/test_gdn_chunk_h.py
+  examples/linear_attention_and_rnn/gdn/gdn_chunk_o.py: examples/linear_attention_and_rnn/gdn/test_gdn_chunk_o.py
+  examples/linear_attention_and_rnn/gdn/gdn_chunk_scaled_dot_kkt.py: examples/linear_attention_and_rnn/gdn/test_gdn_chunk_scaled_dot_kkt.py
+  examples/linear_attention_and_rnn/gdn/gdn_solve_tril.py: examples/linear_attention_and_rnn/gdn/test_gdn_solve_tril.py
+  examples/linear_attention_and_rnn/gdn/gdn_wy_fast.py: examples/linear_attention_and_rnn/gdn/test_gdn_wy_fast.py
+
+  # examples/linear_attention_and_rnn
+  examples/linear_attention_and_rnn/gdn_full.py: examples/linear_attention_and_rnn/test_gdn_full.py
+  examples/linear_attention_and_rnn/linear_attention_causal.py: examples/linear_attention_and_rnn/test_linear_attention_causal.py
+  examples/linear_attention_and_rnn/linear_attention_normalize.py: examples/linear_attention_and_rnn/test_linear_attention_normalize.py
+
+  # examples/linear_attention_and_rnn/opt_gdn
+  examples/linear_attention_and_rnn/opt_gdn/opt_gdn_chunk_cumsum.py: examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_chunk_cumsum.py
+  examples/linear_attention_and_rnn/opt_gdn/opt_gdn_chunk_h.py: examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_chunk_h.py
+  examples/linear_attention_and_rnn/opt_gdn/opt_gdn_chunk_o.py: examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_chunk_o.py
+  examples/linear_attention_and_rnn/opt_gdn/opt_gdn_chunk_scaled_dot_kkt.py: examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_chunk_scaled_dot_kkt.py
+  examples/linear_attention_and_rnn/opt_gdn/opt_gdn_solve_tril.py: examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_solve_tril.py
+  examples/linear_attention_and_rnn/opt_gdn/opt_gdn_wy_fast.py: examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_wy_fast.py
+
+  # examples/linear_attention_and_rnn
+  examples/linear_attention_and_rnn/opt_gdn_full.py: examples/linear_attention_and_rnn/test_opt_gdn_full.py
+
+  # examples/moe_token_permute
+  examples/moe_token_permute/moe_token_permute.py: examples/moe_token_permute/test_moe_token_permute.py
+  examples/moe_token_permute/moe_token_permute_grad.py: examples/moe_token_permute/test_moe_token_permute_grad.py
+  examples/moe_token_permute/moe_token_unpermute.py: examples/moe_token_permute/test_moe_token_unpermute.py
+  examples/moe_token_permute/moe_token_unpermute_grad.py: examples/moe_token_permute/test_moe_token_unpermute_grad.py
+  examples/moe_token_permute/moe_token_utils.py: examples/moe_token_permute/test_moe_token_utils.py
+
+  # examples/normalization
+  examples/normalization/layer_norm.py: examples/normalization/test_layer_norm.py
+  examples/normalization/rms_norm.py: examples/normalization/test_rms_norm.py
+
+  # examples/pad
+  examples/pad/example_broadcast.py: examples/pad/test_example_broadcast.py
+  examples/pad/example_broadcast_pipeline.py: examples/pad/test_example_broadcast_pipeline.py
+
+  # examples/pipeline
+  examples/pipeline/flash_attn_bshd_pipeline.py: examples/pipeline/test_flash_attn_bshd_pipeline.py
+  examples/pipeline/gemm_v0_pipeline.py: examples/pipeline/test_gemm_v0_pipeline.py
+  examples/pipeline/matmul_add_pipeline.py: examples/pipeline/test_matmul_add_pipeline.py
+  examples/pipeline/sparse_flash_attn_gqa_pipeline.py: examples/pipeline/test_sparse_flash_attn_gqa_pipeline.py
+  examples/pipeline/sparse_flash_attn_gqa_pipeline_pto.py: examples/pipeline/test_sparse_flash_attn_gqa_pipeline_pto.py
+
+  # examples/pos_embedding
+  examples/pos_embedding/rms_norm.py: examples/pos_embedding/test_rms_norm.py
+  examples/pos_embedding/rms_rope_fused.py: examples/pos_embedding/test_rms_rope_fused.py
+  examples/pos_embedding/rms_rope_fused_mask.py: examples/pos_embedding/test_rms_rope_fused_mask.py
+  examples/pos_embedding/rope.py: examples/pos_embedding/test_rope.py
+  examples/pos_embedding/rope_mask.py: examples/pos_embedding/test_rope_mask.py
+  examples/pos_embedding/rope_mask_bwd.py: examples/pos_embedding/test_rope_mask_bwd.py
+
+  # examples/print
+  examples/print/elementwise_print.py: examples/print/test_elementwise_print.py
+
+  # examples/quant_batch_matmul
+  examples/quant_batch_matmul/example_quant_batch_matmul.py: examples/quant_batch_matmul/test_example_quant_batch_matmul.py
+  examples/quant_batch_matmul/example_quant_matmul.py: examples/quant_batch_matmul/test_example_quant_matmul.py
+
+  # examples/reduce
+  examples/reduce/example_col_reduce_max_slice_buffer.py: examples/reduce/test_example_col_reduce_max_slice_buffer.py
+  examples/reduce/example_reduce_min.py: examples/reduce/test_example_reduce_min.py
+  examples/reduce/example_reduce_min_pipeline.py: examples/reduce/test_example_reduce_min_pipeline.py
+  examples/reduce/example_row_reduce_max_slice_buffer.py: examples/reduce/test_example_row_reduce_max_slice_buffer.py
+
+  # examples/simple_fusion
+  examples/simple_fusion/matmul_add.py: examples/simple_fusion/test_matmul_add.py
+  examples/simple_fusion/matmul_add_infer_scope.py: examples/simple_fusion/test_matmul_add_infer_scope.py
+
+  # examples/softmax
+  examples/softmax/example_online_softmax.py: examples/softmax/test_example_online_softmax.py
+
+  # examples/sort
+  examples/sort/example_merge_sort.py: examples/sort/test_example_merge_sort.py
 
   # examples/sparse_flash_attention
   examples/sparse_flash_attention/example_sparse_flash_attn.py: examples/sparse_flash_attention/test_example_sparse_flash_attn.py
@@ -31,30 +200,64 @@ mappings:
   examples/sparse_flash_attention/example_sparse_flash_attn_mask.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_mask.py
   examples/sparse_flash_attention/example_sparse_flash_attn_mask_pa.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_mask_pa.py
 
-  # examples/linear_attention_and_rnn
-  examples/linear_attention_and_rnn/gdn_full.py: examples/linear_attention_and_rnn/test_gdn_full.py
-  examples/linear_attention_and_rnn/linear_attention_causal.py: examples/linear_attention_and_rnn/test_linear_attention_causal.py
-  examples/linear_attention_and_rnn/linear_attention_normalize.py: examples/linear_attention_and_rnn/test_linear_attention_normalize.py
-  examples/linear_attention_and_rnn/opt_gdn_full.py: examples/linear_attention_and_rnn/test_opt_gdn_full.py
+  # examples/tail_mask
+  examples/tail_mask/example_tail_add.py: examples/tail_mask/test_example_tail_add.py
 
-  # examples/moe_token_permute
-  examples/moe_token_permute/moe_token_permute.py: examples/moe_token_permute/test_moe_token_permute.py
-  examples/moe_token_permute/moe_token_permute_grad.py: examples/moe_token_permute/test_moe_token_permute_grad.py
-  examples/moe_token_permute/moe_token_unpermute.py: examples/moe_token_permute/test_moe_token_unpermute.py
-  examples/moe_token_permute/moe_token_unpermute_grad.py: examples/moe_token_permute/test_moe_token_unpermute_grad.py
+  # examples/tile_kernels/mhc
+  examples/tile_kernels/mhc/head_compute_mix_kernel.py: examples/tile_kernels/mhc/test_head_compute_mix_kernel.py
 
   # examples/tile_kernels/moe
   examples/tile_kernels/moe/moe_topk_gate.py: examples/tile_kernels/moe/test_moe_topk_gate.py
 
-  # examples/fused_sigmoid_gating_delta_rule
-  examples/fused_sigmoid_gating_delta_rule/fused_sigmoid_gating_delta_rule_varlen.py: examples/fused_sigmoid_gating_delta_rule/test_fused_sigmoid_gating_delta_rule_varlen.py
+  # examples/topk_selector
+  examples/topk_selector/example_topk_selector.py: examples/topk_selector/test_example_topk_selector.py
 
-  # examples_experiment/seer_attention
-  examples_experiment/seer_attention/block_sparse_attn.py: examples_experiment/seer_attention/test_block_sparse_attn.py
+  # examples/unsorted_segment_sum
+  examples/unsorted_segment_sum/unsorted_segment_sum.py: examples/unsorted_segment_sum/test_unsorted_segment_sum.py
+
+  # examples/xattention
+  examples/xattention/xattention.py: examples/xattention/test_xattention.py
+  examples/xattention/xattention_paged.py: examples/xattention/test_xattention_paged.py
+
+  # examples/xllm_kernels
+  examples/xllm_kernels/fused_gdn_gating.py: examples/xllm_kernels/test_fused_gdn_gating.py
+  examples/xllm_kernels/rope.py: examples/xllm_kernels/test_rope.py
+  examples/xllm_kernels/split_qkv_rmsnorm_mrope.py: examples/xllm_kernels/test_split_qkv_rmsnorm_mrope.py
+
+  # examples_experiment/blocksparse_gemm
+  examples_experiment/blocksparse_gemm/example_blocksparse_gemm.py: examples_experiment/blocksparse_gemm/test_example_blocksparse_gemm.py
 
   # examples_experiment/chunk_gated_delta_rule
   examples_experiment/chunk_gated_delta_rule/chunk_gated_delta_rule.py: examples_experiment/chunk_gated_delta_rule/test_chunk_gated_delta_rule.py
   examples_experiment/chunk_gated_delta_rule/expert_chunk_gated_delta_rule.py: examples_experiment/chunk_gated_delta_rule/test_expert_chunk_gated_delta_rule.py
 
+  # examples_experiment/convolution
+  examples_experiment/convolution/example_convolution.py: examples_experiment/convolution/test_example_convolution.py
+  examples_experiment/convolution/example_convolution_autotune.py: examples_experiment/convolution/test_example_convolution_autotune.py
+
   # examples_experiment/cumsum_gdn
   examples_experiment/cumsum_gdn/example_cumsum.py: examples_experiment/cumsum_gdn/test_example_cumsum.py
+
+  # examples_experiment/cumsum_kda
+  examples_experiment/cumsum_kda/example_cumsum_kda.py: examples_experiment/cumsum_kda/test_example_cumsum_kda.py
+
+  # examples_experiment/dequantize_gemm
+  examples_experiment/dequantize_gemm/example_dequant_gemm_fine_grained.py: examples_experiment/dequantize_gemm/test_example_dequant_gemm_fine_grained.py
+  examples_experiment/dequantize_gemm/example_dequant_gemm_w4a8.py: examples_experiment/dequantize_gemm/test_example_dequant_gemm_w4a8.py
+
+  # examples_experiment/gemm_splitk
+  examples_experiment/gemm_splitk/example_tilelang_gemm_splitk.py: examples_experiment/gemm_splitk/test_example_tilelang_gemm_splitk.py
+
+  # examples_experiment/grouped_gemm
+  examples_experiment/grouped_gemm/example_grouped_gemm_bwd.py: examples_experiment/grouped_gemm/test_example_grouped_gemm_bwd.py
+  examples_experiment/grouped_gemm/example_grouped_gemm_fwd.py: examples_experiment/grouped_gemm/test_example_grouped_gemm_fwd.py
+  examples_experiment/grouped_gemm/example_grouped_gemm_fwd_ptr.py: examples_experiment/grouped_gemm/test_example_grouped_gemm_fwd_ptr.py
+
+  # examples_experiment/hadamard_transform
+  examples_experiment/hadamard_transform/example_hadamard_transform.py: examples_experiment/hadamard_transform/test_example_hadamard_transform.py
+
+  # examples_experiment/random_1d
+  examples_experiment/random_1d/random_1d.py: examples_experiment/random_1d/test_random_1d.py
+
+  # examples_experiment/seer_attention
+  examples_experiment/seer_attention/block_sparse_attn.py: examples_experiment/seer_attention/test_block_sparse_attn.py

--- a/ci/operator_test_manifest.yaml
+++ b/ci/operator_test_manifest.yaml
@@ -5,56 +5,56 @@ version: 1
 mappings:
 
   # examples/batch_gemm
-    examples/batch_gemm/batch_gemm.py: examples/batch_gemm/test_batch_gemm.py
+  examples/batch_gemm/batch_gemm.py: examples/batch_gemm/test_batch_gemm.py
 
   # examples/flash_attention
-    examples/flash_attention/flash_attn_bhsd.py: examples/flash_attention/test_flash_attn_bhsd.py
-    examples/flash_attention/flash_attn_bhsd_cc_sync.py: examples/flash_attention/test_flash_attn_bhsd_cc_sync.py
-    examples/flash_attention/paged_flash_attn_bhsd.py: examples/flash_attention/test_paged_flash_attn_bhsd.py
+  examples/flash_attention/flash_attn_bhsd.py: examples/flash_attention/test_flash_attn_bhsd.py
+  examples/flash_attention/flash_attn_bhsd_cc_sync.py: examples/flash_attention/test_flash_attn_bhsd_cc_sync.py
+  examples/flash_attention/paged_flash_attn_bhsd.py: examples/flash_attention/test_paged_flash_attn_bhsd.py
 
   # examples/gqa_fwd_varlen
-    examples/gqa_fwd_varlen/gqa_fwd_varlen.py: examples/gqa_fwd_varlen/test_gqa_fwd_varlen.py
+  examples/gqa_fwd_varlen/gqa_fwd_varlen.py: examples/gqa_fwd_varlen/test_gqa_fwd_varlen.py
 
   # examples/HISA
-    examples/HISA/paged_block_sparse_mqa_attn_expert.py: examples/HISA/test_paged_block_sparse_mqa_attn_expert.py
+  examples/HISA/paged_block_sparse_mqa_attn_expert.py: examples/HISA/test_paged_block_sparse_mqa_attn_expert.py
 
   # examples/xattention
-    examples/xattention/xattention.py: examples/xattention/test_xattention.py
-    examples/xattention/xattention_paged.py: examples/xattention/test_xattention_paged.py
+  examples/xattention/xattention.py: examples/xattention/test_xattention.py
+  examples/xattention/xattention_paged.py: examples/xattention/test_xattention_paged.py
 
   # examples/sparse_flash_attention
-    examples/sparse_flash_attention/example_sparse_flash_attn.py: examples/sparse_flash_attention/test_example_sparse_flash_attn.py
-    examples/sparse_flash_attention/example_sparse_flash_attn_dynamic_shape.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_dynamic_shape.py
-    examples/sparse_flash_attention/example_sparse_flash_attn_gqa.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa.py
-    examples/sparse_flash_attention/example_sparse_flash_attn_gqa_pto.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa_pto.py
-    examples/sparse_flash_attention/example_sparse_flash_attn_gqa_pto_developer.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa_pto_developer.py
-    examples/sparse_flash_attention/example_sparse_flash_attn_mask.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_mask.py
-    examples/sparse_flash_attention/example_sparse_flash_attn_mask_pa.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_mask_pa.py
+  examples/sparse_flash_attention/example_sparse_flash_attn.py: examples/sparse_flash_attention/test_example_sparse_flash_attn.py
+  examples/sparse_flash_attention/example_sparse_flash_attn_dynamic_shape.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_dynamic_shape.py
+  examples/sparse_flash_attention/example_sparse_flash_attn_gqa.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa.py
+  examples/sparse_flash_attention/example_sparse_flash_attn_gqa_pto.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa_pto.py
+  examples/sparse_flash_attention/example_sparse_flash_attn_gqa_pto_developer.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa_pto_developer.py
+  examples/sparse_flash_attention/example_sparse_flash_attn_mask.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_mask.py
+  examples/sparse_flash_attention/example_sparse_flash_attn_mask_pa.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_mask_pa.py
 
   # examples/linear_attention_and_rnn
-    examples/linear_attention_and_rnn/gdn_full.py: examples/linear_attention_and_rnn/test_gdn_full.py
-    examples/linear_attention_and_rnn/linear_attention_causal.py: examples/linear_attention_and_rnn/test_linear_attention_causal.py
-    examples/linear_attention_and_rnn/linear_attention_normalize.py: examples/linear_attention_and_rnn/test_linear_attention_normalize.py
-    examples/linear_attention_and_rnn/opt_gdn_full.py: examples/linear_attention_and_rnn/test_opt_gdn_full.py
+  examples/linear_attention_and_rnn/gdn_full.py: examples/linear_attention_and_rnn/test_gdn_full.py
+  examples/linear_attention_and_rnn/linear_attention_causal.py: examples/linear_attention_and_rnn/test_linear_attention_causal.py
+  examples/linear_attention_and_rnn/linear_attention_normalize.py: examples/linear_attention_and_rnn/test_linear_attention_normalize.py
+  examples/linear_attention_and_rnn/opt_gdn_full.py: examples/linear_attention_and_rnn/test_opt_gdn_full.py
 
   # examples/moe_token_permute
-    examples/moe_token_permute/moe_token_permute.py: examples/moe_token_permute/test_moe_token_permute.py
-    examples/moe_token_permute/moe_token_permute_grad.py: examples/moe_token_permute/test_moe_token_permute_grad.py
-    examples/moe_token_permute/moe_token_unpermute.py: examples/moe_token_permute/test_moe_token_unpermute.py
-    examples/moe_token_permute/moe_token_unpermute_grad.py: examples/moe_token_permute/test_moe_token_unpermute_grad.py
+  examples/moe_token_permute/moe_token_permute.py: examples/moe_token_permute/test_moe_token_permute.py
+  examples/moe_token_permute/moe_token_permute_grad.py: examples/moe_token_permute/test_moe_token_permute_grad.py
+  examples/moe_token_permute/moe_token_unpermute.py: examples/moe_token_permute/test_moe_token_unpermute.py
+  examples/moe_token_permute/moe_token_unpermute_grad.py: examples/moe_token_permute/test_moe_token_unpermute_grad.py
 
   # examples/tile_kernels/moe
-    examples/tile_kernels/moe/moe_topk_gate.py: examples/tile_kernels/moe/test_moe_topk_gate.py
+  examples/tile_kernels/moe/moe_topk_gate.py: examples/tile_kernels/moe/test_moe_topk_gate.py
 
   # examples/fused_sigmoid_gating_delta_rule
-    examples/fused_sigmoid_gating_delta_rule/fused_sigmoid_gating_delta_rule_varlen.py: examples/fused_sigmoid_gating_delta_rule/test_fused_sigmoid_gating_delta_rule_varlen.py
+  examples/fused_sigmoid_gating_delta_rule/fused_sigmoid_gating_delta_rule_varlen.py: examples/fused_sigmoid_gating_delta_rule/test_fused_sigmoid_gating_delta_rule_varlen.py
 
   # examples_experiment/seer_attention
-    examples_experiment/seer_attention/block_sparse_attn.py: examples_experiment/seer_attention/test_block_sparse_attn.py
+  examples_experiment/seer_attention/block_sparse_attn.py: examples_experiment/seer_attention/test_block_sparse_attn.py
 
   # examples_experiment/chunk_gated_delta_rule
-    examples_experiment/chunk_gated_delta_rule/chunk_gated_delta_rule.py: examples_experiment/chunk_gated_delta_rule/test_chunk_gated_delta_rule.py
-    examples_experiment/chunk_gated_delta_rule/expert_chunk_gated_delta_rule.py: examples_experiment/chunk_gated_delta_rule/test_expert_chunk_gated_delta_rule.py
+  examples_experiment/chunk_gated_delta_rule/chunk_gated_delta_rule.py: examples_experiment/chunk_gated_delta_rule/test_chunk_gated_delta_rule.py
+  examples_experiment/chunk_gated_delta_rule/expert_chunk_gated_delta_rule.py: examples_experiment/chunk_gated_delta_rule/test_expert_chunk_gated_delta_rule.py
 
   # examples_experiment/cumsum_gdn
-    examples_experiment/cumsum_gdn/example_cumsum.py: examples_experiment/cumsum_gdn/test_example_cumsum.py
+  examples_experiment/cumsum_gdn/example_cumsum.py: examples_experiment/cumsum_gdn/test_example_cumsum.py

--- a/examples/batch_gemm/test_batch_gemm.py
+++ b/examples/batch_gemm/test_batch_gemm.py
@@ -1,0 +1,53 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_batch_gemm_example() -> ModuleType:
+    source = Path(__file__).with_name("batch_gemm.py")
+    spec = importlib.util.spec_from_file_location("_batch_gemm_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        # batch_gemm.py parses arguments at import time. Hide Pytest arguments
+        # while loading it without changing the original Example.
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_batch_gemm_accuracy() -> None:
+    import torch
+
+    example = _load_batch_gemm_example()
+
+    batch = 8
+    m = 1024
+    n = 1024
+    k = 1024
+
+    kernel = example.batch_matmul(
+        batch,
+        m,
+        n,
+        k,
+        block_M=128,
+        block_N=256,
+        K_L1=64,
+    )
+
+    torch.manual_seed(0)
+    lhs = torch.randn(batch, m, k).half().npu()
+    rhs = torch.randn(batch, k, n).half().npu()
+
+    actual = kernel(lhs, rhs)
+    expected = torch.matmul(lhs, rhs)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)

--- a/examples/bench_test.sh
+++ b/examples/bench_test.sh
@@ -61,6 +61,28 @@ done
 # ================= 全局环境变量设置 =================
 PROJECT_ROOT="$(cd .. && pwd)"
 
+# An operator listed here is covered by its Pytest test, which the workflow
+# runs separately; executing it here as well would compile and run the same
+# kernel twice.
+declare -A MIGRATED_SOURCES=()
+OPERATOR_TEST_RESOLVER="${PROJECT_ROOT}/scripts/ci/resolve_operator_tests.py"
+if [ -f "$OPERATOR_TEST_RESOLVER" ]; then
+    # This script has no `set -e`, so a failure here would otherwise leave the
+    # skip list empty and let every migrated operator run twice unnoticed.
+    if ! python "$OPERATOR_TEST_RESOLVER" validate; then
+        echo "Operator test manifest is invalid" >&2
+        exit 1
+    fi
+    if ! python "$OPERATOR_TEST_RESOLVER" check-orphans; then
+        echo "Operator test names do not match the manifest" >&2
+        exit 1
+    fi
+    while IFS=$'\t' read -r source test; do
+        [ -n "$source" ] || continue
+        MIGRATED_SOURCES["$source"]=1
+    done < <(python "$OPERATOR_TEST_RESOLVER" list --format tsv)
+fi
+
 # experiment 算子根目录（相对 examples 工作目录）
 EXPERIMENT_ROOT="../examples_experiment"
 
@@ -148,6 +170,19 @@ total_scripts=0
 passed_scripts=0
 all_scripts=()
 
+should_skip_python_script() {
+    local candidate="$1"
+    local repo_relative
+
+    repo_relative=$(realpath --relative-to="$PROJECT_ROOT" "$candidate")
+    if [[ -n "${MIGRATED_SOURCES[$repo_relative]:-}" ]]; then
+        echo "Skip migrated operator in legacy runner: $candidate" >&2
+        return 0
+    fi
+
+    return 1
+}
+
 # 函数：收集单个目录下的测试脚本
 collect_test_scripts() {
     local dir="$1"
@@ -169,9 +204,12 @@ collect_test_scripts() {
             # 收集主目录的 py 文件（排除 fa_opt）
             local py_files=$(find "$dir" -maxdepth 1 -name "*.py" \
                 -not -name "__init__.py" \
+                -not -name "test_*.py" \
                 -not -name "*_golden.py" \
                 | sort)
-            for f in $py_files; do scripts+=("$f"); done
+            for f in $py_files; do
+                should_skip_python_script "$f" || scripts+=("$f")
+            done
             
             echo "${scripts[@]}"
             return
@@ -181,6 +219,7 @@ collect_test_scripts() {
     # 搜索 maxdepth 2 的 py 文件（排除特殊文件和 bench_sfa 子目录）
     local py_files=$(find "$dir" -maxdepth 2 -name "*.py" \
         -not -name "__init__.py" \
+        -not -name "test_*.py" \
         -not -name "*_golden.py" \
         -not -name "sfa_golden.py" \
         -not -name "utils.py" \
@@ -188,7 +227,9 @@ collect_test_scripts() {
         -not -path "*/generative_recommendation/golden.py" \
         -not -path "*/generative_recommendation/testcase.py" \
         | sort)
-    for f in $py_files; do scripts+=("$f"); done
+    for f in $py_files; do
+        should_skip_python_script "$f" || scripts+=("$f")
+    done
     
     # 搜索 bash 脚本（特定命名模式）
     local sh_files=$(find "$dir" -maxdepth 2 \( -name "run_*.sh" -o -name "test_*.sh" \) | sort)
@@ -250,7 +291,9 @@ if [ -n "$TEST_DIRS" ] || [ -n "$EXPERIMENT_DIRS" ]; then
         if [ -d "$fa_dir" ]; then
             fa_python_files=$(find "$fa_dir" -maxdepth 1 -name "flash_*.py" | sort)
             if [ -n "$fa_python_files" ]; then
-                for file in $fa_python_files; do all_scripts+=("$file"); done
+                for file in $fa_python_files; do
+                    should_skip_python_script "$file" || all_scripts+=("$file")
+                done
             fi
         fi
     fi
@@ -280,7 +323,9 @@ else
     if [ -d "$fa_dir" ]; then
         fa_python_files=$(find "$fa_dir" -maxdepth 1 -name "flash_*.py" | sort)
         if [ -n "$fa_python_files" ]; then
-            for file in $fa_python_files; do all_scripts+=("$file"); done
+            for file in $fa_python_files; do
+                should_skip_python_script "$file" || all_scripts+=("$file")
+            done
         fi
     fi
 

--- a/examples/flash_attention/test_flash_attn_bhsd.py
+++ b/examples/flash_attention/test_flash_attn_bhsd.py
@@ -1,0 +1,67 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_flash_attn_example() -> ModuleType:
+    source = Path(__file__).with_name("flash_attn_bhsd.py")
+    spec = importlib.util.spec_from_file_location("_flash_attn_bhsd_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        # flash_attn_bhsd.py parses arguments in its __main__ block. Hide Pytest
+        # arguments while loading it without changing the original Example.
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def _reference_flash_attn(query, key, value):
+    # Mirrors ref_flash_attn defined inside the example's __main__ block, which
+    # is not reachable after importing the module.
+    import torch
+
+    query = query.float()
+    key = key.float()
+    value = value.float()
+
+    scores = torch.einsum("bhsd,bhkd->bhsk", query, key) * (1.0 / query.shape[-1]) ** 0.5
+    scores = scores.softmax(dim=-1)
+    out = torch.einsum("bhsk,bhkd->bhsd", scores, value)
+    return out.to(torch.float16)
+
+
+def test_flash_attn_bhsd_accuracy() -> None:
+    import torch
+
+    example = _load_flash_attn_example()
+
+    batch = 1
+    seq_len = 128
+    heads = 1
+    dim = 512
+
+    kernel = example.flash_attention_fwd(
+        batch=batch,
+        seq_len=seq_len,
+        heads=heads,
+        dim=dim,
+    )
+
+    torch.manual_seed(0)
+    query = torch.randn((batch, heads, seq_len, dim), dtype=torch.float16, device="npu")
+    key = torch.randn((batch, heads, seq_len, dim), dtype=torch.float16, device="npu")
+    value = torch.randn((batch, heads, seq_len, dim), dtype=torch.float16, device="npu")
+
+    actual = kernel(query, key, value)
+    expected = _reference_flash_attn(query, key, value)
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)

--- a/scripts/ci/resolve_operator_tests.py
+++ b/scripts/ci/resolve_operator_tests.py
@@ -147,9 +147,9 @@ def _shell_invoked_tests(repo_root: Path) -> set[str]:
 def find_unregistered_tests(repo_root: Path, active: list[tuple[str, str]], pending: list[tuple[str, str]]) -> list[str]:
     """List example tests that match no manifest entry, live or reserved.
 
-    With every operator reserved up front, a test file that matches nothing is
-    almost always a misspelt name: its reservation stays pending, the operator
-    keeps running in the legacy runner, and CI passes without anyone noticing.
+    The legacy runner skips every test_*.py by name, so a test that matches no
+    entry is run by nothing at all while CI stays green. Tests a sibling shell
+    script invokes are exempt: those never went through the manifest.
     """
     expected = {test for _, test in active} | {test for _, test in pending}
     invoked = _shell_invoked_tests(repo_root)

--- a/scripts/ci/resolve_operator_tests.py
+++ b/scripts/ci/resolve_operator_tests.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Validate and query the operator-to-Pytest migration manifest."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path, PurePosixPath
+
+
+DEFAULT_MANIFEST = Path("ci/operator_test_manifest.yaml")
+VERSION_PATTERN = re.compile(r"^version:\s*(\d+)\s*$")
+EXAMPLE_ROOTS = ("examples", "examples_experiment")
+RUNNER_PATTERN = re.compile(r"\b(?:python[0-9.]*|pytest)\b")
+PY_FILE_PATTERN = re.compile(r"[\w./-]+\.py\b")
+
+
+class ManifestError(ValueError):
+    """Raised when the operator test manifest is invalid."""
+
+
+def _parse_manifest(manifest_path: Path) -> list[tuple[str, str]]:
+    version: int | None = None
+    in_mappings = False
+    mappings: list[tuple[str, str]] = []
+
+    for line_number, raw_line in enumerate(
+        manifest_path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        version_match = VERSION_PATTERN.fullmatch(stripped)
+        if version_match:
+            if version is not None:
+                raise ManifestError(f"{manifest_path}:{line_number}: duplicate version")
+            version = int(version_match.group(1))
+            continue
+
+        if stripped == "mappings:":
+            if in_mappings:
+                raise ManifestError(f"{manifest_path}:{line_number}: duplicate mappings section")
+            in_mappings = True
+            continue
+
+        if not in_mappings or not raw_line.startswith("  ") or ":" not in stripped:
+            raise ManifestError(f"{manifest_path}:{line_number}: expected an indented source: test mapping")
+
+        source, test = (part.strip() for part in stripped.split(":", maxsplit=1))
+        if not source or not test:
+            raise ManifestError(f"{manifest_path}:{line_number}: source and test are required")
+        mappings.append((source, test))
+
+    if version != 1:
+        raise ManifestError(f"{manifest_path}: unsupported or missing version: {version}")
+    if not in_mappings:
+        raise ManifestError(f"{manifest_path}: missing mappings section")
+    if not mappings:
+        raise ManifestError(f"{manifest_path}: mappings must not be empty")
+    return mappings
+
+
+def _validate_relative_path(value: str, field: str) -> PurePosixPath:
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or str(path) != value:
+        raise ManifestError(f"{field} must be a normalized repo-relative POSIX path: {value}")
+    return path
+
+
+def load_mappings(repo_root: Path, manifest_path: Path) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """Return the mappings that are live, and those still waiting on their test.
+
+    Registering a source excludes it from the legacy runner, so a mapping whose
+    test has not landed yet must not take effect: it is a plan, not a migration.
+    Holding it back keeps the example running and keeps Pytest from being
+    pointed at a file that does not exist.
+    """
+    if not manifest_path.is_absolute():
+        manifest_path = repo_root / manifest_path
+    if not manifest_path.is_file():
+        raise ManifestError(f"manifest does not exist: {manifest_path}")
+
+    mappings = _parse_manifest(manifest_path)
+    seen_sources: set[str] = set()
+    seen_tests: set[str] = set()
+    active: list[tuple[str, str]] = []
+    pending: list[tuple[str, str]] = []
+
+    for source, test in mappings:
+        source_path = _validate_relative_path(source, "source")
+        test_path = _validate_relative_path(test, "test")
+
+        if source in seen_sources:
+            raise ManifestError(f"duplicate source: {source}")
+        if test in seen_tests:
+            raise ManifestError(f"duplicate test: {test}")
+        if source == test:
+            raise ManifestError(f"source and test must be different: {source}")
+        if source_path.suffix != ".py":
+            raise ManifestError(f"source must be a Python file: {source}")
+        if test_path.suffix != ".py" or not test_path.name.startswith("test_"):
+            raise ManifestError(f"test must be named test_*.py: {test}")
+        if not (repo_root / Path(*source_path.parts)).is_file():
+            raise ManifestError(f"source does not exist: {source}")
+        seen_sources.add(source)
+        seen_tests.add(test)
+
+        if (repo_root / Path(*test_path.parts)).is_file():
+            active.append((source, test))
+        else:
+            pending.append((source, test))
+
+    return active, pending
+
+
+def _shell_invoked_tests(repo_root: Path) -> set[str]:
+    """Collect tests that a shell script under the example roots runs directly.
+
+    Those do not go through the manifest at all, so an unregistered name there
+    is not a mistake. Paths resolve against the script directory because these
+    scripts cd into their own directory first.
+    """
+    invoked: set[str] = set()
+    for root in EXAMPLE_ROOTS:
+        root_path = repo_root / root
+        if not root_path.is_dir():
+            continue
+        for script in root_path.rglob("*.sh"):
+            try:
+                text = script.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            for line in text.splitlines():
+                if line.lstrip().startswith("#") or not RUNNER_PATTERN.search(line):
+                    continue
+                for token in PY_FILE_PATTERN.findall(line):
+                    target = (script.parent / token).resolve()
+                    if target.is_file():
+                        invoked.add(target.as_posix())
+    return invoked
+
+
+def find_unregistered_tests(repo_root: Path, active: list[tuple[str, str]], pending: list[tuple[str, str]]) -> list[str]:
+    """List example tests that match no manifest entry, live or reserved.
+
+    With every operator reserved up front, a test file that matches nothing is
+    almost always a misspelt name: its reservation stays pending, the operator
+    keeps running in the legacy runner, and CI passes without anyone noticing.
+    """
+    expected = {test for _, test in active} | {test for _, test in pending}
+    invoked = _shell_invoked_tests(repo_root)
+    unregistered: list[str] = []
+    for root in EXAMPLE_ROOTS:
+        root_path = repo_root / root
+        if not root_path.is_dir():
+            continue
+        for path in sorted(root_path.rglob("test_*.py")):
+            relative = path.relative_to(repo_root).as_posix()
+            if relative in expected or path.resolve().as_posix() in invoked:
+                continue
+            unregistered.append(relative)
+    return unregistered
+
+
+def _print_lines(values: Iterable[str]) -> None:
+    for value in values:
+        print(value)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="repository root (defaults to the resolver's repository)",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help="manifest path, relative to the repository root by default",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("validate", help="validate the manifest and referenced files")
+
+    list_parser = subparsers.add_parser("list", help="list source-to-test mappings")
+    list_parser.add_argument("--format", choices=("tsv",), default="tsv")
+
+    subparsers.add_parser("list-tests", help="list all migrated Pytest files")
+    subparsers.add_parser("list-sources", help="list all sources excluded from the legacy runner")
+    subparsers.add_parser(
+        "check-orphans",
+        help="fail if an example test matches no manifest entry, live or reserved",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        mappings, pending = load_mappings(args.repo_root.resolve(), args.manifest)
+    except (ManifestError, OSError) as error:
+        print(f"operator test manifest error: {error}", file=sys.stderr)
+        return 1
+
+    if args.command == "validate":
+        print(f"Validated {len(mappings)} operator test mapping(s)")
+        if pending:
+            print(
+                f"{len(pending)} mapping(s) reserved but not migrated yet; the "
+                "example keeps running in the legacy runner until its test lands:"
+            )
+            for source, test in pending:
+                print(f"  {source} -> {test}")
+    elif args.command == "list":
+        _print_lines(f"{source}\t{test}" for source, test in mappings)
+    elif args.command == "list-tests":
+        _print_lines(test for _, test in mappings)
+    elif args.command == "list-sources":
+        _print_lines(source for source, _ in mappings)
+    elif args.command == "check-orphans":
+        unregistered = find_unregistered_tests(args.repo_root.resolve(), mappings, pending)
+        if unregistered:
+            print("operator tests matching no manifest entry:", file=sys.stderr)
+            for item in unregistered:
+                print(f"  {item}", file=sys.stderr)
+            print(
+                "the legacy runner skips every test_*.py, so a test that matches no "
+                "entry runs nowhere: add it to ci/operator_test_manifest.yaml, or "
+                "check its name against the entry meant to cover it",
+                file=sys.stderr,
+            )
+            return 1
+        print("All operator tests match a manifest entry")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 正文

### 为什么

`examples/bench_test.sh` 判定一个算子跑没跑过，靠的是 grep 标准输出里有没有 `Kernel Output Match!` 或 `TEST PASSED!`。算子改了输出文案会被误判为失败；反过来，算错了但打印了这句话，同样判为通过。改用 Pytest 的数值断言来判定。

### 做了什么

**一、`bench_test.sh` 不再执行测试文件，并跳过已登记的算子**

`find` 加上 `-not -name "test_*.py"`，测试交给 Pytest；已登记的算子直接跳过，避免同一个 kernel 编译执行两次。收集数从 146 降到 143。

**二、workflow 把改动映射到它对应的那一个测试**

登记表在 workflow 里建成两张查找表。改了已迁移的算子、或改了它的测试，都只跑那一个测试，`examples` 一个都不跑。

命中的条目单独收集，不进 `pytest_files_array`——那个数组是给 `testing/python/` 用的，收尾时有两条自己的折叠规则会把外来条目丢掉。只有整个改动就是一个已迁移测试时才走这条快路：`pytest --forked ../$PYTEST_FILES_ARG` 只给第一个路径加 `../`，多路径会解析到 `examples/` 下打不开。

**三、映射不到时的兜底**

改动更宽时走原有的增量 examples，并补跑全部已登记的测试，同时把这些算子所在目录并进增量列表，不退化成全量。

### 登记表

`ci/operator_test_manifest.yaml` 只登记正在迁移的目录，29 条。

**一条登记只在其测试文件真实存在时才生效**，当前 3 条生效、26 条待办。待办条目不出现在 `list-tests` 里，Pytest 不会指向不存在的文件；对应算子照常在旧 runner 中执行。

直接效果是**新增测试时不需要改动登记表**——名字已经预留好，PR 因而不会命中「改动 `ci/` → 全量测试」那条规则。

不按全仓自动生成，是因为按 `test_<算子>.py` 拼名会撞上 `examples/` 下已有的独立脚本。`examples/gemm_aot/test_example_gemm.py` 就是一个：它由 `run_example_gemm_aot.sh` 以 `python test_example_gemm.py` 在自己目录里执行，不含任何测试函数，模块级却有 21 条语句（`parse_args()`、三次 `.npu()` 分配、`ctypes.CDLL("./kernel_lib.so")`、发射 kernel、`synchronize()`）。交给 Pytest 之后这些会在收集阶段于每个 xdist worker 里各执行一遍，却收不到任何用例。在昇腾节点上实测，同样六个用例，登记表里没有这一条时 38 秒跑完，有这一条时 300 秒超时。

收窄到正在迁移的目录之后，范围内 29 个源文件按 `test_<算子>.py` 拼出的名字里，已经存在的三个全部是真正的 Pytest 测试。

### 两道守卫

`bench_test.sh` 没有 `set -e`，登记表出问题时脚本会静默继续、跳过名单为空，导致已迁移算子重复执行而无人察觉。因此两道检查显式失败退出，跑在任何算子之前：

- `validate` —— 登记表能解析，每个源文件存在
- `check-orphans` —— `examples/` 下每个 `test_*.py` 都能对上条目。旧 runner 按文件名排除了全部 `test_*.py`，一个对不上条目的测试是两边都不执行而 CI 全绿。被同目录 `.sh` 直接调用的测试（`torch_tl_ascend/`、`gemm_aot/`）予以豁免。

---

## 改动清单

| 文件 | 行数 | |
|---|---|---|
| `examples/bench_test.sh` | +49 / −4 | 排除 `test_*.py`、读登记表、两道守卫、跳过已迁移算子 |
| `.github/workflows/ci_cd.yml` | +89 / −0 | 查找表、路由、决策、兜底执行 |
| `scripts/ci/resolve_operator_tests.py` | +245 | 登记表校验、`list` 系列查询、待办状态、孤儿检测 |
| `ci/operator_test_manifest.yaml` | +60 | 29 条 |
| `examples/batch_gemm/test_batch_gemm.py` | +53 | 样板 |
| `examples/flash_attention/test_flash_attn_bhsd.py` | +67 | 样板 |

`bench_test.sh` 中执行 `testing/python/` 的那段 Pytest 逻辑未作改动。

---

## 验证

在昇腾节点上。

**全量执行**

```
Bench:  Total: 143 | Passed: 143 | Failed: 0
Pytest: Passed: 1403 | Failed: 0 | Xfailed: 2
Total:  1548 | Passed: 1548 | Failed: 0
退出码 0
```

未加改动时 bench 收集 146 个脚本，少的三个正是交给 Pytest 的 `test_*.py`。

**算子测试**，按 workflow 的命令执行：

```
6 passed in 37.14s
退出码 0
```

**新增一个测试的完整路径**，用分支上的 `ci_cd.yml` 原样跑判定脚本：

```
新增 examples/flash_attention/test_paged_flash_attn_bhsd.py（登记表里的待办条目）

Validated 3 -> Validated 4      条目自动生效
登记表未作任何修改

run_examples=false
run_pytest_only=true
pytest_files=examples/flash_attention/test_paged_flash_attn_bhsd.py

实际执行 pytest --forked ../<该文件> -v -n 4
1 passed in 12.29s，退出码 0
bench_test.sh 未启动
```

**路由的其它形态**

| 改动 | 执行 |
|---|---|
| 一个已迁移的算子 | 只跑它对应的测试 |
| 一个已迁移的测试 | 只跑它自己 |
| 两个及以上已迁移的测试 | 增量 examples + 全部已登记测试 |
| 未迁移的算子 | 该目录的增量 examples + Pytest |
| `testing/python/` 下的文件 | 只跑该文件 |

**未登记的测试会被拦下**。新建一个登记表中没有的 `test_xattention_wrongname.py`：

```
operator tests matching no manifest entry:
  examples/xattention/test_xattention_wrongname.py

退出码 1
```

`bench_test.sh` 在开头即终止，日志 32 行，未执行任何算子。

**`.sh` 入口不受影响**

```
[PASSED] ./gemm_aot/run_example_gemm_aot.sh
[PASSED] ./torch_tl_ascend/test_example.sh
```