### PR TITLE
[Test] Route migrated operator tests through Pytest

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -202,6 +202,26 @@ jobs:
           pytest_files_array=()
           pytest_dirs_array=()
 
+          # A migrated operator is covered by its Pytest test, so a change to either
+          # one only needs that test; there is no reason to run the whole directory.
+          declare -A source_to_test=()
+          declare -A test_to_test=()
+          # Collected separately from pytest_files_array: that one is for
+          # testing/python/ and gets collapsed by rules further down. Every rule
+          # that decides on a full run clears these along with the rest, or what
+          # was collected before it would be written back afterwards and narrow
+          # the full run to the directory of whichever operator came first.
+          declare -A routed_tests=()
+          routed_example_dirs=()
+          routed_experiment_dirs=()
+          if [ -f scripts/ci/resolve_operator_tests.py ]; then
+            while IFS=$'\t' read -r source test; do
+              [[ -n "$source" && -n "$test" ]] || continue
+              source_to_test["$source"]="$test"
+              test_to_test["$test"]="$test"
+            done < <(python scripts/ci/resolve_operator_tests.py list --format tsv)
+          fi
+
           for file in $changed_files; do
             # 排除 .agents 目录（skill 配置，无需测试）
             if [[ "$file" =~ ^\.agents/ ]]; then
@@ -251,9 +271,37 @@ jobs:
               experiment_dirs_array=()
               pytest_files_array=()
               pytest_dirs_array=()
+              routed_tests=()
+              routed_example_dirs=()
+              routed_experiment_dirs=()
               break
             fi
             
+            if [[ -n "${source_to_test[$file]:-}" ]]; then
+              mapped_test="${source_to_test[$file]}"
+              routed_tests["$mapped_test"]=1
+              if [[ "$file" =~ ^examples/([^/]+)/ ]]; then
+                routed_example_dirs+=("${BASH_REMATCH[1]}")
+              elif [[ "$file" =~ ^examples_experiment/([^/]+)/ ]]; then
+                routed_experiment_dirs+=("${BASH_REMATCH[1]}")
+              fi
+              should_skip=false
+              echo "Mapped migrated operator $file -> $mapped_test"
+              continue
+            fi
+
+            if [[ -n "${test_to_test[$file]:-}" ]]; then
+              routed_tests["$file"]=1
+              if [[ "$file" =~ ^examples/([^/]+)/ ]]; then
+                routed_example_dirs+=("${BASH_REMATCH[1]}")
+              elif [[ "$file" =~ ^examples_experiment/([^/]+)/ ]]; then
+                routed_experiment_dirs+=("${BASH_REMATCH[1]}")
+              fi
+              should_skip=false
+              echo "Mapped migrated test: $file"
+              continue
+            fi
+
             # examples 文件 → 增量 examples + pytest
             if [[ "$file" =~ ^examples/([^/]+)/ ]]; then
               test_dir="${BASH_REMATCH[1]}"
@@ -298,6 +346,9 @@ jobs:
               experiment_dirs_array=()
               pytest_files_array=()
               pytest_dirs_array=()
+              routed_tests=()
+              routed_example_dirs=()
+              routed_experiment_dirs=()
               break
             fi
 
@@ -318,6 +369,9 @@ jobs:
               experiment_dirs_array=()
               pytest_files_array=()
               pytest_dirs_array=()
+              routed_tests=()
+              routed_example_dirs=()
+              routed_experiment_dirs=()
               break
             fi
             
@@ -335,6 +389,9 @@ jobs:
               experiment_dirs_array=()
               pytest_files_array=()
               pytest_dirs_array=()
+              routed_tests=()
+              routed_example_dirs=()
+              routed_experiment_dirs=()
               break
             fi
           done
@@ -359,6 +416,39 @@ jobs:
           
           test_dirs="${test_dirs_array[*]}"
           experiment_dirs="${experiment_dirs_array[*]}"
+          # Decided after the collapsing above, and overriding it: those two rules
+          # (one subdirectory replaces the list, more than three empties it) exist
+          # for testing/python/ and would drop these entries. Nothing else queued
+          # means the whole change is migrated tests, so run exactly those.
+          if [[ ${#routed_tests[@]} -gt 0 ]]; then
+            if [[ ${#pytest_files_array[@]} -eq 0 ]] \
+               && [[ ${#pytest_dirs_array[@]} -eq 0 ]] \
+               && [[ ${#test_dirs_array[@]} -eq 0 ]] \
+               && [[ ${#experiment_dirs_array[@]} -eq 0 ]] \
+               && [[ "$run_examples" == false ]]; then
+              pytest_files="${!routed_tests[*]}"
+              run_pytest_only=true
+              echo "Only migrated tests changed: ${pytest_files}"
+            else
+              run_examples=true
+              run_pytest_only=false
+              pytest_files=""
+              for routed_dir in "${routed_example_dirs[@]}"; do
+                if [[ ! " ${test_dirs_array[*]} " =~ " $routed_dir " ]]; then
+                  test_dirs_array+=("$routed_dir")
+                fi
+              done
+              for routed_dir in "${routed_experiment_dirs[@]}"; do
+                if [[ ! " ${experiment_dirs_array[*]} " =~ " $routed_dir " ]]; then
+                  experiment_dirs_array+=("$routed_dir")
+                fi
+              done
+              test_dirs="${test_dirs_array[*]}"
+              experiment_dirs="${experiment_dirs_array[*]}"
+              echo "Migrated tests alongside other changes: running examples plus every registered test"
+            fi
+          fi
+
           echo "run_examples=${run_examples}" >> $GITHUB_OUTPUT
           echo "run_pytest_only=${run_pytest_only}" >> $GITHUB_OUTPUT
           echo "test_dirs=${test_dirs}" >> $GITHUB_OUTPUT
@@ -591,8 +681,14 @@ jobs:
                 # 只跑 pytest（testing/ 修改）
                 if [ -n \"\$PYTEST_FILES_ARG\" ]; then
                   echo 'Running incremental pytest for: '\$PYTEST_FILES_ARG
+                  # Prefix every path, not just the first: the value can hold several
+                  # files and the rest would otherwise resolve against examples/.
+                  PYTEST_TARGETS=()
+                  for pytest_target in \$PYTEST_FILES_ARG; do
+                    PYTEST_TARGETS+=(\"../\$pytest_target\")
+                  done
                   set +e
-                  pytest --forked ../\$PYTEST_FILES_ARG -v -n 4 \"\${PYTEST_MARKER_ARGS[@]}\" 2>&1 | tee test_output.log
+                  pytest --forked \"\${PYTEST_TARGETS[@]}\" -v -n 4 \"\${PYTEST_MARKER_ARGS[@]}\" 2>&1 | tee test_output.log
                 else
                   echo 'Running full pytest (testing/ modified)'
                   set +e
@@ -614,6 +710,27 @@ jobs:
                   fi
                 fi
                 TEST_EXIT_CODE=\${PIPESTATUS[0]}
+
+                # Operator tests were moved out of the legacy runner, so run them here:
+                # one Pytest invocation gets xdist scheduling, the marker filter and the
+                # full failure output. Entries reserved but not migrated yet are absent
+                # from list-tests, so nothing points at a file that does not exist.
+                #
+                # Scoped by the same two arguments the runner just took, so an
+                # incremental run tests the operators in the directories it ran and
+                # no others. Both are empty on a full run, which selects them all.
+                OPERATOR_TESTS=()
+                while IFS= read -r operator_test; do
+                  [ -n \"\$operator_test\" ] && OPERATOR_TESTS+=(\"../\$operator_test\")
+                done < <(python ../scripts/ci/resolve_operator_tests.py list-tests \$TEST_DIRS_ARG \$EXPERIMENT_DIRS_ARG)
+                if [ \${#OPERATOR_TESTS[@]} -gt 0 ]; then
+                  echo 'Running operator tests: '\${OPERATOR_TESTS[*]}
+                  pytest --forked \"\${OPERATOR_TESTS[@]}\" -v -n 8 \"\${PYTEST_MARKER_ARGS[@]}\" 2>&1 | tee -a test_output.log
+                  OPERATOR_EXIT_CODE=\${PIPESTATUS[0]}
+                  if [ \"\$TEST_EXIT_CODE\" -eq 0 ]; then
+                    TEST_EXIT_CODE=\$OPERATOR_EXIT_CODE
+                  fi
+                fi
                 set -e
               fi
 

--- a/ci/operator_test_manifest.yaml
+++ b/ci/operator_test_manifest.yaml
@@ -1,0 +1,263 @@
+# 算子源文件 -> 它的 Pytest 测试。
+# 一条登记只有在测试文件真实存在时才生效；否则算子照常由
+# examples/bench_test.sh 执行。
+#
+# 覆盖 bench_test.sh 会收集到的全部算子。以下不在此表：
+#   examples/gemm_aot/example_gemm.py —— 拼出的名字与已有的独立脚本
+#     test_example_gemm.py 相同，那个脚本由 run_example_gemm_aot.sh 直接执行。
+#   dispatch_combine/ 与 shmem/ —— bench_test.sh 全量扫描时就排除了。
+#   sparse_flash_attention/bench_sfa/ —— 由 CUSTOM_TASK 按名字驱动，
+#     不按路径收集，跳过逻辑碰不到。
+#   torch_tl_ascend/ 的包内部与 build/ 产物 —— 不是独立算子。
+version: 1
+mappings:
+
+  # examples/HISA
+  examples/HISA/block_sparse_mqa_attn_expert_test.py: examples/HISA/test_block_sparse_mqa_attn_expert_test.py
+  examples/HISA/paged_block_sparse_mqa_attn_expert.py: examples/HISA/test_paged_block_sparse_mqa_attn_expert.py
+
+  # examples/aclgraph
+  examples/aclgraph/rms_rope_aclgraph.py: examples/aclgraph/test_rms_rope_aclgraph.py
+
+  # examples/activation
+  examples/activation/gelu_grad.py: examples/activation/test_gelu_grad.py
+  examples/activation/gelu_mul.py: examples/activation/test_gelu_mul.py
+  examples/activation/sigmoid.py: examples/activation/test_sigmoid.py
+  examples/activation/sigmoidv2.py: examples/activation/test_sigmoidv2.py
+  examples/activation/sigmoidv2_slice.py: examples/activation/test_sigmoidv2_slice.py
+  examples/activation/silu.py: examples/activation/test_silu.py
+  examples/activation/swi_glu.py: examples/activation/test_swi_glu.py
+  examples/activation/swi_glu_grad.py: examples/activation/test_swi_glu_grad.py
+  examples/activation/swi_glu_v2.py: examples/activation/test_swi_glu_v2.py
+  examples/activation/tanh.py: examples/activation/test_tanh.py
+
+  # examples/autotune
+  examples/autotune/example_gemm_autotune.py: examples/autotune/test_example_gemm_autotune.py
+  examples/autotune/example_gemm_carver.py: examples/autotune/test_example_gemm_carver.py
+
+  # examples/batch_gemm
+  examples/batch_gemm/batch_gemm.py: examples/batch_gemm/test_batch_gemm.py
+
+  # examples/causal_conv1d
+  examples/causal_conv1d/causal_conv1d.py: examples/causal_conv1d/test_causal_conv1d.py
+  examples/causal_conv1d/causal_conv1d_pto.py: examples/causal_conv1d/test_causal_conv1d_pto.py
+
+  # examples/compile_flags
+  examples/compile_flags/compile_flags_example.py: examples/compile_flags/test_compile_flags_example.py
+
+  # examples/cross_entropy_loss
+  examples/cross_entropy_loss/example_cross_entro.py: examples/cross_entropy_loss/test_example_cross_entro.py
+
+  # examples/cummin
+  examples/cummin/example_cummin.py: examples/cummin/test_example_cummin.py
+
+  # examples/deepseek_v4
+  examples/deepseek_v4/act_quant.py: examples/deepseek_v4/test_act_quant.py
+  examples/deepseek_v4/hc_split_sinkhorn.py: examples/deepseek_v4/test_hc_split_sinkhorn.py
+  examples/deepseek_v4/int8_gemm.py: examples/deepseek_v4/test_int8_gemm.py
+  examples/deepseek_v4/sparse_attention.py: examples/deepseek_v4/test_sparse_attention.py
+
+  # examples/developer_mode
+  examples/developer_mode/flash_attn_bshd_developer.py: examples/developer_mode/test_flash_attn_bshd_developer.py
+  examples/developer_mode/gelu_mul_developer.py: examples/developer_mode/test_gelu_mul_developer.py
+  examples/developer_mode/gemm_developer.py: examples/developer_mode/test_gemm_developer.py
+  examples/developer_mode/matmul_add_developer.py: examples/developer_mode/test_matmul_add_developer.py
+  examples/developer_mode/matmul_add_developer_vec_cast.py: examples/developer_mode/test_matmul_add_developer_vec_cast.py
+  examples/developer_mode/sparse_flash_attn_developer.py: examples/developer_mode/test_sparse_flash_attn_developer.py
+  examples/developer_mode/sparse_flash_attn_developer_vid_reduce.py: examples/developer_mode/test_sparse_flash_attn_developer_vid_reduce.py
+
+  # examples/elementwise
+  examples/elementwise/elementwise_add.py: examples/elementwise/test_elementwise_add.py
+  examples/elementwise/elementwise_add_pipeline.py: examples/elementwise/test_elementwise_add_pipeline.py
+  examples/elementwise/setvalue_example.py: examples/elementwise/test_setvalue_example.py
+
+  # examples/flash_attention/fa_opt
+  examples/flash_attention/fa_opt/flash_attn_bhsd_ascendc.py: examples/flash_attention/fa_opt/test_flash_attn_bhsd_ascendc.py
+  examples/flash_attention/fa_opt/flash_attn_bhsd_auto_pipeline_h16_d128.py: examples/flash_attention/fa_opt/test_flash_attn_bhsd_auto_pipeline_h16_d128.py
+  examples/flash_attention/fa_opt/flash_attn_bhsd_auto_pipeline_h32_d512.py: examples/flash_attention/fa_opt/test_flash_attn_bhsd_auto_pipeline_h32_d512.py
+  examples/flash_attention/fa_opt/flash_attn_bhsd_expert_h16_d128.py: examples/flash_attention/fa_opt/test_flash_attn_bhsd_expert_h16_d128.py
+
+  # examples/flash_attention
+  examples/flash_attention/flash_attn_bhsd.py: examples/flash_attention/test_flash_attn_bhsd.py
+  examples/flash_attention/flash_attn_bhsd_cc_sync.py: examples/flash_attention/test_flash_attn_bhsd_cc_sync.py
+  examples/flash_attention/paged_flash_attn_bhsd.py: examples/flash_attention/test_paged_flash_attn_bhsd.py
+
+  # examples/fused_sigmoid_gating_delta_rule
+  examples/fused_sigmoid_gating_delta_rule/fused_sigmoid_gating_delta_rule_varlen.py: examples/fused_sigmoid_gating_delta_rule/test_fused_sigmoid_gating_delta_rule_varlen.py
+
+  # examples/gemm
+  examples/gemm/example_gemm.py: examples/gemm/test_example_gemm.py
+  examples/gemm/example_gemm_fp8_pto.py: examples/gemm/test_example_gemm_fp8_pto.py
+  examples/gemm/example_gemm_infer_scope.py: examples/gemm/test_example_gemm_infer_scope.py
+  examples/gemm/example_gemm_intrinsic.py: examples/gemm/test_example_gemm_intrinsic.py
+  examples/gemm/example_gemm_intrinsic_persistent.py: examples/gemm/test_example_gemm_intrinsic_persistent.py
+  examples/gemm/example_gemm_persistent.py: examples/gemm/test_example_gemm_persistent.py
+  examples/gemm/example_gemm_pto_developer.py: examples/gemm/test_example_gemm_pto_developer.py
+  examples/gemm/example_gemm_tail_block_developer.py: examples/gemm/test_example_gemm_tail_block_developer.py
+  examples/gemm/example_gemm_transpose_l1.py: examples/gemm/test_example_gemm_transpose_l1.py
+
+  # examples/gemv
+  examples/gemv/example_gemv_c.py: examples/gemv/test_example_gemv_c.py
+  examples/gemv/example_gemv_v.py: examples/gemv/test_example_gemv_v.py
+
+  # examples/generative_recommendation
+  examples/generative_recommendation/mtgr_ragged_segment_attention.py: examples/generative_recommendation/test_mtgr_ragged_segment_attention.py
+
+  # examples/gqa_fwd_varlen
+  examples/gqa_fwd_varlen/gqa_fwd_varlen.py: examples/gqa_fwd_varlen/test_gqa_fwd_varlen.py
+  examples/gqa_fwd_varlen/perf_gqa_fwd_varlen.py: examples/gqa_fwd_varlen/test_perf_gqa_fwd_varlen.py
+
+  # examples/group_norm
+  examples/group_norm/example_group_norm.py: examples/group_norm/test_example_group_norm.py
+
+  # examples/lightning_indexer
+  examples/lightning_indexer/example_lightning_indexer.py: examples/lightning_indexer/test_example_lightning_indexer.py
+  examples/lightning_indexer/example_lightning_indexer_dynamic_shape.py: examples/lightning_indexer/test_example_lightning_indexer_dynamic_shape.py
+
+  # examples/linear_attention_and_rnn/gdn
+  examples/linear_attention_and_rnn/gdn/gdn_chunk_cumsum.py: examples/linear_attention_and_rnn/gdn/test_gdn_chunk_cumsum.py
+  examples/linear_attention_and_rnn/gdn/gdn_chunk_h.py: examples/linear_attention_and_rnn/gdn/test_gdn_chunk_h.py
+  examples/linear_attention_and_rnn/gdn/gdn_chunk_o.py: examples/linear_attention_and_rnn/gdn/test_gdn_chunk_o.py
+  examples/linear_attention_and_rnn/gdn/gdn_chunk_scaled_dot_kkt.py: examples/linear_attention_and_rnn/gdn/test_gdn_chunk_scaled_dot_kkt.py
+  examples/linear_attention_and_rnn/gdn/gdn_solve_tril.py: examples/linear_attention_and_rnn/gdn/test_gdn_solve_tril.py
+  examples/linear_attention_and_rnn/gdn/gdn_wy_fast.py: examples/linear_attention_and_rnn/gdn/test_gdn_wy_fast.py
+
+  # examples/linear_attention_and_rnn
+  examples/linear_attention_and_rnn/gdn_full.py: examples/linear_attention_and_rnn/test_gdn_full.py
+  examples/linear_attention_and_rnn/linear_attention_causal.py: examples/linear_attention_and_rnn/test_linear_attention_causal.py
+  examples/linear_attention_and_rnn/linear_attention_normalize.py: examples/linear_attention_and_rnn/test_linear_attention_normalize.py
+
+  # examples/linear_attention_and_rnn/opt_gdn
+  examples/linear_attention_and_rnn/opt_gdn/opt_gdn_chunk_cumsum.py: examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_chunk_cumsum.py
+  examples/linear_attention_and_rnn/opt_gdn/opt_gdn_chunk_h.py: examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_chunk_h.py
+  examples/linear_attention_and_rnn/opt_gdn/opt_gdn_chunk_o.py: examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_chunk_o.py
+  examples/linear_attention_and_rnn/opt_gdn/opt_gdn_chunk_scaled_dot_kkt.py: examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_chunk_scaled_dot_kkt.py
+  examples/linear_attention_and_rnn/opt_gdn/opt_gdn_solve_tril.py: examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_solve_tril.py
+  examples/linear_attention_and_rnn/opt_gdn/opt_gdn_wy_fast.py: examples/linear_attention_and_rnn/opt_gdn/test_opt_gdn_wy_fast.py
+
+  # examples/linear_attention_and_rnn
+  examples/linear_attention_and_rnn/opt_gdn_full.py: examples/linear_attention_and_rnn/test_opt_gdn_full.py
+
+  # examples/moe_token_permute
+  examples/moe_token_permute/moe_token_permute.py: examples/moe_token_permute/test_moe_token_permute.py
+  examples/moe_token_permute/moe_token_permute_grad.py: examples/moe_token_permute/test_moe_token_permute_grad.py
+  examples/moe_token_permute/moe_token_unpermute.py: examples/moe_token_permute/test_moe_token_unpermute.py
+  examples/moe_token_permute/moe_token_unpermute_grad.py: examples/moe_token_permute/test_moe_token_unpermute_grad.py
+  examples/moe_token_permute/moe_token_utils.py: examples/moe_token_permute/test_moe_token_utils.py
+
+  # examples/normalization
+  examples/normalization/layer_norm.py: examples/normalization/test_layer_norm.py
+  examples/normalization/rms_norm.py: examples/normalization/test_rms_norm.py
+
+  # examples/pad
+  examples/pad/example_broadcast.py: examples/pad/test_example_broadcast.py
+  examples/pad/example_broadcast_pipeline.py: examples/pad/test_example_broadcast_pipeline.py
+
+  # examples/pipeline
+  examples/pipeline/flash_attn_bshd_pipeline.py: examples/pipeline/test_flash_attn_bshd_pipeline.py
+  examples/pipeline/gemm_v0_pipeline.py: examples/pipeline/test_gemm_v0_pipeline.py
+  examples/pipeline/matmul_add_pipeline.py: examples/pipeline/test_matmul_add_pipeline.py
+  examples/pipeline/sparse_flash_attn_gqa_pipeline.py: examples/pipeline/test_sparse_flash_attn_gqa_pipeline.py
+  examples/pipeline/sparse_flash_attn_gqa_pipeline_pto.py: examples/pipeline/test_sparse_flash_attn_gqa_pipeline_pto.py
+
+  # examples/pos_embedding
+  examples/pos_embedding/rms_norm.py: examples/pos_embedding/test_rms_norm_pos_embedding.py
+  examples/pos_embedding/rms_rope_fused.py: examples/pos_embedding/test_rms_rope_fused.py
+  examples/pos_embedding/rms_rope_fused_mask.py: examples/pos_embedding/test_rms_rope_fused_mask.py
+  examples/pos_embedding/rope.py: examples/pos_embedding/test_rope.py
+  examples/pos_embedding/rope_mask.py: examples/pos_embedding/test_rope_mask.py
+  examples/pos_embedding/rope_mask_bwd.py: examples/pos_embedding/test_rope_mask_bwd.py
+
+  # examples/print
+  examples/print/elementwise_print.py: examples/print/test_elementwise_print.py
+
+  # examples/quant_batch_matmul
+  examples/quant_batch_matmul/example_quant_batch_matmul.py: examples/quant_batch_matmul/test_example_quant_batch_matmul.py
+  examples/quant_batch_matmul/example_quant_matmul.py: examples/quant_batch_matmul/test_example_quant_matmul.py
+
+  # examples/reduce
+  examples/reduce/example_col_reduce_max_slice_buffer.py: examples/reduce/test_example_col_reduce_max_slice_buffer.py
+  examples/reduce/example_reduce_min.py: examples/reduce/test_example_reduce_min.py
+  examples/reduce/example_reduce_min_pipeline.py: examples/reduce/test_example_reduce_min_pipeline.py
+  examples/reduce/example_row_reduce_max_slice_buffer.py: examples/reduce/test_example_row_reduce_max_slice_buffer.py
+
+  # examples/simple_fusion
+  examples/simple_fusion/matmul_add.py: examples/simple_fusion/test_matmul_add.py
+  examples/simple_fusion/matmul_add_infer_scope.py: examples/simple_fusion/test_matmul_add_infer_scope.py
+
+  # examples/softmax
+  examples/softmax/example_online_softmax.py: examples/softmax/test_example_online_softmax.py
+
+  # examples/sort
+  examples/sort/example_merge_sort.py: examples/sort/test_example_merge_sort.py
+
+  # examples/sparse_flash_attention
+  examples/sparse_flash_attention/example_sparse_flash_attn.py: examples/sparse_flash_attention/test_example_sparse_flash_attn.py
+  examples/sparse_flash_attention/example_sparse_flash_attn_dynamic_shape.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_dynamic_shape.py
+  examples/sparse_flash_attention/example_sparse_flash_attn_gqa.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa.py
+  examples/sparse_flash_attention/example_sparse_flash_attn_gqa_pto.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa_pto.py
+  examples/sparse_flash_attention/example_sparse_flash_attn_gqa_pto_developer.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_gqa_pto_developer.py
+  examples/sparse_flash_attention/example_sparse_flash_attn_mask.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_mask.py
+  examples/sparse_flash_attention/example_sparse_flash_attn_mask_pa.py: examples/sparse_flash_attention/test_example_sparse_flash_attn_mask_pa.py
+
+  # examples/tail_mask
+  examples/tail_mask/example_tail_add.py: examples/tail_mask/test_example_tail_add.py
+
+  # examples/tile_kernels/mhc
+  examples/tile_kernels/mhc/head_compute_mix_kernel.py: examples/tile_kernels/mhc/test_head_compute_mix_kernel.py
+
+  # examples/tile_kernels/moe
+  examples/tile_kernels/moe/moe_topk_gate.py: examples/tile_kernels/moe/test_moe_topk_gate.py
+
+  # examples/topk_selector
+  examples/topk_selector/example_topk_selector.py: examples/topk_selector/test_example_topk_selector.py
+
+  # examples/unsorted_segment_sum
+  examples/unsorted_segment_sum/unsorted_segment_sum.py: examples/unsorted_segment_sum/test_unsorted_segment_sum.py
+
+  # examples/xattention
+  examples/xattention/xattention.py: examples/xattention/test_xattention.py
+  examples/xattention/xattention_paged.py: examples/xattention/test_xattention_paged.py
+
+  # examples/xllm_kernels
+  examples/xllm_kernels/fused_gdn_gating.py: examples/xllm_kernels/test_fused_gdn_gating.py
+  examples/xllm_kernels/rope.py: examples/xllm_kernels/test_rope_xllm_kernels.py
+  examples/xllm_kernels/split_qkv_rmsnorm_mrope.py: examples/xllm_kernels/test_split_qkv_rmsnorm_mrope.py
+
+  # examples_experiment/blocksparse_gemm
+  examples_experiment/blocksparse_gemm/example_blocksparse_gemm.py: examples_experiment/blocksparse_gemm/test_example_blocksparse_gemm.py
+
+  # examples_experiment/chunk_gated_delta_rule
+  examples_experiment/chunk_gated_delta_rule/chunk_gated_delta_rule.py: examples_experiment/chunk_gated_delta_rule/test_chunk_gated_delta_rule.py
+  examples_experiment/chunk_gated_delta_rule/expert_chunk_gated_delta_rule.py: examples_experiment/chunk_gated_delta_rule/test_expert_chunk_gated_delta_rule.py
+
+  # examples_experiment/convolution
+  examples_experiment/convolution/example_convolution.py: examples_experiment/convolution/test_example_convolution.py
+  examples_experiment/convolution/example_convolution_autotune.py: examples_experiment/convolution/test_example_convolution_autotune.py
+
+  # examples_experiment/cumsum_gdn
+  examples_experiment/cumsum_gdn/example_cumsum.py: examples_experiment/cumsum_gdn/test_example_cumsum.py
+
+  # examples_experiment/cumsum_kda
+  examples_experiment/cumsum_kda/example_cumsum_kda.py: examples_experiment/cumsum_kda/test_example_cumsum_kda.py
+
+  # examples_experiment/dequantize_gemm
+  examples_experiment/dequantize_gemm/example_dequant_gemm_fine_grained.py: examples_experiment/dequantize_gemm/test_example_dequant_gemm_fine_grained.py
+  examples_experiment/dequantize_gemm/example_dequant_gemm_w4a8.py: examples_experiment/dequantize_gemm/test_example_dequant_gemm_w4a8.py
+
+  # examples_experiment/gemm_splitk
+  examples_experiment/gemm_splitk/example_tilelang_gemm_splitk.py: examples_experiment/gemm_splitk/test_example_tilelang_gemm_splitk.py
+
+  # examples_experiment/grouped_gemm
+  examples_experiment/grouped_gemm/example_grouped_gemm_bwd.py: examples_experiment/grouped_gemm/test_example_grouped_gemm_bwd.py
+  examples_experiment/grouped_gemm/example_grouped_gemm_fwd.py: examples_experiment/grouped_gemm/test_example_grouped_gemm_fwd.py
+  examples_experiment/grouped_gemm/example_grouped_gemm_fwd_ptr.py: examples_experiment/grouped_gemm/test_example_grouped_gemm_fwd_ptr.py
+
+  # examples_experiment/hadamard_transform
+  examples_experiment/hadamard_transform/example_hadamard_transform.py: examples_experiment/hadamard_transform/test_example_hadamard_transform.py
+
+  # examples_experiment/random_1d
+  examples_experiment/random_1d/random_1d.py: examples_experiment/random_1d/test_random_1d.py
+
+  # examples_experiment/seer_attention
+  examples_experiment/seer_attention/block_sparse_attn.py: examples_experiment/seer_attention/test_block_sparse_attn.py

--- a/examples/batch_gemm/test_batch_gemm.py
+++ b/examples/batch_gemm/test_batch_gemm.py
@@ -1,0 +1,53 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_batch_gemm_example() -> ModuleType:
+    source = Path(__file__).with_name("batch_gemm.py")
+    spec = importlib.util.spec_from_file_location("_batch_gemm_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        # batch_gemm.py parses arguments at import time. Hide Pytest arguments
+        # while loading it without changing the original Example.
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def test_batch_gemm_accuracy() -> None:
+    import torch
+
+    example = _load_batch_gemm_example()
+
+    batch = 8
+    m = 1024
+    n = 1024
+    k = 1024
+
+    kernel = example.batch_matmul(
+        batch,
+        m,
+        n,
+        k,
+        block_M=128,
+        block_N=256,
+        K_L1=64,
+    )
+
+    torch.manual_seed(0)
+    lhs = torch.randn(batch, m, k).half().npu()
+    rhs = torch.randn(batch, k, n).half().npu()
+
+    actual = kernel(lhs, rhs)
+    expected = torch.matmul(lhs, rhs)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)

--- a/examples/bench_test.sh
+++ b/examples/bench_test.sh
@@ -61,6 +61,30 @@ done
 # ================= 全局环境变量设置 =================
 PROJECT_ROOT="$(cd .. && pwd)"
 
+# An operator listed here is covered by its Pytest test, which the workflow
+# runs separately; executing it here as well would compile and run the same
+# kernel twice.
+declare -A MIGRATED_SOURCES=()
+# Its test is skipped here for the same reason, and this is how: by the entry
+# that claims it, not by its name. A test this repository never registered
+# belongs to whoever wrote it and is collected like any other script.
+declare -A MIGRATED_TESTS=()
+OPERATOR_TEST_RESOLVER="${PROJECT_ROOT}/scripts/ci/resolve_operator_tests.py"
+if [ -f "$OPERATOR_TEST_RESOLVER" ]; then
+    # This script has no `set -e`, so a failure here would otherwise leave the
+    # skip list empty and let every migrated operator run twice unnoticed.
+    if ! python "$OPERATOR_TEST_RESOLVER" validate; then
+        echo "Operator test manifest is invalid" >&2
+        exit 1
+    fi
+    python "$OPERATOR_TEST_RESOLVER" check-orphans
+    while IFS=$'\t' read -r source test; do
+        [ -n "$source" ] || continue
+        MIGRATED_SOURCES["$source"]=1
+        MIGRATED_TESTS["$test"]=1
+    done < <(python "$OPERATOR_TEST_RESOLVER" list --format tsv)
+fi
+
 # experiment 算子根目录（相对 examples 工作目录）
 EXPERIMENT_ROOT="../examples_experiment"
 
@@ -148,6 +172,23 @@ total_scripts=0
 passed_scripts=0
 all_scripts=()
 
+should_skip_python_script() {
+    local candidate="$1"
+    local repo_relative
+
+    repo_relative=$(realpath --relative-to="$PROJECT_ROOT" "$candidate")
+    if [[ -n "${MIGRATED_SOURCES[$repo_relative]:-}" ]]; then
+        echo "Skip migrated operator in legacy runner: $candidate" >&2
+        return 0
+    fi
+    if [[ -n "${MIGRATED_TESTS[$repo_relative]:-}" ]]; then
+        echo "Skip migrated operator test in legacy runner: $candidate" >&2
+        return 0
+    fi
+
+    return 1
+}
+
 # 函数：收集单个目录下的测试脚本
 collect_test_scripts() {
     local dir="$1"
@@ -171,7 +212,9 @@ collect_test_scripts() {
                 -not -name "__init__.py" \
                 -not -name "*_golden.py" \
                 | sort)
-            for f in $py_files; do scripts+=("$f"); done
+            for f in $py_files; do
+                should_skip_python_script "$f" || scripts+=("$f")
+            done
             
             echo "${scripts[@]}"
             return
@@ -188,7 +231,9 @@ collect_test_scripts() {
         -not -path "*/generative_recommendation/golden.py" \
         -not -path "*/generative_recommendation/testcase.py" \
         | sort)
-    for f in $py_files; do scripts+=("$f"); done
+    for f in $py_files; do
+        should_skip_python_script "$f" || scripts+=("$f")
+    done
     
     # 搜索 bash 脚本（特定命名模式）
     local sh_files=$(find "$dir" -maxdepth 2 \( -name "run_*.sh" -o -name "test_*.sh" \) | sort)
@@ -250,7 +295,9 @@ if [ -n "$TEST_DIRS" ] || [ -n "$EXPERIMENT_DIRS" ]; then
         if [ -d "$fa_dir" ]; then
             fa_python_files=$(find "$fa_dir" -maxdepth 1 -name "flash_*.py" | sort)
             if [ -n "$fa_python_files" ]; then
-                for file in $fa_python_files; do all_scripts+=("$file"); done
+                for file in $fa_python_files; do
+                    should_skip_python_script "$file" || all_scripts+=("$file")
+                done
             fi
         fi
     fi
@@ -280,7 +327,9 @@ else
     if [ -d "$fa_dir" ]; then
         fa_python_files=$(find "$fa_dir" -maxdepth 1 -name "flash_*.py" | sort)
         if [ -n "$fa_python_files" ]; then
-            for file in $fa_python_files; do all_scripts+=("$file"); done
+            for file in $fa_python_files; do
+                should_skip_python_script "$file" || all_scripts+=("$file")
+            done
         fi
     fi
 
@@ -301,9 +350,92 @@ fi
 echo "Total scripts to run: ${#all_scripts[@]}"
 # =================================================
 
+# Run the migrated operator tests when coverage is being collected.
+# The workflow runs them after this script, so there is nothing to do on the
+# normal path. Coverage is collected by invoking this script by hand, and that
+# path has no workflow behind it: the collection above already skipped these
+# operators, their tests are run by nobody, and what they cover of tilelang
+# drops out of the report. They run before the examples so a scoped invocation
+# that collects no script still reaches them, and so they compile against a
+# cold cache.
+#
+# Narrowed to the directories this invocation was given, as everywhere else
+# those two options appear. A report that mixed the examples of one directory
+# with the operators of all of them would not say what it was measuring.
+operator_exit_code=0
+operator_passed=0
+operator_failed=0
+operator_xfailed=0
+if [ "$ENABLE_COVERAGE" = true ] || [ "$ENABLE_CPP_COVERAGE" = true ]; then
+    OPERATOR_TESTS=()
+    OPERATOR_SCOPE_ARGS=()
+    if [ -n "$TEST_DIRS" ]; then
+        OPERATOR_SCOPE_ARGS+=(--dirs $TEST_DIRS)
+    fi
+    if [ -n "$EXPERIMENT_DIRS" ]; then
+        OPERATOR_SCOPE_ARGS+=(--experiment-dirs $EXPERIMENT_DIRS)
+    fi
+    if [ -f "$OPERATOR_TEST_RESOLVER" ]; then
+        while IFS= read -r operator_test; do
+            [ -n "$operator_test" ] && OPERATOR_TESTS+=("${PROJECT_ROOT}/$operator_test")
+        done < <(python "$OPERATOR_TEST_RESOLVER" list-tests "${OPERATOR_SCOPE_ARGS[@]}")
+    fi
+    if [ ${#OPERATOR_TESTS[@]} -gt 0 ]; then
+        echo -e "\n====================================="
+        echo "Running migrated operator tests for coverage (${#OPERATOR_TESTS[@]} file(s))"
+        echo "====================================="
+        OPERATOR_MARKER_ARGS=()
+        if [ -n "$PYTEST_MARKERS" ]; then
+            OPERATOR_MARKER_ARGS+=(-m "$PYTEST_MARKERS")
+        fi
+        mkdir -p "${PROJECT_ROOT}/coverage_data"
+        # No --forked here, unlike the runs elsewhere in this script: coverage
+        # does not follow the fork, so the lines executed inside it are lost.
+        # Measured over these tests, 2237 lines of tilelang are recorded with it
+        # against 3285 without, and the difference is concentrated in the path
+        # that compiles a kernel: jit/kernel.py 45 against 110,
+        # cache/kernel_cache.py 48 against 125, engine/phase.py 12 against 58.
+        #
+        # One file per call, and no xdist. Without the fork the memory a test
+        # reserves is only returned when the process holding it ends, and these
+        # reserve a lot: of the sparse attention kernels one takes 31 GiB of a
+        # 61 GiB device on its own. Anything that puts two of those in flight,
+        # whether in sequence within a worker or across workers at once, runs
+        # the device out. One at a time is the only arrangement that cannot.
+        #
+        # Each call writes its own coverage file, since pytest-cov merges into
+        # COVERAGE_FILE as it exits and a shared name would leave only the last.
+        # The combine step downstream already globs for them.
+        : > operator_output.log
+        for operator_test_path in "${OPERATOR_TESTS[@]}"; do
+            export COVERAGE_FILE="${PROJECT_ROOT}/coverage_data/.coverage_operator_$(echo "$operator_test_path" | sed 's/[\/\.]/_/g')"
+            pytest "$operator_test_path" -v \
+                --cov=tilelang --cov-config="${PROJECT_ROOT}/.coveragerc" --cov-report= \
+                "${OPERATOR_MARKER_ARGS[@]}" 2>&1 | tee -a operator_output.log
+            operator_batch_code=${PIPESTATUS[0]}
+            if [ "$operator_exit_code" -eq 0 ]; then
+                operator_exit_code=$operator_batch_code
+            fi
+            unset COVERAGE_FILE
+        done
+        # One summary per batch, so these accumulate rather than reading the last.
+        while IFS= read -r operator_summary; do
+            [ -n "$operator_summary" ] || continue
+            batch_passed=$(echo "$operator_summary" | grep -Eo "[0-9]+ passed" | grep -Eo "[0-9]+")
+            batch_failed=$(echo "$operator_summary" | grep -Eo "[0-9]+ failed" | grep -Eo "[0-9]+")
+            batch_xfailed=$(echo "$operator_summary" | grep -Eo "[0-9]+ xfailed" | grep -Eo "[0-9]+")
+            operator_passed=$((operator_passed + ${batch_passed:-0}))
+            operator_failed=$((operator_failed + ${batch_failed:-0}))
+            operator_xfailed=$((operator_xfailed + ${batch_xfailed:-0}))
+        done < <(grep -E "^=+ .*[0-9]+ (passed|failed|error).* =+$" operator_output.log)
+        echo "Operator tests: ${operator_passed} passed, ${operator_failed} failed over ${#OPERATOR_TESTS[@]} file(s)"
+        rm -f operator_output.log
+    fi
+fi
+
 if [ ${#all_scripts[@]} -eq 0 ]; then
     echo "No test scripts found."
-    exit 0
+    exit $operator_exit_code
 fi
 
 # 2. 并行执行逻辑
@@ -395,7 +527,7 @@ if [ "$SKIP_PYTEST" = true ]; then
     echo -e "\n====================================="
     echo "Skipping pytest (only examples/ .py/.md/.png files modified)"
     echo "====================================="
-    exit 0
+    exit $operator_exit_code
 fi
 
 echo -e "\n====================================="
@@ -508,6 +640,10 @@ fi
 # 输出合并后的结果（用于 CI workflow 解析）
 # xfailed 是预期失败的测试，在 pytest 视角下属于"成功"状态（符合预期）
 # 应计入 passed_all，而不应计入 failed_all
+pytest_passed=$((pytest_passed + operator_passed))
+pytest_failed=$((pytest_failed + operator_failed))
+pytest_xfailed=$((pytest_xfailed + operator_xfailed))
+
 total_all=$((total_scripts + pytest_passed + pytest_failed + pytest_xfailed))
 passed_all=$((passed_scripts + pytest_passed + pytest_xfailed))
 failed_all=$((failed_scripts + pytest_failed))
@@ -525,4 +661,7 @@ echo "====================================="
 # 清理临时文件
 rm -f pytest_output.log
 
+if [ "$pytest_exit_code" -eq 0 ]; then
+    exit $operator_exit_code
+fi
 exit $pytest_exit_code

--- a/examples/flash_attention/test_flash_attn_bhsd.py
+++ b/examples/flash_attention/test_flash_attn_bhsd.py
@@ -1,0 +1,67 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_flash_attn_example() -> ModuleType:
+    source = Path(__file__).with_name("flash_attn_bhsd.py")
+    spec = importlib.util.spec_from_file_location("_flash_attn_bhsd_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        # flash_attn_bhsd.py parses arguments in its __main__ block. Hide Pytest
+        # arguments while loading it without changing the original Example.
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+
+    return module
+
+
+def _reference_flash_attn(query, key, value):
+    # Mirrors ref_flash_attn defined inside the example's __main__ block, which
+    # is not reachable after importing the module.
+    import torch
+
+    query = query.float()
+    key = key.float()
+    value = value.float()
+
+    scores = torch.einsum("bhsd,bhkd->bhsk", query, key) * (1.0 / query.shape[-1]) ** 0.5
+    scores = scores.softmax(dim=-1)
+    out = torch.einsum("bhsk,bhkd->bhsd", scores, value)
+    return out.to(torch.float16)
+
+
+def test_flash_attn_bhsd_accuracy() -> None:
+    import torch
+
+    example = _load_flash_attn_example()
+
+    batch = 1
+    seq_len = 128
+    heads = 1
+    dim = 512
+
+    kernel = example.flash_attention_fwd(
+        batch=batch,
+        seq_len=seq_len,
+        heads=heads,
+        dim=dim,
+    )
+
+    torch.manual_seed(0)
+    query = torch.randn((batch, heads, seq_len, dim), dtype=torch.float16, device="npu")
+    key = torch.randn((batch, heads, seq_len, dim), dtype=torch.float16, device="npu")
+    value = torch.randn((batch, heads, seq_len, dim), dtype=torch.float16, device="npu")
+
+    actual = kernel(query, key, value)
+    expected = _reference_flash_attn(query, key, value)
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)

--- a/scripts/ci/resolve_operator_tests.py
+++ b/scripts/ci/resolve_operator_tests.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Validate and query the operator-to-Pytest migration manifest."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path, PurePosixPath
+
+
+DEFAULT_MANIFEST = Path("ci/operator_test_manifest.yaml")
+VERSION_PATTERN = re.compile(r"^version:\s*(\d+)\s*$")
+EXAMPLE_ROOTS = ("examples", "examples_experiment")
+RUNNER_PATTERN = re.compile(r"\b(?:python[0-9.]*|pytest)\b")
+PY_FILE_PATTERN = re.compile(r"[\w./-]+\.py\b")
+
+
+class ManifestError(ValueError):
+    """Raised when the operator test manifest is invalid."""
+
+
+def _parse_manifest(manifest_path: Path) -> list[tuple[str, str]]:
+    version: int | None = None
+    in_mappings = False
+    mappings: list[tuple[str, str]] = []
+
+    for line_number, raw_line in enumerate(
+        manifest_path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        version_match = VERSION_PATTERN.fullmatch(stripped)
+        if version_match:
+            if version is not None:
+                raise ManifestError(f"{manifest_path}:{line_number}: duplicate version")
+            version = int(version_match.group(1))
+            continue
+
+        if stripped == "mappings:":
+            if in_mappings:
+                raise ManifestError(f"{manifest_path}:{line_number}: duplicate mappings section")
+            in_mappings = True
+            continue
+
+        if not in_mappings or not raw_line.startswith("  ") or ":" not in stripped:
+            raise ManifestError(f"{manifest_path}:{line_number}: expected an indented source: test mapping")
+
+        source, test = (part.strip() for part in stripped.split(":", maxsplit=1))
+        if not source or not test:
+            raise ManifestError(f"{manifest_path}:{line_number}: source and test are required")
+        mappings.append((source, test))
+
+    if version != 1:
+        raise ManifestError(f"{manifest_path}: unsupported or missing version: {version}")
+    if not in_mappings:
+        raise ManifestError(f"{manifest_path}: missing mappings section")
+    if not mappings:
+        raise ManifestError(f"{manifest_path}: mappings must not be empty")
+    return mappings
+
+
+def _validate_relative_path(value: str, field: str) -> PurePosixPath:
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or str(path) != value:
+        raise ManifestError(f"{field} must be a normalized repo-relative POSIX path: {value}")
+    return path
+
+
+def load_mappings(repo_root: Path, manifest_path: Path) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """Return the mappings that are live, and those still waiting on their test.
+
+    Registering a source excludes it from the legacy runner, so a mapping whose
+    test has not landed yet must not take effect: it is a plan, not a migration.
+    Holding it back keeps the example running and keeps Pytest from being
+    pointed at a file that does not exist.
+    """
+    if not manifest_path.is_absolute():
+        manifest_path = repo_root / manifest_path
+    if not manifest_path.is_file():
+        raise ManifestError(f"manifest does not exist: {manifest_path}")
+
+    mappings = _parse_manifest(manifest_path)
+    seen_sources: set[str] = set()
+    seen_tests: set[str] = set()
+    active: list[tuple[str, str]] = []
+    pending: list[tuple[str, str]] = []
+
+    for source, test in mappings:
+        source_path = _validate_relative_path(source, "source")
+        test_path = _validate_relative_path(test, "test")
+
+        if source in seen_sources:
+            raise ManifestError(f"duplicate source: {source}")
+        if test in seen_tests:
+            raise ManifestError(f"duplicate test: {test}")
+        if source == test:
+            raise ManifestError(f"source and test must be different: {source}")
+        if source_path.suffix != ".py":
+            raise ManifestError(f"source must be a Python file: {source}")
+        if test_path.suffix != ".py" or not test_path.name.startswith("test_"):
+            raise ManifestError(f"test must be named test_*.py: {test}")
+        if not (repo_root / Path(*source_path.parts)).is_file():
+            raise ManifestError(f"source does not exist: {source}")
+        seen_sources.add(source)
+        seen_tests.add(test)
+
+        if (repo_root / Path(*test_path.parts)).is_file():
+            active.append((source, test))
+        else:
+            pending.append((source, test))
+
+    return active, pending
+
+
+def _shell_invoked_tests(repo_root: Path) -> set[str]:
+    """Collect tests that a shell script under the example roots runs directly.
+
+    Those do not go through the manifest at all, so an unregistered name there
+    is not a mistake. Paths resolve against the script directory because these
+    scripts cd into their own directory first.
+    """
+    invoked: set[str] = set()
+    for root in EXAMPLE_ROOTS:
+        root_path = repo_root / root
+        if not root_path.is_dir():
+            continue
+        for script in root_path.rglob("*.sh"):
+            try:
+                text = script.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            for line in text.splitlines():
+                if line.lstrip().startswith("#") or not RUNNER_PATTERN.search(line):
+                    continue
+                for token in PY_FILE_PATTERN.findall(line):
+                    target = (script.parent / token).resolve()
+                    if target.is_file():
+                        invoked.add(target.as_posix())
+    return invoked
+
+
+def find_unregistered_tests(repo_root: Path, active: list[tuple[str, str]], pending: list[tuple[str, str]]) -> list[str]:
+    """List example tests that match no manifest entry, live or reserved.
+
+    Worth knowing rather than worth failing over: an unregistered test runs as
+    a script in the legacy runner, which is where every test lived before this
+    manifest existed. What it does not get is the Pytest treatment, so saying
+    so gives whoever wrote it the choice. Tests a sibling shell script invokes
+    are exempt: those never went through the manifest.
+    """
+    expected = {test for _, test in active} | {test for _, test in pending}
+    invoked = _shell_invoked_tests(repo_root)
+    unregistered: list[str] = []
+    for root in EXAMPLE_ROOTS:
+        root_path = repo_root / root
+        if not root_path.is_dir():
+            continue
+        for path in sorted(root_path.rglob("test_*.py")):
+            relative = path.relative_to(repo_root).as_posix()
+            if relative in expected or path.resolve().as_posix() in invoked:
+                continue
+            unregistered.append(relative)
+    return unregistered
+
+
+def _scope_to_dirs(mappings: list[tuple[str, str]], dirs: list[str] | None, experiment_dirs: list[str] | None) -> list[tuple[str, str]]:
+    """Narrow the mappings to the example directories a run was scoped to.
+
+    Neither flag given is a full run, and every mapping belongs to it. One given
+    without the other means that root contributed no directory, not that it is
+    unconstrained, so an absent flag selects nothing rather than everything.
+
+    Matching is on the first directory below the root, since that is the unit
+    the runner takes and an operator may sit a level deeper than it.
+    """
+    if dirs is None and experiment_dirs is None:
+        return mappings
+    wanted = {f"examples/{name}" for name in (dirs or [])}
+    wanted |= {f"examples_experiment/{name}" for name in (experiment_dirs or [])}
+    scoped = []
+    for source, test in mappings:
+        parts = PurePosixPath(source).parts
+        if len(parts) > 2 and "/".join(parts[:2]) in wanted:
+            scoped.append((source, test))
+    return scoped
+
+
+def _print_lines(values: Iterable[str]) -> None:
+    for value in values:
+        print(value)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="repository root (defaults to the resolver's repository)",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help="manifest path, relative to the repository root by default",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("validate", help="validate the manifest and referenced files")
+
+    list_parser = subparsers.add_parser("list", help="list source-to-test mappings")
+    list_parser.add_argument("--format", choices=("tsv",), default="tsv")
+
+    list_tests_parser = subparsers.add_parser("list-tests", help="list migrated Pytest files")
+    # Named after the runner's own flags so a caller that scoped a run to some
+    # directories can hand this the value it handed the runner, unchanged.
+    list_tests_parser.add_argument(
+        "--dirs",
+        nargs="*",
+        default=None,
+        help="limit to tests whose operator lives under one of these examples/ directories",
+    )
+    list_tests_parser.add_argument(
+        "--experiment-dirs",
+        nargs="*",
+        default=None,
+        help="the same, for examples_experiment/",
+    )
+    subparsers.add_parser("list-sources", help="list all sources excluded from the legacy runner")
+    subparsers.add_parser(
+        "check-orphans",
+        help="fail if an example test matches no manifest entry, live or reserved",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        mappings, pending = load_mappings(args.repo_root.resolve(), args.manifest)
+    except (ManifestError, OSError) as error:
+        print(f"operator test manifest error: {error}", file=sys.stderr)
+        return 1
+
+    if args.command == "validate":
+        print(f"Validated {len(mappings)} operator test mapping(s)")
+        if pending:
+            print(
+                f"{len(pending)} mapping(s) reserved but not migrated yet; the "
+                "example keeps running in the legacy runner until its test lands:"
+            )
+            for source, test in pending:
+                print(f"  {source} -> {test}")
+    elif args.command == "list":
+        _print_lines(f"{source}\t{test}" for source, test in mappings)
+    elif args.command == "list-tests":
+        scoped = _scope_to_dirs(mappings, args.dirs, args.experiment_dirs)
+        _print_lines(test for _, test in scoped)
+    elif args.command == "list-sources":
+        _print_lines(source for source, _ in mappings)
+    elif args.command == "check-orphans":
+        unregistered = find_unregistered_tests(args.repo_root.resolve(), mappings, pending)
+        if unregistered:
+            print(f"{len(unregistered)} operator test(s) matching no manifest entry:")
+            for item in unregistered:
+                print(f"  {item}")
+            print(
+                "each runs as a script in the legacy runner. To have Pytest run one "
+                "instead, add it to ci/operator_test_manifest.yaml; if an entry was "
+                "meant to cover it already, check the name against that entry"
+            )
+        else:
+            print("All operator tests match a manifest entry")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 背景

现在 `examples/` 下的算子测试是这么跑的：`bench_test.sh` 扫目录收集 `.py` 文件，逐个当脚本执行，然后 grep 输出里有没有 `KERNEL OUTPUT MATCH` 或 `TEST PASSED!` 来判断通过与否。

这套办法有两个不方便的地方：

- 测试没法说清自己测了什么。挂了只知道"输出里没有那句话"，得自己去翻日志
- 想加参数化、加 fixture、按 marker 筛选，都没有地方放

本 PR 引入一张登记表，把算子和它的 Pytest 测试对应起来，让已经写好测试的算子走 Pytest，其余的照旧。

## 改动内容

| 文件 | 状态 | 增删 | 做什么 |
|---|---|---|---|
| `ci/operator_test_manifest.yaml` | 新增 | 263 行 | 登记表，140 条 `算子 → 测试` 映射 |
| `scripts/ci/resolve_operator_tests.py` | 新增 | 283 行 | 读登记表的唯一入口，5 个子命令 |
| `examples/bench_test.sh` | 修改 | +151 / −7 | 按登记表决定跳过哪些；覆盖率路径补跑算子测试 |
| `.github/workflows/ci_cd.yml` | 修改 | +120 / −1 | 改了已登记的算子只跑它的测试；全量时补跑全部已登记测试 |
| `examples/batch_gemm/test_batch_gemm.py` | 新增 | 53 行 | 样板 |
| `examples/flash_attention/test_flash_attn_bhsd.py` | 新增 | 67 行 | 样板 |

合计 6 个文件，+930 / −7。

## 登记表怎么生效

登记表里有 140 条，但**一条登记只有在测试文件真实存在时才生效**：

```yaml
mappings:
  examples/batch_gemm/batch_gemm.py: examples/batch_gemm/test_batch_gemm.py
```

- 测试文件**在** → 这一条生效，算子从 `bench_test.sh` 里跳过，改由 Pytest 跑
- 测试文件**不在** → 这一条只是占位，算子照旧在 `bench_test.sh` 里当脚本跑

本 PR 合入后，140 条里**只有 3 条生效**（`batch_gemm`、`flash_attn_bhsd`，加上仓库里已有的 `gqa_fwd_varlen`），其余 137 条是占位。

这样设计是为了不用一次性把 140 个测试都写完 —— 可以一个算子一个算子地补，写好一个生效一个，中间任何时候仓库都是可用的。

## CI 的行为变化

| 你改了什么 | 现在 | 本 PR 之后 |
|---|---|---|
| 新增 example，或新增 example 和它的测试 | 增量跑那个目录 | 一样 |
| 改任一还没写测试的算子（137 个） | 增量跑那个目录 | 一样 |
| 改 `tilelang/`、`src/` 等核心文件 | 全量 | 一样 |
| 改 `testing/python/` 或文档 | 一样 | 一样 |
| 改 3 个已生效的算子之一 | 增量跑那个目录 | 只跑它的 Pytest 测试，更快 |
| 全量运行时 | — | 末尾补跑已生效的测试（现在是 3 个） |

**137/140 的算子，以及所有没登记的算子，行为完全不变。**

## 测试

本文件修改的相关内容在example-test进行了测试验证，目前提交新的test以及修改example已经验证过
同时本PR已在 Ascend NPU 实跑：

```
全量 bench_test.sh（含 testing/python），30 分 22 秒
  Bench:  156 scripts | 156 passed | 0 failed
  Pytest: 1440 passed | 0 failed | 2 xfailed
  Total:  1598 passed | 0 failed | Pass rate 100%
  OOM 0 次

  Skip migrated operator      : 3   （3 条生效，跳过 3 个算子源）
  Skip migrated operator test : 3

已登记测试（CI 兜底段的原样命令）
  pytest --forked <已生效的测试> -v -n 8 -m "not (low_priority or ci_skip)"
  全部通过，0 个用例被 marker 筛掉
```

另外验了这些：

- **路由没跑偏**：把 `detect_changes` 那段 bash 原样抽出来，喂 14 组改动文件组合，跟本 PR 之前逐一对照 —— **12 组决策完全一样**，只有"改已生效的算子"和"改它的测试"这两组从"跑整个目录"变成"只跑那个测试"
- **改核心文件仍然是全量**：`tilelang/`、`src/`、`install_ascend.sh` 这些，无论是否同时改了已登记的算子，`test_dirs` 都是空的（= 跑全部）
- **该红的时候会红**：故意放一个必然失败的算子进去，`Pass rate` 变成 0%，CI 的 `Check pass rate` 步骤退出码 1，job 判红
- **没有跑两遍**：全量跑完之后核对，已生效的测试一个都没有被 `bench_test.sh` 重复执行
- **没登记的测试照常跑**：仓库里现有 3 个没在登记表里的测试（`test_mha_sink_fwd_bhsd.py`、`test_gqa_sink_fwd_varlen.py`、`test_gqa_bwd.py`），合并后依旧被 `bench_test.sh` 当脚本执行，全部通过
- **登记表写坏了会被拦住**：版本号不对、缺 `mappings`、源文件不存在、重复条目、测试名不是 `test_*.py`、路径含 `..` —— 九种写法都能报出可读的原因
- **覆盖率路径没受影响**：`bash bench_test.sh --coverage` 退出码 0、报告正常生成、OOM 0 次
- ruff format 和 ruff check 全部通过

以上一共 33 项断言（合并结果、登记表状态、路由决策、跳过计数、执行结果、失败传递），全部通过。

## 后续要注意的

### 想给某个算子加 Pytest 测试

1. 打开 `ci/operator_test_manifest.yaml`，找到那个算子对应的行，如果没有代表该算子尚未登记，可以自行登记
2. 冒号右边就是测试文件该放的路径和文件名，**照抄，一个字都别改**，如果是新增的请参考其他算子进行命名，注意不要和已有的测试用例重名
3. 参考 `examples/batch_gemm/test_batch_gemm.py` 写

文件名必须和登记表一致。名字对不上的话，那条登记不会生效，而且你的测试会被当成普通脚本执行 —— Pytest 风格的文件当脚本跑什么都不输出，会被判失败。

### 改名或删除算子文件时

如果动的是登记表里列出的算子源文件（冒号左边那些），**要同步改 `ci/operator_test_manifest.yaml` 对应那行**，否则 `bench_test.sh` 一启动就会报：

```
operator test manifest error: source does not exist: examples/xxx/yyy.py
Operator test manifest is invalid
```

只改文件**内容**不受影响，只有改名和删除需要动登记表。

### 不想用登记表也没关系

`examples/` 下没登记的 `test_*.py` 照旧由 `bench_test.sh` 当脚本执行，跟以前一样。`check-orphans` 会把它们列出来说明一句，但不会让 CI 失败。登记表是这次迁移的内部记账，不是对其他人的要求。

### 手工查登记表

```bash
python scripts/ci/resolve_operator_tests.py validate        # 校验 + 看哪些生效、哪些占位
python scripts/ci/resolve_operator_tests.py list-tests      # 列出已生效的测试
python scripts/ci/resolve_operator_tests.py check-orphans   # 列出没登记的测试
```
