### PR TITLE
[Test] Add pytest coverage for attention, delta rule, MoE and experiment kernels

### DIFF
--- a/examples/HISA/test_block_sparse_mqa_attn_expert_test.py
+++ b/examples/HISA/test_block_sparse_mqa_attn_expert_test.py
@@ -1,0 +1,47 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("block_sparse_mqa_attn_expert_test.py")
+    spec = importlib.util.spec_from_file_location("_block_sparse_mqa_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        # The example parses arguments at import time.
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_block_sparse_mqa_attn_accuracy() -> None:
+    import torch
+
+    example = _load_example()
+
+    # As with the paged variant next to it, the reference receives the tensors
+    # that were never moved, so the default device has to be the accelerator.
+    previous = torch.get_default_device()
+    torch.set_default_device("npu")
+    try:
+        torch.manual_seed(42)
+        example.test_block_sparse_mqa_attn(
+            seq_len=32,
+            seq_len_kv=128 * 1024,
+            heads=32,
+            index_dim=128,
+            kv_block_size=128,
+            topk=64,
+            dtype="float16",
+            num_pairs=16,
+        )
+    finally:
+        torch.set_default_device(previous)

--- a/examples/HISA/test_paged_block_sparse_mqa_attn_expert.py
+++ b/examples/HISA/test_paged_block_sparse_mqa_attn_expert.py
@@ -1,0 +1,50 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("paged_block_sparse_mqa_attn_expert.py")
+    spec = importlib.util.spec_from_file_location("_paged_block_sparse_mqa_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        # The example parses arguments at import time.
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_paged_block_sparse_mqa_attn_accuracy() -> None:
+    import torch
+
+    example = _load_example()
+
+    # The example builds its tensors without naming a device and hands the
+    # unmoved ones to the reference, so the default has to be the device or the
+    # comparison is across two of them. Restoring it keeps the choice from
+    # reaching whatever else shares the process.
+    previous = torch.get_default_device()
+    torch.set_default_device("npu")
+    try:
+        torch.manual_seed(42)
+        example.test_paged_block_sparse_mqa_attn(
+            batch=1,
+            seq_len=1,
+            num_phys_blocks=1024,
+            heads=32,
+            index_dim=128,
+            kv_block_size=128,
+            topk=64,
+            max_blocks=256,
+            dtype="float16",
+        )
+    finally:
+        torch.set_default_device(previous)

--- a/examples/flash_attention/test_flash_attn_bhsd_cc_sync.py
+++ b/examples/flash_attention/test_flash_attn_bhsd_cc_sync.py
@@ -1,0 +1,36 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _run_example() -> ModuleType:
+    source = Path(__file__).with_name("flash_attn_bhsd_cc_sync.py")
+    spec = importlib.util.spec_from_file_location("_flash_attn_bhsd_cc_sync_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_flash_attn_bhsd_cc_sync() -> None:
+    import torch
+
+    # This example has no main guard: it builds its tensors, runs the kernel and
+    # compares against ref_flash_attn at module level, so executing the
+    # module is running the check and a mismatch surfaces as the AssertionError
+    # torch.testing raises. It also sets the default device while doing so,
+    # which is restored here because a test shares its process.
+    previous = torch.get_default_device()
+    try:
+        _run_example()
+    finally:
+        torch.set_default_device(previous)

--- a/examples/flash_attention/test_paged_flash_attn_bhsd.py
+++ b/examples/flash_attention/test_paged_flash_attn_bhsd.py
@@ -1,0 +1,66 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_paged_flash_attn_example() -> ModuleType:
+    source = Path(__file__).with_name("paged_flash_attn_bhsd.py")
+    spec = importlib.util.spec_from_file_location("_paged_flash_attn_bhsd_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        # paged_flash_attn_bhsd.py parses arguments in its __main__ block. Hide
+        # Pytest arguments while loading it without changing the original example.
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_paged_flash_attn_bhsd_accuracy() -> None:
+    import torch
+
+    example = _load_paged_flash_attn_example()
+
+    # Values mirror the argparse defaults in the example's main().
+    batch = 1
+    heads = 16
+    seq_len = 128
+    dim = 128
+    block_size = 128
+
+    # gen_cache and the kernel place their tensors on the device of their inputs,
+    # which is how the example reaches the NPU from its own main().
+    torch.set_default_device("npu")
+    torch.manual_seed(0)
+
+    query = torch.randn((batch, heads, seq_len, dim), dtype=torch.float16)
+    key = torch.randn((batch, heads, seq_len, dim), dtype=torch.float16)
+    value = torch.randn((batch, heads, seq_len, dim), dtype=torch.float16)
+
+    table_blocks = example.ceildiv(seq_len, block_size)
+    block_table = torch.zeros((batch, table_blocks), dtype=torch.int32)
+    key_cache = example.gen_cache(key, block_table, block_size)
+    value_cache = example.gen_cache(value, block_table, block_size)
+
+    kernel = example.paged_flash_attention_fwd(
+        batch,
+        heads,
+        seq_len,
+        dim,
+        key_cache.shape[0],
+        table_blocks,
+        block_size=block_size,
+    )
+
+    actual = kernel(query, key_cache, value_cache, block_table)
+    expected = example.ref_program(query, key_cache, value_cache, block_table)
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)

--- a/examples/fused_sigmoid_gating_delta_rule/test_fused_sigmoid_gating_delta_rule_varlen.py
+++ b/examples/fused_sigmoid_gating_delta_rule/test_fused_sigmoid_gating_delta_rule_varlen.py
@@ -1,0 +1,33 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("fused_sigmoid_gating_delta_rule_varlen.py")
+    spec = importlib.util.spec_from_file_location("_fused_sigmoid_gating_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+# main() takes its shapes as parameters and asserts the output and the final
+# state against golden(), so this drives it directly. The example's own guard
+# wraps the same call in a thread pool, which only matters when several cases
+# run at once and there is one.
+def test_fused_sigmoid_gating_delta_rule_varlen() -> None:
+    example = _load_example()
+
+    # A hundred short sequences of alternating length, which is what makes this
+    # the varlen case rather than a padded batch.
+    example.main(seqlens=[4, 8] * 50, nk=16, nv=32, dk=128, dv=128)

--- a/examples/linear_attention_and_rnn/gdn/test_gdn_chunk_cumsum.py
+++ b/examples/linear_attention_and_rnn/gdn/test_gdn_chunk_cumsum.py
@@ -1,0 +1,41 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("gdn_chunk_cumsum.py")
+    spec = importlib.util.spec_from_file_location("_gdn_chunk_cumsum_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        # Keep Pytest's arguments away from the example while loading it.
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_gdn_chunk_cumsum_accuracy() -> None:
+    import torch
+
+    example = _load_example()
+
+    batch = 2
+    heads = 32
+    seq_len = 256
+    chunk = 32
+
+    torch.manual_seed(0)
+    g = torch.randn((batch, heads, seq_len)).npu().to(torch.float)
+
+    actual = example.chunk_cumsum(g, chunk)
+    expected = example.ref_chunk_cumsum(g, chunk)
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-5, atol=1e-5)

--- a/examples/linear_attention_and_rnn/gdn/test_gdn_chunk_h.py
+++ b/examples/linear_attention_and_rnn/gdn/test_gdn_chunk_h.py
@@ -1,0 +1,55 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("gdn_chunk_h.py")
+    spec = importlib.util.spec_from_file_location("_gdn_chunk_h_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_gdn_chunk_h_accuracy() -> None:
+    import torch
+    import torch.nn.functional as F
+
+    example = _load_example()
+
+    batch = 2
+    heads = 32
+    seq_len = 256
+    key_dim = 64
+    value_dim = 64
+    chunk = 32
+    block_k = 32
+    block_v = 32
+
+    torch.manual_seed(0)
+    k = torch.randn((batch, heads, seq_len, key_dim)).npu().to(torch.float16)
+    w = torch.randn((batch, heads, seq_len, key_dim)).npu().to(torch.float16)
+    u = torch.randn((batch, heads, seq_len, value_dim)).npu().to(torch.float16)
+    g = torch.randn((batch, heads, seq_len)).npu().to(torch.float)
+
+    # The hidden state recurrence expects the gate already accumulated per chunk.
+    g = example.ref_chunk_cumsum(F.logsigmoid(g), chunk)
+    k = F.normalize(k, dim=-1, p=2)
+    w = F.normalize(w, dim=-1, p=2)
+
+    s, new_v, final_s = example.chunk_h(k, w, u, g, chunk, block_k, block_v)
+    ref_s, ref_new_v, ref_final_s = example.ref_chunk_h(k, w, u, g, chunk)
+
+    torch.testing.assert_close(s.cpu(), ref_s.cpu(), rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(new_v.cpu(), ref_new_v.cpu(), rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(final_s.cpu(), ref_final_s.cpu(), rtol=1e-5, atol=1e-5)

--- a/examples/linear_attention_and_rnn/gdn/test_gdn_chunk_o.py
+++ b/examples/linear_attention_and_rnn/gdn/test_gdn_chunk_o.py
@@ -1,0 +1,53 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("gdn_chunk_o.py")
+    spec = importlib.util.spec_from_file_location("_gdn_chunk_o_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_gdn_chunk_o_accuracy() -> None:
+    import torch
+    import torch.nn.functional as F
+
+    example = _load_example()
+
+    batch = 2
+    heads = 32
+    seq_len = 256
+    key_dim = 64
+    value_dim = 64
+    chunk = 32
+    block_k = 32
+    block_v = 32
+    chunk_num = (seq_len + chunk - 1) // chunk
+
+    torch.manual_seed(0)
+    q = torch.randn((batch, heads, seq_len, key_dim)).npu().to(torch.float16)
+    k = torch.randn((batch, heads, seq_len, key_dim)).npu().to(torch.float16)
+    v = torch.randn((batch, heads, seq_len, value_dim)).npu().to(torch.float16)
+    s = torch.randn((batch, heads, chunk_num, key_dim, value_dim)).npu().to(torch.float16)
+    g = torch.randn((batch, heads, seq_len)).npu().to(torch.float)
+
+    q = F.normalize(q, dim=-1, p=2)
+    k = F.normalize(k, dim=-1, p=2)
+
+    actual = example.chunk_o(q, k, v, s, g, chunk, block_k, block_v)
+    expected = example.ref_chunk_o(q, k, v, s, g, chunk)
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-5, atol=1e-5)

--- a/examples/linear_attention_and_rnn/gdn/test_gdn_chunk_scaled_dot_kkt.py
+++ b/examples/linear_attention_and_rnn/gdn/test_gdn_chunk_scaled_dot_kkt.py
@@ -1,0 +1,44 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("gdn_chunk_scaled_dot_kkt.py")
+    spec = importlib.util.spec_from_file_location("_gdn_kkt_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_gdn_chunk_scaled_dot_kkt_accuracy() -> None:
+    import torch
+
+    example = _load_example()
+
+    batch = 2
+    heads = 32
+    seq_len = 256
+    head_dim = 64
+    chunk = 32
+    block_k = 32
+
+    torch.manual_seed(0)
+    k = torch.randn((batch, heads, seq_len, head_dim)).npu().to(torch.float16)
+    beta = torch.randn((batch, heads, seq_len)).npu().to(torch.float16)
+    g = torch.randn((batch, heads, seq_len)).npu().to(torch.float)
+
+    actual = example.kkt(k, beta, g, chunk, block_k)
+    expected = example.ref_kkt(k, beta, g, chunk)
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-5, atol=1e-5)

--- a/examples/linear_attention_and_rnn/gdn/test_gdn_solve_tril.py
+++ b/examples/linear_attention_and_rnn/gdn/test_gdn_solve_tril.py
@@ -1,0 +1,50 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("gdn_solve_tril.py")
+    spec = importlib.util.spec_from_file_location("_gdn_solve_tril_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_gdn_solve_tril_accuracy() -> None:
+    import torch
+    import torch.nn.functional as F
+
+    example = _load_example()
+
+    batch = 2
+    heads = 32
+    seq_len = 256
+    head_dim = 64
+    chunk = 32
+
+    torch.manual_seed(0)
+    k = torch.randn((batch, heads, seq_len, head_dim)).npu().to(torch.float16)
+    beta = torch.rand((batch, heads, seq_len)).npu().to(torch.float16)
+    g = torch.randn((batch, heads, seq_len)).npu().to(torch.float)
+
+    # The kernel solves the triangular system built by the two upstream stages,
+    # so the input has to come through them rather than from raw noise.
+    k = F.normalize(k, dim=-1, p=2)
+    g = example.ref_chunk_cumsum(F.logsigmoid(g), chunk)
+    a = example.ref_kkt(k, beta, g, chunk)
+
+    actual = example.solve_tril(a)
+    expected = example.ref_solve_tril(a)
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-5, atol=1e-5)

--- a/examples/linear_attention_and_rnn/gdn/test_gdn_wy_fast.py
+++ b/examples/linear_attention_and_rnn/gdn/test_gdn_wy_fast.py
@@ -1,0 +1,49 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("gdn_wy_fast.py")
+    spec = importlib.util.spec_from_file_location("_gdn_wy_fast_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_gdn_wy_fast_accuracy() -> None:
+    import torch
+
+    example = _load_example()
+
+    batch = 2
+    heads = 32
+    seq_len = 256
+    key_dim = 64
+    value_dim = 64
+    chunk = 32
+    block_k = 32
+    block_v = 32
+
+    torch.manual_seed(0)
+    k = torch.randn((batch, heads, seq_len, key_dim)).npu().to(torch.float16)
+    v = torch.randn((batch, heads, seq_len, value_dim)).npu().to(torch.float16)
+    beta = torch.randn((batch, heads, seq_len)).npu().to(torch.float16)
+    g = torch.randn((batch, heads, seq_len)).npu().to(torch.float)
+    a = torch.randn((batch, heads, seq_len, chunk)).npu().to(torch.float16)
+
+    w, u = example.wy_fast(k, v, beta, g, a, chunk, block_k, block_v)
+    ref_w, ref_u = example.ref_wy_fast(k, v, beta, g, a, chunk)
+
+    torch.testing.assert_close(w.cpu(), ref_w.cpu(), rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(u.cpu(), ref_u.cpu(), rtol=1e-5, atol=1e-5)

--- a/examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_chunk_cumsum.py
+++ b/examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_chunk_cumsum.py
@@ -1,0 +1,42 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("opt_gdn_chunk_cumsum.py")
+    spec = importlib.util.spec_from_file_location("_opt_gdn_chunk_cumsum_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_opt_gdn_chunk_cumsum_accuracy() -> None:
+    import torch
+
+    example = _load_example()
+
+    # The kernel processes CC=8 chunks at a time, so seq_len has to be a
+    # multiple of chunk * 8.
+    batch = 2
+    heads = 16
+    seq_len = 16384
+    chunk = 128
+
+    torch.manual_seed(0)
+    g = torch.randn((batch, heads, seq_len)).npu().to(torch.float)
+
+    actual = example.chunk_cumsum(g, chunk)
+    expected = example.ref_chunk_cumsum(g, chunk)
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-5, atol=1e-5)

--- a/examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_chunk_h.py
+++ b/examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_chunk_h.py
@@ -1,0 +1,53 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("opt_gdn_chunk_h.py")
+    spec = importlib.util.spec_from_file_location("_opt_gdn_chunk_h_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_opt_gdn_chunk_h_accuracy() -> None:
+    import torch
+    import torch.nn.functional as F
+
+    example = _load_example()
+
+    batch = 2
+    heads = 16
+    seq_len = 16384
+    key_dim = 128
+    value_dim = 128
+    chunk = 128
+
+    torch.manual_seed(0)
+    k = torch.randn((batch, heads, seq_len, key_dim)).npu().to(torch.float16)
+    w = torch.randn((batch, heads, seq_len, key_dim)).npu().to(torch.float16)
+    u = torch.randn((batch, heads, seq_len, value_dim)).npu().to(torch.float16)
+    g = torch.randn((batch, heads, seq_len)).npu().to(torch.float)
+
+    # The recurrence expects the gate already accumulated per chunk.
+    g = example.ref_chunk_cumsum(F.logsigmoid(g), chunk)
+    k = F.normalize(k, dim=-1, p=2)
+    w = F.normalize(w, dim=-1, p=2)
+
+    s, new_v, final_s = example.chunk_h(k, w, u, g, chunk)
+    ref_s, ref_new_v, ref_final_s = example.ref_chunk_h(k, w, u, g, chunk)
+
+    torch.testing.assert_close(s.cpu(), ref_s.cpu(), rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(new_v.cpu(), ref_new_v.cpu(), rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(final_s.cpu(), ref_final_s.cpu(), rtol=1e-5, atol=1e-5)

--- a/examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_chunk_o.py
+++ b/examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_chunk_o.py
@@ -1,0 +1,51 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("opt_gdn_chunk_o.py")
+    spec = importlib.util.spec_from_file_location("_opt_gdn_chunk_o_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_opt_gdn_chunk_o_accuracy() -> None:
+    import torch
+    import torch.nn.functional as F
+
+    example = _load_example()
+
+    batch = 2
+    heads = 16
+    seq_len = 16384
+    key_dim = 128
+    value_dim = 128
+    chunk = 128
+    chunk_num = (seq_len + chunk - 1) // chunk
+
+    torch.manual_seed(0)
+    q = torch.randn((batch, heads, seq_len, key_dim)).npu().to(torch.float16)
+    k = torch.randn((batch, heads, seq_len, key_dim)).npu().to(torch.float16)
+    v = torch.randn((batch, heads, seq_len, value_dim)).npu().to(torch.float16)
+    s = torch.randn((batch, heads, chunk_num, key_dim, value_dim)).npu().to(torch.float16)
+    g = torch.randn((batch, heads, seq_len)).npu().to(torch.float)
+
+    q = F.normalize(q, dim=-1, p=2)
+    k = F.normalize(k, dim=-1, p=2)
+
+    actual = example.chunk_o(q, k, v, s, g, chunk)
+    expected = example.ref_chunk_o(q, k, v, s, g, chunk)
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-5, atol=1e-5)

--- a/examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_chunk_scaled_dot_kkt.py
+++ b/examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_chunk_scaled_dot_kkt.py
@@ -1,0 +1,45 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("opt_gdn_chunk_scaled_dot_kkt.py")
+    spec = importlib.util.spec_from_file_location("_opt_gdn_kkt_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_opt_gdn_chunk_scaled_dot_kkt_accuracy() -> None:
+    import torch
+
+    example = _load_example()
+
+    # The kernel walks CC chunks per iteration, so seq_len is a multiple of
+    # chunk far larger than the plain gdn variant uses.
+    batch = 2
+    heads = 16
+    seq_len = 16384
+    key_dim = 128
+    chunk = 128
+
+    torch.manual_seed(0)
+    k = torch.randn((batch, heads, seq_len, key_dim)).npu().to(torch.float16)
+    beta = torch.rand((batch, heads, seq_len)).npu().to(torch.float16)
+    g = torch.randn((batch, heads, seq_len)).npu().to(torch.float)
+
+    actual = example.kkt(k, beta, g, chunk)
+    expected = example.ref_kkt(k, beta, g, chunk)
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-3, atol=1e-3)

--- a/examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_solve_tril.py
+++ b/examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_solve_tril.py
@@ -1,0 +1,52 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("opt_gdn_solve_tril.py")
+    spec = importlib.util.spec_from_file_location("_opt_gdn_solve_tril_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_opt_gdn_solve_tril_accuracy() -> None:
+    import torch
+    import torch.nn.functional as F
+
+    example = _load_example()
+
+    # solve_tril dispatches on the chunk size, and the example drives the 128
+    # wide path with a single chunk.
+    batch = 1
+    heads = 1
+    seq_len = 128
+    key_dim = 128
+    chunk = 128
+
+    torch.manual_seed(0)
+    k = torch.randn((batch, heads, seq_len, key_dim)).npu().to(torch.float16)
+    beta = torch.rand((batch, heads, seq_len)).npu().to(torch.float16)
+    g = torch.randn((batch, heads, seq_len)).npu().to(torch.float)
+
+    # The kernel solves the system the two upstream stages build, so the input
+    # comes through them rather than from raw noise.
+    k = F.normalize(k, dim=-1, p=2)
+    g = example.ref_chunk_cumsum(F.logsigmoid(g), chunk)
+    a = example.ref_kkt(k, beta, g, chunk)
+
+    actual = example.solve_tril(a)
+    expected = example.ref_solve_tril(a)
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-3, atol=1e-3)

--- a/examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_wy_fast.py
+++ b/examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_wy_fast.py
@@ -1,0 +1,47 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("opt_gdn_wy_fast.py")
+    spec = importlib.util.spec_from_file_location("_opt_gdn_wy_fast_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_opt_gdn_wy_fast_accuracy() -> None:
+    import torch
+
+    example = _load_example()
+
+    batch = 2
+    heads = 16
+    seq_len = 16384
+    key_dim = 128
+    value_dim = 128
+    chunk = 128
+
+    torch.manual_seed(0)
+    k = torch.randn((batch, heads, seq_len, key_dim)).npu().to(torch.float16)
+    v = torch.randn((batch, heads, seq_len, value_dim)).npu().to(torch.float16)
+    beta = torch.rand((batch, heads, seq_len)).npu().to(torch.float16)
+    g = torch.randn((batch, heads, seq_len)).npu().to(torch.float)
+    a = torch.randn((batch, heads, seq_len, chunk)).npu().to(torch.float16)
+
+    w, u = example.wy_fast(k, v, beta, g, a, chunk)
+    ref_w, ref_u = example.ref_wy_fast(k, v, beta, g, a, chunk)
+
+    torch.testing.assert_close(w.cpu(), ref_w.cpu(), rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(u.cpu(), ref_u.cpu(), rtol=1e-5, atol=1e-5)

--- a/examples/linear_attention_and_rnn/test_gdn_full.py
+++ b/examples/linear_attention_and_rnn/test_gdn_full.py
@@ -1,0 +1,29 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _run_example() -> ModuleType:
+    source = Path(__file__).with_name("gdn_full.py")
+    spec = importlib.util.spec_from_file_location("_gdn_full_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_gdn_full() -> None:
+    # This example has no main guard: it builds its tensors, runs the kernel and
+    # compares against ref_seq_gdn and ref_chunk_gdn at module level, so executing the
+    # module is running the check and a mismatch surfaces as the AssertionError
+    # torch.testing raises.
+    _run_example()

--- a/examples/linear_attention_and_rnn/test_linear_attention_causal.py
+++ b/examples/linear_attention_and_rnn/test_linear_attention_causal.py
@@ -1,0 +1,29 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _run_example() -> ModuleType:
+    source = Path(__file__).with_name("linear_attention_causal.py")
+    spec = importlib.util.spec_from_file_location("_linear_attention_causal_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_linear_attention_causal() -> None:
+    # This example has no main guard: it builds its tensors, runs the kernel and
+    # compares against ref_linear_attention at module level, so executing the
+    # module is running the check and a mismatch surfaces as the AssertionError
+    # torch.testing raises.
+    _run_example()

--- a/examples/linear_attention_and_rnn/test_linear_attention_normalize.py
+++ b/examples/linear_attention_and_rnn/test_linear_attention_normalize.py
@@ -1,0 +1,29 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _run_example() -> ModuleType:
+    source = Path(__file__).with_name("linear_attention_normalize.py")
+    spec = importlib.util.spec_from_file_location("_linear_attention_normalize_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_linear_attention_normalize() -> None:
+    # This example has no main guard: it builds its tensors, runs the kernel and
+    # compares against ref_linear_attention at module level, so executing the
+    # module is running the check and a mismatch surfaces as the AssertionError
+    # torch.testing raises.
+    _run_example()

--- a/examples/linear_attention_and_rnn/test_opt_gdn_full.py
+++ b/examples/linear_attention_and_rnn/test_opt_gdn_full.py
@@ -1,0 +1,29 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _run_example() -> ModuleType:
+    source = Path(__file__).with_name("opt_gdn_full.py")
+    spec = importlib.util.spec_from_file_location("_opt_gdn_full_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_opt_gdn_full() -> None:
+    # This example has no main guard: it builds its tensors, runs the kernel and
+    # compares against ref_seq_gdn at module level, so executing the
+    # module is running the check and a mismatch surfaces as the AssertionError
+    # torch.testing raises.
+    _run_example()

--- a/examples/moe_token_permute/test_moe_token_permute.py
+++ b/examples/moe_token_permute/test_moe_token_permute.py
@@ -1,0 +1,45 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("moe_token_permute.py")
+    spec = importlib.util.spec_from_file_location("_moe_token_permute_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+# The example compares against a torch implementation inside
+# test_permute_parameterized and returns whether it matched; its driver prints the
+# outcome and returns nothing, so the value has to be asserted here or a
+# mismatch would pass. The three dtypes are the ones the example itself walks.
+@pytest.mark.parametrize(
+    "torch_dtype_name, tilelang_dtype",
+    [
+        ("float16", "float16"),
+        ("bfloat16", "bfloat16"),
+        ("float32", "float32"),
+    ],
+)
+def test_permute_accuracy(torch_dtype_name, tilelang_dtype) -> None:
+    import torch
+
+    example = _load_example()
+
+    passed = example.test_permute_parameterized(pt_dtype=getattr(torch, torch_dtype_name), tl_dtype_str=tilelang_dtype)
+
+    assert passed, f"permute mismatched the torch reference for {tilelang_dtype}"

--- a/examples/moe_token_permute/test_moe_token_permute_grad.py
+++ b/examples/moe_token_permute/test_moe_token_permute_grad.py
@@ -1,0 +1,45 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("moe_token_permute_grad.py")
+    spec = importlib.util.spec_from_file_location("_moe_token_permute_grad_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+# The example compares against a torch implementation inside
+# test_permute_grad_parameterized and returns whether it matched; its driver prints the
+# outcome and returns nothing, so the value has to be asserted here or a
+# mismatch would pass. The three dtypes are the ones the example itself walks.
+@pytest.mark.parametrize(
+    "torch_dtype_name, tilelang_dtype",
+    [
+        ("float16", "float16"),
+        ("bfloat16", "bfloat16"),
+        ("float32", "float32"),
+    ],
+)
+def test_permute_grad_accuracy(torch_dtype_name, tilelang_dtype) -> None:
+    import torch
+
+    example = _load_example()
+
+    passed = example.test_permute_grad_parameterized(pt_dtype=getattr(torch, torch_dtype_name), tl_dtype_str=tilelang_dtype)
+
+    assert passed, f"permute_grad mismatched the torch reference for {tilelang_dtype}"

--- a/examples/moe_token_permute/test_moe_token_unpermute.py
+++ b/examples/moe_token_permute/test_moe_token_unpermute.py
@@ -1,0 +1,45 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("moe_token_unpermute.py")
+    spec = importlib.util.spec_from_file_location("_moe_token_unpermute_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+# The example compares against a torch implementation inside
+# test_unpermute_parameterized and returns whether it matched; its driver prints the
+# outcome and returns nothing, so the value has to be asserted here or a
+# mismatch would pass. The three dtypes are the ones the example itself walks.
+@pytest.mark.parametrize(
+    "torch_dtype_name, tilelang_dtype",
+    [
+        ("float16", "float16"),
+        ("bfloat16", "bfloat16"),
+        ("float32", "float32"),
+    ],
+)
+def test_unpermute_accuracy(torch_dtype_name, tilelang_dtype) -> None:
+    import torch
+
+    example = _load_example()
+
+    passed = example.test_unpermute_parameterized(pt_dtype=getattr(torch, torch_dtype_name), tl_dtype_str=tilelang_dtype)
+
+    assert passed, f"unpermute mismatched the torch reference for {tilelang_dtype}"

--- a/examples/moe_token_permute/test_moe_token_unpermute_grad.py
+++ b/examples/moe_token_permute/test_moe_token_unpermute_grad.py
@@ -1,0 +1,45 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("moe_token_unpermute_grad.py")
+    spec = importlib.util.spec_from_file_location("_moe_token_unpermute_grad_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+# The example compares against a torch implementation inside
+# test_unpermute_grad_parameterized and returns whether it matched; its driver prints the
+# outcome and returns nothing, so the value has to be asserted here or a
+# mismatch would pass. The three dtypes are the ones the example itself walks.
+@pytest.mark.parametrize(
+    "torch_dtype_name, tilelang_dtype",
+    [
+        ("float16", "float16"),
+        ("bfloat16", "bfloat16"),
+        ("float32", "float32"),
+    ],
+)
+def test_unpermute_grad_accuracy(torch_dtype_name, tilelang_dtype) -> None:
+    import torch
+
+    example = _load_example()
+
+    passed = example.test_unpermute_grad_parameterized(pt_dtype=getattr(torch, torch_dtype_name), tl_dtype_str=tilelang_dtype)
+
+    assert passed, f"unpermute_grad mismatched the torch reference for {tilelang_dtype}"

--- a/examples/sparse_flash_attention/test_example_sparse_flash_attn.py
+++ b/examples/sparse_flash_attention/test_example_sparse_flash_attn.py
@@ -1,0 +1,36 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _run_example() -> ModuleType:
+    source = Path(__file__).with_name("example_sparse_flash_attn.py")
+    spec = importlib.util.spec_from_file_location("_example_sparse_flash_attn_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_sparse_flash_attn() -> None:
+    import torch
+
+    # This example has no main guard: it builds its tensors, runs the kernel and
+    # compares against ref_sparse_attention_fwd_interface at module level, so
+    # executing the module is running the check and a mismatch surfaces as the
+    # AssertionError that torch.testing raises. It also sets the default device
+    # while doing so, which is restored here because a test shares its process.
+    previous = torch.get_default_device()
+    try:
+        _run_example()
+    finally:
+        torch.set_default_device(previous)

--- a/examples/sparse_flash_attention/test_example_sparse_flash_attn_dynamic_shape.py
+++ b/examples/sparse_flash_attention/test_example_sparse_flash_attn_dynamic_shape.py
@@ -1,0 +1,36 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _run_example() -> ModuleType:
+    source = Path(__file__).with_name("example_sparse_flash_attn_dynamic_shape.py")
+    spec = importlib.util.spec_from_file_location("_example_sparse_flash_attn_dynamic_shape_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_sparse_flash_attn_dynamic_shape() -> None:
+    import torch
+
+    # This example has no main guard: it builds its tensors, runs the kernel and
+    # compares against ref_sparse_attention_fwd_interface at module level, so
+    # executing the module is running the check and a mismatch surfaces as the
+    # AssertionError that torch.testing raises. It also sets the default device
+    # while doing so, which is restored here because a test shares its process.
+    previous = torch.get_default_device()
+    try:
+        _run_example()
+    finally:
+        torch.set_default_device(previous)

--- a/examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa.py
+++ b/examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa.py
@@ -1,0 +1,36 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _run_example() -> ModuleType:
+    source = Path(__file__).with_name("example_sparse_flash_attn_gqa.py")
+    spec = importlib.util.spec_from_file_location("_example_sparse_flash_attn_gqa_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_sparse_flash_attn_gqa() -> None:
+    import torch
+
+    # This example has no main guard: it builds its tensors, runs the kernel and
+    # compares against ref_sparse_attention_fwd_interface at module level, so
+    # executing the module is running the check and a mismatch surfaces as the
+    # AssertionError that torch.testing raises. It also sets the default device
+    # while doing so, which is restored here because a test shares its process.
+    previous = torch.get_default_device()
+    try:
+        _run_example()
+    finally:
+        torch.set_default_device(previous)

--- a/examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa_pto.py
+++ b/examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa_pto.py
@@ -1,0 +1,36 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _run_example() -> ModuleType:
+    source = Path(__file__).with_name("example_sparse_flash_attn_gqa_pto.py")
+    spec = importlib.util.spec_from_file_location("_example_sparse_flash_attn_gqa_pto_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_sparse_flash_attn_gqa_pto() -> None:
+    import torch
+
+    # This example has no main guard: it builds its tensors, runs the kernel and
+    # compares against ref_sparse_attention_fwd_interface at module level, so
+    # executing the module is running the check and a mismatch surfaces as the
+    # AssertionError that torch.testing raises. It also sets the default device
+    # while doing so, which is restored here because a test shares its process.
+    previous = torch.get_default_device()
+    try:
+        _run_example()
+    finally:
+        torch.set_default_device(previous)

--- a/examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa_pto_developer.py
+++ b/examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa_pto_developer.py
@@ -1,0 +1,36 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _run_example() -> ModuleType:
+    source = Path(__file__).with_name("example_sparse_flash_attn_gqa_pto_developer.py")
+    spec = importlib.util.spec_from_file_location("_example_sparse_flash_attn_gqa_pto_developer_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_sparse_flash_attn_gqa_pto_developer() -> None:
+    import torch
+
+    # This example has no main guard: it builds its tensors, runs the kernel and
+    # compares against ref_sparse_attention_fwd_interface at module level, so
+    # executing the module is running the check and a mismatch surfaces as the
+    # AssertionError that torch.testing raises. It also sets the default device
+    # while doing so, which is restored here because a test shares its process.
+    previous = torch.get_default_device()
+    try:
+        _run_example()
+    finally:
+        torch.set_default_device(previous)

--- a/examples/sparse_flash_attention/test_example_sparse_flash_attn_mask.py
+++ b/examples/sparse_flash_attention/test_example_sparse_flash_attn_mask.py
@@ -1,0 +1,36 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _run_example() -> ModuleType:
+    source = Path(__file__).with_name("example_sparse_flash_attn_mask.py")
+    spec = importlib.util.spec_from_file_location("_example_sparse_flash_attn_mask_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_sparse_flash_attn_mask() -> None:
+    import torch
+
+    # This example has no main guard: it builds its tensors, runs the kernel and
+    # compares against ref_sparse_attention_fwd_interface at module level, so
+    # executing the module is running the check and a mismatch surfaces as the
+    # AssertionError that torch.testing raises. It also sets the default device
+    # while doing so, which is restored here because a test shares its process.
+    previous = torch.get_default_device()
+    try:
+        _run_example()
+    finally:
+        torch.set_default_device(previous)

--- a/examples/sparse_flash_attention/test_example_sparse_flash_attn_mask_pa.py
+++ b/examples/sparse_flash_attention/test_example_sparse_flash_attn_mask_pa.py
@@ -1,0 +1,36 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _run_example() -> ModuleType:
+    source = Path(__file__).with_name("example_sparse_flash_attn_mask_pa.py")
+    spec = importlib.util.spec_from_file_location("_example_sparse_flash_attn_mask_pa_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_sparse_flash_attn_mask_pa() -> None:
+    import torch
+
+    # This example has no main guard: it builds its tensors, runs the kernel and
+    # compares against ref_sparse_attention_fwd_interface at module level, so
+    # executing the module is running the check and a mismatch surfaces as the
+    # AssertionError that torch.testing raises. It also sets the default device
+    # while doing so, which is restored here because a test shares its process.
+    previous = torch.get_default_device()
+    try:
+        _run_example()
+    finally:
+        torch.set_default_device(previous)

--- a/examples/tile_kernels/mhc/test_head_compute_mix_kernel.py
+++ b/examples/tile_kernels/mhc/test_head_compute_mix_kernel.py
@@ -1,0 +1,36 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("head_compute_mix_kernel.py")
+    spec = importlib.util.spec_from_file_location("_mhc_head_compute_mix_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+# The example asserts against mhc_head_compute_mix_ref on the way forward and
+# against autograd on the way back, and it places every tensor explicitly, so
+# these call it rather than restate the reshape arithmetic that surrounds the
+# kernel. Loading the example under a private module name keeps Pytest from
+# collecting its functions twice.
+def test_head_compute_mix_forward() -> None:
+    example = _load_example()
+    example.test_fwd()
+
+
+def test_head_compute_mix_backward() -> None:
+    example = _load_example()
+    example.test_bwd()

--- a/examples/tile_kernels/moe/test_moe_topk_gate.py
+++ b/examples/tile_kernels/moe/test_moe_topk_gate.py
@@ -1,0 +1,46 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("moe_topk_gate.py")
+    spec = importlib.util.spec_from_file_location("_moe_topk_gate_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+# The example is already written as Pytest cases and asserts the selected
+# indices against a stable topk, but nothing collects it: the legacy runner
+# skips test_*.py by name and this file is not one. Its own parameter set is
+# twenty expert configurations against two token counts, which is more than a
+# per-commit run needs, so these take the smallest, the largest and one in
+# between of the expert counts.
+_EXPERTS = [16, 72, 144]
+
+
+@pytest.mark.parametrize("num_tokens", [4001, 8001])
+@pytest.mark.parametrize("num_experts", _EXPERTS)
+def test_topk_gate(num_tokens, num_experts) -> None:
+    example = _load_example()
+    example.test_topk_gate({"num_tokens": num_tokens, "num_experts": num_experts, "num_topk": 6})
+
+
+@pytest.mark.parametrize("num_tokens", [4001, 8001])
+@pytest.mark.parametrize("num_experts", _EXPERTS)
+def test_topk_gate_backward(num_tokens, num_experts) -> None:
+    example = _load_example()
+    example.test_topk_gate_backward({"num_tokens": num_tokens, "num_experts": num_experts, "num_topk": 6})

--- a/examples_experiment/chunk_gated_delta_rule/test_chunk_gated_delta_rule.py
+++ b/examples_experiment/chunk_gated_delta_rule/test_chunk_gated_delta_rule.py
@@ -1,0 +1,66 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("chunk_gated_delta_rule.py")
+    spec = importlib.util.spec_from_file_location("_chunk_gated_delta_rule_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        # The example parses arguments at import time.
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_chunk_gated_delta_rule_accuracy() -> None:
+    import torch
+
+    example = _load_example()
+
+    # The kernel only takes the varlen layout, so the batch dimension is one and
+    # the sequences are concatenated behind cu_seqlens.
+    seqlens = [2048]
+    heads = 8
+    grouped_heads = 4
+    key_dim = 128
+    value_dim = 128
+
+    total = sum(seqlens)
+    sequences = len(seqlens)
+    cu_seqlens = torch.tensor([0] + [sum(seqlens[: i + 1]) for i in range(len(seqlens))], dtype=torch.int32).npu()
+
+    # The recurrence multiplies these together over 2048 steps, so the example
+    # keeps the inputs small; drawn from randn they overflow float16.
+    torch.manual_seed(41)
+    k = torch.rand(1, total, grouped_heads, key_dim, dtype=torch.float16).npu() * 0.01
+    w = torch.rand(1, total, heads, key_dim, dtype=torch.float16).npu() * 0.01
+    u = torch.rand(1, total, heads, value_dim, dtype=torch.float16).npu() * 0.01
+    g = torch.rand(1, total, heads, dtype=torch.float32).npu() * -1.0
+    initial_state = torch.rand(1, sequences, heads, key_dim, value_dim, dtype=torch.float16).npu() * 0.01
+
+    h, v_new, ht = example.chunk_gated_delta_rule_fwd_h(
+        k, w, u, g, initial_state=initial_state, output_final_state=True, cu_seqlens=cu_seqlens
+    )
+    ref_h, ref_v_new, ref_ht = example.ref_chunk_gated_delta_rule(
+        k.cpu(),
+        w.cpu(),
+        u.cpu(),
+        g.cpu(),
+        initial_state=initial_state.cpu(),
+        output_final_state=True,
+        cu_seqlens=cu_seqlens.cpu(),
+    )
+
+    torch.testing.assert_close(h.cpu(), ref_h.cpu(), rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(v_new.cpu(), ref_v_new.cpu(), rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(ht.cpu(), ref_ht.cpu(), rtol=1e-5, atol=1e-5)

--- a/examples_experiment/chunk_gated_delta_rule/test_expert_chunk_gated_delta_rule.py
+++ b/examples_experiment/chunk_gated_delta_rule/test_expert_chunk_gated_delta_rule.py
@@ -1,0 +1,64 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("expert_chunk_gated_delta_rule.py")
+    spec = importlib.util.spec_from_file_location("_expert_chunk_gated_delta_rule_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        # The example parses arguments at import time.
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_expert_chunk_gated_delta_rule_accuracy() -> None:
+    import torch
+
+    example = _load_example()
+
+    # Same varlen layout and the same tolerances as the non-expert variant next
+    # to it; what differs is how the kernel is scheduled.
+    seqlens = [2048]
+    heads = 8
+    grouped_heads = 4
+    key_dim = 128
+    value_dim = 128
+
+    total = sum(seqlens)
+    sequences = len(seqlens)
+    cu_seqlens = torch.tensor([0] + [sum(seqlens[: i + 1]) for i in range(len(seqlens))], dtype=torch.int32).npu()
+
+    torch.manual_seed(41)
+    k = torch.rand(1, total, grouped_heads, key_dim, dtype=torch.float16).npu() * 0.01
+    w = torch.rand(1, total, heads, key_dim, dtype=torch.float16).npu() * 0.01
+    u = torch.rand(1, total, heads, value_dim, dtype=torch.float16).npu() * 0.01
+    g = torch.rand(1, total, heads, dtype=torch.float32).npu() * -1.0
+    initial_state = torch.rand(1, sequences, heads, key_dim, value_dim, dtype=torch.float16).npu() * 0.01
+
+    h, v_new, ht = example.chunk_gated_delta_rule_fwd_h(
+        k, w, u, g, initial_state=initial_state, output_final_state=True, cu_seqlens=cu_seqlens
+    )
+    ref_h, ref_v_new, ref_ht = example.ref_chunk_gated_delta_rule(
+        k.cpu(),
+        w.cpu(),
+        u.cpu(),
+        g.cpu(),
+        initial_state=initial_state.cpu(),
+        output_final_state=True,
+        cu_seqlens=cu_seqlens.cpu(),
+    )
+
+    torch.testing.assert_close(h.cpu(), ref_h.cpu(), rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(v_new.cpu(), ref_v_new.cpu(), rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(ht.cpu(), ref_ht.cpu(), rtol=1e-5, atol=1e-5)

--- a/examples_experiment/cumsum_gdn/test_example_cumsum.py
+++ b/examples_experiment/cumsum_gdn/test_example_cumsum.py
@@ -1,0 +1,77 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("example_cumsum.py")
+    spec = importlib.util.spec_from_file_location("_cumsum_gdn_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+# Shapes come from the example. Sequence lengths that are not a multiple of the
+# chunk (250 against 32) and head counts that are odd are what exercise the tail
+# handling, so both stay in.
+@pytest.mark.parametrize(
+    "batch, heads, seq_len, chunk, reverse, head_first",
+    [
+        (2, 32, 256, 32, False, True),
+        (2, 32, 256, 32, True, True),
+        (2, 7, 250, 32, False, False),
+        (2, 7, 250, 32, True, False),
+        (4, 8, 512, 64, True, True),
+    ],
+)
+def test_chunk_cumsum(batch, heads, seq_len, chunk, reverse, head_first) -> None:
+    import torch
+
+    example = _load_example()
+
+    shape = (batch, heads, seq_len) if head_first else (batch, seq_len, heads)
+    torch.manual_seed(0)
+    g = torch.randn(shape).npu().to(torch.float)
+
+    actual = example.chunk_cumsum(g, chunk, reverse=reverse, head_first=head_first)
+    expected = example.ref_chunk_cumsum(g, chunk, reverse=reverse, head_first=head_first)
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-5, atol=1e-5)
+
+
+# use_fragment selects a different buffer for the running sum; the reference is
+# the same either way.
+@pytest.mark.parametrize(
+    "batch, heads, seq_len, chunk, reverse, head_first",
+    [
+        (2, 32, 256, 32, False, True),
+        (2, 32, 256, 32, True, True),
+        (2, 7, 250, 32, False, False),
+        (1, 16, 128, 64, True, True),
+    ],
+)
+def test_chunk_cumsum_fragment(batch, heads, seq_len, chunk, reverse, head_first) -> None:
+    import torch
+
+    example = _load_example()
+
+    shape = (batch, heads, seq_len) if head_first else (batch, seq_len, heads)
+    torch.manual_seed(0)
+    g = torch.randn(shape).npu().to(torch.float)
+
+    actual = example.chunk_cumsum(g, chunk, reverse=reverse, head_first=head_first, use_fragment=True)
+    expected = example.ref_chunk_cumsum(g, chunk, reverse=reverse, head_first=head_first)
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-5, atol=1e-5)

--- a/examples_experiment/cumsum_kda/test_example_cumsum_kda.py
+++ b/examples_experiment/cumsum_kda/test_example_cumsum_kda.py
@@ -119,4 +119,9 @@ def test_chunk_global_cumsum_vector(batch, heads, seq_len, s_dim, reverse, head_
     actual = example.chunk_global_cumsum_vector(s, reverse=reverse, head_first=head_first)
     expected = example.ref_chunk_global_cumsum_vector(s, reverse=reverse, head_first=head_first)
 
-    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-5, atol=1e-5)
+    # 1e-4 rather than the 1e-5 the other three hold, which is what the example
+    # itself allows here: this variant accumulates across the whole sequence
+    # instead of within a chunk, and the kernel and the reference reach the same
+    # sum in a different order. At 256 elements that showed up as five values in
+    # 262144 landing 1.4e-5 apart.
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-4, atol=1e-4)

--- a/examples_experiment/cumsum_kda/test_example_cumsum_kda.py
+++ b/examples_experiment/cumsum_kda/test_example_cumsum_kda.py
@@ -1,0 +1,122 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("example_cumsum_kda.py")
+    spec = importlib.util.spec_from_file_location("_cumsum_kda_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+# Shapes come from the example. Sequence lengths that are not a multiple of the
+# block and head counts that are odd are what exercise the tail handling, so
+# both stay in.
+@pytest.mark.parametrize(
+    "batch, heads, seq_len, block_t, reverse, head_first",
+    [
+        (1, 8, 128, 32, False, True),
+        (1, 8, 130, 32, True, False),
+        (1, 7, 130, 32, False, False),
+        (2, 16, 256, 64, True, True),
+    ],
+)
+def test_chunk_local_cumsum_scalar(batch, heads, seq_len, block_t, reverse, head_first) -> None:
+    import torch
+
+    example = _load_example()
+
+    shape = (batch, heads, seq_len) if head_first else (batch, seq_len, heads)
+    torch.manual_seed(0)
+    s = torch.randn(shape).npu().to(torch.float)
+
+    actual = example.chunk_local_cumsum_scalar(s, block_t, reverse=reverse, head_first=head_first)
+    expected = example.ref_chunk_local_cumsum_scalar(s, block_t, reverse=reverse, head_first=head_first)
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "batch, heads, seq_len, reverse, head_first",
+    [
+        (1, 8, 128, False, True),
+        (1, 8, 130, True, False),
+        (1, 7, 130, False, False),
+        (2, 16, 256, True, True),
+    ],
+)
+def test_chunk_global_cumsum_scalar(batch, heads, seq_len, reverse, head_first) -> None:
+    import torch
+
+    example = _load_example()
+
+    shape = (batch, heads, seq_len) if head_first else (batch, seq_len, heads)
+    torch.manual_seed(0)
+    s = torch.randn(shape).npu().to(torch.float)
+
+    actual = example.chunk_global_cumsum_scalar(s, reverse=reverse, head_first=head_first)
+    expected = example.ref_chunk_global_cumsum_scalar(s, reverse=reverse, head_first=head_first)
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "batch, heads, seq_len, s_dim, block_t, reverse, head_first",
+    [
+        (1, 8, 128, 16, 32, False, True),
+        (1, 8, 130, 17, 32, True, False),
+        (1, 7, 130, 17, 32, False, False),
+        (2, 16, 256, 32, 64, True, True),
+    ],
+)
+def test_chunk_local_cumsum_vector(batch, heads, seq_len, s_dim, block_t, reverse, head_first) -> None:
+    import torch
+
+    example = _load_example()
+
+    shape = (batch, heads, seq_len, s_dim) if head_first else (batch, seq_len, heads, s_dim)
+    torch.manual_seed(0)
+    s = torch.randn(shape).npu().to(torch.float)
+
+    actual = example.chunk_local_cumsum_vector(s, block_t, reverse=reverse, head_first=head_first)
+    expected = example.ref_chunk_local_cumsum_vector(s, block_t, reverse=reverse, head_first=head_first)
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "batch, heads, seq_len, s_dim, reverse, head_first",
+    [
+        (1, 8, 128, 16, False, True),
+        (1, 8, 130, 17, True, False),
+        (1, 7, 130, 17, False, False),
+        (2, 16, 256, 32, True, True),
+    ],
+)
+def test_chunk_global_cumsum_vector(batch, heads, seq_len, s_dim, reverse, head_first) -> None:
+    import torch
+
+    example = _load_example()
+
+    shape = (batch, heads, seq_len, s_dim) if head_first else (batch, seq_len, heads, s_dim)
+    torch.manual_seed(0)
+    s = torch.randn(shape).npu().to(torch.float)
+
+    actual = example.chunk_global_cumsum_vector(s, reverse=reverse, head_first=head_first)
+    expected = example.ref_chunk_global_cumsum_vector(s, reverse=reverse, head_first=head_first)
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-5, atol=1e-5)

--- a/examples_experiment/seer_attention/test_block_sparse_attn.py
+++ b/examples_experiment/seer_attention/test_block_sparse_attn.py
@@ -1,0 +1,37 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    source = Path(__file__).with_name("block_sparse_attn.py")
+    spec = importlib.util.spec_from_file_location("_block_sparse_attn_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+# The example already asserts against a reference it builds inline: the block
+# mask is expanded with a Kronecker product, intersected with the causal mask
+# and, for the shorter query, offset by the length difference. Restating that
+# here would duplicate the part most likely to be transcribed wrong, so these
+# call it instead. Loading the example under a private module name keeps Pytest
+# from collecting its functions twice.
+def test_topk_sparse_attention() -> None:
+    example = _load_example()
+    example.test_topk_sparse_attention()
+
+
+def test_topk_sparse_attention_qlen_lt_klen() -> None:
+    example = _load_example()
+    example.test_topk_sparse_attention_qlen_lt_klen()


### PR DESCRIPTION
## 改动内容

为 `examples/` 和 `examples_experiment/` 下 39 个算子新增非侵入式 pytest 测试文件，不修改任何原文件。

### 覆盖范围

| 区域 | 类别 | 文件数 |
|------|------|--------|
| `examples/` | Sparse Flash Attention | 7 |
| | Flash Attention | 2 |
| | HISA | 2 |
| | GDN（`linear_attention_and_rnn/gdn`） | 6 |
| | Optimized GDN（`linear_attention_and_rnn/opt_gdn`） | 6 |
| | Linear Attention & RNN | 4 |
| | Fused Sigmoid Gating Delta Rule | 1 |
| | MoE Token Permute | 4 |
| | Tile Kernels（`mhc` / `moe`） | 2 |
| `examples_experiment/` | Chunk Gated Delta Rule | 2 |
| | Cumsum KDA / Cumsum GDN | 2 |
| | Seer Attention | 1 |
| **合计** | | **39** |

### 加载方式

全部采用 **importlib + argv 隔离**：用 `importlib.util` 按路径加载原文件为模块，加载前后隔离 `sys.argv`，避免原文件的顶层 argparse 读到 pytest 的参数。与 #1489 的 `test_batch_gemm.py` / `test_flash_attn_bhsd.py` 和 #1493 的方案一致。

加载之后按原文件的组织方式分两种：

- **调用参考实现比对**（29 文件）：原文件提供 `ref_*` 参考实现或 `main()` 驱动，测试调用它并断言精度。原文件自带多组 config 的，parametrize 成独立用例。

- **加载即测试**（10 文件）：原文件没有 `__main__` 守卫，断言写在模块顶层，import 完成就等于跑完。这类测试只负责加载并让异常自然抛出。

### 命名规范

所有测试文件名与 `ci/operator_test_manifest.yaml` 预登记的条目一致，未修改 manifest。

### 验证结果

在 Ascend NPU 上验证：

```
83 tests collected
83 passed, 0 failed
```

同时用 CI 的原样命令跑过（`pytest --forked -v -n 8`），无 OOM。

ruff lint + format 全部通过。

### 参考

- #1489：建立 `ci/operator_test_manifest.yaml` 和 CI 路由机制
- #1493 / #1505：importlib + argv 隔离方案的参考实现
