### PR TITLE
[Fix] Lower scalar T.sqrt and T.rsqrt on Ascend

### DIFF
--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -501,7 +501,26 @@ void CodeGenTileLangAscend::VisitStmt_(const BufferStoreNode *op) {
 }
 
 void CodeGenTileLangAscend::VisitExpr_(const CallNode *op, std::ostream &os) {
-  if (op->op.same_as(builtin::call_extern())) {
+  // Parallel sqrt/rsqrt expressions are lowered to AscendC vector intrinsics
+  // before codegen. Serial expressions reach codegen as their original TIR
+  // intrinsics and use Bisheng's float32 scalar sqrt overload instead.
+  if (op->op.same_as(Op::Get("tir.sqrt"))) {
+    ICHECK_EQ(op->args.size(), 1U);
+    ICHECK_EQ(op->dtype.lanes(), 1);
+    ICHECK(op->dtype.is_float() && op->dtype.bits() == 32)
+        << "Scalar tir.sqrt only supports float32, but got " << op->dtype;
+    os << "sqrt(";
+    PrintExpr(op->args[0], os);
+    os << ")";
+  } else if (op->op.same_as(Op::Get("tir.rsqrt"))) {
+    ICHECK_EQ(op->args.size(), 1U);
+    ICHECK_EQ(op->dtype.lanes(), 1);
+    ICHECK(op->dtype.is_float() && op->dtype.bits() == 32)
+        << "Scalar tir.rsqrt only supports float32, but got " << op->dtype;
+    os << "(1.0f / sqrt(";
+    PrintExpr(op->args[0], os);
+    os << "))";
+  } else if (op->op.same_as(builtin::call_extern())) {
     std::string op_name = Downcast<StringImm>(op->args[0])->value;
     if (op_name.find("tl::ascend::copy") != std::string::npos ||
         op_name.find("tl::ascend::atomic_add_ub_to_gm") != std::string::npos ||

--- a/testing/python/language/test_tilelang_ascend_language_scalar_math.py
+++ b/testing/python/language/test_tilelang_ascend_language_scalar_math.py
@@ -1,0 +1,32 @@
+import tilelang
+import tilelang.language as T
+
+
+def scalar_sqrt_rsqrt(length=8):
+
+    @T.prim_func
+    def main(
+            input_tensor: T.Tensor((length,), "float32"),
+            sqrt_output: T.Tensor((length,), "float32"),
+            rsqrt_output: T.Tensor((length,), "float32"),
+    ):
+        with T.Kernel(1, is_npu=True) as (_cid, _vid):
+            input_ub = T.alloc_ub((length,), "float32")
+            sqrt_ub = T.alloc_ub((length,), "float32")
+            rsqrt_ub = T.alloc_ub((length,), "float32")
+            T.copy(input_tensor, input_ub)
+            for i in T.serial(length):
+                value = input_ub[i]
+                sqrt_ub[i] = T.sqrt(value)
+                rsqrt_ub[i] = T.rsqrt(value + 1.0)
+            T.copy(sqrt_ub, sqrt_output)
+            T.copy(rsqrt_ub, rsqrt_output)
+
+    return main
+
+
+def test_scalar_sqrt_rsqrt_codegen():
+    artifact = tilelang.lower(scalar_sqrt_rsqrt(), target="ascendc")
+    source = artifact.kernel_source
+    assert source.count("sqrt(") >= 2
+    assert "1.0f / sqrt(" in source

--- a/testing/python/language/test_tilelang_ascend_language_scalar_math.py
+++ b/testing/python/language/test_tilelang_ascend_language_scalar_math.py
@@ -6,9 +6,9 @@ def scalar_sqrt_rsqrt(length=8):
 
     @T.prim_func
     def main(
-            input_tensor: T.Tensor((length,), "float32"),
-            sqrt_output: T.Tensor((length,), "float32"),
-            rsqrt_output: T.Tensor((length,), "float32"),
+        input_tensor: T.Tensor((length,), "float32"),
+        sqrt_output: T.Tensor((length,), "float32"),
+        rsqrt_output: T.Tensor((length,), "float32"),
     ):
         with T.Kernel(1, is_npu=True) as (_cid, _vid):
             input_ub = T.alloc_ub((length,), "float32")


### PR DESCRIPTION
## Problem

`T.sqrt` and `T.rsqrt` are available as expression APIs, but serial/scalar expressions can survive the parallel-to-vector pass as `tir.sqrt` and `tir.rsqrt`. The Ascend source code generator did not handle these calls, so `CodeGenC` failed with `Unresolved call Op(tir.sqrt)`.

## Changes

- Emit Bisheng's float32 scalar `sqrt` overload for serial `tir.sqrt`.
- Emit scalar `tir.rsqrt` as `1.0f / sqrt(x)`, matching the available CANN scalar interface.
- Keep the existing parallel/vector intrinsic lowering unchanged.
- Add a focused source-code regression covering both expression APIs in a serial loop.

Scalar lowering is intentionally limited to float32. Bisheng/CANN vector lowering remains the path for vector and float16 operations.

## Validation

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DUSE_ASCEND=ON`
- `cmake --build build -j8`
- `python3 -m pytest -q testing/python/language/test_tilelang_ascend_language_scalar_math.py testing/python/language/test_tilelang_ascend_language_src_code.py -s` — 6 passed
- Generated AscendC source compiled successfully with CANN 8.3.RC2 Bisheng; verified emitted `sqrt(value)` and `1.0f / sqrt(...)`.

NPU runtime numerical validation was not run locally because this host currently has a CPU-only PyTorch build incompatible with the installed `torch_npu`.