### PR TITLE
[TEST] Key operator-test skipping and selection off the manifest and the run's scope

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -208,7 +208,10 @@ jobs:
           declare -A source_to_test=()
           declare -A test_to_test=()
           # Collected separately from pytest_files_array: that one is for
-          # testing/python/ and gets collapsed by rules further down.
+          # testing/python/ and gets collapsed by rules further down. Every rule
+          # that decides on a full run clears these along with the rest, or what
+          # was collected before it would be written back afterwards and narrow
+          # the full run to the directory of whichever operator came first.
           declare -A routed_tests=()
           routed_example_dirs=()
           routed_experiment_dirs=()
@@ -269,6 +272,9 @@ jobs:
               experiment_dirs_array=()
               pytest_files_array=()
               pytest_dirs_array=()
+              routed_tests=()
+              routed_example_dirs=()
+              routed_experiment_dirs=()
               break
             fi
             
@@ -341,6 +347,9 @@ jobs:
               experiment_dirs_array=()
               pytest_files_array=()
               pytest_dirs_array=()
+              routed_tests=()
+              routed_example_dirs=()
+              routed_experiment_dirs=()
               break
             fi
 
@@ -361,6 +370,9 @@ jobs:
               experiment_dirs_array=()
               pytest_files_array=()
               pytest_dirs_array=()
+              routed_tests=()
+              routed_example_dirs=()
+              routed_experiment_dirs=()
               break
             fi
             
@@ -378,6 +390,9 @@ jobs:
               experiment_dirs_array=()
               pytest_files_array=()
               pytest_dirs_array=()
+              routed_tests=()
+              routed_example_dirs=()
+              routed_experiment_dirs=()
               break
             fi
           done
@@ -701,10 +716,14 @@ jobs:
                 # one Pytest invocation gets xdist scheduling, the marker filter and the
                 # full failure output. Entries reserved but not migrated yet are absent
                 # from list-tests, so nothing points at a file that does not exist.
+                #
+                # Scoped by the same two arguments the runner just took, so an
+                # incremental run tests the operators in the directories it ran and
+                # no others. Both are empty on a full run, which selects them all.
                 OPERATOR_TESTS=()
                 while IFS= read -r operator_test; do
                   [ -n \"\$operator_test\" ] && OPERATOR_TESTS+=(\"../\$operator_test\")
-                done < <(python ../scripts/ci/resolve_operator_tests.py list-tests)
+                done < <(python ../scripts/ci/resolve_operator_tests.py list-tests \$TEST_DIRS_ARG \$EXPERIMENT_DIRS_ARG)
                 if [ \${#OPERATOR_TESTS[@]} -gt 0 ]; then
                   echo 'Running operator tests: '\${OPERATOR_TESTS[*]}
                   pytest --forked \"\${OPERATOR_TESTS[@]}\" -v -n 8 \"\${PYTEST_MARKER_ARGS[@]}\" 2>&1 | tee -a test_output.log

--- a/examples/bench_test.sh
+++ b/examples/bench_test.sh
@@ -65,6 +65,10 @@ PROJECT_ROOT="$(cd .. && pwd)"
 # runs separately; executing it here as well would compile and run the same
 # kernel twice.
 declare -A MIGRATED_SOURCES=()
+# Its test is skipped here for the same reason, and this is how: by the entry
+# that claims it, not by its name. A test this repository never registered
+# belongs to whoever wrote it and is collected like any other script.
+declare -A MIGRATED_TESTS=()
 OPERATOR_TEST_RESOLVER="${PROJECT_ROOT}/scripts/ci/resolve_operator_tests.py"
 if [ -f "$OPERATOR_TEST_RESOLVER" ]; then
     # This script has no `set -e`, so a failure here would otherwise leave the
@@ -73,13 +77,11 @@ if [ -f "$OPERATOR_TEST_RESOLVER" ]; then
         echo "Operator test manifest is invalid" >&2
         exit 1
     fi
-    if ! python "$OPERATOR_TEST_RESOLVER" check-orphans; then
-        echo "Operator test names do not match the manifest" >&2
-        exit 1
-    fi
+    python "$OPERATOR_TEST_RESOLVER" check-orphans
     while IFS=$'\t' read -r source test; do
         [ -n "$source" ] || continue
         MIGRATED_SOURCES["$source"]=1
+        MIGRATED_TESTS["$test"]=1
     done < <(python "$OPERATOR_TEST_RESOLVER" list --format tsv)
 fi
 
@@ -179,6 +181,10 @@ should_skip_python_script() {
         echo "Skip migrated operator in legacy runner: $candidate" >&2
         return 0
     fi
+    if [[ -n "${MIGRATED_TESTS[$repo_relative]:-}" ]]; then
+        echo "Skip migrated operator test in legacy runner: $candidate" >&2
+        return 0
+    fi
 
     return 1
 }
@@ -204,7 +210,6 @@ collect_test_scripts() {
             # 收集主目录的 py 文件（排除 fa_opt）
             local py_files=$(find "$dir" -maxdepth 1 -name "*.py" \
                 -not -name "__init__.py" \
-                -not -name "test_*.py" \
                 -not -name "*_golden.py" \
                 | sort)
             for f in $py_files; do
@@ -219,7 +224,6 @@ collect_test_scripts() {
     # 搜索 maxdepth 2 的 py 文件（排除特殊文件和 bench_sfa 子目录）
     local py_files=$(find "$dir" -maxdepth 2 -name "*.py" \
         -not -name "__init__.py" \
-        -not -name "test_*.py" \
         -not -name "*_golden.py" \
         -not -name "sfa_golden.py" \
         -not -name "utils.py" \

--- a/examples/bench_test.sh
+++ b/examples/bench_test.sh
@@ -354,20 +354,31 @@ echo "Total scripts to run: ${#all_scripts[@]}"
 # The workflow runs them after this script, so there is nothing to do on the
 # normal path. Coverage is collected by invoking this script by hand, and that
 # path has no workflow behind it: the collection above already skipped these
-# operators by name, their tests are run by nobody, and what they cover of
-# tilelang drops out of the report. They run before the examples so a scoped
-# invocation that collects no script still reaches them, and so they compile
-# against a cold cache.
+# operators, their tests are run by nobody, and what they cover of tilelang
+# drops out of the report. They run before the examples so a scoped invocation
+# that collects no script still reaches them, and so they compile against a
+# cold cache.
+#
+# Narrowed to the directories this invocation was given, as everywhere else
+# those two options appear. A report that mixed the examples of one directory
+# with the operators of all of them would not say what it was measuring.
 operator_exit_code=0
 operator_passed=0
 operator_failed=0
 operator_xfailed=0
 if [ "$ENABLE_COVERAGE" = true ] || [ "$ENABLE_CPP_COVERAGE" = true ]; then
     OPERATOR_TESTS=()
+    OPERATOR_SCOPE_ARGS=()
+    if [ -n "$TEST_DIRS" ]; then
+        OPERATOR_SCOPE_ARGS+=(--dirs $TEST_DIRS)
+    fi
+    if [ -n "$EXPERIMENT_DIRS" ]; then
+        OPERATOR_SCOPE_ARGS+=(--experiment-dirs $EXPERIMENT_DIRS)
+    fi
     if [ -f "$OPERATOR_TEST_RESOLVER" ]; then
         while IFS= read -r operator_test; do
             [ -n "$operator_test" ] && OPERATOR_TESTS+=("${PROJECT_ROOT}/$operator_test")
-        done < <(python "$OPERATOR_TEST_RESOLVER" list-tests)
+        done < <(python "$OPERATOR_TEST_RESOLVER" list-tests "${OPERATOR_SCOPE_ARGS[@]}")
     fi
     if [ ${#OPERATOR_TESTS[@]} -gt 0 ]; then
         echo -e "\n====================================="

--- a/scripts/ci/resolve_operator_tests.py
+++ b/scripts/ci/resolve_operator_tests.py
@@ -147,9 +147,11 @@ def _shell_invoked_tests(repo_root: Path) -> set[str]:
 def find_unregistered_tests(repo_root: Path, active: list[tuple[str, str]], pending: list[tuple[str, str]]) -> list[str]:
     """List example tests that match no manifest entry, live or reserved.
 
-    The legacy runner skips every test_*.py by name, so a test that matches no
-    entry is run by nothing at all while CI stays green. Tests a sibling shell
-    script invokes are exempt: those never went through the manifest.
+    Worth knowing rather than worth failing over: an unregistered test runs as
+    a script in the legacy runner, which is where every test lived before this
+    manifest existed. What it does not get is the Pytest treatment, so saying
+    so gives whoever wrote it the choice. Tests a sibling shell script invokes
+    are exempt: those never went through the manifest.
     """
     expected = {test for _, test in active} | {test for _, test in pending}
     invoked = _shell_invoked_tests(repo_root)
@@ -264,17 +266,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     elif args.command == "check-orphans":
         unregistered = find_unregistered_tests(args.repo_root.resolve(), mappings, pending)
         if unregistered:
-            print("operator tests matching no manifest entry:", file=sys.stderr)
+            print(f"{len(unregistered)} operator test(s) matching no manifest entry:")
             for item in unregistered:
-                print(f"  {item}", file=sys.stderr)
+                print(f"  {item}")
             print(
-                "the legacy runner skips every test_*.py, so a test that matches no "
-                "entry runs nowhere: add it to ci/operator_test_manifest.yaml, or "
-                "check its name against the entry meant to cover it",
-                file=sys.stderr,
+                "each runs as a script in the legacy runner. To have Pytest run one "
+                "instead, add it to ci/operator_test_manifest.yaml; if an entry was "
+                "meant to cover it already, check the name against that entry"
             )
-            return 1
-        print("All operator tests match a manifest entry")
+        else:
+            print("All operator tests match a manifest entry")
     return 0
 
 

--- a/scripts/ci/resolve_operator_tests.py
+++ b/scripts/ci/resolve_operator_tests.py
@@ -166,6 +166,28 @@ def find_unregistered_tests(repo_root: Path, active: list[tuple[str, str]], pend
     return unregistered
 
 
+def _scope_to_dirs(mappings: list[tuple[str, str]], dirs: list[str] | None, experiment_dirs: list[str] | None) -> list[tuple[str, str]]:
+    """Narrow the mappings to the example directories a run was scoped to.
+
+    Neither flag given is a full run, and every mapping belongs to it. One given
+    without the other means that root contributed no directory, not that it is
+    unconstrained, so an absent flag selects nothing rather than everything.
+
+    Matching is on the first directory below the root, since that is the unit
+    the runner takes and an operator may sit a level deeper than it.
+    """
+    if dirs is None and experiment_dirs is None:
+        return mappings
+    wanted = {f"examples/{name}" for name in (dirs or [])}
+    wanted |= {f"examples_experiment/{name}" for name in (experiment_dirs or [])}
+    scoped = []
+    for source, test in mappings:
+        parts = PurePosixPath(source).parts
+        if len(parts) > 2 and "/".join(parts[:2]) in wanted:
+            scoped.append((source, test))
+    return scoped
+
+
 def _print_lines(values: Iterable[str]) -> None:
     for value in values:
         print(value)
@@ -192,7 +214,21 @@ def _build_parser() -> argparse.ArgumentParser:
     list_parser = subparsers.add_parser("list", help="list source-to-test mappings")
     list_parser.add_argument("--format", choices=("tsv",), default="tsv")
 
-    subparsers.add_parser("list-tests", help="list all migrated Pytest files")
+    list_tests_parser = subparsers.add_parser("list-tests", help="list migrated Pytest files")
+    # Named after the runner's own flags so a caller that scoped a run to some
+    # directories can hand this the value it handed the runner, unchanged.
+    list_tests_parser.add_argument(
+        "--dirs",
+        nargs="*",
+        default=None,
+        help="limit to tests whose operator lives under one of these examples/ directories",
+    )
+    list_tests_parser.add_argument(
+        "--experiment-dirs",
+        nargs="*",
+        default=None,
+        help="the same, for examples_experiment/",
+    )
     subparsers.add_parser("list-sources", help="list all sources excluded from the legacy runner")
     subparsers.add_parser(
         "check-orphans",
@@ -221,7 +257,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     elif args.command == "list":
         _print_lines(f"{source}\t{test}" for source, test in mappings)
     elif args.command == "list-tests":
-        _print_lines(test for _, test in mappings)
+        scoped = _scope_to_dirs(mappings, args.dirs, args.experiment_dirs)
+        _print_lines(test for _, test in scoped)
     elif args.command == "list-sources":
         _print_lines(source for source, _ in mappings)
     elif args.command == "check-orphans":


### PR DESCRIPTION
## 背景

算子测试迁移（#1489 / #1497）落地后发现三个问题，共同点是判断依据用错了：该看登记表的地方看了文件名，该看本次运行范围的地方读了整张登记表。

三处修改互相独立，分三个 commit。

| # | 问题 | 影响 | 改在哪 |
| --- | --- | --- | --- |
| 1 | 四条"判定全量"的规则没有清空 #1489 新加的三个变量，循环外又把它们写回 `test_dirs_array` | 改核心文件时若同时改了已迁移算子，全量 examples 静默缩水成一个目录，CI 仍全绿 | `ci_cd.yml` |
| 2 | 兜底算子测试读整张登记表，不看本次跑了哪些目录 | 改一个 example 会把所有已登记的算子测试跑一遍 | `ci_cd.yml`、`bench_test.sh` |
| 3 | `find` 用 `-not -name "test_*.py"` 按文件名排除所有测试 | 未登记的测试谁都不跑；主仓现有三个这样的文件合并后会静默停跑；`check-orphans` 还会让别人的 PR 直接失败 | `bench_test.sh`、`resolve_operator_tests.py` |

---

## 1. 保证全量运行是全量

`detect_changes` 的循环里，四条判定全量的规则都是"清空已收集的数组 + `break`"。#1489 加的 `routed_tests` / `routed_example_dirs` / `routed_experiment_dirs` 不在清理清单里，`break` 之后仍带着值，循环外的归并把它们写回了 `test_dirs_array`，于是 `test_dirs` 从空（= 跑全部）变成了单个目录。

`git diff --name-only` 按字典序输出，`examples/` 永远排在 `tilelang/`、`src/`、`requirements*`、`install_ascend.sh` 前面，所以算子总是先被收集、再撞上全量规则——必然触发，不是偶发。

改法是把这三个变量加进四处清理清单，与相邻写法一致，没有引入新机制。

```bash
 test_dirs_array=()
 experiment_dirs_array=()
 pytest_files_array=()
 pytest_dirs_array=()
+routed_tests=()
+routed_example_dirs=()
+routed_experiment_dirs=()
 break
```

主仓原有的四条全量规则、examples 增量规则、`check_skip_pytest` 未做任何修改。

---

## 2. 算子测试跟随运行范围

`run_examples` 末尾补跑已迁移算子测试是必要的（它们的源文件被 runner 全局跳过），但不该无视范围。`TEST_DIRS_ARG` 本身就是字面的 `--dirs a b c`（全量时为空串），让 `list-tests` 认同样的参数即可原样传下去。

```bash
-done < <(python ../scripts/ci/resolve_operator_tests.py list-tests)
+done < <(python ../scripts/ci/resolve_operator_tests.py list-tests $TEST_DIRS_ARG $EXPERIMENT_DIRS_ARG)
```

`bench_test.sh` 里手工跑覆盖率的那段同样处理，否则 `--coverage --dirs foo` 会产出"一个目录的 examples + 全部算子"的混口径报告。

`list-tests` 新增 `--dirs` / `--experiment-dirs`：两个都不给是全量；只给一个时另一个视为空集；按根目录下第一层目录匹配（算子可能更深一层，如 `examples/tile_kernels/moe/…` 归 `tile_kernels`）。

---

## 3. 跳过依据改为登记表

`find` 按文件名排除 `test_*.py` 是随迁移加进来的，主仓没有，而且与算子的处理方式不对称——算子查登记表，测试看名字。

改成与算子一致：新增 `MIGRATED_TESTS`，在 `should_skip_python_script` 里查一次，然后删掉那两行按名字的排除。四个收集点原本就都经过该函数，无需另加调用。

登记过的测试交给 Pytest，没登记的照旧由 runner 当脚本收集执行——这是登记表出现之前的行为。名字写错的测试也不会再无声消失：它会被当脚本执行，而 runner 要求输出中出现 `KERNEL OUTPUT MATCH` 或 `TEST PASSED!`，Pytest 风格的文件什么都不打印，直接判 `[FAILED]`。

`check-orphans` 随之从报错降级为提示。它原来的理由是"未登记的测试跑不到任何地方"，改完之后不再成立；而且登记表是本分支的内部约定，不应该让其他人的 PR 因此失败。

---

## 测试

改动前后各跑一次 `bash bench_test.sh --coverage`（`docs/coverage_guide.md` 里的原样命令），在一棵 48 条登记生效的树上：

| | 改动前 | 改动后 |
| --- | --- | --- |
| 退出码 / 用时 / OOM | 0 / 44m50s / 0 | 0 / 45m09s / 0 |
| 算子测试 | 95 passed / 48 files | 95 passed / 48 files |
| 收集脚本数 | 98 | 98 |
| Pytest | 1535 passed, 2 xfailed | 1535 passed, 2 xfailed |
| coverage 数据文件 | 142 | 142 |
| `coverage.json` | 28899324 字节 | 28899324 字节 |
| Python 覆盖率 | 74.34% | 74.34% |

`coverage.json` 字节级相同 —— 不带 `--dirs` 时覆盖数据无任何变化。

路由决策：抽出 `detect_changes` 原样跑 29 组改动组合。六种"核心文件 + 已迁移算子"的组合从 `test_dirs=[batch_gemm]` 恢复为 `[]`；其余 23 组决策不变（新增 example、改未登记算子、只改 `testing/python`、只改 docs、算子与其测试同改去重成一个、跨两个根目录混合改动等）。

范围过滤：

| 传入 | 选中 |
| --- | --- |
| 无参数（全量） | 48 |
| `--dirs batch_gemm` | 1 |
| `--dirs elementwise`（无已登记算子） | 0 |
| `--dirs tile_kernels`（算子在两层子目录） | 2 |
| `--dirs HISA flash_attention` | 9 |
| `--experiment-dirs cumsum_kda` | 1 |

收集与执行：

| 项 | 结果 |
| --- | --- |
| 未登记的测试被收集 | 0 → 1 |
| 已登记的测试混进收集清单（跑两遍） | 0 |
| 未登记的测试当脚本跑 | `[PASSED]` |
| 名字写错的 Pytest 风格测试当脚本跑 | `[FAILED]` |
| 全量 `--skip-pytest` | 98 脚本 / 98 通过 / 跳过 48 源 + 44 测试 / 重复 0 |

另：登记表 140 条的源文件在 `ascendc_pto` 当前 HEAD 上全部存在，合并不会导致 `validate` 失败。

---

## 对其他贡献者的影响

登记表 140 条中目前仅 3 条生效（测试文件已落地），其余 137 条为占位，对应算子仍走原有 runner。

| 动作 | 变化 |
| --- | --- |
| 新增 example，或新增 example 及其测试 | 无 |
| 修改任一未迁移的算子 | 无 |
| 修改 `tilelang/` 等核心文件 | 无（本 PR 修复后恢复为全量） |
| 修改 `testing/python/` 或文档 | 无 |
| 提交未登记的测试 | 不再被 `check-orphans` 拦下，且会被当脚本执行 |
| 修改 3 个已迁移算子之一 | 改由其 Pytest 测试覆盖 |

需要留意：登记表中列出的算子源文件如被改名或删除，需同步修改 `ci/operator_test_manifest.yaml` 对应条目，否则 `validate` 会在 runner 启动时报 `source does not exist`。修改文件内容不受影响。
