### PR TITLE
[Fix] Harden row-expand layouts and clean up legacy tooling 🤖

### DIFF
--- a/set_env.sh
+++ b/set_env.sh
@@ -1,8 +1,20 @@
 #!/bin/bash
 
-TL_ROOT=$(readlink -f "${BASH_SOURCE[0]}")
-export TL_ROOT=$(dirname "$TL_ROOT")
-export PYTHONPATH=${TL_ROOT}:$PYTHONPATH
+if [ -n "${ZSH_VERSION:-}" ]; then
+    tilelang_env_script_path="${(%):-%N}"
+else
+    tilelang_env_script_path="${BASH_SOURCE[0]}"
+fi
+
+TL_ROOT=$(dirname "$(readlink -f "$tilelang_env_script_path")")
+export TL_ROOT
+case "${PYTHONPATH:-}" in
+    "$TL_ROOT"|"$TL_ROOT":*) ;;
+    *) PYTHONPATH="$TL_ROOT${PYTHONPATH:+:$PYTHONPATH}" ;;
+esac
+export PYTHONPATH
 
 # disable the import of tvm when using torch_npu
 export ACL_OP_INIT_MODE=1
+
+unset tilelang_env_script_path

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -2226,11 +2226,10 @@ void CodeGenTileLangAscend::RowExpandDivExperimentCodegen(const CallNode *op) {
 void CodeGenTileLangAscend::RowExpandBinOpExperimentCodegen(
     const CallNode *op, const std::string &mask_op_name) {
   // args[0] = op name string, args[1] = dst, args[2] = src0,
-  // args[3] = src1, args[4] = tmp (required for AscendC)
+  // args[3] = src1, args[4] = optional broadcast workspace.
   //
-  // AscendC path: src1 is 1D [R] scalars, but {mul,sub,div}_mask requires
-  // a 2D [R, elems_per_block] broadcast buffer. Use tmp as intermediate:
-  // brcb(src1 → tmp) then {op}_mask(dst, src0, tmp).
+  // With tmp, src1 is a scalar-linear [R] stream that brcb expands into
+  // [R, elems_per_block]. Without tmp, src1 already contains those blocks.
   DataType dtype = GetAccessPtrDtype(op->args[1].as<CallNode>());
   std::string type_str = getType(dtype);
   int elems_per_block = 32 / (dtype.bits() / 8);
@@ -2250,7 +2249,13 @@ void CodeGenTileLangAscend::RowExpandBinOpExperimentCodegen(
       cols = static_cast<int>(shape[shape.size() - 1].as<IntImmNode>()->value);
     }
   }
+  ICHECK_EQ(cols % elems_per_block, 0)
+      << "RowExpandBinOpExperimentCodegen: physical columns=" << cols
+      << " must be divisible by " << elems_per_block;
   int rep_stride = cols / elems_per_block;
+  ICHECK(rep_stride > 0 && rep_stride <= 255)
+      << "RowExpandBinOpExperimentCodegen: repeat stride=" << rep_stride
+      << " must fit uint8_t";
   int repeat_time = 0;
   if (auto *extent_imm = dst_access->args[3].as<IntImmNode>()) {
     int extent = static_cast<int>(extent_imm->value);
@@ -2267,12 +2272,13 @@ void CodeGenTileLangAscend::RowExpandBinOpExperimentCodegen(
   ICHECK(rows % 8 == 0)
       << "RowExpandBinOpExperimentCodegen: rows=" << rows
       << " must be a multiple of 8 (BRCB processes 8 scalars per repeat)";
+  ICHECK_LE(rows, 255) << "RowExpandBinOpExperimentCodegen: rows=" << rows
+                       << " must fit uint8_t";
   int brcb_repeat = rows / 8;
   ICHECK(rows > 0 && cols > 0)
       << "RowExpandBinOpExperimentCodegen: failed to derive rows/cols";
 
-  uint64_t mask0 = 0xFFFFFFFFFFFFFFFF;
-  uint64_t mask1 = (dtype.bits() == 16) ? 0xFFFFFFFFFFFFFFFF : 0;
+  const char *mask1 = (dtype.bits() == 16) ? "0xFFFFFFFFFFFFFFFF" : "0";
 
   std::string dst_name = PrintBufferOffset(op->args[1].as<CallNode>(), true);
   std::string src0_name = PrintBufferOffset(op->args[2].as<CallNode>(), true);

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -770,20 +770,6 @@ void CodeGenTileLangAscend::VisitStmt_(const AttrStmtNode *op) {
     }
     this->VisitStmt(op->body);
     return;
-  } else if (op->attr_key == "init_flag" || op->attr_key == "clear_flag") {
-    const StringImmNode *instn = op->value.as<StringImmNode>();
-
-    std::string inst = std::string(instn->value);
-    size_t st = 0;
-    for (size_t i = 0; i < inst.size(); ++i) {
-      if (inst[i] == '\n') {
-        this->PrintIndent();
-        stream << inst.substr(st, i - st) << "\n";
-        st = i + 1;
-      }
-    }
-    this->VisitStmt(op->body);
-    return;
   } else if (op->attr_key == "resource_scope") {
     auto resource_id = Downcast<IntImm>(op->value)->value;
     auto resource_name = resource_id == 0 ? "AIC" : "AIV";

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -5137,6 +5137,110 @@ def row_expand_div_experiment_kernel(M, N, dtype="float16"):
     return _row_expand_binop_experiment_kernel(M, N, "row_expand_div_experiment", dtype)
 
 
+def row_expand_mul_multistage_region_kernel():
+    stages = 2
+    rows_per_stage = 8
+    cols = 64
+    lanes = 8
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((stages, rows_per_stage, cols), "float"),  # type: ignore
+        Packed: T.Tensor((stages, rows_per_stage, lanes), "float"),  # type: ignore
+        C: T.Tensor((stages, rows_per_stage, cols), "float"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True):
+            a_ring = T.alloc_ub((stages + 1, rows_per_stage, cols), "float")
+            packed_ring = T.alloc_ub((stages + 1, rows_per_stage, lanes), "float")
+            c_ring = T.alloc_ub((stages + 1, rows_per_stage, cols), "float")
+
+            for stage in T.serial(stages):
+                T.copy(A[stage, :, :], a_ring[stage + 1, :, :])
+                T.copy(Packed[stage, :, :], packed_ring[stage + 1, :, :])
+            T.tile.row_expand_mul_experiment(
+                c_ring[1:3, :, :],
+                a_ring[1:3, :, :],
+                packed_ring[1:3, :, :],
+            )
+            for stage in T.serial(stages):
+                T.copy(c_ring[stage + 1, :, :], C[stage, :, :])
+
+    return main
+
+
+def test_row_expand_experiment_folds_and_validates_regions():
+    op = T.tile.row_expand_mul_experiment
+    stage = tir.Var("stage", "int32")
+    dst_ring = tir.decl_buffer((3, 8, 64), "float32", scope="shared.ub")
+    src_ring = tir.decl_buffer((3, 8, 64), "float32", scope="shared.ub")
+    packed_ring = tir.decl_buffer((3, 8, 8), "float32", scope="shared.ub")
+
+    singleton = op(dst_ring[stage, :, :], src_ring[stage, :, :], packed_ring[stage, :, :])
+    multistage = op(dst_ring[1:3, :, :], src_ring[1:3, :, :], packed_ring[1:3, :, :])
+    whole_buffer = op(dst_ring, src_ring, packed_ring)
+
+    assert int(singleton.args[1].args[3]) == 8 * 64
+    assert int(singleton.args[3].args[3]) == 8 * 8
+    assert int(multistage.args[1].args[3]) == 2 * 8 * 64
+    assert int(multistage.args[3].args[3]) == 2 * 8 * 8
+    assert int(whole_buffer.args[1].args[3]) == 3 * 8 * 64
+    assert int(whole_buffer.args[3].args[3]) == 3 * 8 * 8
+
+    chunk = tir.Var("chunk", "int32")
+    wide_dst = tir.decl_buffer((8, 128), "float32", scope="shared.ub")
+    wide_src = tir.decl_buffer((8, 128), "float32", scope="shared.ub")
+    symbolic_window = op(
+        wide_dst[:, chunk * 64 : (chunk + 1) * 64],
+        wide_src[:, chunk * 64 : (chunk + 1) * 64],
+        tir.decl_buffer((8, 8), "float32", scope="shared.ub"),
+    )
+    assert int(symbolic_window.args[1].args[3]) == 8 * 64
+
+    dst = tir.decl_buffer((64, 64), "float32", scope="shared.ub")
+    src = tir.decl_buffer((64, 64), "float32", scope="shared.ub")
+    extra_rows = tir.decl_buffer((2, 64, 8), "float32", scope="shared.ub")
+    mismatch = r"src1 scalar count must match dst rows: src1=128, dst\[0\]=64"
+    with pytest.raises(ValueError, match=mismatch):
+        op(dst, src, extra_rows)
+
+    packed_ring = tir.decl_buffer((2, 128, 8), "float32", scope="shared.ub")
+    with pytest.raises(ValueError, match="must be contiguous when flattened"):
+        op(dst, src, packed_ring[0:2, 0:64, :])
+
+    scalar = tir.decl_buffer((64,), "float32", scope="shared.ub")
+    with pytest.raises(ValueError, match="packed src1 shape"):
+        op(dst, src, scalar)
+    with pytest.raises(ValueError, match="packed src1 shape"):
+        op(dst, src, scalar[:])
+
+    dst_fp16 = tir.decl_buffer((16, 128), "float16", scope="shared.ub")
+    src_fp16 = tir.decl_buffer((16, 128), "float16", scope="shared.ub")
+    scalar_ring = tir.decl_buffer((3, 8, 1), "float16", scope="shared.ub")
+    tmp_fp16 = tir.decl_buffer((16, 16), "float16", scope="shared.ub")
+    with pytest.raises(ValueError, match="32-byte-aligned access offset"):
+        op(dst_fp16, src_fp16, scalar_ring[1:3, :, :], tmp_fp16)
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_row_expand_mul_experiment_multistage_region(target):
+    func = tilelang.compile(
+        row_expand_mul_multistage_region_kernel(),
+        out_idx=[-1],
+        pass_configs=pass_configs,
+        target=target,
+    )
+
+    a = torch.arange(1, 2 * 8 * 64 + 1, dtype=torch.float32).reshape(2, 8, 64) / 64
+    scalars = torch.arange(1, 2 * 8 + 1, dtype=torch.float32).reshape(2, 8) / 4
+    packed_scalars = scalars.unsqueeze(-1).expand(2, 8, 8).contiguous()
+
+    c = func(a.npu(), packed_scalars.npu())
+    torch.npu.synchronize()
+    ref_c = a * scalars.unsqueeze(-1)
+
+    torch.testing.assert_close(c.cpu(), ref_c, rtol=1e-5, atol=1e-5)
+
+
 @pytest.mark.parametrize("dtype,shape", [("float16", (16, 128)), ("float", (16, 64))])
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
 def test_row_expand_mul_experiment(dtype, target, shape):

--- a/testing/python/language/test_tilelang_ascend_language_legacy_flags.py
+++ b/testing/python/language/test_tilelang_ascend_language_legacy_flags.py
@@ -1,0 +1,8 @@
+"""Regression tests for removal of legacy string-based flag helpers."""
+
+import tilelang.language as T
+
+
+def test_legacy_flag_helpers_are_not_exported():
+    assert not hasattr(T, "init_flag")
+    assert not hasattr(T, "clear_flag")

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -173,32 +173,6 @@ def import_source(source: str | None = None):
     return block_attr({"pragma_import_c": source}) if source is not None else None
 
 
-def init_flag(fmap):
-    inst = ""
-    for src, d in fmap.items():
-        for dst, stages in d.items():
-            for stage in stages:
-                inst += f"AscendC::SetFlag<AscendC::HardEvent::{src}_{dst}>({stage});\n"
-
-    return attr(None, "init_flag", inst)
-
-
-def clear_flag(fmap):
-    inst = ""
-    for src, d in fmap.items():
-        for dst, stages in d.items():
-            for stage in stages:
-                inst += f"AscendC::WaitFlag<AscendC::HardEvent::{src}_{dst}>({stage});\n"
-
-    @macro
-    def _get_inst():
-        with attr(None, "clear_flag", inst):
-            call_extern("handle", "...")
-
-    # return attr(call_extern("handle", "..."), "clear_flag", inst)
-    return _get_inst()
-
-
 def npu_use_swizzle(cid, m, n, k, block_m, block_n, off=1, dir=0, in_loop=False):
     # If order is row, use rasterization2DRow, otherwise use rasterization2DColumn
     # The panel size is the number of threads in a warp

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import tilelang.language as T
 from tvm.ir import Range
 from tvm.tir import PrimExpr, Buffer, BufferRegion, BufferLoad, Call, IntImm, Ramp
-from tvm import DataType, tir
+from tvm import DataType, arith, tir
 from tilelang.language.ascend import _dtype
 import functools
 import warnings
@@ -68,7 +68,117 @@ def _handle_buffer_region(br: BufferRegion, mask):
     return bf.access_ptr(mask, offset=offset, extent=size_extent), extent
 
 
-def _handle_buffer_region_2d(br: BufferRegion, mask):
+def _is_const_one(val) -> bool:
+    """Check if a value is constant 1 (int or IntImm)."""
+    if isinstance(val, (int, float)):
+        return val == 1
+    if isinstance(val, IntImm):
+        return val.value == 1
+    return False
+
+
+def _const_int(val) -> int | None:
+    """Return a Python int for a static integer expression."""
+    if isinstance(val, int):
+        return val
+    if isinstance(val, IntImm):
+        return int(val)
+    return None
+
+
+def _resolve_let_expr(val):
+    """Substitute scalar let bindings that are visible while building TIR."""
+    if not isinstance(val, PrimExpr):
+        return val
+
+    bindings = {}
+
+    def collect(node):
+        if isinstance(node, tir.Var) and T.has_let_value(node):
+            bound = T.get_let_value(node)
+            if isinstance(bound, PrimExpr):
+                bindings[node] = bound
+
+    while True:
+        bindings.clear()
+        tir.stmt_functor.post_order_visit(val, collect)
+        if not bindings:
+            return val
+        val = tir.stmt_functor.substitute(val, bindings)
+
+
+def _is_provably_divisible(val, divisor: int) -> bool:
+    """Check whether a static or symbolic integer is divisible by a constant."""
+    val = _resolve_let_expr(val)
+    static_val = _const_int(val)
+    if static_val is not None:
+        return static_val % divisor == 0
+    return arith.Analyzer().can_prove(val % divisor == 0)
+
+
+def _const_equal(a, b) -> bool:
+    """Compare two values that may be int, IntImm, or symbolic PrimExpr."""
+    if isinstance(a, (int, float)) and isinstance(b, (int, float)):
+        return a == b
+    if isinstance(a, IntImm) and isinstance(b, IntImm):
+        return a.value == b.value
+    if isinstance(a, (int, float)) and isinstance(b, IntImm):
+        return a == b.value
+    if isinstance(a, IntImm) and isinstance(b, (int, float)):
+        return a.value == b
+    import tvm
+
+    return tvm.ir.structural_equal(a, b)
+
+
+def _shapes_equal(shape1, shape2) -> bool:
+    """Compare two shape lists that may contain symbolic PrimExpr."""
+    if len(shape1) != len(shape2):
+        return False
+    return all(_const_equal(x, y) for x, y in zip(shape1, shape2))
+
+
+def _fold_nd_shape_to_2d(shape):
+    """Fold all leading dimensions of a shape into a single row dimension."""
+    shape = list(shape)
+    if len(shape) <= 1:
+        return shape
+    return [math.prod(shape[:-1]), shape[-1]]
+
+
+def _validate_buffer_region_contiguity(
+    br: BufferRegion,
+    *,
+    require_flat_contiguous: bool,
+) -> None:
+    """Reject rectangular regions that cross gaps in a dense row-major buffer.
+
+    A 2D row operation may use a narrower final-axis window because codegen
+    retains the physical row stride. A flat stream must include the final axis
+    in the same check.
+    """
+    regions = br.region if require_flat_contiguous else br.region[:-1]
+    spans_multiple_entries = False
+    for axis, region in enumerate(regions):
+        if spans_multiple_entries:
+            starts_at_zero = _const_equal(region.min, 0)
+            has_full_extent = _const_equal(region.extent, br.buffer.shape[axis])
+            if not (starts_at_zero and has_full_extent):
+                if require_flat_contiguous:
+                    requirement = "BufferRegion must be contiguous when flattened"
+                else:
+                    requirement = "BufferRegion outer dimensions must be contiguous"
+                raise ValueError(f"{requirement}; axis {axis} is not selected in full.")
+        elif not _is_const_one(region.extent):
+            spans_multiple_entries = True
+
+
+def _handle_buffer_region_2d(
+    br: BufferRegion,
+    mask,
+    *,
+    require_flat_contiguous: bool = False,
+):
     """Like _handle_buffer_region but flattens ND extents to 2D [rows, cols].
 
     For a 3D buffer s_ub[T, 32, 512] sliced as s_ub[tile, :, :]:
@@ -76,15 +186,16 @@ def _handle_buffer_region_2d(br: BufferRegion, mask):
 
     Leading dimensions are folded into rows; the innermost dimension is kept as cols.
     """
+    _validate_buffer_region_contiguity(
+        br,
+        require_flat_contiguous=require_flat_contiguous,
+    )
     bf = br.buffer
     indices = [x.min for x in br.region]
     offset = bf.offset_of(indices)[0]
     extent_nd = [x.extent for x in br.region]
     size_extent = math.prod(extent_nd)
-    if len(extent_nd) >= 2:
-        extent_2d = [math.prod(extent_nd[:-1]), extent_nd[-1]]
-    else:
-        extent_2d = [1, extent_nd[0]]
+    extent_2d = _fold_nd_shape_to_2d(extent_nd)
     return bf.access_ptr(mask, offset=offset, extent=size_extent), extent_2d
 
 
@@ -2269,35 +2380,101 @@ def _normalize_buffer_arg(obj: Buffer | BufferRegion | BufferLoad) -> Buffer | B
     return obj
 
 
-def _is_const_one(val) -> bool:
-    """Check if a value is constant 1 (int or IntImm)."""
-    if isinstance(val, (int, float)):
-        return val == 1
-    if isinstance(val, IntImm):
-        return val.value == 1
-    return False
+def _underlying_buffer(obj: Buffer | BufferRegion) -> Buffer:
+    """Return the Buffer referenced by a Buffer or BufferRegion."""
+    return obj.buffer if isinstance(obj, BufferRegion) else obj
 
 
-def _const_equal(a, b) -> bool:
-    """Compare two values that may be int, IntImm, or symbolic PrimExpr."""
-    if isinstance(a, (int, float)) and isinstance(b, (int, float)):
-        return a == b
-    if isinstance(a, IntImm) and isinstance(b, IntImm):
-        return a.value == b.value
-    if isinstance(a, (int, float)) and isinstance(b, IntImm):
-        return a == b.value
-    if isinstance(a, IntImm) and isinstance(b, (int, float)):
-        return a.value == b
-    import tvm
+def _get_folded_2d_access(
+    obj: Buffer | BufferRegion,
+    mask: str,
+    *,
+    require_flat_contiguous: bool = False,
+):
+    """Return an access pointer and a shape with all leading dimensions folded."""
+    if isinstance(obj, BufferRegion):
+        return _handle_buffer_region_2d(
+            obj,
+            mask,
+            require_flat_contiguous=require_flat_contiguous,
+        )
+    return obj.access_ptr(mask), _fold_nd_shape_to_2d(obj.shape)
 
-    return tvm.ir.structural_equal(a, b)
+
+_ROW_EXPAND_BLOCK_BYTES = 32
+_ROW_EXPAND_ROW_BYTES = 256
+_ROW_EXPAND_MAX_ROWS = 248
+_ROW_EXPAND_SUPPORTED_DTYPES = (DataType("float16"), DataType("float32"))
 
 
-def _shapes_equal(shape1, shape2) -> bool:
-    """Compare two shape lists that may contain symbolic PrimExpr."""
-    if len(shape1) != len(shape2):
-        return False
-    return all(_const_equal(x, y) for x, y in zip(shape1, shape2))
+def _validate_row_expand_access_alignment(
+    obj: Buffer | BufferRegion,
+    *,
+    elems_per_block: int,
+    op_name: str,
+    arg_name: str,
+) -> None:
+    """Require an access pointer aligned to one 32-byte vector block."""
+    buffer = _underlying_buffer(obj)
+    indices = [region.min for region in obj.region] if isinstance(obj, BufferRegion) else [0] * len(buffer.shape)
+    element_offset = buffer.offset_of(indices)[0]
+    if not _is_provably_divisible(element_offset, elems_per_block):
+        requirement = f"a {_ROW_EXPAND_BLOCK_BYTES}-byte-aligned access offset"
+        raise ValueError(f"{op_name} requires {requirement} for {arg_name}.")
+
+
+def _row_expand_physical_stride_blocks(
+    obj: Buffer | BufferRegion,
+    *,
+    elems_per_block: int,
+    op_name: str,
+    arg_name: str,
+) -> int:
+    """Validate one data operand's physical row layout."""
+    buffer = _underlying_buffer(obj)
+    physical_cols = _const_int(buffer.shape[-1]) if len(buffer.shape) > 0 else None
+    if physical_cols is None:
+        raise ValueError(f"{op_name} requires a static physical last dimension for {arg_name}.")
+    if physical_cols % elems_per_block != 0:
+        requirement = f"a physical row stride aligned to {_ROW_EXPAND_BLOCK_BYTES} bytes"
+        raise ValueError(f"{op_name} requires {requirement} for {arg_name}; got {physical_cols} elements.")
+
+    stride_blocks = physical_cols // elems_per_block
+    if not 1 <= stride_blocks <= 255:
+        raise ValueError(f"{op_name} requires {arg_name} physical row stride to fit 1..255 blocks; got {stride_blocks}.")
+
+    _validate_row_expand_access_alignment(
+        obj,
+        elems_per_block=elems_per_block,
+        op_name=op_name,
+        arg_name=arg_name,
+    )
+    return stride_blocks
+
+
+def _row_expand_src1_rows(
+    shape,
+    *,
+    has_tmp: bool,
+    elems_per_block: int,
+    op_name: str,
+):
+    """Validate src1's physical layout and return its logical row count."""
+    if not has_tmp:
+        if len(shape) == 2 and _const_equal(shape[1], elems_per_block):
+            return shape[0]
+        requirement = f"packed src1 shape [R, {elems_per_block}] when tmp is omitted"
+        raise ValueError(f"{op_name} requires {requirement}; got {shape}.")
+
+    if len(shape) == 1:
+        return shape[0]
+    if len(shape) == 2:
+        if _is_const_one(shape[0]):
+            return shape[1]
+        if _is_const_one(shape[1]):
+            return shape[0]
+    requirement = "scalar src1 shape [R], [1, R], or [R, 1] when tmp is provided"
+    raise ValueError(f"{op_name} requires {requirement}; got {shape}.")
 
 
 def _row_expand_binop_experiment(
@@ -2307,7 +2484,6 @@ def _row_expand_binop_experiment(
     tmp,
     op_name: str,
     ir_op_name: str,
-    desc: str,
 ):
     dst = _normalize_buffer_arg(dst)
     src0 = _normalize_buffer_arg(src0)
@@ -2315,46 +2491,98 @@ def _row_expand_binop_experiment(
     if tmp is not None:
         tmp = _normalize_buffer_arg(tmp)
 
-    if isinstance(dst, BufferRegion):
-        dst_ptr, dst_shape = _handle_buffer_region_2d(dst, "w")
-    else:
-        dst_ptr = dst.access_ptr("w")
-        dst_shape = list(dst.shape[-2:])
+    dst_ptr, dst_shape = _get_folded_2d_access(dst, "w")
+    src0_ptr, src0_shape = _get_folded_2d_access(src0, "r")
 
-    if isinstance(src0, BufferRegion):
-        src0_ptr, src0_shape = _handle_buffer_region_2d(src0, "r")
-    else:
-        src0_ptr = src0.access_ptr("r")
-        src0_shape = list(src0.shape[-2:])
-
-    if isinstance(src1, BufferRegion):
-        src1_ptr, src1_nd_extent = _handle_buffer_region(src1, "r")
-        src1_full_shape = [src1_nd_extent[-1]] if len(src1_nd_extent) >= 2 else src1_nd_extent
-    else:
-        src1_ptr = src1.access_ptr("r")
-        src1_full_shape = list(src1.shape)
-
-    if len(src1_full_shape) == 1:
-        src1_len = src1_full_shape[0]
-    elif len(src1_full_shape) == 2:
-        s0, s1 = src1_full_shape[-2], src1_full_shape[-1]
-        if _is_const_one(s0):
-            src1_len = s1
-        elif _is_const_one(s1) or _const_equal(s0, dst_shape[0]):
-            src1_len = s0
-        else:
-            raise ValueError(f"src1 must be 1D [R], [1, R], or [R, 1]; got {src1_full_shape}")
-    else:
-        raise ValueError(f"src1 must be 1D or 2D, got shape {src1_full_shape}")
+    dst_buffer = _underlying_buffer(dst)
+    src0_buffer = _underlying_buffer(src0)
+    src1_buffer = _underlying_buffer(src1)
+    dst_dtype = DataType(dst_buffer.dtype)
+    src0_dtype = DataType(src0_buffer.dtype)
+    src1_dtype = DataType(src1_buffer.dtype)
+    if not (dst_dtype == src0_dtype == src1_dtype):
+        mismatch = f"dst={dst_buffer.dtype}, src0={src0_buffer.dtype}, src1={src1_buffer.dtype}"
+        raise ValueError(f"{op_name} requires matching operand dtypes: {mismatch}")
+    if dst_dtype not in _ROW_EXPAND_SUPPORTED_DTYPES:
+        raise ValueError(f"{op_name} supports only float16 and float32 operands; got {dst_buffer.dtype}.")
 
     if len(dst_shape) != 2 or len(src0_shape) != 2:
         raise ValueError(f"{op_name} requires 2D buffers for dst and src0.")
-
     if not _shapes_equal(dst_shape, src0_shape):
         raise ValueError(f"dst and src0 shapes must match: dst={dst_shape}, src0={src0_shape}")
 
-    if not _const_equal(src1_len, dst_shape[0]):
-        raise ValueError(f"src1 scalar count must match dst rows: src1={src1_len}, dst[0]={dst_shape[0]}")
+    dtype_bits = dst_dtype.bits
+    elems_per_block = _ROW_EXPAND_BLOCK_BYTES * 8 // dtype_bits
+
+    expected_cols = _ROW_EXPAND_ROW_BYTES * 8 // dtype_bits
+    if not _const_equal(dst_shape[1], expected_cols):
+        requirement = f"a {_ROW_EXPAND_ROW_BYTES}-byte last dimension ({expected_cols} {dst_buffer.dtype} elements)"
+        raise ValueError(f"{op_name} requires {requirement}, got {dst_shape[1]}.")
+
+    rows = _const_int(dst_shape[0])
+    if rows is None or rows < 8 or rows > _ROW_EXPAND_MAX_ROWS or rows % 8 != 0:
+        requirement = f"a static row count in 8..{_ROW_EXPAND_MAX_ROWS}, divisible by 8"
+        raise ValueError(f"{op_name} requires {requirement}; got {dst_shape[0]}.")
+
+    dst_stride = _row_expand_physical_stride_blocks(
+        dst,
+        elems_per_block=elems_per_block,
+        op_name=op_name,
+        arg_name="dst",
+    )
+    src0_stride = _row_expand_physical_stride_blocks(
+        src0,
+        elems_per_block=elems_per_block,
+        op_name=op_name,
+        arg_name="src0",
+    )
+    if dst_stride != src0_stride:
+        mismatch = f"dst={dst_stride}, src0={src0_stride} blocks"
+        raise ValueError(f"{op_name} requires matching dst/src0 physical row strides: {mismatch}")
+
+    src1_ptr, src1_shape = _get_folded_2d_access(
+        src1,
+        "r",
+        require_flat_contiguous=True,
+    )
+    src1_rows = _row_expand_src1_rows(
+        src1_shape,
+        has_tmp=tmp is not None,
+        elems_per_block=elems_per_block,
+        op_name=op_name,
+    )
+    _validate_row_expand_access_alignment(
+        src1,
+        elems_per_block=elems_per_block,
+        op_name=op_name,
+        arg_name="src1",
+    )
+    if not _const_equal(src1_rows, dst_shape[0]):
+        mismatch = f"src1={src1_rows}, dst[0]={dst_shape[0]}"
+        raise ValueError(f"src1 scalar count must match dst rows: {mismatch}")
+
+    tmp_ptr = None
+    if tmp is not None:
+        tmp_buffer = _underlying_buffer(tmp)
+        if DataType(tmp_buffer.dtype) != dst_dtype:
+            mismatch = f"tmp={tmp_buffer.dtype}, operands={dst_buffer.dtype}"
+            raise ValueError(f"{op_name} requires matching tmp and operand dtypes: {mismatch}")
+        tmp_ptr, tmp_shape = _get_folded_2d_access(
+            tmp,
+            "rw",
+            require_flat_contiguous=True,
+        )
+        _validate_row_expand_access_alignment(
+            tmp,
+            elems_per_block=elems_per_block,
+            op_name=op_name,
+            arg_name="tmp",
+        )
+        tmp_size = math.prod(tmp_shape)
+        expected_tmp_size = dst_shape[0] * elems_per_block
+        if not _const_equal(tmp_size, expected_tmp_size):
+            requirement = f"tmp must contain {expected_tmp_size} elements"
+            raise ValueError(f"{op_name} {requirement}; got {tmp_size}.")
 
     dtype = _dtype(src0)
     args = [
@@ -2364,10 +2592,6 @@ def _row_expand_binop_experiment(
         src1_ptr,
     ]
     if tmp is not None:
-        if isinstance(tmp, BufferRegion):
-            tmp_ptr, _ = _handle_buffer_region(tmp, "rw")
-        else:
-            tmp_ptr = tmp.access_ptr("rw")
         args.append(tmp_ptr)
 
     return tir.call_intrin(
@@ -2387,6 +2611,12 @@ def row_expand_mul_experiment(
 
     AscendC: brcb(src1→tmp) + mul_mask(dst, src0, tmp).
     PTO: TROWEXPANDMUL_row_vec(dst, src0, src1).
+
+    Contiguous leading dimensions of dst/src0 are folded into 8..248 rows in
+    multiples of 8; each row is 256 bytes. Their physical row strides must
+    match, and row windows are 32-byte aligned. Without tmp, src1 contains one
+    packed 32-byte block per row with the scalar replicated across its lanes.
+    With tmp, src1 is scalar-linear and tmp supplies those packed blocks.
     """
     return _row_expand_binop_experiment(
         dst,
@@ -2395,7 +2625,6 @@ def row_expand_mul_experiment(
         tmp,
         "RowExpandMulExperiment",
         "tl.ascend_row_expand_mul_experiment",
-        "multiply",
     )
 
 
@@ -2409,6 +2638,12 @@ def row_expand_sub_experiment(
 
     AscendC: brcb(src1→tmp) + sub_mask(dst, src0, tmp).
     PTO: TROWEXPANDSUB_row_vec(dst, src0, src1).
+
+    Contiguous leading dimensions of dst/src0 are folded into 8..248 rows in
+    multiples of 8; each row is 256 bytes. Their physical row strides must
+    match, and row windows are 32-byte aligned. Without tmp, src1 contains one
+    packed 32-byte block per row with the scalar replicated across its lanes.
+    With tmp, src1 is scalar-linear and tmp supplies those packed blocks.
     """
     return _row_expand_binop_experiment(
         dst,
@@ -2417,7 +2652,6 @@ def row_expand_sub_experiment(
         tmp,
         "RowExpandSubExperiment",
         "tl.ascend_row_expand_sub_experiment",
-        "subtract",
     )
 
 
@@ -2431,6 +2665,12 @@ def row_expand_div_experiment(
 
     AscendC: brcb(src1→tmp) + div_mask(dst, src0, tmp).
     PTO: TROWEXPANDDIV_row_vec(dst, src0, src1).
+
+    Contiguous leading dimensions of dst/src0 are folded into 8..248 rows in
+    multiples of 8; each row is 256 bytes. Their physical row strides must
+    match, and row windows are 32-byte aligned. Without tmp, src1 contains one
+    packed 32-byte block per row with the scalar replicated across its lanes.
+    With tmp, src1 is scalar-linear and tmp supplies those packed blocks.
     """
     return _row_expand_binop_experiment(
         dst,
@@ -2439,7 +2679,6 @@ def row_expand_div_experiment(
         tmp,
         "RowExpandDivExperiment",
         "tl.ascend_row_expand_div_experiment",
-        "divide",
     )
 
 


### PR DESCRIPTION
## 背景

本 PR 处理三个“调用看起来有效，但实际行为已经偏离接口表面含义”的问题：

- row-expand 的访问指针覆盖多 stage，frontend 却可能只记录一个 stage 的行数；
- `T.init_flag` / `T.clear_flag` 在 AscendC 生成 flag 指令，在 PTO 则被静默忽略；
- `set_env.sh` 在 Bash 首次 source 时正常，但换成 Zsh 或重复 source 后结果会变化。

三项修改相互独立，因此分别放在三个 commit 中 review。

## 1. [修正 row-expand 的行数和布局](https://github.com/tile-ai/tilelang-ascend/pull/1495/commits/25d8bc71d3b5c104d1a463a0aae10382bd2032e6)

Row-expand 的最后一维固定为 256 字节，即 fp32 的 64 列或 fp16 的 128 列；前面的维度都应合并为行数。

例如，一个 fp32 Buffer 的 shape 是 `[3, 8, 64]`。完整 Buffer 应被视为 `[24, 64]`，但旧逻辑只看到 `[8, 64]`。类似地，`[1:3, :, :]` 的指针已经覆盖两个 stage，`src1` 的 shape 计算却可能丢掉 stage 维，导致行标量数量与实际数据不一致。

本 PR 让 `Buffer` 和 `BufferRegion` 都按同一规则折叠前导维度。只有实际连续的 region 才能折叠；例如从 `[2, 128, 8]` 中选择 `[0:2, 0:64, :]` 会跨过未选择的内存，因此现在直接报错。

这不改变乘、减、除的计算，只修正 shape，并在进入 codegen 前拒绝当前后端无法表示的布局。

在下面列出的支持范围内，AscendC 和 PTO 现在都会使用同一个折叠后的 `rows`，并通过了相同的单 stage 和多 stage 数值用例。

<details>
<summary>具体接受哪些布局</summary>

- dst、src0、src1 使用相同的 fp16/fp32 dtype；
- `rows` 是静态的 8 的倍数，范围为 `8..248`；
- dst/src0 的物理行 stride 相同，并按 32 字节对齐；
- 不带 `tmp` 时，`src1` 每行包含一个重复标量的 32 字节 block；
- 带 `tmp` 时，`src1` 是连续标量数组，`tmp` 每行提供一个 32 字节 block；
- `chunk * 64` 等符号化 offset 在 TIR 能证明其对齐时仍可使用。

AscendC codegen 也会检查 `uint8_t` 能表示的 row 数和 stride，防止手工构造 intrinsic 时发生截断。

</details>

## 2. [删除只在 AscendC 生效的旧 flag 接口](https://github.com/tile-ai/tilelang-ascend/pull/1495/commits/a6e0b17cb450919df9d4a3b5f550fe9dbe5856f6)

`T.init_flag` / `T.clear_flag` 随 2025 年的[实验性 AscendC backend](https://github.com/tile-ai/tilelang-ascend/commit/9f4df3a3a61a4b537db18e8a60cb7be44f8f7bee)加入。名字像通用同步 API，实际却是在 Python 端拼接 `AscendC::SetFlag/WaitFlag` 源码，再由 AscendC codegen 原样输出。

PTO 只支持结构化的 `T.set_flag` / `T.wait_flag`，不会处理这种 AscendC 字符串 AttrStmt。调用旧接口时 PTO 不报错，但也不生成 flag 指令，因而可能静默丢失同步。

当前代码和历史中没有找到这两个公开函数的调用、测试或文档；示例中的同名函数是各自定义的局部 `T.macro`，与它们无关。经 ChaoyangJi 确认，本 PR 直接删除这组公开函数及 AscendC 特例；结构化 flag API 保持不变。

## 3. [让 `set_env.sh` 在 Bash/Zsh 中保持稳定](https://github.com/tile-ai/tilelang-ascend/pull/1495/commits/d079907ebe8b6a71a747c6c728b42a739b6da6d4)

新脚本分别用 `BASH_SOURCE[0]` 和 `${(%):-%N}` 找到被 source 的文件，并只在需要时把 canonical `TL_ROOT` 放到 `PYTHONPATH` 首位：

| 场景 | 旧结果 | 新结果 |
|---|---|---|
| Bash 首次 source，原值为 `/opt/lib` | `$TL_ROOT:/opt/lib` | 相同 |
| `PYTHONPATH` 为空 | `$TL_ROOT:`，包含当前目录 | `$TL_ROOT` |
| 连续 source 两次 | `$TL_ROOT:$TL_ROOT:$old` | `$TL_ROOT:$old` |
| 从 Zsh source | 不能可靠定位脚本 | 正确得到同一个 `TL_ROOT` |

因此，常见的 Bash 首次 source 保持原搜索顺序；空环境和重复 source 的差异则是有意删除空 path 和重复前缀。

## 测试

仓库中只保留最小回归，大矩阵仅在本地执行：

- TileLang 增量重建通过；
- row-expand pytest `15 passed`，本地 AscendC/PTO 多 stage NPU 矩阵 `24/24 passed`；
- 现有 xAttention 完整编译通过，`exp_experiment` 回归 `5 passed`；
- legacy flag 回归 `1 passed`，Bash/Zsh 环境矩阵 `12/12 passed`；
- Ruff、clang-format、shell syntax 和 `git diff --check` 均通过。
