### PR TITLE
[Fix] Fallback for rank-changing parallel copies 🤖

### DIFF
--- a/src/transform/ascend_lower_parallel_to_vector.cc
+++ b/src/transform/ascend_lower_parallel_to_vector.cc
@@ -901,6 +901,14 @@ private:
     if (auto load = expr.as<BufferLoadNode>()) {
       Buffer input_buffer = load->buffer;
 
+      // GenerateAscendCopy currently builds source and destination regions
+      // symmetrically. A rank-changing projection needs rank-aware regions,
+      // so use the scalar serial fallback instead of indexing a shape with the
+      // other buffer's rank.
+      if (input_buffer->shape.size() != output_buffer->shape.size()) {
+        return false;
+      }
+
       // Compact->aligned UB->UB copy (different inner/row width) cannot be
       // lowered to copy_ub_to_ub safely: the strided variant needs 32B-aligned
       // per-row UB addresses (sub-32B compact rows trap the VEC instruction),

--- a/testing/python/language/parallel/test_tilelang_ascend_language_parallel_rank_mismatch.py
+++ b/testing/python/language/parallel/test_tilelang_ascend_language_parallel_rank_mismatch.py
@@ -1,0 +1,93 @@
+"""Regression tests for rank-changing T.Parallel buffer projections.
+
+The vector-copy helper assumes matching source and destination ranks. A 2D UB
+row projected into a 1D UB buffer must use the scalar serial fallback rather
+than indexing the 1D destination shape as if it were 2D.
+"""
+
+import pytest
+import tilelang
+import tilelang.language as T
+import torch
+
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    tilelang.cache.clear_cache()
+    yield
+
+
+@pytest.fixture
+def setup_random_seed():
+    torch.manual_seed(0)
+    yield
+
+
+@tilelang.jit(out_idx=[-1], pass_configs=pass_configs)
+def row_projection_kernel(rows, lanes, dtype="float32"):
+    @T.prim_func
+    def main(
+        source: T.Tensor((rows, lanes), dtype),
+        destination: T.Tensor((lanes,), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            source_ub = T.alloc_ub((rows, lanes), dtype)
+            destination_ub = T.alloc_ub((lanes,), dtype)
+            with T.Scope("V"):
+                T.copy(source, source_ub)
+                for lane in T.Parallel(lanes):
+                    destination_ub[lane] = source_ub[rows - 1, lane]
+                T.copy(destination_ub, destination)
+
+    return main
+
+
+@tilelang.jit(out_idx=[-1], pass_configs=pass_configs)
+def rank_matched_row_kernel(rows, lanes, dtype="float32"):
+    @T.prim_func
+    def main(
+        source: T.Tensor((rows, lanes), dtype),
+        destination: T.Tensor((1, lanes), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            source_ub = T.alloc_ub((rows, lanes), dtype)
+            destination_ub = T.alloc_ub((1, lanes), dtype)
+            with T.Scope("V"):
+                T.copy(source, source_ub)
+                for lane in T.Parallel(lanes):
+                    destination_ub[0, lane] = source_ub[rows - 1, lane]
+                T.copy(destination_ub, destination)
+
+    return main
+
+
+def test_parallel_2d_to_1d_projection_uses_serial_fallback(setup_random_seed):
+    rows, lanes = 4, 16
+    kernel = row_projection_kernel(rows, lanes)
+    source = torch.randn((rows, lanes), dtype=torch.float32, device="npu")
+    out = kernel(source)
+
+    torch.testing.assert_close(out, source[-1], rtol=0, atol=0)
+
+    kernel_source = kernel.get_kernel_source()
+    assert "GetValue" in kernel_source
+    assert "SetValue" in kernel_source
+
+
+def test_parallel_rank_matched_projection_remains_valid(setup_random_seed):
+    rows, lanes = 4, 16
+    kernel = rank_matched_row_kernel(rows, lanes)
+    source = torch.randn((rows, lanes), dtype=torch.float32, device="npu")
+    out = kernel(source)
+
+    torch.testing.assert_close(out[0], source[-1], rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-n", "0"])


### PR DESCRIPTION
## Summary

Use the existing scalar serial fallback for rank-changing `T.Parallel` buffer projections. This prevents `AscendLowerParallelToVector` from indexing a one-dimensional destination shape as though it had the source buffer's rank.

## Changes

- Reject the current vector-copy path when source and destination buffer ranks differ
- Reuse the established `T.Parallel` to serial fallback instead of constructing invalid symmetric regions
- Add a 2D UB row to 1D UB regression kernel using a nonzero source row
- Add a rank-matched 2D control kernel
- Check that the rank-changing kernel lowers to scalar `GetValue`/`SetValue`
- Validate both kernels on a real Ascend NPU

## Failure trajectory

For `dst[lane] = src[row, lane]`, vector-plan detection used only the rank-1 destination and accepted a one-dimensional vector plan. The direct BufferLoad path then passed the rank-2 source and rank-1 destination to `GenerateAscendCopy`, which constructed source extents using `destination.shape[0]` and `destination.shape[1]`. Accessing `shape[1]` raised an internal TVM `IndexError` before target code generation.

## Testing

- `make -j$(nproc)` with `USE_ASCEND=ON`
- `python3 -m ruff check testing/python/language/parallel/test_tilelang_ascend_language_parallel_rank_mismatch.py`
- Compile/codegen check: rank-changing projection compiled and emitted scalar `GetValue`/`SetValue`
- `python3 -m pytest testing/python/language/parallel/test_tilelang_ascend_language_parallel_rank_mismatch.py -v -s -n 0`
  - 2 passed
  - 2D-to-1D real-device correctness passed
  - rank-matched control passed
