### PR TITLE
[Skills] transpose tilelang-perf-optimization

### DIFF
--- a/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/SKILL.md
+++ b/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/SKILL.md
@@ -30,6 +30,7 @@ description: TileLang Ascend API 使用最佳实践。提供内存分配、数�
 | **多核负载均衡** | [api-schedule-sync](references/api-schedule-sync.md) | T.Persistent 缓存友好调度 |
 | **排序** | [api-compute](references/api-compute.md) | T.tile.sort → T.tile.merge_sort → T.tile.topk |
 | **Kernel 调试** | [api-schedule-sync](references/api-schedule-sync.md) | T.printf、T.dump_tensor、get_kernel_source() |
+| **dtype 标量回退适配** | [api-compute](references/api-compute.md) | 先确认硬件支持；同宽 reinterpret / kernel 内 cast / record-aware DMA / 块 DMA + UB-local fallback；宽 dtype lane 拆分仅作已验证实验 |
 
 ---
 

--- a/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-compute.md
+++ b/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-compute.md
@@ -476,9 +476,9 @@ a_cal = T.alloc_ub((block_M, block_N), cal_dtype)
 b_cal = T.alloc_ub((block_N, block_M), cal_dtype)
 
 if use_b16_cast:
-    T.tile.cast(a_cal, a_ub, CAST_LOW2HIGH, tile_elem)   # int8 → float16
+    T.tile.cast(a_cal, a_ub, "CAST_NONE", tile_elem)     # int8 → float16
     T.tile.transpose(b_cal, a_cal)                        # float16 硬件 transpose
-    T.tile.cast(b_ub, b_cal, CAST_HIGH2LOW, tile_elem)    # float16 → int8
+    T.tile.cast(b_ub, b_cal, "CAST_RINT", tile_elem)      # float16 → int8
 else:
     T.tile.transpose(b_ub, a_ub)
 ```
@@ -552,7 +552,8 @@ else:
 > - `x.to(torch.int16)` / `x.to(torch.int8)` —— host 侧 dtype 转换触发 `aclnnCast`
 > - `x32[..., 0].contiguous()` —— 跨步切片后 `.contiguous()` 触发 `aclnnCopy`
 > - `torch.stack([lo_t, hi_t], dim=-1)` —— 创建新 buffer + 数据拷贝，触发 `aclnnCat`
-> - `x.view(torch.int32).reshape(*shape, 2)` 后拆分 —— 虽然view 本身不搬数据，但后续拆分操作会搬
+> - `x.view(torch.int32).reshape(*shape, 2)` 后再 `.contiguous()`/`stack`/`copy`
+>   物理化 lane；view、切片或 unbind 本身不一定搬运，需审计完整链路
 
 > **约束**：
 > - 同宽 reinterpret：两 dtype 字节数必须相同；算子计算逻辑不能改变 bit pattern（transpose 只搬运安全；cast/exp 等改变 bit pattern 的不适用）
@@ -639,7 +640,7 @@ T.tile.atomic_add(C[..., ...], src_l0c)
 **底层实现**：
 
 底层会生成 Ascend C 的 DMA atomic add 语义：开启 `SetAtomicAdd<T>()`，执行 local -> GM 的 `DataCopyPad`，再通过兼容 helper 关闭 atomic 状态。
-### 4.11 排序操作
+### 4.12 排序操作
 
 #### T.tile.sort(dst, src, actual_num)
 
@@ -696,7 +697,7 @@ T.tile.topk(topk_global, sort_result, K, actual_num)
 **注意事项**：
   - `src` 的大小需要满足32或32的整数倍
 
-### 4.12 两种编程范式对比
+### 4.13 两种编程范式对比
 
 ```python
 # 方式一：T.Parallel + 符号 API（Developer 模式，跨平台兼容）

--- a/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-compute.md
+++ b/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-compute.md
@@ -435,11 +435,161 @@ T.tile.cast(b_ub, a_ub, "CAST_RINT", 4096)
 |-----|------|
 | `T.tile.fill(buffer, value)` | 用 value 填充 buffer |
 | `T.tile.createvecindex(dst, first_value)` | 创建从 first_value 开始的向量索引序列 |
-| `T.tile.transpose(dst, src)` | 16×16 二维矩阵数据块转置 |
+| `T.tile.transpose(dst, src)` | 二维矩阵数据块转置（详见下方 dtype 支持说明） |
 | `T.tile.gather(dst, src, src_offset, src_base_addr)` | 按偏移收集数据 |
 | `T.tile.arith_progression(buffer, first_value, diff_value, count)` | 生成等差数列 |
 
-### 4.10 原子操作
+#### T.tile.transpose 的 dtype 支持与标量回退
+
+`T.tile.transpose` 的硬件加速路径**支持 2 字节和 4 字节类型**（float16/int16/uint16/float32/int32），其他 dtype 会静默回退到逐元素 `SetValue` 标量路径，性能下降数十倍。
+
+| dtype | 硬件加速 | 说明 |
+|-------|---------|------|
+| float16 / int16 / uint16 | ✅ 硬件 `AscendC::Transpose` | 2 字节，16×16 块走硬件指令 |
+| float32 / int32 | ✅ 硬件 `transpose_block` | 4 字节，同样走硬件指令（`sizeof(T)==4` 满足条件） |
+| bfloat16 | ❌ 回退标量 | 2 字节但被 `!is_same_v<bfloat16_t>` 显式排除 → host 侧 `view(torch.int16)` 零拷贝 reinterpret（详见下方） |
+| int8 / uint8 | ❌ 回退标量 | 1 字节（`sizeof(T)==1` 不满足） → kernel 内 `T.tile.cast` 到 float16 后用硬件指令 |
+| int64 | ❌ 回退标量 | 8 字节（`sizeof(T)==8` 不满足）→ 优先 record-aware DMA；通用路径用块 DMA + UB-local reorder，并做最大 case 验证 |
+
+> **判断方法**：查看 `src/tl_templates/ascend/common.h` 的 `Transpose` 模板特化，确认目标 dtype 是否在硬件支持集合。或用 `get_kernel_source()` 查看是否出现 `SetValue`（标量回退标志）。
+
+**bfloat16 处理方法（host 侧零拷贝 reinterpret）**：
+
+bfloat16 与 int16 均 2 字节，且 transpose 只搬数据不改 bit pattern，可安全 reinterpret。**这是 bfloat16 的首选方法**——零开销，不需要额外 UB buffer：
+
+```python
+# host 侧入口
+if x.dtype == torch.bfloat16:
+    return transpose(x.view(torch.int16), perm).view(torch.bfloat16)
+```
+
+**int8 处理方法（kernel 内 cast）**：
+
+int8 无同宽的硬件加速 dtype 可 reinterpret，需 kernel 内 cast 到 float16 后用硬件指令。**⚠️ 禁止在 host 侧用 `.to(torch.int16)` 转换**——会触发 `aclnnCast` 且产生数据搬移。
+
+```python
+# kernel 内
+use_b16_cast = dtype == "int8"
+cal_dtype = "float16" if use_b16_cast else dtype
+
+a_cal = T.alloc_ub((block_M, block_N), cal_dtype)
+b_cal = T.alloc_ub((block_N, block_M), cal_dtype)
+
+if use_b16_cast:
+    T.tile.cast(a_cal, a_ub, CAST_LOW2HIGH, tile_elem)   # int8 → float16
+    T.tile.transpose(b_cal, a_cal)                        # float16 硬件 transpose
+    T.tile.cast(b_ub, b_cal, CAST_HIGH2LOW, tile_elem)    # float16 → int8
+else:
+    T.tile.transpose(b_ub, a_ub)
+```
+
+#### int64 正确实现路线：不做类型转换，优先聚合 DMA，否则保留 UB-local fallback
+
+int64 没有已确认的硬件 transpose 指令，但“逐行 `T.copy`”不能完成任意二维转置。
+先寻找输入/输出共同连续的 suffix record，用二维/成组 DMA 聚合搬运；通用场景用
+块 DMA GM→UB、UB 内局部重排、块 DMA UB→GM。`T.tile.transpose` 若 lowering
+为标量，只要 `GetValue/SetValue` 局限在 UB，可以作为经最大 case 超时验证的
+fallback；禁止逐元素 strided GM load/store。
+
+拆成两个 int32 lane 不是默认方案。只有 lane 提取、交织写回及 UB planner 在当前
+后端上经端到端精度验证后才能使用，不得凭 API 名称假定硬件语义。
+
+> **结论先行**：对于要求 bit-exact 的纯数据重排，int64 不应转换成 float32、
+> int32、float16 或其他 dtype。cast 会丢失高位或改变 bit pattern；host 拆成两个
+> int32 又会引入 aclnn 搬运。这里的“dtype 适配”是为 int64 选择不同的数据路径，
+> 不是执行 dtype cast。
+
+**可机械执行的选择流程**：
+
+1. 用 `get_kernel_source()` 确认 int64 的目标 tile 指令确实没有硬件路径。
+2. 计算 `record_bytes = record_len * 8`。只有 record 在输入/输出两侧都连续、
+   其搬运确实完成目标布局，并且单次地址/长度/gap 满足 DataCopy 约束时，才选择
+   record-aware DMA。
+3. `record_bytes < 32` 时（例如 `record_len=1` 的单个 int64 只有 8B），不得每条
+   record 单独 `T.copy`。应聚合至少 32B 的相邻连续数据；如果目标布局无法这样
+   聚合，使用块 DMA + UB-local reorder。
+4. 通用 fallback 保留块状输入输出：
+
+```python
+valid_m = T.min(block_M, M - m_start)
+valid_n = T.min(block_N, N - n_start)
+T.copy(
+    x[b, m_start:m_start + valid_m, n_start:n_start + valid_n],
+    a_ub[0:valid_m, 0:valid_n],
+)
+T.tile.transpose(b_ub, a_ub)  # int64 可在 UB 内标量 lowering
+T.copy(
+    b_ub[0:valid_n, 0:valid_m],
+    y[b, n_start:n_start + valid_n, m_start:m_start + valid_m],
+)
+```
+
+这条路线不声称 int64 获得硬件 transpose；它保证 GM 两侧仍是块 DMA，并把慢路径
+限制在 UB。可参考 `examples/transpose/transpose.py::_kernel_3d` 的动态切片结构。
+若实测没有收益，结论应是“该硬件适配对 int64 不适用”，而不是强制改写。
+
+5. 验证同时覆盖：非整除尾块、`torch.npu.synchronize()` 后无 ACL/AICore 错误、
+   高 32 位非零的 int64 bit-exact 数据，以及所有受影响的官方 case。
+
+**Agent 应直接采用的分派伪代码**：
+
+```python
+if dtype != "int64":
+    # 按该 dtype 已验证的硬件/cast 路径处理
+    ...
+elif shared_contiguous_record and record_bytes >= 32 and datacopy_layout_legal:
+    # int64 路线 A：不 cast；一次聚合多条连续 record
+    return record_dma_kernel(x, metadata)
+else:
+    # int64 路线 B：不 cast；GM 两侧块 DMA，UB 内允许标量 lowering
+    return tiled_ub_reorder_kernel(x, metadata)
+```
+
+若路线 A 不能同时满足 `record_bytes >= 32`、连续性和目标布局语义，就直接选择
+路线 B。不得先尝试“单个 int64 的 8B T.copy”；这不是候选路线。
+
+> **⚠️ 禁止在 host 侧做以下操作**（会触发数据搬移或 aclnn）：
+> - `x.to(torch.int16)` / `x.to(torch.int8)` —— host 侧 dtype 转换触发 `aclnnCast`
+> - `x32[..., 0].contiguous()` —— 跨步切片后 `.contiguous()` 触发 `aclnnCopy`
+> - `torch.stack([lo_t, hi_t], dim=-1)` —— 创建新 buffer + 数据拷贝，触发 `aclnnCat`
+> - `x.view(torch.int32).reshape(*shape, 2)` 后拆分 —— 虽然view 本身不搬数据，但后续拆分操作会搬
+
+> **约束**：
+> - 同宽 reinterpret：两 dtype 字节数必须相同；算子计算逻辑不能改变 bit pattern（transpose 只搬运安全；cast/exp 等改变 bit pattern 的不适用）
+> - kernel 内 cast：cast 方向 low→high 用 `CAST_NONE`、high→low 用 `CAST_RINT`；元素数须 16 对齐；需额外 UB 空间存放 cal_dtype buffer；**禁止 host 侧 `.to()` 转换**
+> - 无 tile 指令支持的 dtype（如 int64）：优先 record-aware DMA 或块 DMA +
+>   UB-local reorder，禁止逐元素 strided GM 主路径；**禁止 host 侧拆分/拼回**
+>
+> 性能优化的判断准则见 [tilelang-perf-optimization/references/optimization-guide.md §2.16](../../tilelang-perf-optimization/references/optimization-guide.md#216-特定-dtype-的硬件指令适配dtype-specific-hardware-path-adaptation)。
+
+#### Stride 参数作为 JIT 编译期常量传入 kernel（避免创建 GM tensor）
+
+**约束**：当 kernel 需要stride/shape 等元数据参数时，优先作为 `@tilelang.jit` 函数的 Python 参数传入（JIT 编译期常量），而不是打包成 int32 GM tensor 在运行时传入。JIT 编译期常量在 kernel 内可以直接用于地址计算，无需 GM→UB 搬运。
+
+**使用方法**：把 stride/shape 列表作为 Python tuple 传入 jit 函数，kernel 内用 `T.alloc_var` + 静态展开循环累加偏移：
+
+```python
+@tilelang.jit(out_idx=[1], pass_configs=PASS_CONFIGS)
+def kernel(total_numel, M, N, dtype, block_M, block_N,
+           src_stride_m, src_stride_n,           # JIT 编译期常量
+           dst_stride_n, dst_stride_m,
+           nbatch, batch_num, core_num, single_core_load,
+           src_batch_strides,                     # Python tuple
+           dst_batch_strides,
+           batch_dims_sizes):
+    # kernel 内用 alloc_var 累加 batch 偏移，stride 是编译期常量直接用
+    boff_s = T.alloc_var("int32", init=0)
+    # 静态展开（最多 6 个 batch 轴，不存在的用 stride=0/dim=1 填充）
+    boff_s = boff_s + (bidx_s % batch_ds[0]) * src_bs[0]
+    bidx_s = bidx_s // batch_ds[0]
+    # ...
+```
+
+**对比**：如果打包成 int32 GM tensor 传入，kernel 需要额外 `T.copy(stride_buf, ub_s)` 把 stride 从 GM 搬到 UB，增加一次 GM→UB 搬运。作为 JIT 编译期常量则无此开销。
+
+> **适用条件**：stride/shape 参数数量有限（不超过约 20 个），可以作为 JIT 参数传入。如果参数过多或需要运行时动态计算，则仍需用 GM tensor。
+
+### 4.11 原子操作
 
 #### T.tile.atomic_add(dst, src)
 

--- a/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-kernel-memory.md
+++ b/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-kernel-memory.md
@@ -265,7 +265,10 @@ T.copy(K[bz, by, k * block_N:(k + 1) * block_N, :], k_l1)
 
 #### T.copy 动态 shape 切片
 
-`T.copy` 支持用**运行期动态变量**做切片范围，自动处理尾块（非整除 shape），**不需要 host 侧 zero-padding**。
+`T.copy` 支持用 `BufferRegion` 切片表达尾块（非整除 shape），**不需要 host 侧
+zero-padding**。切片端点既可以是运行期计算的 valid extent，也可以是经现有
+lowering 验证能按 tensor 边界裁剪的有界 block 端点。关键是输入和输出 GM
+region 都要显式存在；只传起始标量地址并把完整 UB 作为另一端，不能可靠表达尾块。
 
 **用法**：
 
@@ -280,8 +283,58 @@ T.copy(C_L0, Y[m_start : m_start + valid_m, ...])  # 只写 valid_m 行，不溢
 ```
 
 **适用场景**：
-- 尾块处理（维度非 block 整数倍）：非整除时，最后的尾块无需特殊处理，框架已支持自动尾块搬运。
+- 尾块处理（维度非 block 整数倍）：最后的尾块必须通过 GM `BufferRegion` 切片表达；无需 host zero-padding。
 - 变长序列：每次要搬运的序列长度是动态的，框架支持切片范围为运行期动态变量。
+
+**错误与正确对照**：
+
+```python
+# 错误：尾块仍按完整 block 读写，可能越界或覆盖相邻 tile
+T.copy(x[b, m_start, n_start], a_ub)
+T.copy(b_ub, y[b, n_start, m_start])
+
+# 正确：输入、UB 有效区和输出都显式携带 valid extent
+valid_m = T.min(block_M, M - m_start)
+valid_n = T.min(block_N, N - n_start)
+T.copy(
+    x[b, m_start:m_start + valid_m, n_start:n_start + valid_n],
+    a_ub[0:valid_m, 0:valid_n],
+)
+T.copy(
+    b_ub[0:valid_n, 0:valid_m],
+    y[b, n_start:n_start + valid_n, m_start:m_start + valid_m],
+)
+```
+
+已验证的现有实现也可能写成
+`x[..., m_start:m_start + block_M, n_start:n_start + block_N]`，由 lowering
+按 tensor 边界裁剪；这种写法必须连同对应 kernel 的 tile、任务解码和输出切片
+整体复用，不能据此推断“标量起始地址 + 完整 UB”同样安全。
+
+输出侧尤其必须限制 valid extent，避免不同尾 tile 写入重叠区域。布局变换使用
+多 stage 时，每个 stage 都要单独验证其当前 shape 的尾块，不能只验证最终 shape。
+
+#### T.copy 多维切片的硬件限制（重要）
+
+`T.copy` 的 GM↔UB / GM↔L1 / L0C→GM 搬运底层使用 AscendC 的 `DataCopyPad` 硬件指令，该指令的搬运模型是**每行内数据连续、行间可有 gap**（通过 `srcGap`/`dstGap` 参数控制）。**不支持列方向（行内）strided access**——即每行内相邻元素之间不能有间隔。
+
+**受限场景**：当切片的列维度（最后一个 `extent != 1` 的维度）**不是 buffer 的最内维**，且列维之后还有 `shape > 1` 的维度时，列方向数据不连续，会产生**静默数据错位**（不报错，结果错误）。
+
+| 切片形式 | extents | 列维 | 列维是否最内维 | 是否支持 | 说明 |
+|----------|---------|------|---------------|---------|------|
+| `x[b, m:m+M, n:n+N]`（3D，buffer `[B,M,N]`）| `[1, M, N]` | N (dim 2) | 是 | ✅ | 列数据连续 |
+| `x[b, m:m+M, n:n+N, :]`（4D 全取 K，buffer `[B,M,N,K]`）| `[1, M, N, K]` | K (dim 3) | 是 | ✅ | 列数据连续（K 维全取） |
+| `x[b, 1, m:m+M, n:n+N]`（4D，buffer `[B,H,M,N]`，H=1）| `[1, 1, M, N]` | N (dim 3) | 是 | ✅ | 列数据连续 |
+| `x[b, m:m+M, n:n+N, k:k+1]`（4D 单取 K，buffer `[B,M,N,K]`，K>1）| `[1, M, N, 1]` | N (dim 2) | **否**（dim 3 的 K>1） | ❌ | 列方向每个元素间隔 K 个位置，DataCopyPad 无法搬运 |
+
+**根因**：`src/op/ascend.cc` 的 `find_active_dim_indices` 和 `compute_strideN` 对 4D+ 切片的维度识别有缺陷，且即使修复后，`DataCopyPad` 硬件指令本身也不支持列方向 strided access。
+
+**规避方案**：
+1. **3D 切片 + 循环遍历额外维度**：将 4D+ 切片改为 3D 切片，用 `T.serial` 循环遍历额外维度。例如 `x[b, m:m+M, n:n+N, k:k+1]` 改为 `for k in T.serial(K): T.copy(x[b, m:m+M, n:n+N, k], a_ub)`——但这仍然受限于列不连续，**不可行**。
+2. **host 侧 reshape 降维到 3D**：host 侧用 `permute` + `reshape` 把 4D+ 降维到 3D `(batch, M, N)`，使列维成为最内维。**⚠️ `reshape(-1)` 对非 contiguous 张量会触发物理拷贝（等价于 `.contiguous()`），属禁止行为。** 仅当输入已 contiguous 时可用；非 contiguous 时需用 stride 作为 JIT 编译期常量传入 kernel（详见 [api-compute.md §4.10](api-compute.md#stride-参数作为-jit-编译期常量传入-kernel避免创建-gm-tensor)）。
+3. **调整 buffer 布局**：将 GM buffer 的维度排列调整为让列维（需要切片的维度）成为最内维。
+
+> **设计阶段预警**：设计 4D+ 算子时，如果 `T.copy` 需要在非最内维上做切片搬运，必须在 design.md 中明确说明规避方案。不要假设 `T.copy` 支持任意维度的 strided 切片。
 
 ---
 

--- a/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-kernel-memory.md
+++ b/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-kernel-memory.md
@@ -327,12 +327,18 @@ T.copy(
 | `x[b, 1, m:m+M, n:n+N]`（4D，buffer `[B,H,M,N]`，H=1）| `[1, 1, M, N]` | N (dim 3) | 是 | ✅ | 列数据连续 |
 | `x[b, m:m+M, n:n+N, k:k+1]`（4D 单取 K，buffer `[B,M,N,K]`，K>1）| `[1, M, N, 1]` | N (dim 2) | **否**（dim 3 的 K>1） | ❌ | 列方向每个元素间隔 K 个位置，DataCopyPad 无法搬运 |
 
-**根因**：`src/op/ascend.cc` 的 `find_active_dim_indices` 和 `compute_strideN` 对 4D+ 切片的维度识别有缺陷，且即使修复后，`DataCopyPad` 硬件指令本身也不支持列方向 strided access。
+**边界**：先用最小复现和生成代码确认当前切片是否可表示为“行内连续、行间有 gap”的
+`DataCopyPad`。若实际需要行内 stride，则硬件搬运模型不支持；不要把所有 4D+ 切片
+统一归因为 codegen 缺陷。
 
 **规避方案**：
-1. **3D 切片 + 循环遍历额外维度**：将 4D+ 切片改为 3D 切片，用 `T.serial` 循环遍历额外维度。例如 `x[b, m:m+M, n:n+N, k:k+1]` 改为 `for k in T.serial(K): T.copy(x[b, m:m+M, n:n+N, k], a_ub)`——但这仍然受限于列不连续，**不可行**。
-2. **host 侧 reshape 降维到 3D**：host 侧用 `permute` + `reshape` 把 4D+ 降维到 3D `(batch, M, N)`，使列维成为最内维。**⚠️ `reshape(-1)` 对非 contiguous 张量会触发物理拷贝（等价于 `.contiguous()`），属禁止行为。** 仅当输入已 contiguous 时可用；非 contiguous 时需用 stride 作为 JIT 编译期常量传入 kernel（详见 [api-compute.md §4.10](api-compute.md#stride-参数作为-jit-编译期常量传入-kernel避免创建-gm-tensor)）。
-3. **调整 buffer 布局**：将 GM buffer 的维度排列调整为让列维（需要切片的维度）成为最内维。
+1. **按真实连续段循环**：只在每次 `T.copy` 的片段本身物理连续时，循环额外维度。
+   若片段仍有行内 stride，此方案不适用。
+2. **零拷贝维度归一化**：仅在目标 reshape 与当前 stride 兼容并共享原 storage 时，
+   降维到可合法搬运的形态；否则使用 stride-aware kernel（详见
+   [api-compute.md §4.10](api-compute.md#stride-参数作为-jit-编译期常量传入-kernel避免创建-gm-tensor)）。
+3. **调整 kernel 的逻辑布局或分阶段**：让每次 GM 搬运的列维成为物理最内连续维，
+   必要时块 DMA 到 UB 后再做局部重排。
 
 > **设计阶段预警**：设计 4D+ 算子时，如果 `T.copy` 需要在非最内维上做切片搬运，必须在 design.md 中明确说明规避方案。不要假设 `T.copy` 支持任意维度的 strided 切片。
 

--- a/.agents/skills/tilelang-op-design/SKILL.md
+++ b/.agents/skills/tilelang-op-design/SKILL.md
@@ -73,64 +73,40 @@ description: "根据算子需求生成 TileLang-Ascend 算子设计文档（desi
 
 ### 3.1 算子 kernel 划分原则（强制规则）⭐
 
-> **⚠️ 核心原则：禁止按"不可穷举的条件"划分 kernel**
->
-> 一个算子可以有多个 kernel，但划分 kernel 的条件必须是**封闭可穷举**的。如果划分条件的取值集合无法列全或可无限扩展，则禁止按此条件划分——否则没覆盖到的取值就不支持了，违背算子通用性。
+多 kernel 方案必须保证支持域完整：先提供覆盖全部声明输入域的通用路径，再按 dtype、
+shape、对齐性或输入拓扑增加有限快路径。具体取值可以用于性能特化；只要未命中的输入
+可靠回落到通用路径，就不要求特化条件本身“封闭可穷举”。
 
-#### 判断方法（设计多 kernel 方案前必须执行，不能跳过）
+设计时记录每条路径的适用谓词、fallback、语义等价依据和验证用例。禁止仅枚举若干
+ndim、perm 或 shape 而没有 fallback，也禁止新增一个取值就让算子变成“不支持”。
 
-按以下 3 步逐一判断，任何一步不通过则禁止按该条件划分：
+生成 design.md 前必须写出以下审计；任一项无法回答时，不得进入实现阶段：
 
-1. **列出划分条件的所有可能取值**：把条件写成集合，如 `dtype ∈ {float16, float32, bfloat16, int8, int16, int32, int64}` 或 `ndim ∈ {2, 3, 4, 5, 6, 7, 8, ...}`
-2. **判断集合是否封闭可穷举**：
-   - 集合元素有限且固定 → 可穷举 → ✅ 允许划分
-   - 集合元素可扩展 / 连续值 / 阶乘或指数增长 → 不可穷举 → ❌ 禁止划分
-3. **新增取值测试**：假设集合新增一个取值（如 ndim 从 8 扩展到 9），是否需要写新 kernel？
-   - 需要 → ❌ 禁止划分，改为通用实现
-   - 不需要（通用 kernel 自动覆盖） → ✅ 允许划分
+```text
+[DISPATCH-COVERAGE]
+supported_domain: <design 声明的 shape/dtype/attr 范围>
+generic_fallback: <kernel/path；没有则写 none>
+specializations:
+  - predicate: <纯 metadata 可判定条件>
+    fallback_on_miss: <path>
+    equivalence_evidence: <索引映射或参考实现>
+unsupported_inputs: <必须与 supported_domain 不冲突>
+result: pass/fail
+```
 
-#### 反例（多种"不可穷举"实例化，禁止照搬其中任何一个当成规则全集）
+判定规则：
 
-> ⚠️ 以下每个反例都是"不可穷举"的**不同实例化**，规则是针对**所有不可穷举的情况**，不只是下列具体例子。判断时必须用上面的 3 步判断方法，不能只记反例。
-
-| ❌ 反例 | 为什么不可穷举 |
-|---------|---------------|
-| 按维度数划分（2D/3D/4D... 各写一个 kernel） | 维度数可无限增长，永远写不完，没写的维度就不支持 |
-| 按 (i,j) 轴组合划分（3D 有 3 种、4D 有 6 种...） | 组合数随维度数爆炸，C(n,2) 增长 |
-| 按 shape 大小档位划分（小/中/大/超大 tensor 各一个 kernel） | shape 是连续值，档位无法穷举 |
-| 按 perm 具体值划分（[1,0]、[0,2,1,3]、[4,3,2,1,0]... 各一个 kernel） | 排列数阶乘增长 n! |
-| 按输出 numel 划分（< 1M / 1M~16M / > 16M 各一个 kernel） | numel 是连续值 |
-
-#### 正例（封闭可穷举的划分，允许）
-
-| ✅ 正例 | 为什么可穷举 |
-|---------|-------------|
-| 按 dtype 划分（7 种，集合封闭） | dtype 是有限集合，硬件支持也是有限的 |
-| 按对齐性划分（对齐 / 非对齐，二分） | 二值集合，封闭 |
-| 按硬件计算路径划分（Cube / Vector） | 硬件路径有限，封闭 |
-| 按 GEMM 的 K 是否整除 block_K 划分（整除 / 有尾块，二分） | 二值集合，封闭 |
-
-#### 默认通用 + 有限特化原则
-
-当不确定划分条件是否可穷举时，**默认写一个通用 kernel 处理所有情况**，通过 host 侧 `reshape`/`permute`/`view` 等 view 操作把输入归一化到统一形态（如把任意 ndim 的转置降维到 3D `(batch, M, N)`），让一个 kernel 覆盖所有情况。性能优化阶段再按**封闭可穷举**的条件（如 dtype、对齐性）做有限特化。
-
-**反例参考**：transpose 算子曾因按维度数特化（2D/3D/4D 各写一个 kernel）被否决，后改为一个通用 3D kernel + host reshape 降维处理 2D~8D。
-
-#### 设计自检（Phase 4 质量自检时核对）
-
-design.md 中如果出现多个 kernel，必须回答：
-- 划分条件是什么？取值集合是否封闭可穷举？
-- 如果新增一个取值，是否需要写新 kernel？
-- 如果答案是"需要写新 kernel"且条件不可穷举 → **设计违规**，必须改为通用 kernel + host 归一化方案
-
-**⚠️ host 侧分派逻辑同样适用此规则**：host 侧的多路径分派逻辑（如 `if perm == [0,2,1,3]: ...`）也不得硬编码不可穷举的取值。如果分派条件是 perm 具体值、shape 具体值等不可穷举集合，必须改为通用算法（如基于 perm 拓扑特征的分类器、基于 shape 的连续性判断等）。判断方法同上：假设新增一个 perm 取值，是否需要加新的 `if` 分支？如果需要 → **设计违规**，必须改为通用算法。
+1. `generic_fallback == none` 时，所有分支谓词的并集必须覆盖 `supported_domain`，否则 fail。
+2. 有 fallback 时允许具体 dtype/shape/perm 快路径，但每条未命中输入必须落入 fallback。
+3. 分派只能读取 shape、stride、dtype、attr 等 metadata，不能读取或改动 tensor 数据。
+4. 每条 specialization 和 fallback 都必须在验证计划中至少有一个命中 case。
 
 ### 3.1.1 基于输入结构特征的多路径分派（性能设计指导）
 
 > 当算子输入具有多种结构特征（如 perm 拓扑类型、数据连续性、对齐性等）时，可设计多条快路径按结构特征分派。这不同于 §3.1 的"通用+特化"——特化是按 dtype 等封闭条件划分 kernel，多路径分派是按**输入的结构拓扑**选择不同的搬运/计算策略。
 
 **约束**：
-- 分派条件必须是**封闭可穷举**的（同 §3.1 判断方法）。典型封闭分派条件：数据连续性（连续/非连续，二值）、输入拓扑类型（有限分类）、硬件路径（有加速/回退，有限集合）
+- 分派谓词必须可判定，且不能读取或改动 tensor 数据
 - 必须保留**通用 fallback**路径：无法归入任何快路径的输入走通用实现
 - 快路径的判断逻辑在 host 侧完成（纯 Python 整数/元数据运算），不触碰数据
 
@@ -145,33 +121,28 @@ design.md 中如果出现多个 kernel，必须回答：
 
 ### 3.1.2 数据重排的性能可行性（强制）
 
-对涉及物理布局变化的算子，先按
-[coding-conventions.md §6.1](../tilelang-op-generate/references/coding-conventions.md#61-数据重排的正向实现配方)
-生成至少一个正向候选方案。该配方基于“连续 record + 聚合 DMA + UB-local reorder”
-这一通用数据流，不绑定 transpose、固定 perm 或固定维数，可迁移到 layout
-transform、pack/unpack、blocked layout 与 gather/scatter。
+涉及物理布局变化时，必须读取
+[coding-conventions.md §6.1](../tilelang-op-develop/references/coding-conventions.md#61-数据重排的正向实现配方)，
+为每条结构路径和最大/关键用例完成 GM/DMA/地址解码/并行度成本验收。具体 record、
+UB-local reorder 和 dtype fallback 配方以该 reference 为准，不在主流程重复。
 
-对 transpose、layout transform、gather/scatter 等纯搬运算子，精度正确不等于设计可交付。
-design.md 必须对每条结构路径和用户给出的最大/关键用例量化以下成本：
+design.md 必须为每条路径输出：
 
-- GM 完整读写次数、DMA transaction 数量及平均每次搬运字节数
-- GM 标量 load/store 数量，以及地址计算中的整除/取模次数
-- 实际使用的 AIV core 数、每个 core 内的串行任务数
+```text
+[REORDER-COST]
+path: <name>
+gm_passes: <完整读写次数>
+dma_transactions: <估算值>
+average_dma_bytes: <估算值>
+gm_scalar_accesses: <估算值>
+address_div_mod_per_element: <估算值>
+active_cores / serial_tasks_per_core: <估算值>
+largest_case_timeout_gate: <case + timeout>
+result: pass/fail
+```
 
-以下实现不得作为大张量主路径：
-
-- 按元素从 GM 做 strided scalar load/store
-- 对数十万或数百万个短 record 各发一次 GM→UB 和 UB→GM `T.copy`
-- 每个元素重复执行多维 `//`、`%` 地址解码
-
-若输入和输出都保留一个物理连续 suffix record，应按结构谓词识别
-`prefix + A + B + suffix -> prefix + B + A + suffix` 一类拓扑，设计 record-aware
-快路径：用二维/成组 `T.copy` 聚合多条 suffix record，在 UB 内完成必要的局部重排，再连续写回。
-不得写死某个 ndim、perm 或 shape；未匹配的输入仍走通用 fallback。
-
-无硬件 tile 指令的 dtype（如 int64）也必须遵守上述 GM 搬运规则。允许 UB 内局部标量
-重排，但大张量主路径禁止逐元素 strided GM 访问。若最大官方用例无法在超时预算内完成，
-这是设计不可行，必须调整方案或明确返回设计错误，不能留给后续性能阶段。
+若大张量主路径的 GM 标量访问接近 numel、短 DMA 达到数十万次，或没有最大 case
+timeout 门禁，结果必须为 fail，并按 reference 重新选择候选实现。
 
 ### 3.2 Host 侧 Buffer 操作约束（设计阶段必须遵守）⭐
 
@@ -184,28 +155,52 @@ design.md 必须对每条结构路径和用户给出的最大/关键用例量化
 > - host 侧 padding：`x_padded = torch.zeros(...); x_padded[:, :M] = x; x = x_padded` —— 创建新 buffer + 写入数据 + 顶替原输入
 > - **`torch.nn.functional.pad(x, ...)` / `torch.cat` / `torch.stack`** —— 隐蔽违规：表面是函数调用，实质是创建新 buffer + 数据拷贝，在 NPU 上会调用 `aclnnPad`/`aclnnCat` 等 aclnn 算子。等同禁止行为"用新 buffer 作弊"
 > - 直接改写 buffer 内容：`x[:] = ...`、`x.add_(1)`、`torch.mul(x, 2, out=x)`
-> - 改数据指针顶替：`x = y`（y 是另一个 tensor）后传入 kernel
-> - **`reshape` 对非 contiguous 张量**（隐蔽违规）：`reshape` 仅在张量 contiguous 时是零拷贝 view；对非 contiguous 张量（如 `permute`/`transpose` 后），`reshape`（尤其是 `reshape(-1)`）会触发物理拷贝，等价于 `.contiguous()`。代码中没有 `.contiguous()` 字样但行为相同——一律禁止
+> - 用另一个经过 host 计算或物理化的 tensor 替代原输入后传入 kernel
+> - `reshape` 无法保持原 storage/stride 时发生的隐式物理化；不能仅凭
+>   `is_contiguous()` 判断，需证明目标 shape 与当前 stride 兼容，或比较操作前后的
+>   storage/data pointer
 > - **输出侧切片 + reshape**（隐蔽违规，group_norm 案例）：kernel 输出后对输出张量做切片（如 `y[:, :, :, :S]`）使 tensor 变为非 contiguous，随后 `reshape` 会隐式调用 `.contiguous()` → `aclnnCopy`。**约束范围不仅限于输入侧，kernel 调用后的输出后处理同样适用**。解法：让 kernel 直接输出到与原始 shape 一致的 buffer（通过 `T.copy` 的 `pad_value` 处理尾块），host 侧无需切片+reshape
 >
-> **允许**的 host 侧操作：`reshape`/`view`/`transpose`/`permute`/`expand` 等**只改 stride/shape 元数据、不触碰真实数据**的视图操作；以及数据准备（输入 tensor 创建）、kernel 调用、结果验证。**⚠️ `reshape` 的零拷贝性质以 `x.is_contiguous()` 为前提**——非 contiguous 张量的 `reshape` 触发物理拷贝，属违规。
+> **允许**的 host 侧操作：经证明只改 stride/shape 元数据、不触碰 storage 的
+> `reshape`/`view`/`transpose`/`permute`/`expand`，以及数据准备、kernel 调用和结果验证。
 >
 > **判定准则**：host 侧任何会改变 NPU 张量「数据指针」或「物理存储内容/排布」的操作均禁止；只改 metadata（stride/shape）的允许。拿不准时，一律放入 kernel。
 >
-> **`reshape` 语义判定**：判断 `reshape` 是否安全——检查 `x.is_contiguous()`：为 `True` 则 `reshape` 是零拷贝 view（允许）；为 `False` 则 `reshape` 触发物理拷贝（禁止）。常见非 contiguous 场景包括 `permute`/`transpose`/`movedim` 后的张量，**但不限于这些**——任何改变了 stride 但未拷贝数据的操作都会产生非 contiguous 张量。**替代方案**：当需要对非 contiguous 张量做维度归一化时，改用 stride buffer 方案（host 侧只算 stride 参数传入 kernel，kernel 内逐行搬运），不在此做 `reshape`。
+> **`reshape` 语义判定**：`is_contiguous()` 为 True 是常见充分条件，不是必要条件。
+> 对非 contiguous 输入先证明该目标 reshape 可返回共享 storage 的 view；不能证明时，
+> 使用 stride-aware kernel 路径。
 >
-> **非整除处理**：前端框架已支持自动尾块搬运（`T.copy` 动态 shape 切片，非整除时尾块无需特殊处理，详见 `tilelang-api-best-practices/references/api-kernel-memory.md` §T.copy 动态 shape 切片），**不需要 host padding**。design.md 中不得出现 host padding + crop 的设计描述。
+> **非整除处理**：输入、输出 GM 两侧必须显式使用 valid extent/BufferRegion；前端按
+> 动态切片裁剪搬运，但不会替设计补齐错误的完整 tile 区域。无需 host padding，
+> design.md 中不得出现 host padding + crop。
 >
 > **aclnn 依赖约束**（评测环境兼容性）：cann-bench 评测环境中 aclnn 编译产物可能被裁剪，host 侧任何会隐式触发 aclnn 调用的操作都会导致运行时失败。以下操作在 NPU tensor 上会触发 aclnn，一律禁止：
 > - `torch.nn.functional.pad` / `torch.nn.functional.interpolate` / `torch.nn.functional.cat` 等 `torch.nn.functional.*` 计算 API
-> - `torch.cat` / `torch.stack` / `torch.split` 等会创建新 buffer 的操作
+> - `torch.cat` / `torch.stack` 等会创建并填充新 buffer 的操作；`split`/切片本身可能
+>   只是 view，需审计其后是否发生物理化
 > - 对非 contiguous 张量的 `reshape`（隐式 `.contiguous()` → `aclnnCopy`），**包括输出侧切片后的 reshape**
 > - `.to(another_dtype)` dtype 转换（触发 `aclnnCast`）；如需 dtype 转换应在 kernel 内用 `T.tile.cast` 完成
 > - `.clone()` / `.copy_()` 等显式拷贝
 >
-> **判定方法**：host 侧代码只允许出现 `reshape`/`view`/`transpose`/`permute`/`expand`（仅限 contiguous 张量）和 kernel 调用。任何其他对 NPU tensor 的操作都应视为可疑，检查是否触发 aclnn。
+> **判定方法**：逐项证明 host tensor 操作只改变 metadata；不能从 API 名称或
+> `is_contiguous()` 单一布尔值直接下结论。
 >
-> **设计自检**（Phase 4 质量自检时核对）：design.md 的 host 侧步骤（**含 kernel 调用后的输出后处理**）是否仅限视图操作（`reshape`/`view`/`transpose`/`permute`/`expand`）+ kernel 调用 + 结果 reshape？是否出现 `.contiguous()` / host padding / `torch.nn.functional.*` / `torch.cat` / 新建 buffer 切片赋值 / `x = 新tensor` 顶替 / 输出切片+reshape 等描述？命中即违规，必须修订。下游 `tilelang-op-generate` skill 会按相同规则再次校验，违规设计会在 Stage 2 触发 `[DESIGN_ERROR]` 设计回退（详见 [tilelang-op-generate SKILL.md §3](../tilelang-op-generate/SKILL.md)）。
+> **设计自检**（Phase 4 质量自检时核对）：审计 kernel 前后完整 host 路径。下游
+> [tilelang-op-develop SKILL.md §3](../tilelang-op-develop/SKILL.md) 会再次校验，
+> 违规设计在 Stage 2 返回 `[DESIGN_ERROR]`。
+
+审计必须记录：
+
+```text
+[HOST-METADATA-AUDIT]
+operation: <host tensor operation>
+input_stride -> output_stride: <...>
+shares_storage / same_data_ptr: true/false/unknown
+aclnn_or_physical_copy: true/false/unknown
+result: allow/reject
+```
+
+任何 `unknown` 按 reject 处理；改为 kernel 内实现或用可证明的 metadata-only 路径。
 
 ---
 
@@ -237,7 +232,8 @@ design.md 必须对每条结构路径和用户给出的最大/关键用例量化
 
 ### Phase 3：生成 design.md
 
-> **⚠️ 生成 design.md 时必须遵守 §3.1「Host 侧 Buffer 操作约束」**：设计文档中 host 侧（kernel 外的 Python 代码）对 NPU 张量只能做「只改元数据」的视图操作（`reshape`/`view`/`transpose`/`permute`/`expand`）以及数据准备 / kernel 调用 / 结果验证；禁止改数据指针、禁止 `.contiguous()` 等真实重排、禁止改写 buffer 内容、禁止用新 buffer 作弊。**所有数据搬运、padding、维度重排、非整除处理等核心计算逻辑必须落入 `@tilelang.jit` kernel 内部**。拿不准时，一律放入 kernel。下游 `tilelang-op-generate` skill 会按相同规则再次校验，违规设计会在 Stage 2 触发 `[DESIGN_ERROR]` 设计回退。
+> **⚠️ 生成 design.md 时必须遵守 §3.2「Host 侧 Buffer 操作约束」**。下游
+> `tilelang-op-develop` 会再次校验；违规设计在 Stage 2 返回 `[DESIGN_ERROR]`。
 
 基于 [examples/design-template.md](examples/design-template.md) 模板，填充所有章节：
 
@@ -245,7 +241,8 @@ design.md 必须对每条结构路径和用户给出的最大/关键用例量化
 2. 编程模式选型
 3. API 映射设计
 4. 数据规格与内存规划
-5. Tiling 策略（**含非整除处理说明**：前端框架已支持自动尾块搬运，非整除时尾块无需特殊处理；**host 侧不允许 padding + crop**）
+5. Tiling 策略（非整除时用输入、输出两侧显式 valid extent/BufferRegion；前端负责
+   按这些动态切片裁剪搬运，**不代表尾块无需设计**；host 侧不允许 padding + crop）
 6. 循环与调度结构
 7. 同步策略
 8. CV 融合设计（**按模式分支**：Developer 默认消除 workspace/vid——`threads=2` + 片上直连，不产出 workspace 规格；仅 Expert/混合或复杂场景回退才设计 workspace + `workspace_idx`。详见 design-template.md §8.2）
@@ -262,7 +259,8 @@ design.md 必须对每条结构路径和用户给出的最大/关键用例量化
 
 **⚠️ 首要检查：host 侧 Buffer 操作合规性（违反则立即修订，不得继续）**
 
-核对 design.md 的 host 侧步骤描述：是否仅限视图操作（`reshape`/`view`/`transpose`/`permute`/`expand`，只改 stride/shape 元数据）+ kernel 调用 + 结果 reshape？是否出现 `.contiguous()` / host padding / 新建 buffer 切片赋值 / `x = 新tensor` 顶替 等改动 buffer 真实内容的描述？命中即违规，必须修订后再继续后续检查（详见 §3.1）。
+核对 design.md 的完整 host 路径是否只含经证明不物理化的 metadata view、kernel
+调用与验证；命中真实拷贝或 aclnn 调用必须修订（详见 §3.2）。
 
 按照 [references/quality-checklist.md](references/quality-checklist.md) 中的自检清单逐项检查，确保文档质量。
 
@@ -317,7 +315,7 @@ design.md 必须对每条结构路径和用户给出的最大/关键用例量化
 
 - [references/ascend-constraints.md](references/ascend-constraints.md) — 技术约束清单、强制检测规则、警告输出格式
 - [references/decision-tree.md](references/decision-tree.md) — 算子特征分析决策树、平台识别、NPU 硬件约束、API 映射规则
-- [references/quality-checklist.md](references/quality-checklist.md) — 18 项质量自检清单
+- [references/quality-checklist.md](references/quality-checklist.md) — 质量自检清单
 - [references/info-sources.md](references/info-sources.md) — 信息收集步骤、信息源优先级、冲突处理原则
 - [examples/design-template.md](examples/design-template.md) — design.md 完整模板
 - [examples/completion-report-template.md](examples/completion-report-template.md) — 完成报告输出模板

--- a/.agents/skills/tilelang-op-design/SKILL.md
+++ b/.agents/skills/tilelang-op-design/SKILL.md
@@ -71,6 +71,142 @@ description: "根据算子需求生成 TileLang-Ascend 算子设计文档（desi
 
 详细已知限制清单、强制检测规则、警告输出模板见 [references/ascend-constraints.md](references/ascend-constraints.md)。
 
+### 3.1 算子 kernel 划分原则（强制规则）⭐
+
+> **⚠️ 核心原则：禁止按"不可穷举的条件"划分 kernel**
+>
+> 一个算子可以有多个 kernel，但划分 kernel 的条件必须是**封闭可穷举**的。如果划分条件的取值集合无法列全或可无限扩展，则禁止按此条件划分——否则没覆盖到的取值就不支持了，违背算子通用性。
+
+#### 判断方法（设计多 kernel 方案前必须执行，不能跳过）
+
+按以下 3 步逐一判断，任何一步不通过则禁止按该条件划分：
+
+1. **列出划分条件的所有可能取值**：把条件写成集合，如 `dtype ∈ {float16, float32, bfloat16, int8, int16, int32, int64}` 或 `ndim ∈ {2, 3, 4, 5, 6, 7, 8, ...}`
+2. **判断集合是否封闭可穷举**：
+   - 集合元素有限且固定 → 可穷举 → ✅ 允许划分
+   - 集合元素可扩展 / 连续值 / 阶乘或指数增长 → 不可穷举 → ❌ 禁止划分
+3. **新增取值测试**：假设集合新增一个取值（如 ndim 从 8 扩展到 9），是否需要写新 kernel？
+   - 需要 → ❌ 禁止划分，改为通用实现
+   - 不需要（通用 kernel 自动覆盖） → ✅ 允许划分
+
+#### 反例（多种"不可穷举"实例化，禁止照搬其中任何一个当成规则全集）
+
+> ⚠️ 以下每个反例都是"不可穷举"的**不同实例化**，规则是针对**所有不可穷举的情况**，不只是下列具体例子。判断时必须用上面的 3 步判断方法，不能只记反例。
+
+| ❌ 反例 | 为什么不可穷举 |
+|---------|---------------|
+| 按维度数划分（2D/3D/4D... 各写一个 kernel） | 维度数可无限增长，永远写不完，没写的维度就不支持 |
+| 按 (i,j) 轴组合划分（3D 有 3 种、4D 有 6 种...） | 组合数随维度数爆炸，C(n,2) 增长 |
+| 按 shape 大小档位划分（小/中/大/超大 tensor 各一个 kernel） | shape 是连续值，档位无法穷举 |
+| 按 perm 具体值划分（[1,0]、[0,2,1,3]、[4,3,2,1,0]... 各一个 kernel） | 排列数阶乘增长 n! |
+| 按输出 numel 划分（< 1M / 1M~16M / > 16M 各一个 kernel） | numel 是连续值 |
+
+#### 正例（封闭可穷举的划分，允许）
+
+| ✅ 正例 | 为什么可穷举 |
+|---------|-------------|
+| 按 dtype 划分（7 种，集合封闭） | dtype 是有限集合，硬件支持也是有限的 |
+| 按对齐性划分（对齐 / 非对齐，二分） | 二值集合，封闭 |
+| 按硬件计算路径划分（Cube / Vector） | 硬件路径有限，封闭 |
+| 按 GEMM 的 K 是否整除 block_K 划分（整除 / 有尾块，二分） | 二值集合，封闭 |
+
+#### 默认通用 + 有限特化原则
+
+当不确定划分条件是否可穷举时，**默认写一个通用 kernel 处理所有情况**，通过 host 侧 `reshape`/`permute`/`view` 等 view 操作把输入归一化到统一形态（如把任意 ndim 的转置降维到 3D `(batch, M, N)`），让一个 kernel 覆盖所有情况。性能优化阶段再按**封闭可穷举**的条件（如 dtype、对齐性）做有限特化。
+
+**反例参考**：transpose 算子曾因按维度数特化（2D/3D/4D 各写一个 kernel）被否决，后改为一个通用 3D kernel + host reshape 降维处理 2D~8D。
+
+#### 设计自检（Phase 4 质量自检时核对）
+
+design.md 中如果出现多个 kernel，必须回答：
+- 划分条件是什么？取值集合是否封闭可穷举？
+- 如果新增一个取值，是否需要写新 kernel？
+- 如果答案是"需要写新 kernel"且条件不可穷举 → **设计违规**，必须改为通用 kernel + host 归一化方案
+
+**⚠️ host 侧分派逻辑同样适用此规则**：host 侧的多路径分派逻辑（如 `if perm == [0,2,1,3]: ...`）也不得硬编码不可穷举的取值。如果分派条件是 perm 具体值、shape 具体值等不可穷举集合，必须改为通用算法（如基于 perm 拓扑特征的分类器、基于 shape 的连续性判断等）。判断方法同上：假设新增一个 perm 取值，是否需要加新的 `if` 分支？如果需要 → **设计违规**，必须改为通用算法。
+
+### 3.1.1 基于输入结构特征的多路径分派（性能设计指导）
+
+> 当算子输入具有多种结构特征（如 perm 拓扑类型、数据连续性、对齐性等）时，可设计多条快路径按结构特征分派。这不同于 §3.1 的"通用+特化"——特化是按 dtype 等封闭条件划分 kernel，多路径分派是按**输入的结构拓扑**选择不同的搬运/计算策略。
+
+**约束**：
+- 分派条件必须是**封闭可穷举**的（同 §3.1 判断方法）。典型封闭分派条件：数据连续性（连续/非连续，二值）、输入拓扑类型（有限分类）、硬件路径（有加速/回退，有限集合）
+- 必须保留**通用 fallback**路径：无法归入任何快路径的输入走通用实现
+- 快路径的判断逻辑在 host 侧完成（纯 Python 整数/元数据运算），不触碰数据
+
+**思路**：
+1. 分析算子输入可能的结构形态，找出可利用的结构特征（如"哪些轴连续""最内轴是否移动"等）
+2. 每种结构形态设计一条快路径——核心是利用结构特征减少搬运次数或避免非连续访问
+3. 保留通用 fallback 处理无法归类的输入
+
+> **⚠️ 避免示例覆盖**：上述思路适用于所有输入具有结构差异的算子，**不限于 transpose 的 perm 拓扑**。判断准则是有没有可利用的结构特征让某些输入走更快的路径，有就分派，没有就统一处理。
+
+参考思路：host 侧入口按输入结构特征（如 perm 拓扑）分派多条快路径，通用 fallback 兜底
+
+### 3.1.2 数据重排的性能可行性（强制）
+
+对涉及物理布局变化的算子，先按
+[coding-conventions.md §6.1](../tilelang-op-generate/references/coding-conventions.md#61-数据重排的正向实现配方)
+生成至少一个正向候选方案。该配方基于“连续 record + 聚合 DMA + UB-local reorder”
+这一通用数据流，不绑定 transpose、固定 perm 或固定维数，可迁移到 layout
+transform、pack/unpack、blocked layout 与 gather/scatter。
+
+对 transpose、layout transform、gather/scatter 等纯搬运算子，精度正确不等于设计可交付。
+design.md 必须对每条结构路径和用户给出的最大/关键用例量化以下成本：
+
+- GM 完整读写次数、DMA transaction 数量及平均每次搬运字节数
+- GM 标量 load/store 数量，以及地址计算中的整除/取模次数
+- 实际使用的 AIV core 数、每个 core 内的串行任务数
+
+以下实现不得作为大张量主路径：
+
+- 按元素从 GM 做 strided scalar load/store
+- 对数十万或数百万个短 record 各发一次 GM→UB 和 UB→GM `T.copy`
+- 每个元素重复执行多维 `//`、`%` 地址解码
+
+若输入和输出都保留一个物理连续 suffix record，应按结构谓词识别
+`prefix + A + B + suffix -> prefix + B + A + suffix` 一类拓扑，设计 record-aware
+快路径：用二维/成组 `T.copy` 聚合多条 suffix record，在 UB 内完成必要的局部重排，再连续写回。
+不得写死某个 ndim、perm 或 shape；未匹配的输入仍走通用 fallback。
+
+无硬件 tile 指令的 dtype（如 int64）也必须遵守上述 GM 搬运规则。允许 UB 内局部标量
+重排，但大张量主路径禁止逐元素 strided GM 访问。若最大官方用例无法在超时预算内完成，
+这是设计不可行，必须调整方案或明确返回设计错误，不能留给后续性能阶段。
+
+### 3.2 Host 侧 Buffer 操作约束（设计阶段必须遵守）⭐
+
+> **⚠️ 核心原则：host 侧禁止改动 NPU 张量 buffer 内的真实内容，禁止触发任何 aclnn 调用**
+>
+> 算子的所有核心计算逻辑（数据搬运、数学运算、归约、维度重排、padding 等）必须在 `@tilelang.jit` 装饰的 kernel 函数内部完成。**host 侧（kernel 外的 Python 代码）对 NPU 侧张量 buffer 内的真实内容（数据值、物理排布、数据指针）一律不得改动**——只允许做只改 stride/shape 元数据的视图操作。**约束范围覆盖 kernel 调用前（输入预处理）和 kernel 调用后（输出后处理）的完整 host 代码路径。**
+>
+> **违规示例**（都属于"改动 buffer 真实内容"或"触发 aclnn"，一律禁止）：
+> - `.contiguous()` / `.reshape(...).contiguous()` / `.permute(...).contiguous()` / `.transpose(...).contiguous()` —— 触发真实数据拷贝/重排
+> - host 侧 padding：`x_padded = torch.zeros(...); x_padded[:, :M] = x; x = x_padded` —— 创建新 buffer + 写入数据 + 顶替原输入
+> - **`torch.nn.functional.pad(x, ...)` / `torch.cat` / `torch.stack`** —— 隐蔽违规：表面是函数调用，实质是创建新 buffer + 数据拷贝，在 NPU 上会调用 `aclnnPad`/`aclnnCat` 等 aclnn 算子。等同禁止行为"用新 buffer 作弊"
+> - 直接改写 buffer 内容：`x[:] = ...`、`x.add_(1)`、`torch.mul(x, 2, out=x)`
+> - 改数据指针顶替：`x = y`（y 是另一个 tensor）后传入 kernel
+> - **`reshape` 对非 contiguous 张量**（隐蔽违规）：`reshape` 仅在张量 contiguous 时是零拷贝 view；对非 contiguous 张量（如 `permute`/`transpose` 后），`reshape`（尤其是 `reshape(-1)`）会触发物理拷贝，等价于 `.contiguous()`。代码中没有 `.contiguous()` 字样但行为相同——一律禁止
+> - **输出侧切片 + reshape**（隐蔽违规，group_norm 案例）：kernel 输出后对输出张量做切片（如 `y[:, :, :, :S]`）使 tensor 变为非 contiguous，随后 `reshape` 会隐式调用 `.contiguous()` → `aclnnCopy`。**约束范围不仅限于输入侧，kernel 调用后的输出后处理同样适用**。解法：让 kernel 直接输出到与原始 shape 一致的 buffer（通过 `T.copy` 的 `pad_value` 处理尾块），host 侧无需切片+reshape
+>
+> **允许**的 host 侧操作：`reshape`/`view`/`transpose`/`permute`/`expand` 等**只改 stride/shape 元数据、不触碰真实数据**的视图操作；以及数据准备（输入 tensor 创建）、kernel 调用、结果验证。**⚠️ `reshape` 的零拷贝性质以 `x.is_contiguous()` 为前提**——非 contiguous 张量的 `reshape` 触发物理拷贝，属违规。
+>
+> **判定准则**：host 侧任何会改变 NPU 张量「数据指针」或「物理存储内容/排布」的操作均禁止；只改 metadata（stride/shape）的允许。拿不准时，一律放入 kernel。
+>
+> **`reshape` 语义判定**：判断 `reshape` 是否安全——检查 `x.is_contiguous()`：为 `True` 则 `reshape` 是零拷贝 view（允许）；为 `False` 则 `reshape` 触发物理拷贝（禁止）。常见非 contiguous 场景包括 `permute`/`transpose`/`movedim` 后的张量，**但不限于这些**——任何改变了 stride 但未拷贝数据的操作都会产生非 contiguous 张量。**替代方案**：当需要对非 contiguous 张量做维度归一化时，改用 stride buffer 方案（host 侧只算 stride 参数传入 kernel，kernel 内逐行搬运），不在此做 `reshape`。
+>
+> **非整除处理**：前端框架已支持自动尾块搬运（`T.copy` 动态 shape 切片，非整除时尾块无需特殊处理，详见 `tilelang-api-best-practices/references/api-kernel-memory.md` §T.copy 动态 shape 切片），**不需要 host padding**。design.md 中不得出现 host padding + crop 的设计描述。
+>
+> **aclnn 依赖约束**（评测环境兼容性）：cann-bench 评测环境中 aclnn 编译产物可能被裁剪，host 侧任何会隐式触发 aclnn 调用的操作都会导致运行时失败。以下操作在 NPU tensor 上会触发 aclnn，一律禁止：
+> - `torch.nn.functional.pad` / `torch.nn.functional.interpolate` / `torch.nn.functional.cat` 等 `torch.nn.functional.*` 计算 API
+> - `torch.cat` / `torch.stack` / `torch.split` 等会创建新 buffer 的操作
+> - 对非 contiguous 张量的 `reshape`（隐式 `.contiguous()` → `aclnnCopy`），**包括输出侧切片后的 reshape**
+> - `.to(another_dtype)` dtype 转换（触发 `aclnnCast`）；如需 dtype 转换应在 kernel 内用 `T.tile.cast` 完成
+> - `.clone()` / `.copy_()` 等显式拷贝
+>
+> **判定方法**：host 侧代码只允许出现 `reshape`/`view`/`transpose`/`permute`/`expand`（仅限 contiguous 张量）和 kernel 调用。任何其他对 NPU tensor 的操作都应视为可疑，检查是否触发 aclnn。
+>
+> **设计自检**（Phase 4 质量自检时核对）：design.md 的 host 侧步骤（**含 kernel 调用后的输出后处理**）是否仅限视图操作（`reshape`/`view`/`transpose`/`permute`/`expand`）+ kernel 调用 + 结果 reshape？是否出现 `.contiguous()` / host padding / `torch.nn.functional.*` / `torch.cat` / 新建 buffer 切片赋值 / `x = 新tensor` 顶替 / 输出切片+reshape 等描述？命中即违规，必须修订。下游 `tilelang-op-generate` skill 会按相同规则再次校验，违规设计会在 Stage 2 触发 `[DESIGN_ERROR]` 设计回退（详见 [tilelang-op-generate SKILL.md §3](../tilelang-op-generate/SKILL.md)）。
+
 ---
 
 ## 4. 工作流程
@@ -92,6 +228,8 @@ description: "根据算子需求生成 TileLang-Ascend 算子设计文档（desi
    - **动态 shape 判定**：是否存在运行时才确定的维度
 4. **非整除场景预判**：检查输入 shape 是否可能不被 block size 整除。`T.ceildiv(M, block_M)` 对非整除或 `M < block_M` 返回 ≥1（非零），`T.copy` 已支持动态 shape 切片自动处理尾块，**不需要 host padding**。用 `T.ceildiv` + 动态切片 `T.copy(A[m:m+valid, ...])`，参考 `examples/chunk_gated_delta_rule/expert_chunk_gated_delta_rule.py:107-108`。仅当多个 group 共享同一输出 buffer 时需注意尾块写入竞态——用 metadata 的 valid_m 字段限制写入范围 `T.copy(C_L0, Y[m:m+valid_m, ...])`
 5. **多 group 输出竞态约束**（grouped 类算子）：当多个 group 共享同一输出 buffer（紧凑排列，不 padding）时，尾块按 block_M 整块写会溢出到隔壁 group 的区域，导致竞态条件（执行顺序不确定→结果不确定）。解法：metadata 记录 valid_m，kernel 用 `T.copy(C_L0, Y[m_start : m_start + valid_m, ...])` 只写有效行。参考 `examples/grouped_gemm/example_grouped_gemm_fwd.py` 的 block_metadata[2]（valid_m 字段，当前未使用，应启用）。
+6. **数据重排成本建模**：按 §3.1.2 为每条路径和最大/关键 case 计算 DMA/GM
+   标量访问/地址解码/并行度；不能只给 tile shape，不计算 transaction 数量。
 
 ### Phase 2：信息收集
 
@@ -99,21 +237,32 @@ description: "根据算子需求生成 TileLang-Ascend 算子设计文档（desi
 
 ### Phase 3：生成 design.md
 
+> **⚠️ 生成 design.md 时必须遵守 §3.1「Host 侧 Buffer 操作约束」**：设计文档中 host 侧（kernel 外的 Python 代码）对 NPU 张量只能做「只改元数据」的视图操作（`reshape`/`view`/`transpose`/`permute`/`expand`）以及数据准备 / kernel 调用 / 结果验证；禁止改数据指针、禁止 `.contiguous()` 等真实重排、禁止改写 buffer 内容、禁止用新 buffer 作弊。**所有数据搬运、padding、维度重排、非整除处理等核心计算逻辑必须落入 `@tilelang.jit` kernel 内部**。拿不准时，一律放入 kernel。下游 `tilelang-op-generate` skill 会按相同规则再次校验，违规设计会在 Stage 2 触发 `[DESIGN_ERROR]` 设计回退。
+
 基于 [examples/design-template.md](examples/design-template.md) 模板，填充所有章节：
 
 1. 概述
 2. 编程模式选型
 3. API 映射设计
 4. 数据规格与内存规划
-5. Tiling 策略（**必含：非整除时 padding+crop 策略，或 Kernel 内动态 block 方案**）
+5. Tiling 策略（**含非整除处理说明**：前端框架已支持自动尾块搬运，非整除时尾块无需特殊处理；**host 侧不允许 padding + crop**）
 6. 循环与调度结构
 7. 同步策略
 8. CV 融合设计（**按模式分支**：Developer 默认消除 workspace/vid——`threads=2` + 片上直连，不产出 workspace 规格；仅 Expert/混合或复杂场景回退才设计 workspace + `workspace_idx`。详见 design-template.md §8.2）
-9. 验证方案（Golden + **L0 门槛测试计划**；完整分层套件 L1/L2/Boundary 交由 `tilelang-op-test-design`，不在此枚举）
+9. 验证方案（Golden + **L0 门槛测试计划** + **性能可行性哨兵**；除规则
+   shape 外，至少包含每条路径最坏 dtype/最大任务数的用户关键 case，并给出单 case 超时预算；
+   完整分层套件 L1/L2/Boundary 交由 `tilelang-op-test-design`）。若算子支持
+   NaN/Inf，精度方案必须声明位置敏感比较：特殊值用“有限值 + 稀疏特殊值”的
+   混合输入，先严格比较 NaN/正 Inf/负 Inf mask，再只对有限值应用数值容差；
+   禁止使用全 NaN/全 Inf 输入作为唯一特殊值用例，因为数据重排或索引错误可能被掩盖
 10. 风险点与注意事项
 11. 交付清单
 
 ### Phase 4：质量自检
+
+**⚠️ 首要检查：host 侧 Buffer 操作合规性（违反则立即修订，不得继续）**
+
+核对 design.md 的 host 侧步骤描述：是否仅限视图操作（`reshape`/`view`/`transpose`/`permute`/`expand`，只改 stride/shape 元数据）+ kernel 调用 + 结果 reshape？是否出现 `.contiguous()` / host padding / 新建 buffer 切片赋值 / `x = 新tensor` 顶替 等改动 buffer 真实内容的描述？命中即违规，必须修订后再继续后续检查（详见 §3.1）。
 
 按照 [references/quality-checklist.md](references/quality-checklist.md) 中的自检清单逐项检查，确保文档质量。
 

--- a/.agents/skills/tilelang-op-design/examples/design-template.md
+++ b/.agents/skills/tilelang-op-design/examples/design-template.md
@@ -20,6 +20,8 @@ $$
 
 {对于多步算子，描述计算步骤的分解逻辑。单步算子可省略。}
 
+> **⚠️ Host 侧 Buffer 操作约束**（详见 SKILL.md §3.1）：host 侧禁止改动 NPU 张量 buffer 内的真实内容。本节描述计算步骤时，host 侧只能做视图操作（`reshape`/`view`/`transpose`/`permute`/`expand`，只改 stride/shape 元数据）+ kernel 调用 + 结果 reshape。**禁止**：`.contiguous()`、host padding（新建 buffer + 切片赋值 + 顶替）、`x[:] =`、`x = 新tensor` 顶替等。所有数据搬运/padding/维度重排必须落入 `@tilelang.jit` kernel 内部。
+
 ### 1.5 数据流图
 
 ```
@@ -218,6 +220,17 @@ block_num = (M // block_M) * (N // block_N)
 
 {非整除情况的处理策略、边界块的特殊逻辑等}
 
+> **⚠️ 非整除由前端自动处理**（详见 SKILL.md §3.1）：前端框架已支持自动尾块搬运（`T.copy` 动态 shape 切片），非整除时尾块无需特殊处理。**host 侧不允许 padding + crop**（`x_padded = torch.zeros(...); x_padded[:, :M] = x; x = x_padded` 属于违规：新建 buffer + 切片赋值 + 顶替原输入）。
+
+### 5.5 数据搬运性能可行性（数据重排算子必填）
+
+| 结构/dtype 路径 | 代表性最大 case | GM pass | DMA 数/平均字节 | GM 标量访问 | 地址 div/mod | AIV 并行度 | 结论 |
+|-----------------|-----------------|---------|------------------|-------------|--------------|------------|------|
+| {通用 fallback} | {shape, dtype} | {次数} | {数量/字节} | {数量} | {数量} | {core/串行任务} | {可行/需重设计} |
+
+> 大张量主路径禁止逐元素 strided GM 访问。若输入/输出共享连续 suffix record，
+> 应按结构谓词设计 record-aware 二维/成组搬运，不得按具体 perm/shape 写死分支。
+
 ---
 
 ## 6. 循环与调度结构
@@ -245,6 +258,8 @@ with T.Kernel(block_num, is_npu=True) as (cid, vid):
 ### 6.4 尾块处理
 
 {当输入 shape 不能被 block size 整除时的处理策略}
+
+> **⚠️ 尾块由前端自动处理**（详见 SKILL.md §3.1）：前端框架已支持 `T.copy` 动态 shape 切片自动尾块搬运，非整除时尾块无需特殊处理。**host 侧不允许 padding + crop**。
 
 ---
 
@@ -366,6 +381,12 @@ def golden_{算子名}({参数}):
 
 > 采用**混合容差**：逐元素 `|actual-golden| ≤ atol + rtol·|golden|`，整体判定 `matched_ratio ≥ required_matched_ratio` **且** `max_abs_error ≤ max_abs_error_limit`。
 > 阈值**仅按 dtype**（与算子类别无关），L0/L1/Boundary 套用精度比对（L2 为非法输入负向测试，不比精度）；整型按 0 误差精确匹配。完整定义见 `tilelang-op-test-design/references/precision-standard.md`。
+>
+> **特殊浮点值的位置契约**：若算子支持 NaN/Inf，测试输入使用有限值与稀疏特殊值
+> 混合的确定性数据，并保证至少存在一个特殊值和一个有限值。比较时先分别严格检查
+> `isnan`、正 Inf、负 Inf mask 完全一致，再仅对双方均为有限值的位置应用上面的
+> 混合容差。全 NaN/全 Inf 输入可作为补充边界用例，但不能作为唯一特殊值测试；
+> `allclose(equal_nan=True)` 不能替代显式 mask 检查。
 
 | dtype | atol | rtol | max_abs_error_limit | required_matched_ratio |
 |-------|------|------|---------------------|------------------------|
@@ -375,6 +396,15 @@ def golden_{算子名}({参数}):
 | int8/16/32, uint8 | 0 | 0 | 0 | 1.0（精确匹配） |
 
 > 上表按本算子 **§4 数据规格实际支持的 dtype** 填写，未支持的行删除；有额外 dtype（hifloat32 / float8_e4m3 / float8_e5m2 等）按 `precision-standard.md §二` 补齐。§4 声明的每个 dtype 都应在表中有对应行（浮点给 atol/rtol/max_abs_error_limit/required_matched_ratio，整型为 0/0/0/1.0）。
+
+### 9.4 性能可行性哨兵（强制执行，不可因 large/L1 跳过）
+
+| 用例名 | Shape | dtype/属性 | 覆盖路径 | 单 case timeout | 选择理由 |
+|--------|-------|------------|----------|-----------------|----------|
+| {perf_worst_path} | {最大/关键 shape} | {最坏 dtype} | {结构路径} | {秒} | {最大 DMA/标量任务数} |
+
+测试数据、随机数、特殊值和 golden 物理重排均在 CPU 完成；运行阶段只做
+H2D → TileLang kernel → D2H，避免测试 harness 引入 aclnn 依赖。
 
 ---
 

--- a/.agents/skills/tilelang-op-design/examples/design-template.md
+++ b/.agents/skills/tilelang-op-design/examples/design-template.md
@@ -20,7 +20,9 @@ $$
 
 {对于多步算子，描述计算步骤的分解逻辑。单步算子可省略。}
 
-> **⚠️ Host 侧 Buffer 操作约束**（详见 SKILL.md §3.1）：host 侧禁止改动 NPU 张量 buffer 内的真实内容。本节描述计算步骤时，host 侧只能做视图操作（`reshape`/`view`/`transpose`/`permute`/`expand`，只改 stride/shape 元数据）+ kernel 调用 + 结果 reshape。**禁止**：`.contiguous()`、host padding（新建 buffer + 切片赋值 + 顶替）、`x[:] =`、`x = 新tensor` 顶替等。所有数据搬运/padding/维度重排必须落入 `@tilelang.jit` kernel 内部。
+> **⚠️ Host 侧 Buffer 操作约束**（详见 SKILL.md §3.2）：host 侧只允许经证明共享
+> 原 storage、只改 metadata 的 view 操作，以及 kernel 调用和验证；禁止真实数据搬运
+> 和 aclnn 计算。`reshape` 需按目标 shape/stride 证明零拷贝。
 
 ### 1.5 数据流图
 
@@ -220,7 +222,9 @@ block_num = (M // block_M) * (N // block_N)
 
 {非整除情况的处理策略、边界块的特殊逻辑等}
 
-> **⚠️ 非整除由前端自动处理**（详见 SKILL.md §3.1）：前端框架已支持自动尾块搬运（`T.copy` 动态 shape 切片），非整除时尾块无需特殊处理。**host 侧不允许 padding + crop**（`x_padded = torch.zeros(...); x_padded[:, :M] = x; x = x_padded` 属于违规：新建 buffer + 切片赋值 + 顶替原输入）。
+> **⚠️ 非整除必须显式设计**（详见 SKILL.md §3.2）：输入、输出 GM 两侧使用
+> `valid_*` extent 的 BufferRegion，前端按动态切片裁剪搬运。不得使用标量 GM 起点配
+> 完整 UB tile；host 侧不允许 padding + crop。
 
 ### 5.5 数据搬运性能可行性（数据重排算子必填）
 
@@ -259,7 +263,9 @@ with T.Kernel(block_num, is_npu=True) as (cid, vid):
 
 {当输入 shape 不能被 block size 整除时的处理策略}
 
-> **⚠️ 尾块由前端自动处理**（详见 SKILL.md §3.1）：前端框架已支持 `T.copy` 动态 shape 切片自动尾块搬运，非整除时尾块无需特殊处理。**host 侧不允许 padding + crop**。
+> **⚠️ 尾块必须显式设计**（详见 SKILL.md §3.2）：输入、输出 GM 两侧都使用
+> `valid_*` extent 的 BufferRegion；前端按这些动态切片裁剪搬运。不得用标量 GM
+> 起点配完整 UB tile，也不得在 host 侧 padding + crop。
 
 ---
 

--- a/.agents/skills/tilelang-op-design/references/ascend-constraints.md
+++ b/.agents/skills/tilelang-op-design/references/ascend-constraints.md
@@ -21,6 +21,7 @@
 | **流水线不支持动态边界** | `T.Pipelined` 的循环次数必须静态 | 动态批次无法流水线 | 改用 `T.serial` 或预计算固定迭代次数 |
 | **部分 GPU API 不可用** | CUDA 专用 API 在 Ascend 不存在 | 直接移植 GPU 代码失败 | 查阅本项目 `examples/` 确认 Ascend API |
 | **L0C 容量上限** | A2/A3 设备 L0C = 128KB | `block_M × block_N × sizeof(accum) > 128KB` 导致 segfault | 设计 block 时满足 `block_M × block_N ≤ 16384`（float32 accum） |
+| **T.copy 不支持列方向 strided 切片** | AscendC `DataCopyPad` 硬件指令只支持行间 gap、不支持行内（列方向）strided access。当切片的列维（最后一个 extent≠1 的维度）不是 buffer 最内维且之后有 shape>1 的维度时，产生**静默数据错位** | 4D+ 切片如 `x[b, m:m+M, n:n+N, k:k+1]`（K>1）无法正确搬运 | 用 3D 切片 + host 侧 `permute`+`reshape` 降维到 3D `(batch, M, N)` 使列维成为最内维（仅 contiguous 张量可用）；详见 `tilelang-api-best-practices/references/api-kernel-memory.md` §T.copy 多维切片的硬件限制 |
 
 ## 2. 强制检测规则
 
@@ -34,6 +35,10 @@
 | GPU 专用 API | CUDA 相关 API（如 `T.gemm` 通用版） | **立即警告**，查阅本项目确认 Ascend API |
 | GEMM 非整除风险 | `M` 或 `N` 不被 block size 整除（即 `M % block_M ≠ 0` 或 `N % block_N ≠ 0`） | **立即警告**，要求 design 中明确使用 `T.ceildiv(M, block_M)` 或 `T.ceildiv(N, block_N)` |
 | L0C 溢出风险 | block_M × block_N × sizeof(accum_dtype) > 131072 (128KB) | **立即警告**，建议减小 block 或拆分 |
+| T.copy 列方向 strided 切片 | design.md 中出现 4D+ 切片搬运，且切片的列维（最后一个 extent≠1 的维度）不是 buffer 最内维 | **立即警告**，要求改为 3D 切片 + host 侧 reshape 降维方案；详见 `tilelang-api-best-practices/references/api-kernel-memory.md` §T.copy 多维切片的硬件限制 |
+| Host 侧 `reshape` 隐式拷贝 | design.md 中 host 侧对 `permute`/`transpose`/`movedim` 后（非 contiguous）的张量做 `reshape`（尤其是 `reshape(-1)`） | **立即警告**，指出 `reshape` 对非 contiguous 张量等价于 `.contiguous()`，属 §3.2 禁止行为；要求改用 stride buffer 方案（见下方「非连续数据归一化设计」） |
+| Host 侧 `torch.nn.functional.*` / `torch.cat` 等隐式 aclnn 调用 | design.md 中 host 侧出现 `torch.nn.functional.pad`/`cat`/`interpolate`、`torch.cat`/`stack`、`.to(dtype)` dtype 转换、`.clone()` 等操作 | **立即警告**，指出这些操作在 NPU tensor 上会触发 aclnn 调用，cann-bench 评测环境可能裁剪 aclnn 导致运行时失败；属 §3.2 禁止行为 #5；要求改为在 kernel 内用 `T.tile.cast`/`T.copy`+`pad_value` 等完成 |
+| 输出侧切片 + reshape 隐式 contiguous | design.md 中 kernel 调用后对输出张量做切片（如 `y[:,:,:,:S]`）再 `reshape` | **立即警告**，指出切片后 tensor 非 contiguous，reshape 会隐式 `.contiguous()` → `aclnnCopy`；属 §3.2 禁止行为 #5；要求改为让 kernel 直接输出到与原始 shape 一致的 buffer（`T.copy`+`pad_value` 处理尾块），host 侧仅做纯 view reshape |
 
 ## 3. 警告输出格式
 
@@ -58,3 +63,35 @@
 
 是否继续生成设计文档？
 ```
+
+---
+
+## 4. 非连续数据归一化设计
+
+当算子输入数据在 GM 中非连续（如 `permute`/`transpose`/`movedim` 后），需要做维度归一化才能交给 kernel 处理。有以下方案，选错会导致严重性能问题或 aclnn 调用。
+
+### 方案 A：host 侧 reshape 降维（仅 contiguous 张量可用）
+
+host 侧用 `reshape` 降维到连续形态。
+
+**约束**：`reshape` 仅在张量 contiguous 时是零拷贝 view。对非 contiguous 张量，`reshape`（尤其是 `reshape(-1)`）会触发物理拷贝，等价于 `.contiguous()`，属 §3.2 禁止行为。**仅当输入已 contiguous 时可用此方案。**
+
+### 方案 B：stride 作为 JIT 编译期常量传入 kernel（推荐）
+
+host 侧只算 stride 参数（纯 Python 整数运算），作为 `@tilelang.jit` 函数的 Python 参数传入（JIT 编译期常量）。kernel 内用 `T.alloc_var` 累加偏移 + 逐行 `T.copy` 搬运，完全消除 host 侧物理拷贝。
+
+**适用条件**：不限于 transpose——任何算子需要对非 contiguous 张量做维度归一化或数据重排时均可使用。典型场景包括 N-D permute、gather/scatter 后的重排、非连续切片的批量处理等。
+
+**设计要点**：
+- stride/shape 参数作为 JIT 编译期常量传入 kernel（**不打包成 GM tensor**，避免额外 GM→UB 搬运）
+- kernel 接受 1D flat GM tensor + stride 参数（Python int）
+- `T.alloc_var` 声明累加变量，用 stride 常量累加计算 batch_offset
+- 逐行 `T.copy` 搬运（每次只搬一段物理连续的数据）
+- 纯 Vector 算子**不开** `AUTO_CV_COMBINE`（会导致 `alloc_var` 赋值/读取分离到不同核）
+
+### 设计自检
+
+design.md 中如果对非 contiguous 张量做 `reshape` 降维，必须回答：
+- 输入张量在 `reshape` 之前是否 contiguous？（`x.is_contiguous()`）
+- 如果非 contiguous，`reshape` 会触发物理拷贝——是否已改用方案 B（stride 作为 JIT 编译期常量传入 kernel）？
+- 如果答案仍是 `reshape` → **设计违规**，必须改用方案 B

--- a/.agents/skills/tilelang-op-design/references/ascend-constraints.md
+++ b/.agents/skills/tilelang-op-design/references/ascend-constraints.md
@@ -87,7 +87,8 @@ host 侧只算 stride 参数（纯 Python 整数运算），作为 `@tilelang.ji
 - kernel 接受 1D flat GM tensor + stride 参数（Python int）
 - `T.alloc_var` 声明累加变量，用 stride 常量累加计算 batch_offset
 - 逐行 `T.copy` 搬运（每次只搬一段物理连续的数据）
-- 纯 Vector 算子**不开** `AUTO_CV_COMBINE`（会导致 `alloc_var` 赋值/读取分离到不同核）
+- 纯 Vector 算子启用 `AUTO_CV_COMBINE` 时检查生成代码中 `alloc_var` 的定义/使用核归属；
+  只有确认发生误分核时才关闭该配置
 
 ### 设计自检
 

--- a/.agents/skills/tilelang-op-design/references/quality-checklist.md
+++ b/.agents/skills/tilelang-op-design/references/quality-checklist.md
@@ -6,7 +6,7 @@
 
 | # | 检查项 | 是否必须通过 |
 |---|--------|-------------|
-| 0 | **Host 侧 Buffer 操作合规性**（对应 SKILL.md §3.1）| ✅ 必须 |
+| 0 | **Host 侧 Buffer 操作合规性**（对应 SKILL.md §3.2）| ✅ 必须 |
 
 **第 0 项核对**：design.md 的 host 侧（kernel 外的 Python 代码）步骤是否仅限视图操作（`reshape`/`view`/`transpose`/`permute`/`expand`，只改 stride/shape 元数据）+ kernel 调用 + 结果 reshape？是否出现以下改动 buffer 真实内容的描述（命中即违规，必须修订后再继续后续检查）：
 
@@ -15,7 +15,10 @@
 - 直接改写 buffer 内容：`x[:] = ...`、`x.add_(1)`、`out=`
 - 改数据指针顶替：`x = y`（y 是另一个 tensor）后传入 kernel
 
-**允许**：`reshape`/`view`/`transpose`/`permute`/`expand` 等只改元数据的视图操作；数据准备（输入 tensor 创建）、kernel 调用、结果验证。**非整除处理**：前端框架已支持自动尾块搬运（`T.copy` 动态 shape 切片），不需要 host padding。所有数据搬运/padding/维度重排必须落入 `@tilelang.jit` kernel 内部。下游 `tilelang-op-generate` skill 会按相同规则再次校验。
+**允许**：经证明共享原 storage、只改 metadata 的 view 操作；数据准备、kernel 调用和
+结果验证。`reshape` 是否物理化取决于目标 shape 与当前 stride 的兼容性。非整除尾块
+必须在 kernel 输入、输出两侧写出显式 valid extent/BufferRegion，不需要 host padding。
+下游 `tilelang-op-develop` 会再次校验。
 
 ## 1. 设计质量检查
 

--- a/.agents/skills/tilelang-op-design/references/quality-checklist.md
+++ b/.agents/skills/tilelang-op-design/references/quality-checklist.md
@@ -2,6 +2,23 @@
 
 生成 `design.md` 后，逐项检查：
 
+## 0. 前置检查（必须最先确认）
+
+| # | 检查项 | 是否必须通过 |
+|---|--------|-------------|
+| 0 | **Host 侧 Buffer 操作合规性**（对应 SKILL.md §3.1）| ✅ 必须 |
+
+**第 0 项核对**：design.md 的 host 侧（kernel 外的 Python 代码）步骤是否仅限视图操作（`reshape`/`view`/`transpose`/`permute`/`expand`，只改 stride/shape 元数据）+ kernel 调用 + 结果 reshape？是否出现以下改动 buffer 真实内容的描述（命中即违规，必须修订后再继续后续检查）：
+
+- `.contiguous()` / `.reshape(...).contiguous()` / `.permute(...).contiguous()` 等触发真实数据重排
+- host 侧 padding：`x_padded = torch.zeros(...); x_padded[:, :M] = x; x = x_padded`（新建 buffer + 切片赋值 + 顶替原输入）
+- 直接改写 buffer 内容：`x[:] = ...`、`x.add_(1)`、`out=`
+- 改数据指针顶替：`x = y`（y 是另一个 tensor）后传入 kernel
+
+**允许**：`reshape`/`view`/`transpose`/`permute`/`expand` 等只改元数据的视图操作；数据准备（输入 tensor 创建）、kernel 调用、结果验证。**非整除处理**：前端框架已支持自动尾块搬运（`T.copy` 动态 shape 切片），不需要 host padding。所有数据搬运/padding/维度重排必须落入 `@tilelang.jit` kernel 内部。下游 `tilelang-op-generate` skill 会按相同规则再次校验。
+
+## 1. 设计质量检查
+
 | # | 检查项 | 是否必须通过 |
 |---|--------|-------------|
 | 1 | **编程模式有明确结论和理由**：不是笼统的「视情况而定」 | ✅ 必须 |
@@ -24,5 +41,7 @@
 | 18 | **函数无全局变量依赖**：维度参数从 tensor shape 或函数参数获取，支持多场景顺序测试 | ⭕ 推荐 |
 | 19 | **精度标准已定义**：§9.3 精度标准表填了具体数值（非占位符），且 §4 声明的每个 dtype 都有对应行（浮点给 atol/rtol/max_abs_error_limit/required_matched_ratio，整型为 0/0/0/1.0） | ✅ 必须 |
 | 20 | **proto.yaml 已产出**：同目录 `proto.yaml` 存在（模板见 design-template.md §11.5），`operator.inputs[].dtype` 与 §9.3 精度表的 dtype 行一致（全集），`attrs[].name` 覆盖所有关键属性——供覆盖门禁派生 D-DTYPE-*/D-PARAM-* | ✅ 必须 |
+| 21 | **数据重排性能可行性已量化**：每条结构路径列出 GM pass、DMA transaction/平均字节、GM 标量访问、地址 div/mod 和有效并行度；大张量无逐元素 strided GM 主路径 | ✅ 必须 |
+| 22 | **最大/关键 case 有超时门禁**：用户给出的最大 shape、最坏 dtype 和最高任务数路径至少各有一个性能哨兵，不能全部放入可跳过的 L1/large | ✅ 必须 |
 
-**通过条件**：必须项（1, 2, 3, 7, 8, 9, 13, 19, 20）全部通过，推荐项至少通过 4/9。
+**通过条件**：前置检查（第 0 项）必须通过 + 必须项（1, 2, 3, 7, 8, 9, 13, 19, 20, 21, 22）全部通过 + 推荐项至少通过 4/9。

--- a/.agents/skills/tilelang-op-develop/SKILL.md
+++ b/.agents/skills/tilelang-op-develop/SKILL.md
@@ -25,11 +25,14 @@ design.md 可能很长，**只提取以下字段，忽略其余内容**：
 | Golden 函数 | §9.1 Golden 函数 | 测试对比基准 |
 | 测试用例表 | §9.2 L0 门槛测试计划 | 测试配置 |
 | 精度标准 | §9.3 精度标准 | 混合容差：atol / rtol / max_abs_error_limit / required_matched_ratio（按 dtype） |
+| 路径性能可行性表 | §5/§6 | GM pass、DMA transaction、GM 标量访问、地址计算和并行度 |
+| 性能可行性哨兵 | §9 | 每条路径最坏 dtype/最大任务数 case 与单 case 超时预算 |
 
 **明确忽略的内容**（这些容易误导）：
 - 模式选型的分析推理过程
 - 内存预算的计算过程和多轮优化迭代
-- 风险点与注意事项（过于笼统）
+- 仅忽略没有量化证据的笼统风险；凡是包含具体 shape、dtype、超时、GM/DMA
+  成本或回退路径的风险必须提取并作为验收约束
 - 交付清单（仅是文件列表）
 - 任何标注为"待确认"的内容
 
@@ -56,6 +59,8 @@ design.md 可能很长，**只提取以下字段，忽略其余内容**：
 | GEMM | `examples/gemm/`、`examples/developer_mode/gemm_developer.py` |
 | 融合算子 | `examples/flash_attention/`、`examples/pipeline/`、`examples/developer_mode/matmul_add_developer.py` |
 | Developer 模式 | `examples/developer_mode/` |
+| transpose / layout transform | `examples/transpose/transpose.py`（提取结构谓词、
+连续 suffix-record 聚合搬运和通用 fallback；不得照抄具体 perm/shape 分支） |
 
 查阅示例时关注：
 1. **Kernel 结构**：`T.Kernel` 参数、`cid`/`vid` 用法
@@ -68,9 +73,83 @@ design.md 可能很长，**只提取以下字段，忽略其余内容**：
 
 ## 3. 代码生成流程
 
-> **⚠️ 核心原则：算子的主要操作必须全部在 kernel 内实现**
+### 3.1 算子 kernel 划分原则（强制规则，生成代码前必须遵守）⭐
+
+> **⚠️ 核心原则：禁止按"不可穷举的条件"划分 kernel**
 >
-> 算子的所有核心计算逻辑（包括数据搬运、数学运算、归约、归一化等）必须在 `@tilelang.jit` 装饰的 kernel 函数内部完成。**禁止**将算子的主要操作放在 kernel 外部（如 host 端 Python 代码）来实现。kernel 外部只允许做数据准备（输入 tensor 创建）、kernel 调用和结果验证。
+> 一个算子可以有多个 kernel，但划分 kernel 的条件必须是**封闭可穷举**的。如果划分条件的取值集合无法列全或可无限扩展，则禁止按此条件划分——否则没覆盖到的取值就不支持了，违背算子通用性。
+
+#### 判断方法（写多个 kernel 前必须执行，不能跳过）
+
+按以下 3 步逐一判断，任何一步不通过则禁止按该条件划分：
+
+1. **列出划分条件的所有可能取值**：把条件写成集合，如 `dtype ∈ {float16, float32, bfloat16, int8, int16, int32, int64}` 或 `ndim ∈ {2, 3, 4, 5, 6, 7, 8, ...}`
+2. **判断集合是否封闭可穷举**：
+   - 集合元素有限且固定 → 可穷举 → ✅ 允许划分
+   - 集合元素可扩展 / 连续值 / 阶乘或指数增长 → 不可穷举 → ❌ 禁止划分
+3. **新增取值测试**：假设集合新增一个取值（如 ndim 从 8 扩展到 9），是否需要写新 kernel？
+   - 需要 → ❌ 禁止划分，改为通用实现
+   - 不需要（通用 kernel 自动覆盖） → ✅ 允许划分
+
+#### 写多个 kernel 前必答的自检 checklist
+
+- [ ] 划分条件是什么？（dtype / 维度数 / shape / 对齐性 / ...）
+- [ ] 取值集合是否封闭可穷举？（执行上面 3 步判断方法）
+- [ ] 新增一个取值时是否需要写新 kernel？是→禁止；否→允许
+- [ ] 如果不确定是否可穷举，是否已改为通用 kernel + host 归一化？
+
+#### 反例（多种"不可穷举"实例化，禁止照搬其中任何一个当成规则全集）
+
+> ⚠️ 以下每个反例都是"不可穷举"的**不同实例化**，规则是针对**所有不可穷举的情况**，不只是下列具体例子。判断时必须用上面的 3 步判断方法，不能只记反例。
+
+| ❌ 反例 | 为什么不可穷举 |
+|---------|---------------|
+| 按维度数划分（2D/3D/4D... 各写一个 kernel） | 维度数可无限增长，永远写不完，没写的维度就不支持 |
+| 按 (i,j) 轴组合划分（3D 有 3 种、4D 有 6 种...） | 组合数随维度数爆炸，C(n,2) 增长 |
+| 按 shape 大小档位划分（小/中/大/超大 tensor 各一个 kernel） | shape 是连续值，档位无法穷举 |
+| 按 perm 具体值划分（[1,0]、[0,2,1,3]、[4,3,2,1,0]... 各一个 kernel） | 排列数阶乘增长 n! |
+| 按输出 numel 划分（< 1M / 1M~16M / > 16M 各一个 kernel） | numel 是连续值 |
+
+#### 正例（封闭可穷举的划分，允许）
+
+| ✅ 正例 | 为什么可穷举 |
+|---------|-------------|
+| 按 dtype 划分（7 种，集合封闭） | dtype 是有限集合，硬件支持也是有限的 |
+| 按对齐性划分（对齐 / 非对齐，二分） | 二值集合，封闭 |
+| 按硬件计算路径划分（Cube / Vector） | 硬件路径有限，封闭 |
+| 按 GEMM 的 K 是否整除 block_K 划分（整除 / 有尾块，二分） | 二值集合，封闭 |
+
+#### 默认通用 + 有限特化原则
+
+当不确定划分条件是否可穷举时，**默认写一个通用 kernel 处理所有情况**，通过 host 侧 `reshape`/`permute`/`view` 等 view 操作把输入归一化到统一形态（如把任意 ndim 的转置降维到 3D `(batch, M, N)`），让一个 kernel 覆盖所有情况。性能优化阶段再按**封闭可穷举**的条件（如 dtype、对齐性）做有限特化。
+
+**反例参考**：transpose 算子曾因按维度数特化（2D/3D/4D 各写一个 kernel）被否决，后改为一个通用 3D kernel + host reshape 降维处理 2D~8D。
+
+#### 代码生成时的强制自检
+
+生成 `{op}.py` 时如果出现多个 `@tilelang.jit` 装饰的 kernel 函数，必须执行上面 3 步判断方法验证每个划分条件是否可穷举。命中不可穷举条件 → 立即重构为通用 kernel + host 归一化方案，不得继续。
+
+**⚠️ host 侧分派逻辑同样适用**：host 侧的多路径分派逻辑（如 `if perm == [0,2,1,3]: ...`）也不得硬编码不可穷举的取值（perm 具体值、shape 具体值等）。如果新增一个取值需要加新的 `if` 分支 → **违规**，必须改为通用算法（如基于 perm 拓扑特征的分类器、基于 shape 连续性的判断等）。
+
+---
+
+### 3.2 Host 侧 Buffer 操作约束（生成代码时必须遵守）⭐
+
+> **⚠️ 核心原则：算子的主要操作必须全部在 kernel 内实现，host 侧禁止触发 aclnn 调用**
+>
+> 算子的所有核心计算逻辑（包括数据搬运、数学运算、归约、归一化等）必须在 `@tilelang.jit` 装饰的 kernel 函数内部完成。**kernel 外部（host 侧 Python 代码）对 NPU 侧张量数据严禁以下行为**（约束范围覆盖 kernel 调用前的输入预处理和 kernel 调用后的输出后处理）：
+>
+> | # | 禁止行为 | 说明 | 典型反例 |
+> |---|---------|------|---------|
+> | 1 | 修改张量数据指针 | 禁止把输入/输出 tensor 重新绑定到另一个 tensor（改变 `data_ptr`）后传入 kernel | `x = y`（y 是另一个 tensor）后再传入 kernel |
+> | 2 | 修改张量真实排布 | 禁止任何会触发真实数据拷贝/重排的操作 | `x.reshape(...).contiguous()`、`x.transpose(...).contiguous()`、`x.permute(...).contiguous()`、**`x_perm.reshape(-1)`（x_perm 非 contiguous 时等价于 `.contiguous()`）** |
+> | 3 | 修改 buffer 真实内容 | 禁止在 host 侧直接改写 tensor 数据 | `x[:] = ...`、`x.add_(1)`、`torch.mul(x, 2, out=x)` |
+> | 4 | 用新 buffer 作弊 | 禁止「创建新 buffer → host 侧处理 → 替换原 tensor」绕过限制 | `x = x.add(1)`（host 算完用新 tensor 顶替原输入） |
+> | 5 | **隐式触发 aclnn 调用** | cann-bench 评测环境可能裁剪 aclnn 编译产物，以下操作在 NPU tensor 上会触发 aclnn 调用导致运行时失败：`torch.nn.functional.pad`/`cat`/`interpolate`、`torch.cat`/`stack`、`.to(dtype)` dtype 转换、`.clone()`、对非 contiguous 张量的 `reshape`（含**输出侧切片+reshape**） | `y = y[:, :, :, :S]; y.reshape(shape)`（切片后非 contiguous，reshape 隐式 `.contiguous()` → `aclnnCopy`）；`x = torch.nn.functional.pad(x, (0, pad_size))`（→ `aclnnPad`） |
+>
+> **允许**的 host 侧操作：`reshape`/`view`/`transpose`/`permute`/`expand` 等**只改 stride/shape 元数据、不触碰真实数据**的视图操作；以及数据准备（输入 tensor 创建）、kernel 调用、结果验证。**⚠️ `reshape` 的零拷贝性质以 `x.is_contiguous()` 为前提**——非 contiguous 张量（如 `permute`/`transpose`/`movedim` 后，**但不限于这些**——切片如 `y[:,:,:,:S]` 也会产生非 contiguous 张量）的 `reshape` 会触发物理拷贝，属禁止行为 #2/#5。
+>
+> **判定准则**：host 侧任何会改变 NPU 张量「数据指针」或「物理存储内容/排布」或「隐式触发 aclnn 调用」的操作均禁止；只改 metadata（stride/shape）的允许。拿不准时，一律放入 kernel。**`reshape` 安全判定**：检查 `x.is_contiguous()`——`True` 则 `reshape` 零拷贝（允许）；`False` 则触发拷贝（禁止），改用 stride buffer 方案（host 侧只算 stride 参数传入 kernel，kernel 内逐行搬运）。**输出侧判定**：kernel 调用后对输出 tensor 的任何操作（切片、reshape、dtype 转换等）同样需遵守上述规则——若需要从 padded 输出中裁剪有效部分，应改为让 kernel 直接输出到与原始 shape 一致的 buffer（通过 `T.copy` + `pad_value` 处理尾块），host 侧无需切片。
 
 ### 步骤 1：读取设计文档
 
@@ -106,6 +185,23 @@ design.md 可能很长，**只提取以下字段，忽略其余内容**：
 
 ### 步骤 3：生成实现代码
 
+> **⚠️ 生成代码时必须遵守 §3 开头的「核心原则」**：算子的核心计算逻辑全部在 kernel 内实现。host 侧对 NPU 张量只能做「只改元数据」的视图操作（`reshape`/`view`/`transpose`/`permute`/`expand`）以及数据准备 / kernel 调用 / 结果验证；禁止改数据指针、禁止 `.contiguous()` 等真实重排、禁止改写 buffer 内容、禁止用新 buffer 作弊。拿不准时，一律放入 kernel。
+
+> **⚠️ dtype 特化检查（支持多 dtype 的算子必须执行）**：生成代码时必须检查每个支持的 dtype 是否走硬件加速路径。如果 dtype 回退标量路径，必须比较同宽 reinterpret、kernel 内 cast、record-aware DMA、块 DMA + UB-local 标量重排等候选。**禁止把大张量降级成逐元素 strided GM load/store，也不能把“逐行 T.copy”误当成可完成任意转置。** UB 内局部标量 lowering 可以作为经最大 case 验证的 fallback；不得在 host 侧用 `.to(dtype)` / `.contiguous()` / `torch.stack` 绕过。详见 [references/coding-conventions.md §7](references/coding-conventions.md#7-dtype-性能特化)。
+
+> **⚠️ stride/shape 参数传递（kernel 需要地址偏移时）**：优先作为 `@tilelang.jit` 函数的 Python 参数传入（JIT 编译期常量），kernel 内用 `T.alloc_var` 累加偏移。**不要打包成 int32 GM tensor 在运行时传入**——会增加一次 GM→UB 搬运。详见 [tilelang-api-best-practices/references/api-compute.md §4.10 Stride 参数作为 JIT 编译期常量](../tilelang-custom-skill/tilelang-api-best-practices/references/api-compute.md#stride-参数作为-jit-编译期常量传入-kernel避免创建-gm-tensor)。
+
+> **⚠️ 数据重排实现门禁**：GM↔UB 应使用尽可能大的块/二维 `T.copy`。标量循环只能用于
+> UB-local reorder，不能在大张量主路径中写成 `ub[i] = gm[base + i * stride]`。
+> 对连续 suffix record，必须按通用结构谓词聚合多条 record，而不是每条 record 发两次短 DMA。
+> 生成后用 `get_kernel_source()` 检查每条 dtype/路径；若 `GetValue/SetValue` 对 GM
+> 按 numel 展开，或 DMA transaction 估算达到数十万/百万级，必须重新设计。
+>
+> 不要只执行上述门禁。凡是涉及数据布局变化，必须按
+> [coding-conventions.md §6.1](references/coding-conventions.md#61-数据重排的正向实现配方)
+> 的六步配方生成候选实现：识别连续 record → 按成本选路径 → 聚合搬运 →
+> UB-local reorder → 必要时分阶段 → 数字验收。
+
 基于 design.md 的 API 映射 + 参考示例的代码风格，生成**两个文件**：`{op}.py`（纯 kernel）与 `test_{op}.py`（golden + L0 + main，L1/L2/Boundary 留桩，从 `{op}.py` import kernel）。完整文件结构骨架与融合算子注意事项见 [examples/code-skeleton.md](examples/code-skeleton.md)。
 
 > **写代码时遇到**具体编码规范问题（Buffer 分配 / 索引一致性 / 同步 / 广播 / 测试模板）查 [references/coding-conventions.md](references/coding-conventions.md)。
@@ -116,11 +212,32 @@ design.md 可能很长，**只提取以下字段，忽略其余内容**：
 
 ### 步骤 4：运行验证
 
-本 skill 只负责 L0（精度收敛）。先只跑 L0：
+本 skill 负责 L0 精度收敛，同时负责实现的最低性能可行性。先跑 L0：
 
 ```bash
 python examples/{op}/test_{op}.py --level l0
 ```
+
+随后必须运行 design.md 中的性能可行性哨兵（即使它被标为 large/L1），为每个 case
+设置明确 timeout。用户明确给出的失败或超时 case 必须全部实际运行。任一哨兵超时，
+不得宣称生成完成：应修复搬运路径；若现有 API 无法满足，则返回 `[DESIGN_ERROR]`
+并附 GM/DMA 成本证据。
+
+测试数据准备同样属于 aclnn 审计范围：随机数、特殊值注入、dtype 转换和 golden
+物理重排全部在 CPU 完成，然后只做一次 H2D；验证时只做 D2H。不得在 NPU 上调用
+`torch.rand/randint`、in-place random、`.contiguous()` 或 golden 计算。报错中若出现
+`aclnnInplaceRandom`，说明失败发生在测试输入准备，不是 kernel 内存不足或精度问题。
+
+若测试规格包含 NaN/Inf，生成的测试必须采用位置敏感验证：
+
+1. 在 CPU 上用固定 seed 生成有限基础值和稀疏特殊值 mask，并保证至少一个特殊值、
+   一个有限值；`[nan, nan]` 不得直接退化为全 NaN。
+2. 数值容差判断前，分别要求 actual/golden 的 NaN、正 Inf、负 Inf mask 完全相等。
+3. mask 一致后，只在双方有限的位置计算 atol/rtol、matched ratio 和 max absolute error。
+4. 全 NaN/全 Inf 只能作为补充用例，不能作为唯一特殊值门禁；
+   `torch.allclose(..., equal_nan=True)` 不能替代显式 mask 比较。
+
+具体生成骨架见 [references/coding-conventions.md §5](references/coding-conventions.md#5-测试模板)。
 
 > L0 通过后，由 `tilelang-op-test-design`（场景 B）填充 L1/L2/Boundary 桩体，再 `--level all` 跑全量。
 > main 分发器与 `--level` 接口由本 skill 生成并保持稳定（模板见 code-skeleton.md），扩展时不改动。
@@ -139,9 +256,18 @@ python examples/{op}/test_{op}.py --level l0
 
 运行通过后，必须按 [references/checklist.md](references/checklist.md) 全部 22 项检查。
 
-**⚠️ 首先检查：算子主要操作是否全部在 kernel 内实现**
+**⚠️ 首要检查：算子主要操作是否全部在 kernel 内实现（违反则立即修改，不得继续）**
 
-逐项检查前，先回顾生成的代码，确认算子的所有核心计算逻辑（数据搬运、数学运算、归约、归一化等）都在 `@tilelang.jit` 装饰的 kernel 函数内部完成。若发现有任何主要操作被放在 kernel 外部（host 端 Python 代码）实现，**必须立即修改**，将这些操作移入 kernel 内部，直到满足要求后才能继续后续检查。kernel 外部只允许做数据准备（输入 tensor 创建）、kernel 调用和结果验证。
+逐项检查前，先回顾生成的代码，按 §3 开头「核心原则」的五条禁令逐条核对 host 侧代码（**含 kernel 调用后的输出后处理路径**）：
+
+1. 是否把输入/输出 tensor 重新绑定到别的 tensor（改了 `data_ptr`）后传入 kernel？
+2. 是否对张量做了 `.contiguous()` 或其他会触发真实数据拷贝/重排的操作？（`reshape`/`view`/`transpose`/`permute`/`expand` **仅在张量 contiguous 时允许**；对非 contiguous 张量的 `reshape`（尤其是 `reshape(-1)`）会触发物理拷贝，同样禁止。判定方法：`x.is_contiguous() == False` 时 `reshape` 触发拷贝）
+3. 是否在 host 侧直接改写了 tensor 数据（`x[:] =`、in-place `_()`、`out=` 等）？
+4. 是否用「新建 buffer → host 侧处理 → 替换原 tensor」的方式作弊？
+5. 是否在 host 侧隐式触发了 aclnn 调用？重点检查：`torch.nn.functional.pad`/`cat`/`interpolate`、`torch.cat`/`stack`、`.to(dtype)` dtype 转换、`.clone()`、以及**输出侧切片+reshape**（如 `y = y[:,:,:,:S]; y.reshape(shape)`——切片后非 contiguous，reshape 隐式 `.contiguous()` → `aclnnCopy`）。若需要从 padded 输出裁剪有效部分，应改为让 kernel 直接输出到与原始 shape 一致的 buffer（通过 `T.copy` + `pad_value` 处理尾块），host 侧无需切片。
+6. 是否对所有支持的 dtype 做了特化检查？用 `get_kernel_source()` 确认每个 dtype 是否走硬件加速路径。标量回退的 dtype 是否在 kernel 内处理（cast 或逐行搬运），**而不是在 host 侧用 `.to()` / `.contiguous()` / `torch.stack` 绕过**？
+
+任何一条命中，**必须立即修改**——把这些操作移入 kernel 内部，直到满足要求后才能继续后续检查。允许的 host 侧操作仅限：`reshape`/`view`/`transpose`/`permute`/`expand` 等只改元数据的视图操作，以及数据准备、kernel 调用、结果验证。
 
 **最容易踩坑的 4 项重点提醒**：
 

--- a/.agents/skills/tilelang-op-develop/SKILL.md
+++ b/.agents/skills/tilelang-op-develop/SKILL.md
@@ -75,61 +75,26 @@ design.md 可能很长，**只提取以下字段，忽略其余内容**：
 
 ### 3.1 算子 kernel 划分原则（强制规则，生成代码前必须遵守）⭐
 
-> **⚠️ 核心原则：禁止按"不可穷举的条件"划分 kernel**
->
-> 一个算子可以有多个 kernel，但划分 kernel 的条件必须是**封闭可穷举**的。如果划分条件的取值集合无法列全或可无限扩展，则禁止按此条件划分——否则没覆盖到的取值就不支持了，违背算子通用性。
+多 kernel 或 host 多路径方案必须保证支持域完整：保留覆盖全部声明输入域的通用
+fallback，再按可判定的 dtype、shape、对齐性或输入拓扑增加有限快路径。具体 shape 或
+perm 特化本身不是违规；没有 fallback、未命中即不支持才是设计错误。
 
-#### 判断方法（写多个 kernel 前必须执行，不能跳过）
+生成前记录每条路径的适用谓词、fallback、语义等价依据和验证用例。若 design.md 没有
+完整覆盖支持域，返回 `[DESIGN_ERROR]`；不要擅自缩小支持范围。
 
-按以下 3 步逐一判断，任何一步不通过则禁止按该条件划分：
+Edit 前必须从 design.md 读取 `[DISPATCH-COVERAGE]` 并在实现日志复核：
 
-1. **列出划分条件的所有可能取值**：把条件写成集合，如 `dtype ∈ {float16, float32, bfloat16, int8, int16, int32, int64}` 或 `ndim ∈ {2, 3, 4, 5, 6, 7, 8, ...}`
-2. **判断集合是否封闭可穷举**：
-   - 集合元素有限且固定 → 可穷举 → ✅ 允许划分
-   - 集合元素可扩展 / 连续值 / 阶乘或指数增长 → 不可穷举 → ❌ 禁止划分
-3. **新增取值测试**：假设集合新增一个取值（如 ndim 从 8 扩展到 9），是否需要写新 kernel？
-   - 需要 → ❌ 禁止划分，改为通用实现
-   - 不需要（通用 kernel 自动覆盖） → ✅ 允许划分
+```text
+[DISPATCH-COVERAGE-AUDIT]
+supported_domain: <...>
+generic_fallback: <...>
+uncovered_input: none/<反例>
+specialization_cases: <每条路径至少一个>
+result: pass/fail
+```
 
-#### 写多个 kernel 前必答的自检 checklist
-
-- [ ] 划分条件是什么？（dtype / 维度数 / shape / 对齐性 / ...）
-- [ ] 取值集合是否封闭可穷举？（执行上面 3 步判断方法）
-- [ ] 新增一个取值时是否需要写新 kernel？是→禁止；否→允许
-- [ ] 如果不确定是否可穷举，是否已改为通用 kernel + host 归一化？
-
-#### 反例（多种"不可穷举"实例化，禁止照搬其中任何一个当成规则全集）
-
-> ⚠️ 以下每个反例都是"不可穷举"的**不同实例化**，规则是针对**所有不可穷举的情况**，不只是下列具体例子。判断时必须用上面的 3 步判断方法，不能只记反例。
-
-| ❌ 反例 | 为什么不可穷举 |
-|---------|---------------|
-| 按维度数划分（2D/3D/4D... 各写一个 kernel） | 维度数可无限增长，永远写不完，没写的维度就不支持 |
-| 按 (i,j) 轴组合划分（3D 有 3 种、4D 有 6 种...） | 组合数随维度数爆炸，C(n,2) 增长 |
-| 按 shape 大小档位划分（小/中/大/超大 tensor 各一个 kernel） | shape 是连续值，档位无法穷举 |
-| 按 perm 具体值划分（[1,0]、[0,2,1,3]、[4,3,2,1,0]... 各一个 kernel） | 排列数阶乘增长 n! |
-| 按输出 numel 划分（< 1M / 1M~16M / > 16M 各一个 kernel） | numel 是连续值 |
-
-#### 正例（封闭可穷举的划分，允许）
-
-| ✅ 正例 | 为什么可穷举 |
-|---------|-------------|
-| 按 dtype 划分（7 种，集合封闭） | dtype 是有限集合，硬件支持也是有限的 |
-| 按对齐性划分（对齐 / 非对齐，二分） | 二值集合，封闭 |
-| 按硬件计算路径划分（Cube / Vector） | 硬件路径有限，封闭 |
-| 按 GEMM 的 K 是否整除 block_K 划分（整除 / 有尾块，二分） | 二值集合，封闭 |
-
-#### 默认通用 + 有限特化原则
-
-当不确定划分条件是否可穷举时，**默认写一个通用 kernel 处理所有情况**，通过 host 侧 `reshape`/`permute`/`view` 等 view 操作把输入归一化到统一形态（如把任意 ndim 的转置降维到 3D `(batch, M, N)`），让一个 kernel 覆盖所有情况。性能优化阶段再按**封闭可穷举**的条件（如 dtype、对齐性）做有限特化。
-
-**反例参考**：transpose 算子曾因按维度数特化（2D/3D/4D 各写一个 kernel）被否决，后改为一个通用 3D kernel + host reshape 降维处理 2D~8D。
-
-#### 代码生成时的强制自检
-
-生成 `{op}.py` 时如果出现多个 `@tilelang.jit` 装饰的 kernel 函数，必须执行上面 3 步判断方法验证每个划分条件是否可穷举。命中不可穷举条件 → 立即重构为通用 kernel + host 归一化方案，不得继续。
-
-**⚠️ host 侧分派逻辑同样适用**：host 侧的多路径分派逻辑（如 `if perm == [0,2,1,3]: ...`）也不得硬编码不可穷举的取值（perm 具体值、shape 具体值等）。如果新增一个取值需要加新的 `if` 分支 → **违规**，必须改为通用算法（如基于 perm 拓扑特征的分类器、基于 shape 连续性的判断等）。
+找出任何未覆盖输入时立即返回 `[DESIGN_ERROR]`，不得靠删除 case、缩小输入域或新增
+无 fallback 的枚举分支继续。
 
 ---
 
@@ -147,9 +112,16 @@ design.md 可能很长，**只提取以下字段，忽略其余内容**：
 > | 4 | 用新 buffer 作弊 | 禁止「创建新 buffer → host 侧处理 → 替换原 tensor」绕过限制 | `x = x.add(1)`（host 算完用新 tensor 顶替原输入） |
 > | 5 | **隐式触发 aclnn 调用** | cann-bench 评测环境可能裁剪 aclnn 编译产物，以下操作在 NPU tensor 上会触发 aclnn 调用导致运行时失败：`torch.nn.functional.pad`/`cat`/`interpolate`、`torch.cat`/`stack`、`.to(dtype)` dtype 转换、`.clone()`、对非 contiguous 张量的 `reshape`（含**输出侧切片+reshape**） | `y = y[:, :, :, :S]; y.reshape(shape)`（切片后非 contiguous，reshape 隐式 `.contiguous()` → `aclnnCopy`）；`x = torch.nn.functional.pad(x, (0, pad_size))`（→ `aclnnPad`） |
 >
-> **允许**的 host 侧操作：`reshape`/`view`/`transpose`/`permute`/`expand` 等**只改 stride/shape 元数据、不触碰真实数据**的视图操作；以及数据准备（输入 tensor 创建）、kernel 调用、结果验证。**⚠️ `reshape` 的零拷贝性质以 `x.is_contiguous()` 为前提**——非 contiguous 张量（如 `permute`/`transpose`/`movedim` 后，**但不限于这些**——切片如 `y[:,:,:,:S]` 也会产生非 contiguous 张量）的 `reshape` 会触发物理拷贝，属禁止行为 #2/#5。
+> **允许**的 host 侧操作：经证明只改 metadata、共享原 storage 的 view 操作，以及
+> 数据准备、kernel 调用和结果验证。
 >
-> **判定准则**：host 侧任何会改变 NPU 张量「数据指针」或「物理存储内容/排布」或「隐式触发 aclnn 调用」的操作均禁止；只改 metadata（stride/shape）的允许。拿不准时，一律放入 kernel。**`reshape` 安全判定**：检查 `x.is_contiguous()`——`True` 则 `reshape` 零拷贝（允许）；`False` 则触发拷贝（禁止），改用 stride buffer 方案（host 侧只算 stride 参数传入 kernel，kernel 内逐行搬运）。**输出侧判定**：kernel 调用后对输出 tensor 的任何操作（切片、reshape、dtype 转换等）同样需遵守上述规则——若需要从 padded 输出中裁剪有效部分，应改为让 kernel 直接输出到与原始 shape 一致的 buffer（通过 `T.copy` + `pad_value` 处理尾块），host 侧无需切片。
+> **判定准则**：`is_contiguous()` 为 True 是 reshape 常见的零拷贝充分条件，不是必要
+> 条件。非 contiguous 输入需证明目标 shape 与 stride 兼容且操作前后共享 storage；
+> 不能证明时改用 stride-aware kernel。`permute`/`transpose` 本身通常只是 metadata view。
+
+生成代码后逐项记录 `[HOST-METADATA-AUDIT]`。对每个 host tensor 操作写明输入/输出
+stride、是否共享 storage/data pointer、是否触发 aclnn/物理拷贝；任一结论为 unknown
+都不得交付。具体检查项见 [references/checklist.md §0](references/checklist.md#0-前置检查必须最先确认)。
 
 ### 步骤 1：读取设计文档
 
@@ -201,6 +173,11 @@ design.md 可能很长，**只提取以下字段，忽略其余内容**：
 > [coding-conventions.md §6.1](references/coding-conventions.md#61-数据重排的正向实现配方)
 > 的六步配方生成候选实现：识别连续 record → 按成本选路径 → 聚合搬运 →
 > UB-local reorder → 必要时分阶段 → 数字验收。
+
+完成候选后必须写 `[REORDER-COST-AUDIT]`，包含 GM pass、DMA transaction/平均字节、
+GM 标量访问、逐元素 div/mod、active cores、每核串行任务和最大 case timeout。任一
+指标无法估算时先读取 §6.1 补齐；大张量路径出现 numel 级 GM 标量访问或海量短 DMA
+时不得进入精度验收。
 
 基于 design.md 的 API 映射 + 参考示例的代码风格，生成**两个文件**：`{op}.py`（纯 kernel）与 `test_{op}.py`（golden + L0 + main，L1/L2/Boundary 留桩，从 `{op}.py` import kernel）。完整文件结构骨架与融合算子注意事项见 [examples/code-skeleton.md](examples/code-skeleton.md)。
 
@@ -254,14 +231,15 @@ python examples/{op}/test_{op}.py --level l0
 
 ### 步骤 5：上库前检查清单
 
-运行通过后，必须按 [references/checklist.md](references/checklist.md) 全部 22 项检查。
+运行通过后，必须按 [references/checklist.md](references/checklist.md) 逐项检查。
 
 **⚠️ 首要检查：算子主要操作是否全部在 kernel 内实现（违反则立即修改，不得继续）**
 
 逐项检查前，先回顾生成的代码，按 §3 开头「核心原则」的五条禁令逐条核对 host 侧代码（**含 kernel 调用后的输出后处理路径**）：
 
 1. 是否把输入/输出 tensor 重新绑定到别的 tensor（改了 `data_ptr`）后传入 kernel？
-2. 是否对张量做了 `.contiguous()` 或其他会触发真实数据拷贝/重排的操作？（`reshape`/`view`/`transpose`/`permute`/`expand` **仅在张量 contiguous 时允许**；对非 contiguous 张量的 `reshape`（尤其是 `reshape(-1)`）会触发物理拷贝，同样禁止。判定方法：`x.is_contiguous() == False` 时 `reshape` 触发拷贝）
+2. 是否存在真实数据拷贝/重排？对 reshape 应验证 storage/stride 兼容性，不能把
+   `is_contiguous() == False` 直接等同于一定复制；`permute`/`transpose` 通常只改 metadata。
 3. 是否在 host 侧直接改写了 tensor 数据（`x[:] =`、in-place `_()`、`out=` 等）？
 4. 是否用「新建 buffer → host 侧处理 → 替换原 tensor」的方式作弊？
 5. 是否在 host 侧隐式触发了 aclnn 调用？重点检查：`torch.nn.functional.pad`/`cat`/`interpolate`、`torch.cat`/`stack`、`.to(dtype)` dtype 转换、`.clone()`、以及**输出侧切片+reshape**（如 `y = y[:,:,:,:S]; y.reshape(shape)`——切片后非 contiguous，reshape 隐式 `.contiguous()` → `aclnnCopy`）。若需要从 padded 输出裁剪有效部分，应改为让 kernel 直接输出到与原始 shape 一致的 buffer（通过 `T.copy` + `pad_value` 处理尾块），host 侧无需切片。
@@ -293,7 +271,7 @@ python examples/{op}/test_{op}.py --level l0
 - [references/coding-conventions.md](references/coding-conventions.md) — Buffer 分配 / 索引 / 同步 / 广播 / 测试模板（写代码遇到具体规范时查）
 - [references/vector-parallelism.md](references/vector-parallelism.md) — V 核并行化（用到 vid 切分时查）
 - [references/gemm-cv-fusion.md](references/gemm-cv-fusion.md) — GEMM 与 CV 融合 pass_configs（含 GEMM 或融合算子时查）
-- [references/checklist.md](references/checklist.md) — 22 项上库前检查清单（生成代码后逐项过）
+- [references/checklist.md](references/checklist.md) — 上库前检查清单（生成代码后逐项过）
 - [references/troubleshooting.md](references/troubleshooting.md) — 编译 / 运行 / 精度错误排查手册（遇到具体错误时查）
 - [references/skill-feedback.md](references/skill-feedback.md) — Skill 反馈采集流程（流程结束时查，orchestrator 模式跳过）
 - [examples/code-skeleton.md](examples/code-skeleton.md) — `{op}.py`（kernel）+ `test_{op}.py`（测试）文件结构骨架

--- a/.agents/skills/tilelang-op-develop/references/checklist.md
+++ b/.agents/skills/tilelang-op-develop/references/checklist.md
@@ -17,7 +17,12 @@
 
 | # | 检查项 | 说明 |
 |---|--------|------|
-| 0 | **算子主要操作全部在 kernel 内实现** | 算子的所有核心计算逻辑（数据搬运、数学运算、归约、归一化等）必须在 `@tilelang.jit` 装饰的 kernel 函数内部完成。kernel 外部只允许做数据准备（输入 tensor 创建）、kernel 调用和结果验证。**不满足时必须立即修改后再继续后续检查** |
+| 0 | **算子主要操作全部在 kernel 内实现** | 算子的所有核心计算逻辑（数据搬运、数学运算、归约、归一化等）必须在 `@tilelang.jit` 装饰的 kernel 函数内部完成。host 侧对 NPU 张量严禁：①改数据指针（把输入/输出 tensor 重新绑定到别的 tensor）；②`.contiguous()` 等会触发真实数据拷贝/重排的操作（只改 stride 的 `reshape`/`view`/`transpose`/`permute`/`expand` 允许）；③直接改写 buffer 内容（`x[:]=`、in-place `_()`、`out=`）；④用新 buffer 作弊（host 侧处理完用新 tensor 顶替原输入）。**不满足时必须立即修改后再继续后续检查** |
+| 0a | **host 侧无隐式 aclnn 调用** | host 侧代码（含 kernel 调用前的输入预处理和 kernel 调用后的输出后处理）不得出现会触发 aclnn 的操作：`torch.nn.functional.pad`/`cat`/`interpolate`、`torch.cat`/`stack`、`.to(dtype)` dtype 转换、`.clone()`/`.copy_()`、对非 contiguous 张量的 `reshape`。**重点检查输出侧**：若 kernel 输出为 padded shape，host 侧不得用切片（如 `y[:,:,:,:S]`）+ `reshape` 裁剪——切片后 tensor 非 contiguous，reshape 会隐式 `.contiguous()` → `aclnnCopy`。应改为让 kernel 直接输出到与原始 shape 一致的 buffer（`T.copy` + `pad_value` 处理尾块），host 侧仅做纯 view 的 `reshape` |
+| 0b | **T.copy 4D+ 切片列方向 strided 检查** | 检查 kernel 内所有 `T.copy` 调用的切片表达式：如果切片的列维不是 buffer 最内有效维，且其后还有 shape>1 的维度，会产生静默错位。必须改成 JIT stride + 合法二维/逐连续段搬运，或在输入本来 contiguous 且 reshape 确认为零拷贝时做轴组归一化；**禁止对 permute 后的非 contiguous NPU tensor 做 host reshape**。详见 coding-conventions.md §2.1/§6 |
+| 0c | **测试路径无 aclnn** | 测试输入、随机数、特殊值注入、dtype 转换和 golden 物理重排均在 CPU 完成；仅 H2D→kernel→D2H。`aclnnInplaceRandom` 属测试准备错误，不得归因于 kernel |
+| 0d | **数据搬运成本通过** | 每条结构/dtype 路径已核算 GM pass、DMA transaction、GM 标量访问和地址 div/mod；大张量无逐元素 strided GM，连续 suffix record 已聚合搬运 |
+| 0e | **性能哨兵通过** | 用户关键/最大 case 和每条最坏路径均实际执行且未超时；不得因标记 large/L1 而 skip 后宣称完成 |
 
 ## 1. 功能验证
 
@@ -38,6 +43,7 @@
 |---|--------|------|
 | 9 | **Golden 实现一致** | 迁移算子必须使用原算子的 golden 实现 |
 | 10 | **输出形状匹配** | 检查是否需要 transpose 来匹配原算子输出 shape |
+| 10a | **特殊值位置敏感验证** | 支持 NaN/Inf 时，至少一个阻塞用例使用“有限值 + 稀疏特殊值”的确定性混合输入；先严格比较 NaN/正 Inf/负 Inf mask，再比较有限值。全 NaN/全 Inf 及 `allclose(equal_nan=True)` 不得作为唯一门禁 |
 
 ## 3. 上库前收尾检查
 

--- a/.agents/skills/tilelang-op-develop/references/coding-conventions.md
+++ b/.agents/skills/tilelang-op-develop/references/coding-conventions.md
@@ -4,9 +4,11 @@
 
 - [1. Buffer 分配](#1-buffer-分配)
 - [2. 数据搬运索引](#2-数据搬运索引)
+  - [2.1 T.copy 多维切片的硬件限制](#21-tcopy-多维切片的硬件限制)
 - [3. 同步](#3-同步)
 - [4. 广播](#4-广播)
 - [5. 测试模板](#5-测试模板)
+- [6. Stride Buffer 非连续数据归一化](#6-stride-buffer-非连续数据归一化)
 
 ---
 
@@ -67,6 +69,28 @@ T.copy(workspace[bn * block_N, k_offset], B_L1)  # 完整 block_N
 
 **易错点（仅回退写法）**：workspace 写入时忘记使用 `actual_row`，导致数据错乱。
 
+### 2.1 T.copy 多维切片的硬件限制
+
+`T.copy` 的 GM↔UB / GM↔L1 / L0C→GM 搬运底层使用 AscendC 的 `DataCopyPad` 硬件指令。该指令的搬运模型是**每行内数据连续、行间可有 gap**（通过 `srcGap`/`dstGap` 参数控制），**不支持列方向（行内）strided access**——即每行内相邻元素之间不能有间隔。
+
+**受限场景**：当切片的列维度（最后一个 `extent != 1` 的维度）**不是 buffer 的最内维**，且列维之后还有 `shape > 1` 的维度时，列方向数据不连续，会产生**静默数据错位**（不报错，结果错误）。
+
+| 切片形式 | extents | 列维 | 列维是否最内维 | 是否支持 | 说明 |
+|----------|---------|------|---------------|---------|------|
+| `x[b, m:m+M, n:n+N]`（3D，buffer `[B,M,N]`）| `[1, M, N]` | N (dim 2) | 是 | ✅ | 列数据连续 |
+| `x[b, m:m+M, n:n+N, :]`（4D 全取 K，buffer `[B,M,N,K]`）| `[1, M, N, K]` | K (dim 3) | 是 | ✅ | 列数据连续（K 维全取） |
+| `x[b, 1, m:m+M, n:n+N]`（4D，buffer `[B,H,M,N]`，H=1）| `[1, 1, M, N]` | N (dim 3) | 是 | ✅ | 列数据连续 |
+| `x[b, m:m+M, n:n+N, k:k+1]`（4D 单取 K，buffer `[B,M,N,K]`，K>1）| `[1, M, N, 1]` | N (dim 2) | **否**（dim 3 的 K>1） | ❌ | 列方向每个元素间隔 K 个位置，DataCopyPad 无法搬运 |
+
+**判定方法**：检查 `T.copy` 的 GM 切片表达式，找出最后一个 `extent != 1` 的维度（即列维），确认它是 buffer 的最后一维（`shape.size() - 1`）。如果不是，且列维之后的维度有 `shape > 1`，则受限。
+
+**规避方案**：
+
+1. **host 侧 reshape 降维到 3D**：host 侧用 `permute` + `reshape` 把 4D+ 降维到 3D `(batch, M, N)`，使列维成为最内维。**⚠️ `reshape(-1)` 对非 contiguous 张量（如 `permute` 后）会触发物理拷贝，等价于 `.contiguous()`，属 [SKILL.md §3.2](../SKILL.md) 禁止行为 #2，不得使用。** 替代方案：用 stride 作为 JIT 编译期常量传入 kernel（详见 §6 方案 A）。
+2. **调整 buffer 布局**：将 GM buffer 的维度排列调整为让列维（需要切片的维度）成为最内维。
+
+> **根因**：`src/op/ascend.cc` 的 `find_active_dim_indices` 和 `compute_strideN` 对 4D+ 切片的维度识别有缺陷，且即使修复后，`DataCopyPad` 硬件指令本身也不支持列方向 strided access。这是 AscendC 硬件的固有限制，非 codegen bug。详见 `tilelang-api-best-practices/references/api-kernel-memory.md` §T.copy 多维切片的硬件限制。
+
 ## 3. 同步
 
 ```python
@@ -109,3 +133,232 @@ passed, ratio, max_abs = check_precision(output, ref_output, dtype)
 # Boundary（合法特殊值，非阻塞）：同上比精度，精度过 → "[BOUNDARY_PASS]"；不过或抛异常 → "[BOUNDARY_WARN]"
 # L2（负向，非阻塞）：不比精度——非法输入正确抛异常 → "[BOUNDARY_PASS]"；静默接受 → "[BOUNDARY_WARN]"
 ```
+
+### 5.1 NaN/Inf 位置敏感输入与比较
+
+对支持 NaN/Inf 的浮点算子，特殊值用例必须能发现数据重排、索引和尾块覆盖错误。
+全 NaN 输入在元素被搬到错误位置后仍然处处为 NaN，因此不能作为唯一门禁。
+
+```python
+def make_mixed_nan_input(shape, dtype, seed=0):
+    gen = torch.Generator().manual_seed(seed)
+    x = torch.rand(shape, dtype=torch.float32, generator=gen) * 2.0 - 1.0
+    nan_mask = torch.rand(shape, dtype=torch.float32, generator=gen) < 0.5
+    flat_mask = nan_mask.view(-1)
+    if flat_mask.numel() > 0:
+        flat_mask[0] = True   # 至少一个 NaN
+    if flat_mask.numel() > 1:
+        flat_mask[1] = False  # 至少一个有限值
+    x[nan_mask] = float("nan")
+    return x.to(dtype)        # CPU 上完成，随后只做一次 H2D
+
+
+def check_special_masks(actual, golden):
+    actual = actual.float()
+    golden = golden.float()
+    masks_match = (
+        torch.equal(torch.isnan(actual), torch.isnan(golden))
+        and torch.equal(torch.isposinf(actual), torch.isposinf(golden))
+        and torch.equal(torch.isneginf(actual), torch.isneginf(golden))
+    )
+    finite = torch.isfinite(actual) & torch.isfinite(golden)
+    return masks_match, finite
+```
+
+`check_precision()` 先调用 `check_special_masks()`；mask 不一致立即失败，mask 一致后
+只在 `finite` 区域计算混合容差。普通有限值用例不需要注入特殊值。全 NaN/全 Inf
+可以作为补充语义用例，但不能替代混合特殊值门禁。不要仅依赖
+`torch.allclose(equal_nan=True)`，显式 mask 能分别验证 NaN、正 Inf 和负 Inf 的位置。
+
+## 6. 非连续数据维度归一化（消除 host 侧 reshape 物理拷贝）
+
+当算子需要对非 contiguous 张量做维度归一化时，`reshape(-1)` 会触发物理拷贝（属禁止行为）。以下两种替代方案按优先级选择。
+
+### 方案 A：stride 作为 JIT 编译期常量传入 kernel（推荐，无额外 GM 搬运）
+
+**约束**：
+1. stride/shape 参数作为 `@tilelang.jit` 函数的 Python 参数传入（JIT 编译期常量），**不打包成 GM tensor**
+2. kernel 内用 `T.alloc_var` 累加偏移，stride 直接用于地址计算（静态展开，最多约 6 个 batch 轴）
+3. `T.copy` 不暴露 stride 参数：每次只搬一段物理连续的数据，非连续方向用逐行循环搬运
+4. 纯 Vector 算子不开 `AUTO_CV_COMBINE`（`alloc_var` 赋值/读取需在同一核）
+
+**使用方法**：
+
+```
+host 侧：
+  1. 计算 row-major strides（纯 Python 整数运算）
+  2. 把 stride 值作为 Python int 传入 @tilelang.jit 函数参数
+  3. x.reshape(total_numel) 作为 1D flat 输入（contiguous 张量的 reshape 是零拷贝 view）
+
+kernel 内：
+  1. T.alloc_var 声明累加变量（boff_s, bidx_s 等）
+  2. 用 stride（JIT 编译期常量）+ var 累加计算 batch_offset
+  3. 逐行 T.copy(x[src_offset], ub) — 每次搬一段物理连续的行
+  4. T.tile 计算或转置
+  5. 逐行 T.copy(ub, y[dst_offset]) — 写回
+```
+
+> **为什么不用 GM tensor 传 stride**：打包成 int32 GM tensor 传入 kernel 会增加一次 GM→UB 搬运（`T.copy(stride_buf, ub_s)`），且需要额外分配 GM 空间。作为 JIT 编译期常量传入则无此开销。
+
+### 方案 B：连续轴组 reshape（仅 contiguous 张量可用）
+
+**约束**：仅当输入张量 contiguous 时可用。contiguous 张量的 `reshape` 是零拷贝 view，不触发物理拷贝。
+
+**使用方法**：当 perm 可以分解为"连续轴组交换"（`prefix + A + B → prefix + B + A`）时，host 侧直接 `reshape(batch, M, N)`（零拷贝），调用 3D kernel 完成 `(batch, M, N) → (batch, N, M)`。
+
+> **判定**：`x.is_contiguous() == True` 时 `reshape` 安全；`False` 则必须用方案 A。
+
+> **适用条件**：不限于 transpose——任何算子需要对非 contiguous 张量做维度归一化时均可使用方案 A；输入本身 contiguous 且可分解为连续轴组交换时可用方案 B。
+
+### 6.1 数据重排的正向实现配方
+
+本节适用于 transpose、layout transform、blocked/unblocked layout、通用 gather/scatter
+以及任何“输入输出元素不变、物理位置改变”的算子。按以下步骤生成实现，不要从禁止项
+反推代码。
+
+#### 步骤 1：识别最大连续 record
+
+分别分析输入和输出 stride，找到两侧都保持物理连续的最大元素组，将它视为一个
+`record`。record 可以是一条尾轴、多个相邻轴的乘积，也可以是 blocked layout 中
+的一个内块。
+
+```text
+logical layout: prefix + group_A + group_B + record
+target layout:  prefix + group_B + group_A + record
+```
+
+这里的 `prefix/group_A/group_B/record` 是结构角色，不代表固定 ndim、perm 或 shape。
+host 只用 Python 整数计算各组乘积与 stride，不读取 NPU 数据。
+
+#### 步骤 2：按成本从低到高选择路径
+
+| 顺序 | 可利用的结构 | 正向实现 |
+|------|--------------|----------|
+| 1 | 输入输出都有同一连续 record | 用二维/成组 `T.copy` 一次聚合多条 record |
+| 2 | 可零拷贝折叠成二维 tile | 块 DMA 到 UB → UB 内 tile 运算/重排 → 块 DMA 写回 |
+| 3 | 一次变换无法覆盖，但可拆为相邻连续组变换 | 执行有限次块状 stage，每 stage 完整顺序搬运 |
+| 4 | 无可利用连续结构 | JIT stride 通用 fallback，保证完整覆盖 |
+
+选择路径时先计算 transaction 数量，而不是先调 core 数。增加 core 只能分摊已有任务，
+不能消除数百万次短 DMA 或逐元素 GM 访问。
+
+#### 步骤 3：实现 record-aware 聚合搬运
+
+若一个 task 固定外层坐标和 `record_group`，让它一次处理
+`valid_rows × record_len`，不要每条 record 单独发命令：
+
+```python
+record_ub = T.alloc_ub((block_rows, record_len), dtype)
+
+for local_task in T.serial(single_core_load):
+    task = cid * single_core_load + local_task
+    if task < task_count:
+        # 由 task 解码外层坐标、row_start 和 valid_rows
+        T.copy(
+            x[outer, row_start:row_start + valid_rows, record_group, 0:record_len],
+            record_ub[0:valid_rows, 0:record_len],
+        )
+        T.copy(
+            record_ub[0:valid_rows, 0:record_len],
+            y[outer, record_group, row_start:row_start + valid_rows, 0:record_len],
+        )
+```
+
+`block_rows` 由 UB 容量机械计算：
+
+```python
+block_rows = max(1, min(rows, ub_budget_bytes // (record_len * dtype_bytes)))
+task_count = outer_count * record_group_count * ceildiv(rows, block_rows)
+core_num = max(1, min(task_count, vector_core_count))
+single_core_load = ceildiv(task_count, core_num)
+```
+
+这一骨架利用 DataCopy 的行间 gap 收集连续 record。应用到其他算子时，替换结构角色
+和坐标解码即可，不要照抄固定四维签名。可从已验证实现
+`examples/transpose/transpose.py::_kernel_4d_record_swap` 学习 `T.copy` 切片形式。
+
+#### 步骤 4：没有直接 record 路径时，在 UB 内重排
+
+GM 两侧仍然使用块 DMA，把不连续/标量工作限制在 UB：
+
+```python
+T.copy(x[input_tile_slice], input_ub)
+local_reorder(output_ub, input_ub)  # tile primitive、cast 或 UB-local scalar fallback
+T.copy(output_ub, y[output_tile_slice])
+```
+
+`local_reorder` 可以是 transpose、pack/unpack、lane 交换、索引选择或其他片上操作。
+关键不变量是：GM→UB 和 UB→GM 为块搬运，标量循环不直接遍历 strided GM。
+
+#### 步骤 5：复杂排列采用分阶段连续组变换
+
+若目标布局无法一次转换，把它分解为若干相邻连续组的交换/旋转。每个 stage 都套用
+步骤 3 或步骤 4，并更新当前 shape/轴顺序，直到得到目标布局。这会增加完整 GM pass，
+但通常比海量 4B/8B 短 DMA 更稳定。
+
+设计时记录 `stage_count`，估算完整 GM 流量约为：
+
+```text
+read_write_bytes = 2 * stage_count * numel * dtype_bytes
+```
+
+#### 步骤 6：用数字决定是否接受
+
+对每条路径至少输出：
+
+```text
+task_count
+estimated_dma_transactions
+average_dma_bytes
+gm_scalar_access_count
+per_core_serial_tasks
+```
+
+经验性的诊断顺序：
+
+- `estimated_dma_transactions` 很大：扩大每个 task 聚合的 record/row 数。
+- `average_dma_bytes` 只有几个或几十字节：改用块状 stage。
+- `gm_scalar_access_count` 接近 `numel`：改成块 DMA + UB-local reorder。
+- transaction 已合理但单 core 任务多：最后再调整 tile 与 core_num。
+
+生成后用 `get_kernel_source()` 确认 DataCopy 位于 GM↔UB，`GetValue/SetValue`
+等标量操作只访问 UB，并用最大任务数/最差 dtype case 做 timeout 验证。
+
+## 7. Dtype 性能特化
+
+某些 dtype 在硬件指令中回退标量路径（无向量加速），可通过 dtype 变换使用硬件加速。**不限于下列具体 dtype**——判断准则是"目标 dtype 是否有硬件加速指令"，适用于任何符合此条件的 dtype。
+
+### 约束
+
+1. **零拷贝 reinterpret 仅限同宽 dtype**：`view` 不拷贝数据，但要求两个 dtype 字节数相同（如 bfloat16 ↔ int16 均 2 字节）
+2. **kernel 内 cast 须用 `T.tile.cast`**：low2high / high2low 方向，元素数须 16 对齐
+3. **禁止 host 侧 dtype 转换/拆分**：`.to(dtype)` 触发 `aclnnCast`、`.contiguous()` 触发 `aclnnCopy`、`torch.stack` 触发 `aclnnCat`——dtype 适配必须在 kernel 内完成
+
+### 思路
+
+**场景 A：目标 dtype 有同宽的硬件加速 dtype** → host 侧零拷贝 `view` reinterpret，用硬件加速 dtype 处理，输出再 `view` 回来
+
+**场景 B：目标 dtype 在 kernel 内可 cast 到硬件支持 dtype** → kernel 内 `T.tile.cast` 到支持 dtype 处理，再 cast 回来（UB 需额外分配 cal_dtype buffer）
+
+**场景 C：目标 dtype 超出硬件指令范围且算子是纯数据搬运** → 优先把数据当作
+opaque record，用块/二维 `T.copy` 完成结构重排；无法直接搬运时，使用块 DMA
+GM→UB、UB-local 标量重排、块 DMA UB→GM。不得退化成逐元素 strided GM 访问。
+
+> **通用判断方法**：查看 `get_kernel_source()` 输出或 `src/tl_templates/ascend/common.h`，确认目标 dtype 是否走标量路径。如果走标量路径，寻找同宽的有硬件加速的 dtype 做 reinterpret，或 cast 到更宽的 dtype 做 kernel 内转换。
+
+参考实现：bfloat16→int16 host 侧 `view` reinterpret、int8 kernel 内 `T.tile.cast`
+到 float16；int64 优先 record-aware DMA，通用 fallback 可接受 `T.tile.transpose`
+lowering 成 UB-local scalar，但必须以块 DMA 包住并通过最大 case 超时门禁。详见
+[tilelang-api-best-practices/references/api-compute.md §4.10](../../tilelang-custom-skill/tilelang-api-best-practices/references/api-compute.md#ttiletranspose-的-dtype-支持与标量回退)。
+
+### int64 数据重排补充
+
+单纯“逐行 `T.copy`”只能搬连续行，不能完成任意二维转置。候选顺序是：
+
+1. 输入/输出共享连续 suffix record 时，用二维/成组 DMA 直接完成 record 重排。
+2. 其他情况用块 DMA 搬入 UB，在 UB 内做局部标量重排，再块 DMA 写回。
+3. `T.tile.transpose` 对 int64 即使 lowering 为 `SetValue/GetValue`，只要标量访问
+   局限于 UB，仍可能比逐元素 strided GM 更好；须检查生成源码并实测最大 case。
+
+拆成两个 int32 lane 仅是可选实验；lane 提取、交织写回和 UB planner 未经端到端
+精度验证时不得采用，也不得在 host 侧拆分/拼回。

--- a/.agents/skills/tilelang-op-develop/references/coding-conventions.md
+++ b/.agents/skills/tilelang-op-develop/references/coding-conventions.md
@@ -8,7 +8,8 @@
 - [3. 同步](#3-同步)
 - [4. 广播](#4-广播)
 - [5. 测试模板](#5-测试模板)
-- [6. Stride Buffer 非连续数据归一化](#6-stride-buffer-非连续数据归一化)
+- [6. 非连续数据维度归一化](#6-非连续数据维度归一化消除-host-侧-reshape-物理拷贝)
+- [7. Dtype 性能特化](#7-dtype-性能特化)
 
 ---
 
@@ -180,7 +181,8 @@ def check_special_masks(actual, golden):
 1. stride/shape 参数作为 `@tilelang.jit` 函数的 Python 参数传入（JIT 编译期常量），**不打包成 GM tensor**
 2. kernel 内用 `T.alloc_var` 累加偏移，stride 直接用于地址计算（静态展开，最多约 6 个 batch 轴）
 3. `T.copy` 不暴露 stride 参数：每次只搬一段物理连续的数据，非连续方向用逐行循环搬运
-4. 纯 Vector 算子不开 `AUTO_CV_COMBINE`（`alloc_var` 赋值/读取需在同一核）
+4. 若启用 `AUTO_CV_COMBINE`，检查生成代码中 `alloc_var` 的定义和使用是否在正确核；
+   只有确认发生误分核时才关闭该配置
 
 **使用方法**：
 
@@ -188,7 +190,8 @@ def check_special_masks(actual, golden):
 host 侧：
   1. 计算 row-major strides（纯 Python 整数运算）
   2. 把 stride 值作为 Python int 传入 @tilelang.jit 函数参数
-  3. x.reshape(total_numel) 作为 1D flat 输入（contiguous 张量的 reshape 是零拷贝 view）
+  3. 仅当输入 storage 本来连续且目标 flatten 与 stride 兼容时，传入共享 storage 的
+     1D view；否则保留原 rank，让 kernel 按原 shape/stride 计算合法连续 BufferRegion
 
 kernel 内：
   1. T.alloc_var 声明累加变量（boff_s, bidx_s 等）
@@ -206,7 +209,8 @@ kernel 内：
 
 **使用方法**：当 perm 可以分解为"连续轴组交换"（`prefix + A + B → prefix + B + A`）时，host 侧直接 `reshape(batch, M, N)`（零拷贝），调用 3D kernel 完成 `(batch, M, N) → (batch, N, M)`。
 
-> **判定**：`x.is_contiguous() == True` 时 `reshape` 安全；`False` 则必须用方案 A。
+> **判定**：`x.is_contiguous() == True` 是常见充分条件；为 False 时仍需检查目标
+> shape 与 stride 的兼容性及是否共享 storage，不能直接断言一定复制。
 
 > **适用条件**：不限于 transpose——任何算子需要对非 contiguous 张量做维度归一化时均可使用方案 A；输入本身 contiguous 且可分解为连续轴组交换时可用方案 B。
 

--- a/.agents/skills/tilelang-op-develop/references/troubleshooting.md
+++ b/.agents/skills/tilelang-op-develop/references/troubleshooting.md
@@ -140,6 +140,16 @@ block_M = [bs for bs in [64, 128] if bs <= M]  # 排除 256
 
 ## 运行时错误
 
+### 0. 先按执行阶段归因 aclnn 报错
+
+看到 `aclnnInplaceRandom`、`aclnnCast`、`aclnnCopy` 等名称时，先定位它发生在
+输入准备、kernel launch、golden 还是结果验证阶段。`aclnnInplaceRandom` 表示测试
+在 NPU 上生成/改写随机输入，不是 kernel 内存不足、精度失败或 kernel 超时。
+
+评测兼容测试应在 CPU 完成随机数、特殊值注入、dtype 转换和 golden 物理重排，
+随后只执行 H2D → TileLang kernel → D2H。不得把 host/test aclnn 缺失误诊为 NPU
+容量问题，也不得通过跳过 large case 规避。
+
 ### 1. 结果不正确
 
 **可能原因**:

--- a/.agents/skills/tilelang-perf-optimization/SKILL.md
+++ b/.agents/skills/tilelang-perf-optimization/SKILL.md
@@ -67,13 +67,24 @@ print(func.get_kernel_source())
 
 ### Step 3: 识别优化点（强制，禁止与 Step 4 合并）
 
-根据算子类型阅读 `optimization-guide.md` 对应章节 + `performance-antipatterns.md`，如果是 cube 核额外参考 `best-practices/cube_optimization_path.md`，如果是 vector 核额外参考 `vector-practices/` 目录下的文档，在 `optimization_log.md` 中输出：
+先读取 `optimization-guide.md` 的目录和各章节标题 + `performance-antipatterns.md` 的各条目标题，根据算子类型（Step 2 判定）和算子实现特征初步筛选出可能适用的优化点清单。再针对每个候选优化点，读取其"适用场景"、"约束"、"使用条件"等描述，确认是否真正适用。如果是 cube 核额外参考 `best-practices/cube_optimization_path.md`，如果是 vector 核额外参考 `vector-practices/` 目录下的文档。
+
+在 `optimization_log.md` 中输出：
 
 **Part A 优化点清单**：逐条标注适用/不适用 + 原因 + 参考文件行号。`pass_configs` 不是独立优化点，是伴随修改。
 
 ```
 [#1] [名称]（参考: optimization-guide.md L445-L650 §2.13）：[适用/不适用] — [原因]
 ```
+
+若候选方案包含“复用现有 kernel，但扩大它的调用域”（新增 shape、batch、dtype、
+尾块或多 stage），Part A 就必须先写 `[KERNEL-REUSE-PRECHECK]`，按该候选优化点
+在 `optimization-guide.md` 中定义的兼容性维度检查当前 kernel。任何维度不能从当前
+代码直接证明时，候选描述必须写成“需先修复/新建 kernel，再实施调用方改造”，不得在
+ORDER-PLAN 中写“直接复用现有 kernel”。Step 4-B 的 `[KERNEL-REUSE-AUDIT]`
+是 Edit 前的最终复核，不是第一次发现兼容性问题。
+
+> **重点**：每节都需读取其"适用场景"和"约束"描述确认是否适用。仅当章节标题明确标注了特定算子类型专属（如"Cube 核"）且当前算子不属于该类型时，才可初步排除；其余所有章节必须读约束确认，不得仅凭标题或算子类型跳过。
 
 **Part B `[ORDER-PLAN]`**：分析依赖关系，排出实施顺序链。依赖分析三条规则：
 1. **布局依赖**：改变 layout 的优化排在依赖此 layout 的优化之前
@@ -98,10 +109,22 @@ print(func.get_kernel_source())
 
 **门禁**：`[ORDER-CHECK]` 未写禁止 Read；`[IMPL-#N]` 未写禁止 Edit；`[RESULT-#N]` 未写禁止下一个。
 
+**Step 4-B 复用 kernel 的兼容性门禁**：若优化会扩大现有 kernel 的调用域，Edit
+调用方、dispatch 或 planner 前必须先读取该优化点在 `optimization-guide.md` 中的
+兼容性清单，并在日志写 `[KERNEL-REUSE-AUDIT]`。任一维度为 `unknown/false`，
+禁止直接复用；必须先修复或新建 kernel，并单独验证后才能扩大调用域。原路径的 case
+通过不能证明扩展后的调用域安全。
+
+例如“离散重排 fallback 的多阶段连续化”使用
+[optimization-guide.md §2.17](references/optimization-guide.md#217-离散重排-fallback-的多阶段连续化)
+定义的 stage table、tile、core、tail、multibatch、specialization 审计；其他优化点
+使用各自章节定义的约束，不机械套用这些 layout 专属字段。
+
 **日志格式**：
 ```
 [ORDER-CHECK] 准备实施: [#N] [名称] | 前置依赖: [#1 ✅ / #2 ❌] | 结论: [✅/❌]
 [IMPL-#N] 已阅读 <文件> L行号（§X.X），关键约束: ...
+[KERNEL-REUSE-AUDIT] 依据: <optimization-guide 章节> | 兼容性维度及结论: ...
 [SELF-CHECK] 本次 Edit 只涉及 [#N]
 [RESULT-#N] 优化点: [名称] | 精度: [pass/fail] | 性能: [X us] | 对比: [+/-X%]
 ```

--- a/.agents/skills/tilelang-perf-optimization/SKILL.md
+++ b/.agents/skills/tilelang-perf-optimization/SKILL.md
@@ -77,12 +77,19 @@ print(func.get_kernel_source())
 [#1] [名称]（参考: optimization-guide.md L445-L650 §2.13）：[适用/不适用] — [原因]
 ```
 
-若候选方案包含“复用现有 kernel，但扩大它的调用域”（新增 shape、batch、dtype、
-尾块或多 stage），Part A 就必须先写 `[KERNEL-REUSE-PRECHECK]`，按该候选优化点
-在 `optimization-guide.md` 中定义的兼容性维度检查当前 kernel。任何维度不能从当前
-代码直接证明时，候选描述必须写成“需先修复/新建 kernel，再实施调用方改造”，不得在
-ORDER-PLAN 中写“直接复用现有 kernel”。Step 4-B 的 `[KERNEL-REUSE-AUDIT]`
-是 Edit 前的最终复核，不是第一次发现兼容性问题。
+若候选会扩大现有 kernel 的调用域（新增 shape、batch、dtype、尾块或多 stage），
+Part A 必须先写：
+
+```text
+[KERNEL-REUSE-PRECHECK]
+candidate: <优化点及 reference 章节>
+expanded_domain: <新增调用域>
+compatibility_dimensions: <从该章节读取，不自行猜测>
+unknown_or_false: <none/列表>
+plan: direct-reuse / repair-kernel-first / new-kernel-first
+```
+
+存在 `unknown/false` 时，ORDER-PLAN 不得写 direct reuse。
 
 > **重点**：每节都需读取其"适用场景"和"约束"描述确认是否适用。仅当章节标题明确标注了特定算子类型专属（如"Cube 核"）且当前算子不属于该类型时，才可初步排除；其余所有章节必须读约束确认，不得仅凭标题或算子类型跳过。
 
@@ -109,22 +116,15 @@ ORDER-PLAN 中写“直接复用现有 kernel”。Step 4-B 的 `[KERNEL-REUSE-A
 
 **门禁**：`[ORDER-CHECK]` 未写禁止 Read；`[IMPL-#N]` 未写禁止 Edit；`[RESULT-#N]` 未写禁止下一个。
 
-**Step 4-B 复用 kernel 的兼容性门禁**：若优化会扩大现有 kernel 的调用域，Edit
-调用方、dispatch 或 planner 前必须先读取该优化点在 `optimization-guide.md` 中的
-兼容性清单，并在日志写 `[KERNEL-REUSE-AUDIT]`。任一维度为 `unknown/false`，
-禁止直接复用；必须先修复或新建 kernel，并单独验证后才能扩大调用域。原路径的 case
-通过不能证明扩展后的调用域安全。
-
-例如“离散重排 fallback 的多阶段连续化”使用
-[optimization-guide.md §2.17](references/optimization-guide.md#217-离散重排-fallback-的多阶段连续化)
-定义的 stage table、tile、core、tail、multibatch、specialization 审计；其他优化点
-使用各自章节定义的约束，不机械套用这些 layout 专属字段。
+Edit 调用方、dispatch 或 planner 前，再写 `[KERNEL-REUSE-AUDIT]` 复核候选章节规定的
+兼容性维度。任一项仍为 unknown/false，先修复或新建 kernel，并单独验证后再扩大调用域。
+不同优化点使用各自 reference 章节的维度，不套用其他优化的专属字段。
 
 **日志格式**：
 ```
 [ORDER-CHECK] 准备实施: [#N] [名称] | 前置依赖: [#1 ✅ / #2 ❌] | 结论: [✅/❌]
 [IMPL-#N] 已阅读 <文件> L行号（§X.X），关键约束: ...
-[KERNEL-REUSE-AUDIT] 依据: <optimization-guide 章节> | 兼容性维度及结论: ...
+[KERNEL-REUSE-AUDIT] 依据: <章节> | 维度及结论: <...> | 结论: <reuse/repair/new>
 [SELF-CHECK] 本次 Edit 只涉及 [#N]
 [RESULT-#N] 优化点: [名称] | 精度: [pass/fail] | 性能: [X us] | 对比: [+/-X%]
 ```

--- a/.agents/skills/tilelang-perf-optimization/references/optimization-guide.md
+++ b/.agents/skills/tilelang-perf-optimization/references/optimization-guide.md
@@ -4,11 +4,24 @@
 
 - [一、优化优先级与算子类型对应](#一优化优先级与算子类型对应)
 - [二、核内优化](#二核内优化)
+  - [2.1 Split-K 切分策略（Cube 核）](#21-split-k-切分策略cube-核)
+  - [2.2 Double Buffer（Cube / Vector 核通用）](#22-double-buffercube--vector-核通用)
+  - [2.3 MTE2 预取优化（Cube 核）](#23-mte2-预取优化cube-核)
+  - [2.4 减少重复载入 / Full-Load（Cube 核）](#24-减少重复载入--full-loadcube-核)
+  - [2.5 小数据块合并载入（Cube 核）](#25-小数据块合并载入cube-核)
+  - [2.6 指令向量化（Vector 核）](#26-指令向量化vector-核)
+  - [2.7 指令融合（Vector 核）](#27-指令融合vector-核)
+  - [2.8 稀疏访存优化（Vector 核）](#28-稀疏访存优化vector-核)
+  - [2.9 Fixed Core 模式（所有算子类型通用）](#29-fixed-core-模式所有算子类型通用)
+  - [2.10 pass_configs 调优（最后手段）](#210-pass_configs-调优最后手段)
   - [2.11 UB 预算优化（Vector 核 tile size 首选方法）](#211-ub-预算优化vector-核-tile-size-首选方法)
   - [2.12 Host 侧预处理内化（消除 pad / contiguous）](#212-host-侧预处理内化消除-pad--contiguous)
+  - [2.12.1 Stride Buffer 归一化（消除非连续数据的 host 物理拷贝）](#2121-stride-buffer-归一化消除非连续数据的-host-物理拷贝)
   - [2.13 多行 Tile 粒度扩展（Multi-row Tile Granularity）](#213-多行-tile-粒度扩展multi-row-tile-granularity)
   - [2.14 Host 侧 D2H 消除（输出后处理 NPU 化）](#214-host-侧-d2h-消除输出后处理-npu-化)
   - [2.15 正交轴向量化（Orthogonal Axis Vectorization）](#215-正交轴向量化orthogonal-axis-vectorization)
+  - [2.16 特定 dtype 的硬件指令适配（Dtype-Specific Hardware Path Adaptation）](#216-特定-dtype-的硬件指令适配dtype-specific-hardware-path-adaptation)
+  - [2.17 离散重排 fallback 的多阶段连续化](#217-离散重排-fallback-的多阶段连续化)
 - [三、核间优化](#三核间优化)
 - [四、常见问题速查](#四常见问题速查)
 
@@ -702,6 +715,8 @@ if partial > 0:
 
 **适用场景**：Host 中有 `F.pad` / `.contiguous()` / padded tensor 传入 kernel。
 
+**诊断方法**：当整体性能不达标时，需分离 host 侧操作耗时和 kernel 耗时，定位瓶颈在 host 还是 kernel。分别计时 host 侧各步操作（`permute`/`reshape`/stride 计算等 view 操作应接近 0；`reshape(-1)` 或 `.contiguous()` 如有显著耗时说明触发了物理拷贝）和 kernel 调用本身。如果 host 操作耗时接近或超过 kernel，说明 host 侧有隐式拷贝，需用本节的 stride buffer 方案消除。任何 host wrapper 中有 `reshape`/`contiguous`/`permute` 等操作的算子均应做此分离诊断。
+
 **核心思路**：Host 直接传原始 tensor（不 pad、不 contiguous），Kernel 用「整块循环 + 余数块」覆盖所有数据，Host 对输出做 view-slice 裁剪。
 
 #### 关键约束
@@ -793,6 +808,20 @@ out = out_LR.movedim(0, d).contiguous()  # 1 次转置
 # 若 kernel 直接输出原始 shape 的布局，则零转置
 ```
 
+**场景 4：`reshape` 对非 contiguous 张量触发隐式拷贝（最隐蔽）**
+
+`reshape` 在张量 contiguous 时是零拷贝 view，但对非 contiguous 张量会触发物理拷贝，等价于 `.contiguous()`。代码中没有 `.contiguous()` 字样，但行为完全相同——是最容易遗漏的性能陷阱。**不限于 transpose 场景**，任何对非 contiguous 张量做 `reshape`（尤其是 `reshape(-1)`）的算子均可能命中。
+
+```python
+# ❌ reshape(-1) 对非 contiguous 张量等价于 .contiguous()
+x_perm = x.permute(perm)                          # 非 contiguous
+x_3d = x_perm.reshape(-1).reshape(batch, M, N)    # reshape(-1) 触发物理拷贝！
+```
+
+**识别方法**：搜索代码中所有 `reshape` 调用，检查其操作的张量是否 contiguous（`x.is_contiguous() == False` 时 `reshape` 触发拷贝）。常见前置非 contiguous 场景：`permute`/`transpose`/`movedim` 后的张量，**但不限于这些**。
+
+**优化方法**：用 stride buffer 归一化替代（host 侧只算 stride 参数传入 kernel，kernel 内逐行搬运），消除 host 侧物理拷贝。详见下方「Stride Buffer 归一化」模式。
+
 **优化方法**：
 
 **方法 1：合并 view 操作，减少 `.contiguous()` 次数**
@@ -869,6 +898,22 @@ out = out_LR.reshape(moved_shape).movedim(0, d).contiguous()
 | dim=last/中间 | 2 次（浪费） | **1 次** | 不适用（N<64 时回退方法 1） |
 
 > **方法 2 的适用条件**：kernel 的并行轴（N）在原始布局中是连续内维，且 N ≥ 向量化对齐要求（通常 64）。当并行轴太窄（如 dim=-1, N=1）时，必须通过转置将正交轴变为连续内维才能向量化，此时只能用方法 1。
+
+---
+
+### 2.12.1 非连续数据归一化（消除 host 侧 reshape 物理拷贝）
+
+**适用场景**：算子输入数据在 GM 中非连续（如 `permute`/`transpose`/`movedim` 后），host 侧用 `reshape(-1)` 或 `.contiguous()` 做物理重排。**不限于 transpose**——任何处理非 contiguous 输入的算子均可能命中。
+
+**约束**：
+- host 侧只算 stride 参数（纯 Python 整数运算），不触发任何物理拷贝
+- stride 作为 `@tilelang.jit` 函数的 Python 参数传入（JIT 编译期常量），**不打包成 GM tensor**（避免额外 GM→UB 搬运）
+- 纯 Vector 算子不开 `AUTO_CV_COMBINE`（`alloc_var` 赋值/读取需在同一核）
+- `T.copy` 不暴露 stride 参数：每次只搬一段物理连续的数据
+
+**思路**：把"数据在哪里"的计算从 host 侧 `reshape`（物理拷贝）转移到 kernel 内 `alloc_var` 累加（零拷贝）。host 侧只传地址偏移参数（JIT 编译期常量），kernel 内逐行搬运。
+
+具体使用方法见 [tilelang-api-best-practices/references/api-compute.md §4.10 Stride 参数作为 JIT 编译期常量传入 kernel](../../tilelang-custom-skill/tilelang-api-best-practices/references/api-compute.md#stride-参数作为-jit-编译期常量传入-kernel避免创建-gm-tensor)。
 
 ---
 
@@ -1361,6 +1406,205 @@ else:
 - [ ] NaN 用 `EQ(curr, curr)` 自比较检测，值用 `T.tile.min` 传播？
 - [ ] has_nan 编译期分路：无 NaN 走 4 op 快路径，有 NaN 走 6 op 慢路径？
 - [ ] 向量化路径与标量路径并存，host 侧按需选择？
+
+---
+
+### 2.16 特定 dtype 的硬件指令适配（Dtype-Specific Hardware Path Adaptation）
+
+**适用场景**：算子使用 `T.tile.transpose` 等 tile 指令，且目标 dtype 是 **bfloat16、int8、int64** 之一。这三种 dtype 不在 `T.tile.transpose` 硬件指令支持集合内（详见 `src/tl_templates/ascend/common.h` L1805-L1823 的模板分支），底层会静默回退到标量路径（逐元素 SetValue），性能下降数十倍。遇到 `T.tile.transpose` + 这三种 dtype 时即应实施本优化点。
+
+> 也适用于其他 `T.tile.xxx` 指令 + 不支持 dtype 的组合，判断准则一致：先到 `common.h` 确认该指令的模板分支条件，再按本节候选路线选择处理方案。
+
+**识别方法（两步，缺一不可）**：
+
+**第一步：分支条件分析法**。读 `src/tl_templates/ascend/common.h` 中目标 tile 指令的 C++ 模板分支条件，列出每个 dtype 的路径归属。以 `T.tile.transpose` 为例，其模板（`common.h` L1805-L1823）有三个分支：
+
+| 分支 | 条件 | 命中 dtype | 路径 |
+|------|------|-----------|------|
+| 1（最优） | `sizeof(T)==2 && !bfloat16_t && M==N==16` | float16, int16 | `AscendC::Transpose` |
+| 2（硬件） | `(sizeof(T)==2 \|\| sizeof(T)==4) && !bfloat16_t && M%16==0 && N%16==0` | float16, int16, float32, int32 | `transpose_block`（TransDataTo5HD） |
+| 3（标量回退） | else | **bfloat16, int8, int64** | `SetValue` 逐元素 |
+
+从表中可直接看出：**标量回退的 dtype 有 3 个**（bfloat16、int8、int64）。bfloat16 虽然 `sizeof==2`，但被 `!std::is_same_v<T, bfloat16_t>` 显式排除；int8（`sizeof==1`）和 int64（`sizeof==8`）因不满足 `sizeof==2 || sizeof==4` 而回退。
+
+> **必须逐个 dtype 检查，不能只看性能最差的 case 就跳过其他 dtype**。三种标量回退 dtype 都有对应的处理方案（见下方候选路线），需要逐一确认当前代码是否已实施。
+
+> **UB 内 M/N 一定是 block 对齐**：使用 block 端点 + `T.tile.fill` 清零方案时，copy 到 UB 的始终是完整的 `[block_M, block_N]`（编译期常量，如 128×128），一定是 16 的倍数。因此分支条件中的 `M%16==0 && N%16==0` 自动满足，前端无感，不需要考虑"M/N 非 16 倍数导致标量回退"的情况。
+
+**第二步：`get_kernel_source()` 验证**。对每个 dtype 编译 kernel 并检查生成代码中是否出现 `SetValue`（标量回退标志）。这一步用于验证第一步的分析结论，特别是当 common.h 的分支条件复杂或经过多轮 lowering 时。
+
+**候选路线（按 dtype 逐一对应，详见 [api-compute.md §4.10](../../tilelang-custom-skill/tilelang-api-best-practices/references/api-compute.md#ttiletranspose-的-dtype-支持与标量回退)）**：
+
+| dtype | 处理方案 | 核心思路 | 关键约束 |
+|-------|---------|---------|---------|
+| **bfloat16** | host 侧 `view(int16)` 零拷贝 reinterpret | bfloat16 与 int16 均 2 字节，transpose 只搬数据不改 bit pattern，可安全 reinterpret | 零开销，不需额外 UB buffer；**这是首选方法** |
+| **int8** | kernel 内 `T.tile.cast` 到 float16 | int8 无同宽硬件 dtype，需 cast 到 float16 后用硬件指令 | 需额外 cal_dtype UB buffer；cast 用 `CAST_NONE`（low→high）/`CAST_RINT`（high→low）；**禁止 host 侧 `.to()` 转换** |
+| **int64** | 路线 B：块 DMA + UB-local 标量 lowering | GM 两侧块 DMA，`T.tile.transpose` 的标量 lowering 限制在 UB 内，禁止逐元素 strided GM 访问 | **不做类型转换**（cast 会丢失高位）；优先 record-aware DMA（路线 A），不满足时用路线 B；标量 lowering 在 UB 内是正确方案，不是"需要消除的标量回退" |
+
+> **int64 路线 B 是正确方案，不是"接受标量回退"**：路线 B 的核心是 GM 两侧用块 DMA（`T.copy` 搬运完整 `[block_M, block_N]`），`T.tile.transpose` 的标量 lowering 只发生在 UB 内部。这与"逐元素 strided GM load/store"（path3 的逐元素 DMA）有本质区别——前者把慢路径限制在 UB，后者直接在 GM 上逐元素操作。若实测路线 B 没有比 baseline 更快，应标为"不适用/无收益"，但不能为了消除 `SetValue` 强制改成逐元素短 DMA。
+
+> **int64 的两条路线**（详见 [api-compute.md "int64 正确实现路线"](../../tilelang-custom-skill/tilelang-api-best-practices/references/api-compute.md#int64-正确实现路线不做类型转换优先聚合-dma否则保留-ub-local-fallback)）：
+> - 路线 A（record-aware DMA）：输入/输出存在共同连续 suffix record，且 `record_bytes = record_len * 8 ≥ 32`，单次地址/长度/gap 满足 DataCopy 约束时使用。
+> - 路线 B（块 DMA + UB-local）：通用 fallback。`T.tile.transpose(b_ub, a_ub)` 标量 lowering 局限在 UB，GM 两侧仍是块 DMA。
+
+> **DataCopy 前置条件**：逐行/record 搬运只有在该连续段本身就是正确输出单位，且地址、单次字节数和 gap 满足当前后端 DataCopy 要求时才成立。尤其 `record_len * dtype_bytes < 32`（如单个 int64 为 8B）时，不能把每个 record 单独 `T.copy` 当作通用方案；应聚合多个相邻 record 使单次搬运达到合法粒度，或回到块 DMA + UB-local reorder。尾块必须用显式 valid extent。
+
+> **⚠️ 禁止在 host 侧做 dtype 转换/拆分来绕过标量回退**：`x.to(torch.int16)` 触发 `aclnnCast`、`.contiguous()` 触发 `aclnnCopy`、`torch.stack` 触发 `aclnnCat`。int32 lane 拆分只有在 kernel 内提取/交织语义和 UB planner 已经端到端验证时才是实验候选，不是默认路线。
+
+#### 检查清单
+
+- [ ] 已用分支条件分析法逐个 dtype 列出路径归属（读 `common.h` 模板分支条件）？bfloat16、int8、int64 三种标量回退 dtype 是否**全部**识别到？
+- [ ] 已用 `get_kernel_source()` 验证每个标量回退 dtype 的生成代码中确实出现 `SetValue`？
+- [ ] bfloat16 是否已用 host 侧 `view(int16)` 零拷贝 reinterpret？
+- [ ] int8 是否已用 kernel 内 `T.tile.cast` 到 float16？（禁止 host 侧 `.to()` 转换）
+- [ ] int64 是否已用路线 B（块 DMA + UB-local 标量 lowering）？GM 两侧是否为块 DMA 而非逐元素 strided GM？
+- [ ] 每次 DataCopy 是否满足连续段、最小粒度、地址/gap 和显式尾块 valid extent？
+- [ ] int64 是否用高 32 位非零数据验证 bit-exact，并在同步后确认无 ACL/AICore 错误？
+- [ ] 是否运行了该优化影响的全部 canonical cases，而非只跑 profiling subset？
+- [ ] host 侧是否有 `.to(dtype)` / `.contiguous()` / `torch.stack` 等触发 aclnn 的操作？（有则必须移入 kernel）
+
+---
+
+### 2.17 离散重排 fallback 的多阶段连续化
+
+**适用场景**：layout transform / transpose 的通用 fallback 因连续
+`record_len` 很短而产生大量离散 GM 访问；目标 permutation 可以分解成有限个相邻
+连续轴组 rotation，每个 stage 可改为块 DMA + UB-local transpose。
+
+这是对 kernel 内离散 fallback 的优化，不属于 §2.12 的 host `.contiguous()` 消除。
+full reversal 只是可能命中的一种 permutation，不是启用条件。
+
+#### 实施顺序：先证明 stage kernel，再写 planner
+
+不得先写 rotation planner 并直接复用现有 path1 kernel。单 stage case 通过不能证明
+该 kernel 能安全处理多 stage 产生的多 batch、双尾块和 `M/N < tile`。
+
+在修改 dispatch 前，必须输出：
+
+```text
+[KERNEL-REUSE-AUDIT]
+stage table: [(batch, M, N), ...]
+tile: true/false + 推导
+core: true/false + physical_core_num/single_core_load
+tail: true/false + 输入/输出 BufferRegion
+multibatch: true/false + 非整除时的 batch 边界证明
+specialization: true/false + dtype 静态 UB 变体
+```
+
+任一项为 false/unknown 时，先新建或修复 stage kernel，不得接入 planner。
+
+#### 为什么“标量 GM 起点 + 完整 tile”会跨 batch
+
+设 stage 输入声明为 `x[batch, M, N]`。下面的写法没有把当前 batch 的合法二维区域
+传给 `T.copy`：
+
+```python
+# 错误
+a_ub = T.alloc_ub((block_M, block_N), dtype)
+T.copy(x[b, m_start, n_start], a_ub)
+```
+
+当 `M=11`、`N=13`、`block_M=block_N=128` 时，一个 batch 只有 `11*13=143`
+个元素，而完整 UB tile 有 `128*128=16384` 个元素。标量起点之后的搬运范围远超
+当前 batch 的 143 个元素，会继续覆盖后续 batch 的物理地址。输出侧若同样使用
+`T.copy(full_ub, y[b, n_start, m_start])`，还会把完整 tile 写入后续 batch。
+因此污染在大 batch 下被重复放大；全 NaN 输入看不出来，稀疏 NaN mask 会直接错位。
+
+这不是 rotation 的轴顺序错误，也不能通过减少物理核数修复。fixed-core 只解决任务
+调度，无法改变每个 task 的非法搬运范围。正确写法必须让 GM 两侧显式携带当前 tile
+的二维 BufferRegion：
+
+```python
+T.copy(
+    x[b,
+      m_start:m_start + block_M,
+      n_start:n_start + block_N],
+    a_ub,
+)
+T.tile.transpose(b_ub, a_ub)
+T.copy(
+    b_ub,
+    y[b,
+      n_start:n_start + block_N,
+      m_start:m_start + block_M],
+)
+```
+
+只有在当前 lowering 已验证会按 tensor 边界裁剪上述 BufferRegion 时才能使用该
+有界 block 端点；否则显式计算 `valid_m/valid_n`，并对 GM 与 UB 两侧都使用有效
+切片。禁止只修输入侧或只修输出侧。
+
+#### 正确的 stage kernel 契约
+
+1. 为每个 stage 基于当前 `M/N`、dtype、静态指令对齐和 UB buffer 总量重新选 tile；
+   不能所有 stage 固定 `128×128`。tile 可以大于尾块，但其静态 shape 必须满足指令
+   对齐且 UB 不超限。
+2. 逻辑任务数与物理核数分离：
+
+```python
+logical_tasks = batch * ceildiv(M, block_M) * ceildiv(N, block_N)
+core_num = max(1, min(logical_tasks, vector_core_count))
+single_core_load = ceildiv(logical_tasks, core_num)
+```
+
+3. kernel 使用 `T.Kernel(core_num)`，每核用 `T.serial(single_core_load)` 覆盖逻辑
+   task；输入和输出 GM 两侧都必须是 BufferRegion：
+
+```python
+with T.Kernel(core_num, is_npu=True) as (cid, vid):
+    a_ub = T.alloc_ub((block_M, block_N), dtype)
+    b_ub = T.alloc_ub((block_N, block_M), dtype)
+    for t in T.serial(single_core_load):
+        task = cid * single_core_load + t
+        if task < logical_tasks:
+            n_blk = task % n_blocks
+            m_blk = (task // n_blocks) % m_blocks
+            b_idx = task // (n_blocks * m_blocks)
+            T.copy(
+                x[b_idx,
+                  m_blk * block_M:(m_blk + 1) * block_M,
+                  n_blk * block_N:(n_blk + 1) * block_N],
+                a_ub,
+            )
+            T.tile.transpose(b_ub, a_ub)
+            T.copy(
+                b_ub,
+                y[b_idx,
+                  n_blk * block_N:(n_blk + 1) * block_N,
+                  m_blk * block_M:(m_blk + 1) * block_M],
+            )
+```
+
+需要 cast 的 dtype 使用独立静态 JIT 变体；不得在 TIR 内条件分配可能未定义或动态
+shape 的 UB。没有合法硬件 transpose 路线的 dtype 不强制进入本优化。
+
+#### planner 与逐步验证
+
+planner 每轮必须从更新后的 `cur_shape/cur_axes` 计算 `batch/M/N`，输出本轮 stage
+表，并在最后断言 axes 等于目标 permutation。接入 dispatch 前先单独验证 stage
+kernel 的以下形态：
+
+- `batch > 1` 且 M/N 都非 tile 整除；
+- `M < block_M`、`N < block_N`；
+- 输入和输出同时存在尾块；
+- 最大 batch 和最大逻辑任务数。
+
+接入 planner 后立即运行所有受影响 canonical cases，特殊浮点值使用“有限值 +
+稀疏 NaN”并严格比较 NaN mask。精度失败时停止本优化，不能继续下一个优化点，也
+不能用旧轮报告或 fallback 路径的通过结果填写当前 `[RESULT]`。
+
+#### 必须规避
+
+- `T.Kernel(logical_tasks)` 直接按逻辑 tile 数启动。
+- `T.copy(x[b, m_start, n_start], full_ub)` 这类标量 GM 起点写法。
+- 认为 fixed-core 可以修复越界/跨 batch；它只改变任务分配，不改变单 task 搬运范围。
+- 只在输入侧添加 BufferRegion，输出仍按完整 UB 写回，或反过来。
+- 所有 stage 固定相同 tile。
+- planner 正确就假定被复用 kernel 也正确。
+- 只验证最终 shape/axes，不验证各 stage 尾块和 batch 边界。
+- 优化失败后静默回退，却报告该优化精度通过或性能有收益。
+
+无端到端收益时保留正确 fallback，并将本优化记录为“不适用/无收益”。
 
 ---
 

--- a/.agents/skills/tilelang-perf-optimization/references/optimization-guide.md
+++ b/.agents/skills/tilelang-perf-optimization/references/optimization-guide.md
@@ -818,7 +818,8 @@ x_perm = x.permute(perm)                          # 非 contiguous
 x_3d = x_perm.reshape(-1).reshape(batch, M, N)    # reshape(-1) 触发物理拷贝！
 ```
 
-**识别方法**：搜索代码中所有 `reshape` 调用，检查其操作的张量是否 contiguous（`x.is_contiguous() == False` 时 `reshape` 触发拷贝）。常见前置非 contiguous 场景：`permute`/`transpose`/`movedim` 后的张量，**但不限于这些**。
+**识别方法**：搜索所有 `reshape`，检查目标 shape 与当前 stride 是否兼容，并验证结果
+是否共享原 storage。`is_contiguous() == True` 是常见充分条件；False 不等于必然复制。
 
 **优化方法**：用 stride buffer 归一化替代（host 侧只算 stride 参数传入 kernel，kernel 内逐行搬运），消除 host 侧物理拷贝。详见下方「Stride Buffer 归一化」模式。
 
@@ -908,7 +909,7 @@ out = out_LR.reshape(moved_shape).movedim(0, d).contiguous()
 **约束**：
 - host 侧只算 stride 参数（纯 Python 整数运算），不触发任何物理拷贝
 - stride 作为 `@tilelang.jit` 函数的 Python 参数传入（JIT 编译期常量），**不打包成 GM tensor**（避免额外 GM→UB 搬运）
-- 纯 Vector 算子不开 `AUTO_CV_COMBINE`（`alloc_var` 赋值/读取需在同一核）
+- 启用 `AUTO_CV_COMBINE` 时检查生成代码中 `alloc_var` 的定义/使用核归属；确认误分核后再关闭
 - `T.copy` 不暴露 stride 参数：每次只搬一段物理连续的数据
 
 **思路**：把"数据在哪里"的计算从 host 侧 `reshape`（物理拷贝）转移到 kernel 内 `alloc_var` 累加（零拷贝）。host 侧只传地址偏移参数（JIT 编译期常量），kernel 内逐行搬运。
@@ -1411,13 +1412,17 @@ else:
 
 ### 2.16 特定 dtype 的硬件指令适配（Dtype-Specific Hardware Path Adaptation）
 
-**适用场景**：算子使用 `T.tile.transpose` 等 tile 指令，且目标 dtype 是 **bfloat16、int8、int64** 之一。这三种 dtype 不在 `T.tile.transpose` 硬件指令支持集合内（详见 `src/tl_templates/ascend/common.h` L1805-L1823 的模板分支），底层会静默回退到标量路径（逐元素 SetValue），性能下降数十倍。遇到 `T.tile.transpose` + 这三种 dtype 时即应实施本优化点。
+**适用场景**：算子声明支持的 dtype 命中目标 tile 指令的非硬件路径，并且基线或生成
+代码证明该路径是实际瓶颈。以 `T.tile.transpose` 为例，检查
+`src/tl_templates/ascend/common.h` 中对应 `Transpose` 模板分支，不依赖容易漂移的固定行号。
 
 > 也适用于其他 `T.tile.xxx` 指令 + 不支持 dtype 的组合，判断准则一致：先到 `common.h` 确认该指令的模板分支条件，再按本节候选路线选择处理方案。
 
 **识别方法（两步，缺一不可）**：
 
-**第一步：分支条件分析法**。读 `src/tl_templates/ascend/common.h` 中目标 tile 指令的 C++ 模板分支条件，列出每个 dtype 的路径归属。以 `T.tile.transpose` 为例，其模板（`common.h` L1805-L1823）有三个分支：
+**第一步：分支条件分析法**。按 `Transpose` 符号定位
+`src/tl_templates/ascend/common.h` 中目标 tile 指令的 C++ 模板分支，列出当前算子所
+支持 dtype 的路径归属，不依赖固定源码行号。
 
 | 分支 | 条件 | 命中 dtype | 路径 |
 |------|------|-----------|------|
@@ -1427,7 +1432,8 @@ else:
 
 从表中可直接看出：**标量回退的 dtype 有 3 个**（bfloat16、int8、int64）。bfloat16 虽然 `sizeof==2`，但被 `!std::is_same_v<T, bfloat16_t>` 显式排除；int8（`sizeof==1`）和 int64（`sizeof==8`）因不满足 `sizeof==2 || sizeof==4` 而回退。
 
-> **必须逐个 dtype 检查，不能只看性能最差的 case 就跳过其他 dtype**。三种标量回退 dtype 都有对应的处理方案（见下方候选路线），需要逐一确认当前代码是否已实施。
+> 只检查算子规格实际支持且受当前修改影响的 dtype；不得要求只支持一种 dtype 的算子
+> 顺带实现其他 dtype。每条候选路线仍需单独验证正确性和收益。
 
 > **UB 内 M/N 一定是 block 对齐**：使用 block 端点 + `T.tile.fill` 清零方案时，copy 到 UB 的始终是完整的 `[block_M, block_N]`（编译期常量，如 128×128），一定是 16 的倍数。因此分支条件中的 `M%16==0 && N%16==0` 自动满足，前端无感，不需要考虑"M/N 非 16 倍数导致标量回退"的情况。
 
@@ -1453,7 +1459,7 @@ else:
 
 #### 检查清单
 
-- [ ] 已用分支条件分析法逐个 dtype 列出路径归属（读 `common.h` 模板分支条件）？bfloat16、int8、int64 三种标量回退 dtype 是否**全部**识别到？
+- [ ] 已对算子规格实际支持且受本次修改影响的 dtype 分析 `common.h` 模板分支？
 - [ ] 已用 `get_kernel_source()` 验证每个标量回退 dtype 的生成代码中确实出现 `SetValue`？
 - [ ] bfloat16 是否已用 host 侧 `view(int16)` 零拷贝 reinterpret？
 - [ ] int8 是否已用 kernel 内 `T.tile.cast` 到 float16？（禁止 host 侧 `.to()` 转换）
@@ -1479,7 +1485,9 @@ full reversal 只是可能命中的一种 permutation，不是启用条件。
 不得先写 rotation planner 并直接复用现有 path1 kernel。单 stage case 通过不能证明
 该 kernel 能安全处理多 stage 产生的多 batch、双尾块和 `M/N < tile`。
 
-在修改 dispatch 前，必须输出：
+识别本优化点时，先在 Part A 输出 `[KERNEL-REUSE-PRECHECK]`；不能从当前代码证明
+stage kernel 满足下列维度时，候选方案应写成“先修复/新建 stage kernel，再实施
+planner”，不能写“直接复用 path1”。进入 Step 4 后，在修改 dispatch 前再次输出：
 
 ```text
 [KERNEL-REUSE-AUDIT]

--- a/.agents/skills/tilelang-perf-optimization/references/performance-antipatterns.md
+++ b/.agents/skills/tilelang-perf-optimization/references/performance-antipatterns.md
@@ -458,6 +458,30 @@ for j in range(1, L):
 
 ---
 
+## 纯 Vector 算子误开 AUTO_CV_COMBINE
+
+**识别特征**：纯 Vector 算子（`get_kernel_source()` 只有 `IS_ASCEND_AIV`），pass_configs 中开了 `TL_ASCEND_AUTO_CV_COMBINE: True`，且 kernel 内使用了 `T.alloc_var`。
+
+**性能/正确性原因**：`AUTO_CV_COMBINE` 会把 `alloc_var` 的赋值分配到 Cube 核、读取分配到 Vector 核。纯 Vector 算子没有 Cube 计算路径，赋值和读取分离到不同核后值不传递，导致地址计算错误（静默数据错位，不报错但结果错误）。**不限于使用 stride buffer 的算子**——任何纯 Vector 算子中使用 `alloc_var` 的情况均受影响。
+
+**替代写法**：纯 Vector 算子**不开** `AUTO_CV_COMBINE`：
+
+```python
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    # 不开 AUTO_CV_COMBINE：纯 Vector 算子不需要，且会导致 alloc_var 跨核
+}
+```
+
+**检查点**：
+- `get_kernel_source()` 是否只有 `IS_ASCEND_AIV`（纯 Vector）？
+- pass_configs 是否开了 `AUTO_CV_COMBINE`？
+- kernel 内是否使用了 `T.alloc_var`？
+- 三者同时满足 → 立即关闭 `AUTO_CV_COMBINE`
+
+---
+
 ## 评审记录模板
 
 发现性能关注项但暂不修改时，在优化记录中写清楚：

--- a/.agents/skills/tilelang-perf-optimization/references/performance-antipatterns.md
+++ b/.agents/skills/tilelang-perf-optimization/references/performance-antipatterns.md
@@ -458,19 +458,21 @@ for j in range(1, L):
 
 ---
 
-## 纯 Vector 算子误开 AUTO_CV_COMBINE
+## 纯 Vector 算子的 AUTO_CV_COMBINE 误分核风险
 
 **识别特征**：纯 Vector 算子（`get_kernel_source()` 只有 `IS_ASCEND_AIV`），pass_configs 中开了 `TL_ASCEND_AUTO_CV_COMBINE: True`，且 kernel 内使用了 `T.alloc_var`。
 
-**性能/正确性原因**：`AUTO_CV_COMBINE` 会把 `alloc_var` 的赋值分配到 Cube 核、读取分配到 Vector 核。纯 Vector 算子没有 Cube 计算路径，赋值和读取分离到不同核后值不传递，导致地址计算错误（静默数据错位，不报错但结果错误）。**不限于使用 stride buffer 的算子**——任何纯 Vector 算子中使用 `alloc_var` 的情况均受影响。
+**风险**：某些 lowering 形态可能把 `alloc_var` 的定义和使用错误分到不同核，但这不是
+“纯 Vector + AUTO_CV_COMBINE + alloc_var”必然失败的全局规则；仓内也有该组合的正向
+测试。必须先检查生成代码或最小复现，确认变量确实跨核且没有正确传递。
 
-**替代写法**：纯 Vector 算子**不开** `AUTO_CV_COMBINE`：
+确认发生误分核后，纯 Vector 算子可关闭不需要的 `AUTO_CV_COMBINE`：
 
 ```python
 PASS_CONFIGS = {
     tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
     tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
-    # 不开 AUTO_CV_COMBINE：纯 Vector 算子不需要，且会导致 alloc_var 跨核
+    # 已通过生成代码确认误分核时，关闭不需要的 AUTO_CV_COMBINE
 }
 ```
 
@@ -478,7 +480,8 @@ PASS_CONFIGS = {
 - `get_kernel_source()` 是否只有 `IS_ASCEND_AIV`（纯 Vector）？
 - pass_configs 是否开了 `AUTO_CV_COMBINE`？
 - kernel 内是否使用了 `T.alloc_var`？
-- 三者同时满足 → 立即关闭 `AUTO_CV_COMBINE`
+- 三者同时满足 → 检查生成代码中变量定义/使用的核归属；仅在确认误分核后关闭
+  `AUTO_CV_COMBINE`
 
 ---
 


### PR DESCRIPTION
根据 transpose 算子生成与优化过程中 提取的skill 修改点：
1. .agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-compute.md 中 添加 T.tile.transpose 的 bfloat16 int64 int8 的正确处理路径，避免走 标量计算路径，依赖PR: https://github.com/tile-ai/tilelang-ascend/pull/1408
2. .agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-kernel-memory.md  补充 无需进行手动 进行尾块处理 补充
3. .agents/skills/tilelang-op-design/examples/design-template.md   添加不允许 host 侧进行 相关底层 aclnn 调用的操作（cann-bench明令禁止）； 前端无需手动进行尾块处理信息补充；
4. .agents/skills/tilelang-op-design/references/ascend-constraints.md 添加 T.copy 不支持列方向 strided 切片 描述；添加 隐式 aclnn 调用规避，及一些方法：host 侧 reshape 降维（仅 contiguous 张量可用）， stride 作为 JIT 编译期常量传入 kernel（推荐）
5. .agents/skills/tilelang-op-design/references/quality-checklist.md 添加不允许 host 侧进行 相关底层 aclnn 调用的操作
6. .agents/skills/tilelang-op-design/SKILL.md  算子 kernel 划分原则  避免 为了在 host 不适用 aclnn 调用，一个示例一个kernel。
7. .agents/skills/tilelang-op-develop/references/coding-conventions.md  添加 T.copy 多维切片的硬件限制 ； 添加NaN/Inf 位置敏感输入与比较，使其特殊值用例必须能发现数据重排、索引和尾块覆盖错误；非连续数据维度归一化（消除 host 侧 reshape 物理拷贝）；
8. .agents/skills/tilelang-op-develop/SKILL.md  添加 算子 kernel 划分原则；  Host 侧 Buffer 操作约束
9. .agents/skills/tilelang-perf-optimization/references/optimization-guide.md  补充目录，使其运行初步识别可用优化点是可用看目录即可；reshape` 对非 contiguous 张量触发隐式拷贝（最隐蔽）情况 优化； 特定 dtype 的硬件指令适配（T.tile.transpose 的 bfloat16 int64 int32 的正确处理路径）；离散tranpose fallback 的多阶段连续化。
10. .agents/skills/tilelang-perf-optimization/references/performance-antipatterns.md 纯 Vector 算子误开 AUTO_CV_COMBINE  
11. .agents/skills/tilelang-perf-optimization/SKILL.md  优化 优化点识别逻辑，先看目录根据类型第一次识别优化点， 

算子优化后效果：（baseline经过 torch.transpose测试进行刷新过）
### Transpose（level3/transpose）

| 指标 | 数值 |
|------|------|
| 用例数 | 20 |
| 通过数 | 20 |
| 失败数 | 0 |
| 通过率 | 100.00% |
| 平均加速比 | 1.82x |
| 编译/运行得分 | 20.00 |
| 精度得分 | 30.00 |
| 性能得分 | 23.23 |
| 得分 | 73.23 |

| 用例ID | 状态 | 耗时(μs) | 加速比 | 精度误差 |
|--------|------|----------|--------|----------|
| level3/transpose_1 | ✅ | 657.61 | 1.61x | 0.000000 |
| level3/transpose_2 | ✅ | 27.48 | 1.68x | 0.000000 |
| level3/transpose_3 | ✅ | 62.24 | 1.22x | 0.000000 |
| level3/transpose_4 | ✅ | 612.75 | 1.25x | 0.000000 |
| level3/transpose_5 | ✅ | 13323.09 | 0.06x | 0.000000 |
| level3/transpose_6 | ✅ | 144.66 | 0.09x | 0.000000 |
| level3/transpose_7 | ✅ | 13.62 | 1.90x | 0.000000 |
| level3/transpose_8 | ✅ | 20.90 | 1.50x | 0.000000 |
| level3/transpose_9 | ✅ | 13.52 | 1.72x | 0.000000 |
| level3/transpose_10 | ✅ | 712.65 | 0.97x | 0.000000 |
| level3/transpose_11 | ✅ | 12.92 | 1.61x | 0.000000 |
| level3/transpose_12 | ✅ | 28.74 | 1.00x | 0.000000 |
| level3/transpose_13 | ✅ | 5.56 | 2.22x | 0.000000 |
| level3/transpose_14 | ✅ | 149.10 | 0.68x | 0.000000 |
| level3/transpose_15 | ✅ | 110092.90 | 0.00x | 0.000000 |
| level3/transpose_16 | ✅ | 30746.37 | 0.00x | 0.000000 |
| level3/transpose_17 | ✅ | 15.78 | 1.41x | 0.000000 |
| level3/transpose_18 | ✅ | 26.06 | 1.21x | 0.000000 |
| level3/transpose_19 | ✅ | 18.00 | 16.24x | 0.000000 |
| level3/transpose_20 | ✅ | 21422.35 | 0.00x | 0.000000 |