### PR TITLE
[Fix] Handle compact unaligned Ascend GM/UB copies 🤖

### DIFF
--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -235,26 +235,13 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
 
       ss << "copy_gm_to_ub<";
       ss << get_dtype(src) << ", ";
-      // The column dim is a COMPILE-TIME template arg. A runtime inner-extent
-      // slice (dynamic width, e.g. a softmax's actual window tw_a < buffer
-      // width) would put a non-const expr in the template -> invalid C++ ("use
-      // of undeclared identifier"). Use the buffer's compile-time shape for the
-      // template; the runtime width is already carried by the maskShapeN
-      // function arg (validCol_dst). A const extent stays byte-identical (==
-      // shape for a full copy, or the const slice width), so every existing
-      // caller is unchanged -- only the previously-uncompilable runtime-slice
-      // case changes.
-      PrimExpr gm2ub_tmpl_n = dst_extents[dst->shape.size() - 1];
-      if (!gm2ub_tmpl_n->IsInstance<IntImmNode>()) {
-        gm2ub_tmpl_n = dst->shape[dst->shape.size() - 1];
-        // The shape fallback must itself be a compile-time constant; a buffer
-        // declared with a dynamic inner dim would still emit a non-const
-        // template arg (the invalid-C++ case above), so fail early and clearly.
-        ICHECK(gm2ub_tmpl_n->IsInstance<IntImmNode>())
-            << "copy_gm_to_ub: the inner (column) dimension of the destination "
-               "buffer shape must be a compile-time constant, but got "
-            << gm2ub_tmpl_n;
-      }
+      // The helper needs the physical UB row pitch, not merely the copied
+      // region width.  maskShapeN carries the valid region width separately.
+      PrimExpr gm2ub_tmpl_n = dst->shape[dst->shape.size() - 1];
+      ICHECK(gm2ub_tmpl_n->IsInstance<IntImmNode>())
+          << "copy_gm_to_ub: the inner (column) dimension of the destination "
+             "buffer shape must be a compile-time constant, but got "
+          << gm2ub_tmpl_n;
       ss << gm2ub_tmpl_n;
       if (dst->shape.size() > 1) {
         ss << ", " << compute_blocklen(dst, dst_extents);
@@ -267,18 +254,11 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
 
       ss << "copy_ub_to_gm<";
       ss << get_dtype(dst) << ", ";
-      // See copy_gm_to_ub above: a runtime inner-extent must use the buffer's
-      // compile-time shape for the template col dim (runtime width is carried
-      // by the maskShapeN function arg); const extents are byte-identical.
-      PrimExpr ub2gm_tmpl_n = src_extents[src->shape.size() - 1];
-      if (!ub2gm_tmpl_n->IsInstance<IntImmNode>()) {
-        ub2gm_tmpl_n = src->shape[src->shape.size() - 1];
-        // See copy_gm_to_ub: the shape fallback must itself be compile-time.
-        ICHECK(ub2gm_tmpl_n->IsInstance<IntImmNode>())
-            << "copy_ub_to_gm: the inner (column) dimension of the source "
-               "buffer shape must be a compile-time constant, but got "
-            << ub2gm_tmpl_n;
-      }
+      PrimExpr ub2gm_tmpl_n = src->shape[src->shape.size() - 1];
+      ICHECK(ub2gm_tmpl_n->IsInstance<IntImmNode>())
+          << "copy_ub_to_gm: the inner (column) dimension of the source "
+             "buffer shape must be a compile-time constant, but got "
+          << ub2gm_tmpl_n;
       ss << ub2gm_tmpl_n;
       if (src->shape.size() > 1) {
         ss << ", " << compute_blocklen(src, src_extents);
@@ -492,6 +472,46 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
   } else {
     validRow_dst = 0;
     validCol_dst = 0;
+  }
+
+  auto validate_unaligned_local_rows =
+      [&](const Array<Range> &gm_range, const Array<PrimExpr> &gm_extents,
+          const Buffer &local, const Array<Range> &local_range,
+          const Array<PrimExpr> &local_extents, const PrimExpr &gm_stride,
+          const char *op_name) {
+        if (local->shape.size() < 2) {
+          return;
+        }
+        const auto *local_cols = local->shape.back().as<IntImmNode>();
+        const auto *local_rows =
+            compute_blocklen(local, local_extents).as<IntImmNode>();
+        if (local_cols == nullptr || local_rows == nullptr ||
+            local_rows->value <= 1 ||
+            (local_cols->value * local->dtype.bytes()) % 32 == 0) {
+          return;
+        }
+
+        PrimExpr expected_cols = local->shape.back();
+        bool compact_full_rows =
+            analyzer->CanProveEqual(gm_stride, expected_cols) &&
+            analyzer->CanProveEqual(gm_range.back()->min, Integer(0)) &&
+            analyzer->CanProveEqual(gm_extents.back(), expected_cols) &&
+            analyzer->CanProveEqual(local_range.back()->min, Integer(0)) &&
+            analyzer->CanProveEqual(local_extents.back(), expected_cols);
+        ICHECK(compact_full_rows)
+            << op_name
+            << ": multi-row copies with a non-32-byte-aligned UB "
+               "row pitch require compact full rows on both GM and UB; buffer "
+            << local->name << " has "
+            << local_cols->value * local->dtype.bytes() << " bytes per row";
+      };
+
+  if (config.gm2ub) {
+    validate_unaligned_local_rows(src_range, src_extents, dst, dst_range,
+                                  dst_extents, strideN, "copy_gm_to_ub");
+  } else if (config.ub2gm) {
+    validate_unaligned_local_rows(dst_range, dst_extents, src, src_range,
+                                  src_extents, strideN, "copy_ub_to_gm");
   }
 
   Array<PrimExpr> new_args;
@@ -761,22 +781,13 @@ Stmt AscendAtomicAdd::Lower(const LowerArgs &T,
          "destination buffer rank";
 
   std::stringstream ss;
-  // Same compile-time-template-arg fix as the GM<->UB copy above (see
-  // AscendCopy::Lower): the inner (column) dim is a template arg, so a runtime
-  // inner-extent -- e.g. atomic_add(A[rows, 0:n], src_ub[:, 0:n]) with a
-  // dynamic n -- would put a non-const expr in the template and emit invalid
-  // C++. Use the source buffer's compile-time shape for the template; the
-  // runtime column count is carried by validCol_dst below, so the DMA still
-  // adds exactly the runtime number of columns. A const extent stays
-  // byte-identical, so every existing caller is unchanged.
-  PrimExpr atomic_tmpl_n = src_extents[src->shape.size() - 1];
-  if (!atomic_tmpl_n->IsInstance<IntImmNode>()) {
-    atomic_tmpl_n = src->shape[src->shape.size() - 1];
-    ICHECK(atomic_tmpl_n->IsInstance<IntImmNode>())
-        << "tl.ascend_atomic_add: the inner (column) dimension of the source "
-           "buffer shape must be a compile-time constant, but got "
-        << atomic_tmpl_n;
-  }
+  // atomic_add_ub_to_gm reuses copy_ub_to_gm, so it also needs the physical UB
+  // row pitch.  The runtime valid column count is passed separately below.
+  PrimExpr atomic_tmpl_n = src->shape[src->shape.size() - 1];
+  ICHECK(atomic_tmpl_n->IsInstance<IntImmNode>())
+      << "tl.ascend_atomic_add: the inner (column) dimension of the source "
+         "buffer shape must be a compile-time constant, but got "
+      << atomic_tmpl_n;
   if (src.scope() == "shared.ub") {
     ss << "tl::ascend::atomic_add_ub_to_gm<";
     ss << get_dtype(dst) << ", " << atomic_tmpl_n;
@@ -934,6 +945,28 @@ Stmt AscendAtomicAdd::Lower(const LowerArgs &T,
     }
   } else {
     strideN = compute_strideN(dst, dst_extents);
+  }
+
+  if (src.scope() == "shared.ub" && src->shape.size() > 1) {
+    const auto *local_cols = src->shape.back().as<IntImmNode>();
+    const auto *local_rows =
+        compute_blocklen(src, src_extents).as<IntImmNode>();
+    if (local_cols != nullptr && local_rows != nullptr &&
+        local_rows->value > 1 &&
+        (local_cols->value * src->dtype.bytes()) % 32 != 0) {
+      PrimExpr expected_cols = src->shape.back();
+      bool compact_full_rows =
+          analyzer->CanProveEqual(strideN, expected_cols) &&
+          analyzer->CanProveEqual(validCol_dst, expected_cols) &&
+          analyzer->CanProveEqual(src_range.back()->min, Integer(0)) &&
+          analyzer->CanProveEqual(src_extents.back(), expected_cols);
+      ICHECK(compact_full_rows)
+          << "tl.ascend_atomic_add: multi-row copies with a "
+             "non-32-byte-aligned UB row pitch require compact full rows on "
+             "both GM and UB; buffer "
+          << src->name << " has " << local_cols->value * src->dtype.bytes()
+          << " bytes per row";
+    }
   }
 
   Array<PrimExpr> new_args;

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -241,9 +241,19 @@ copy_gm_to_ub(LocalTensor<T> dstTensor, GlobalTensor<T> srcTensor,
       WaitFlag<HardEvent::V_MTE2>(0);
     }
   }
-  AscendC::DataCopyExtParams dataCopyParams(
-      maskShapeM, maskShapeN * sizeof(T), (realSrcN - maskShapeN) * sizeof(T),
-      (dstN - maskShapeN) * sizeof(T) / 32, 0);
+  AscendC::DataCopyExtParams dataCopyParams;
+  if (realSrcN == dstN && maskShapeN == dstN) {
+    // DataCopyPad rounds every local block up to 32 bytes.  A compact tile
+    // whose row width is not 32-byte aligned would therefore acquire a gap
+    // between rows when represented as multiple blocks.  Both sides are
+    // contiguous here, so describe the whole valid rectangle as one block.
+    dataCopyParams = AscendC::DataCopyExtParams(
+        1, maskShapeM * maskShapeN * sizeof(T), 0, 0, 0);
+  } else {
+    dataCopyParams = AscendC::DataCopyExtParams(
+        maskShapeM, maskShapeN * sizeof(T), (realSrcN - maskShapeN) * sizeof(T),
+        (dstN - maskShapeN) * sizeof(T) / 32, 0);
+  }
   AscendC::DataCopyPadExtParams<T> padParams(isPad, 0, rightPadding, padValue);
   AscendC::DataCopyPad(dstTensor, srcTensor, dataCopyParams, padParams);
 }
@@ -253,9 +263,16 @@ CATLASS_DEVICE void
 copy_ub_to_gm(GlobalTensor<T> dstTensor, LocalTensor<T> srcTensor,
               uint32_t realdstN = 1, uint32_t maskShapeM = srcM,
               uint32_t maskShapeN = srcN) {
-  AscendC::DataCopyExtParams dataCopyParams(
-      maskShapeM, maskShapeN * sizeof(T), (srcN - maskShapeN) * sizeof(T) / 32,
-      (realdstN - maskShapeN) * sizeof(T), 0);
+  AscendC::DataCopyExtParams dataCopyParams;
+  if (realdstN == srcN && maskShapeN == srcN) {
+    dataCopyParams = AscendC::DataCopyExtParams(
+        1, maskShapeM * maskShapeN * sizeof(T), 0, 0, 0);
+  } else {
+    dataCopyParams =
+        AscendC::DataCopyExtParams(maskShapeM, maskShapeN * sizeof(T),
+                                   (srcN - maskShapeN) * sizeof(T) / 32,
+                                   (realdstN - maskShapeN) * sizeof(T), 0);
+  }
   AscendC::DataCopyPad(dstTensor, srcTensor, dataCopyParams);
 }
 

--- a/testing/python/language/test_tilelang_ascend_language_copy_compact_rows.py
+++ b/testing/python/language/test_tilelang_ascend_language_copy_compact_rows.py
@@ -1,0 +1,257 @@
+"""Regression tests for compact multi-row GM/UB copies on AscendC.
+
+DataCopyPad rounds each local block to 32 bytes.  Representing a compact UB tile
+with a non-32-byte-aligned row pitch as one DMA block per logical row therefore
+reads or writes a padded layout instead.  These tests isolate GM->UB and UB->GM
+so that two symmetric layout errors cannot cancel in a round trip.
+"""
+
+import pytest
+import tilelang
+import tilelang.language as T
+import torch
+import tvm
+
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    tilelang.cache.clear_cache()
+    yield
+
+
+def _dtype_bytes(dtype):
+    return {"int8": 1, "float16": 2, "float": 4}[dtype]
+
+
+def _torch_dtype(dtype):
+    return {"int8": torch.int8, "float16": torch.float16, "float": torch.float32}[dtype]
+
+
+def _ordered_input(rows, cols, torch_dtype):
+    # Keep integer inputs representable so expected values are independent of
+    # host-side overflow behaviour.
+    values = torch.arange(rows * cols, dtype=torch.int32, device="npu") % 127
+    return values.to(torch_dtype).reshape(rows, cols)
+
+
+def compact_row_copy(rows, cols, dtype):
+    dtype_bytes = _dtype_bytes(dtype)
+    aligned_cols = ((cols * dtype_bytes + 31) // 32 * 32) // dtype_bytes
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((rows, cols), dtype),
+        B: T.Tensor((rows, aligned_cols), dtype),
+        C: T.Tensor((rows, cols), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (_cid, _vid):
+            loaded = T.alloc_ub((rows, cols), dtype)
+            loaded_out = T.alloc_ub((rows, aligned_cols), dtype)
+            produced = T.alloc_ub((rows, cols), dtype)
+
+            # Isolate GM->UB: a scalar consumer reads compact logical offsets,
+            # then the aligned output tile takes the safe MTE3 path.
+            T.copy(A, loaded)
+            for row in T.serial(rows):
+                for col in T.serial(aligned_cols):
+                    loaded_out[row, col] = T.cast(0, dtype)
+            for row in T.serial(rows):
+                for col in T.serial(cols):
+                    loaded_out[row, col] = loaded[row, col]
+            T.copy(loaded_out, B)
+
+            # Isolate UB->GM: scalar stores produce a genuinely compact tile.
+            for row in T.serial(rows):
+                for col in T.serial(cols):
+                    produced[row, col] = T.cast((row * cols + col) % 127, dtype)
+            T.copy(produced, C)
+
+    return main
+
+
+@pytest.mark.parametrize(
+    "rows, cols, dtype",
+    [
+        (256, 4, "float"),  # 16 B: original SVD transpose failure
+        (16, 9, "float"),  # 36 B: above 32 B but still unaligned
+        (16, 15, "int8"),  # 15 B
+        (16, 33, "int8"),  # 33 B
+        (16, 15, "float16"),  # 30 B
+        (16, 17, "float16"),  # 34 B
+        (16, 8, "float"),  # 32 B aligned control
+        (16, 16, "float16"),  # 32 B aligned control
+    ],
+)
+def test_compact_row_copy(rows, cols, dtype):
+    kernel = tilelang.compile(
+        compact_row_copy(rows, cols, dtype),
+        out_idx=[],
+        pass_configs=PASS_CONFIGS,
+        target="ascendc",
+    )
+    torch_dtype = _torch_dtype(dtype)
+    a = _ordered_input(rows, cols, torch_dtype)
+    aligned_cols = ((cols * _dtype_bytes(dtype) + 31) // 32 * 32) // _dtype_bytes(dtype)
+    b = torch.empty((rows, aligned_cols), dtype=torch_dtype, device="npu")
+    c = torch.empty((rows, cols), dtype=torch_dtype, device="npu")
+
+    kernel(a, b, c)
+    torch.npu.synchronize()
+
+    expected_c = _ordered_input(rows, cols, torch_dtype)
+    torch.testing.assert_close(b[:, :cols], a, rtol=0, atol=0)
+    torch.testing.assert_close(b[:, cols:], torch.zeros_like(b[:, cols:]), rtol=0, atol=0)
+    torch.testing.assert_close(c, expected_c, rtol=0, atol=0)
+
+
+def compact_row_m_tail_copy():
+    rows, cols, block_rows = 10, 9, 4
+
+    @T.prim_func
+    def main(A: T.Tensor((rows, cols), "float"), C: T.Tensor((rows, cols), "float")):
+        with T.Kernel(T.ceildiv(rows, block_rows), is_npu=True) as (cid, _vid):
+            data = T.alloc_ub((block_rows, cols), "float")
+            T.copy(A[cid * block_rows, 0], data)
+            for row in T.serial(block_rows):
+                for col in T.serial(cols):
+                    data[row, col] = data[row, col] + 1
+            T.copy(data, C[cid * block_rows, 0])
+
+    return main
+
+
+def test_compact_row_m_tail_copy():
+    kernel = tilelang.compile(
+        compact_row_m_tail_copy(),
+        out_idx=[-1],
+        pass_configs=PASS_CONFIGS,
+        target="ascendc",
+    )
+    a = torch.arange(10 * 9, dtype=torch.float32, device="npu").reshape(10, 9)
+    c = kernel(a)
+    torch.npu.synchronize()
+    torch.testing.assert_close(c, a + 1, rtol=0, atol=0)
+
+
+def aligned_pitch_slice_copy():
+    rows, gm_cols, ub_cols, copy_cols = 8, 32, 16, 8
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((rows, gm_cols), "float"),
+        B: T.Tensor((rows, gm_cols), "float"),
+    ):
+        with T.Kernel(1, is_npu=True) as (_cid, _vid):
+            data = T.alloc_ub((rows, ub_cols), "float")
+            T.copy(A[:, :copy_cols], data[:, :copy_cols])
+            for row in T.serial(rows):
+                for col in T.serial(copy_cols):
+                    data[row, col] = data[row, col] + 1
+            T.copy(data[:, :copy_cols], B[:, :copy_cols])
+
+    return main
+
+
+def test_aligned_physical_ub_pitch_for_slices():
+    with tvm.transform.PassContext(opt_level=3, config=PASS_CONFIGS):
+        artifact = tilelang.lower(aligned_pitch_slice_copy(), target="ascendc")
+    assert "copy_gm_to_ub<float, 16, 8>" in artifact.kernel_source
+    assert "copy_ub_to_gm<float, 16, 8>" in artifact.kernel_source
+
+    kernel = tilelang.compile(
+        aligned_pitch_slice_copy(),
+        out_idx=[],
+        pass_configs=PASS_CONFIGS,
+        target="ascendc",
+    )
+    a = torch.arange(8 * 32, dtype=torch.float32, device="npu").reshape(8, 32)
+    b = torch.zeros_like(a)
+    kernel(a, b)
+    torch.npu.synchronize()
+    torch.testing.assert_close(b[:, :8], a[:, :8] + 1, rtol=0, atol=0)
+
+
+def unsupported_unaligned_strided_copy():
+    @T.prim_func
+    def main(A: T.Tensor((8, 8), "float"), B: T.Tensor((8, 4), "float")):
+        with T.Kernel(1, is_npu=True) as (_cid, _vid):
+            data = T.alloc_ub((8, 4), "float")
+            T.copy(A[:, :4], data)
+            T.copy(data, B)
+
+    return main
+
+
+def test_unaligned_compact_rows_with_gm_stride_fail_loudly():
+    with pytest.raises(
+        tvm.error.InternalError,
+        match="non-32-byte-aligned UB row pitch require compact full rows",
+    ):
+        tilelang.lower(unsupported_unaligned_strided_copy(), target="ascendc")
+
+
+def compact_row_atomic_add():
+    @T.prim_func
+    def main(C: T.Tensor((16, 9), "float")):
+        with T.Kernel(1, is_npu=True) as (_cid, _vid):
+            produced = T.alloc_ub((16, 9), "float")
+            for row in T.serial(16):
+                for col in T.serial(9):
+                    produced[row, col] = T.cast(row * 9 + col, "float")
+            T.tile.atomic_add(C, produced)
+
+    return main
+
+
+def test_compact_row_atomic_add():
+    kernel = tilelang.compile(
+        compact_row_atomic_add(),
+        out_idx=[],
+        pass_configs=PASS_CONFIGS,
+        target="ascendc",
+    )
+    c = torch.zeros((16, 9), dtype=torch.float32, device="npu")
+    kernel(c)
+    torch.npu.synchronize()
+    # Both vector cores execute the body, so every value is atomically added
+    # twice on 910B.
+    expected = 2 * torch.arange(16 * 9, dtype=torch.float32, device="npu").reshape(16, 9)
+    torch.testing.assert_close(c, expected, rtol=0, atol=0)
+
+
+def unsupported_unaligned_strided_atomic_add():
+    @T.prim_func
+    def main(C: T.Tensor((8, 8), "float")):
+        with T.Kernel(1, is_npu=True) as (_cid, _vid):
+            produced = T.alloc_ub((8, 4), "float")
+            T.tile.fill(produced, 1)
+            T.tile.atomic_add(C[:, :4], produced)
+
+    return main
+
+
+def test_unaligned_atomic_add_with_gm_stride_fails_loudly():
+    with pytest.raises(
+        tvm.error.InternalError,
+        match="non-32-byte-aligned UB row pitch require compact full rows",
+    ):
+        tilelang.lower(unsupported_unaligned_strided_atomic_add(), target="ascendc")
+
+
+def test_scalar_to_mte3_sync_is_preserved():
+    with tvm.transform.PassContext(opt_level=3, config=PASS_CONFIGS):
+        artifact = tilelang.lower(compact_row_copy(16, 9, "float"), target="ascendc")
+    assert "SetFlag<AscendC::HardEvent::S_MTE3>" in artifact.kernel_source
+    assert "WaitFlag<AscendC::HardEvent::S_MTE3>" in artifact.kernel_source
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-n", "0"])


### PR DESCRIPTION
## Summary

Fix silent data corruption in AscendC multi-row GM↔UB copies when the physical UB row pitch is not 32-byte aligned. Contiguous rectangles are emitted as one `DataCopyPad` block; layouts that the DMA cannot represent safely now fail during lowering.

## Changes

- Use the physical UB row pitch, rather than the copied slice width, in GM↔UB and UB atomic-add helper template arguments.
- Coalesce full-width contiguous rectangles into one DMA block so compact 15B, 16B, 30B, 33B, 34B, and 36B rows are not padded between logical rows.
- Reject non-32-byte-aligned UB rows combined with strided GM/column slices instead of silently returning incorrect data.
- Add real-910B regression coverage that isolates MTE2 and MTE3, covers int8/float16/float32, an M-tail, aligned physical pitches, atomic add, and S→MTE3 synchronization.

## Testing

- `cmake --build build -j8`
- `ruff format --check` and `ruff check` on affected Python tests
- `pytest -q testing/python/language/test_tilelang_ascend_language_copy_compact_rows.py -n 0` — 14 passed on Ascend 910B
- Runtime-extent GM↔UB copy cases — 2 passed on Ascend 910B
- End-to-end `tilelang_ascend_precoding_svd_b256_4x256` Executor wrapper with a fresh TileLang cache — success, 2.1769 ms (2 warmup / 10 benchmark), all 3 numeric stress cases passed
- `msprof op` on the same SVD kernel — success, mix op, 24 block dim / 48 mix block dim, 2534.30 µs task duration
