### PR TITLE
[Example] Ascend: elementwise bitwise OR

### DIFF
--- a/examples/elementwise/elementwise_bitwise_or.py
+++ b/examples/elementwise/elementwise_bitwise_or.py
@@ -1,0 +1,66 @@
+import argparse
+
+import tilelang
+import tilelang.language as T
+import torch
+
+tilelang.cache.clear_cache()
+
+parser = argparse.ArgumentParser(description="NPU Kernel Compilation")
+parser.add_argument("--m", type=int, default=1024, help="Matrix M dimension")
+parser.add_argument("--n", type=int, default=1024, help="Matrix N dimension")
+args = parser.parse_args()
+
+M = args.m
+N = args.n
+
+
+@tilelang.jit(out_idx=[-1])
+def vec_bitwise_or(M, N, block_M, block_N, dtype="int16"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    VEC_NUM = 2
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, N), dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            with T.Scope("V"):
+                T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+                T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+
+                T.barrier_all()
+                T.tile.bitwise_or(c_ub, a_ub, b_ub)
+                T.barrier_all()
+
+                T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    return main
+
+
+func = vec_bitwise_or(M, N, 128, 256)
+
+torch.manual_seed(0)
+
+a = torch.randint(0, 10, (M, N), dtype=torch.int16).npu()
+b = torch.randint(0, 10, (M, N), dtype=torch.int16).npu()
+
+torch.npu.synchronize()
+print("init successful!")
+
+c = func(a, b)
+
+ref_c = a | b
+
+torch.testing.assert_close(c, ref_c, rtol=0, atol=0)
+print("Kernel Output Match!")


### PR DESCRIPTION
T.tile.bitwise_or has a language test in
testing/python/language/test_tilelang_ascend_language_elementwise.py but no example, unlike bitwise_and and bitwise_xor which several examples use. Shapes and block sizes follow that test, and the comparison is exact rather than tolerance based because the operation is integral.