### PR TITLE
Add Ascend T.reduce_abssum、T.reduce_absmax 、T.cumsum support

### DIFF
--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -57,6 +57,34 @@ AscendCopy::AscendCopy(Array<PrimExpr> args, BufferMap vmap) : args_(args) {
   } else {
     padValue = Integer(0);
   }
+  // Handle tmp parameter: check if it's a valid region (not IntImm(0) marker)
+  if (args.size() >= 6) {
+    auto tmp_expr = args[5];
+    // Check if tmp is a Call (valid region) or IntImm (none marker)
+    if (auto *tmp_call = tmp_expr.as<CallNode>()) {
+      auto tmp_region = RegionOp(tmp_call->args, vmap);
+      this->tmp = tmp_region.GetBuffer();
+      this->tmp_range = tmp_region.GetRanges();
+      this->tmp_extents = tmp_region.GetExtents();
+    }
+    // If tmp_expr is IntImm(0), leave tmp as undefined (default)
+  }
+  // Optional trailing runtime arguments for the kernel-driven cube path. All
+  // default to 0, which reproduces the previous behaviour exactly: unitFlag 0
+  // is a standalone fixpipe, and realK/realN 0 mean "take the extent from the
+  // destination L0 buffer".
+  unitFlag = Integer(0);
+  realK = Integer(0);
+  realN = Integer(0);
+  if (args.size() >= 7) {
+    unitFlag = args[6];
+  }
+  if (args.size() >= 8) {
+    realK = args[7];
+  }
+  if (args.size() >= 9) {
+    realN = args[8];
+  }
   std::tie(this->src, this->dst) = std::tie(bf[0], bf[1]);
   std::tie(this->src_range, this->dst_range) = std::tie(rgs[0], rgs[1]);
   std::tie(this->src_extents, this->dst_extents) = std::tie(ets[0], ets[1]);
@@ -207,8 +235,27 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
 
       ss << "copy_gm_to_ub<";
       ss << get_dtype(src) << ", ";
-      ss << dst_extents[dst->shape.size() - 1];
-      // ss << dst->shape[dst->shape.size() - 1];
+      // The column dim is a COMPILE-TIME template arg. A runtime inner-extent
+      // slice (dynamic width, e.g. a softmax's actual window tw_a < buffer
+      // width) would put a non-const expr in the template -> invalid C++ ("use
+      // of undeclared identifier"). Use the buffer's compile-time shape for the
+      // template; the runtime width is already carried by the maskShapeN
+      // function arg (validCol_dst). A const extent stays byte-identical (==
+      // shape for a full copy, or the const slice width), so every existing
+      // caller is unchanged -- only the previously-uncompilable runtime-slice
+      // case changes.
+      PrimExpr gm2ub_tmpl_n = dst_extents[dst->shape.size() - 1];
+      if (!gm2ub_tmpl_n->IsInstance<IntImmNode>()) {
+        gm2ub_tmpl_n = dst->shape[dst->shape.size() - 1];
+        // The shape fallback must itself be a compile-time constant; a buffer
+        // declared with a dynamic inner dim would still emit a non-const
+        // template arg (the invalid-C++ case above), so fail early and clearly.
+        ICHECK(gm2ub_tmpl_n->IsInstance<IntImmNode>())
+            << "copy_gm_to_ub: the inner (column) dimension of the destination "
+               "buffer shape must be a compile-time constant, but got "
+            << gm2ub_tmpl_n;
+      }
+      ss << gm2ub_tmpl_n;
       if (dst->shape.size() > 1) {
         ss << ", " << compute_blocklen(dst, dst_extents);
       }
@@ -220,26 +267,37 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
 
       ss << "copy_ub_to_gm<";
       ss << get_dtype(dst) << ", ";
-      ss << src_extents[src->shape.size() - 1];
-      // ss << src->shape[src->shape.size() - 1];
+      // See copy_gm_to_ub above: a runtime inner-extent must use the buffer's
+      // compile-time shape for the template col dim (runtime width is carried
+      // by the maskShapeN function arg); const extents are byte-identical.
+      PrimExpr ub2gm_tmpl_n = src_extents[src->shape.size() - 1];
+      if (!ub2gm_tmpl_n->IsInstance<IntImmNode>()) {
+        ub2gm_tmpl_n = src->shape[src->shape.size() - 1];
+        // See copy_gm_to_ub: the shape fallback must itself be compile-time.
+        ICHECK(ub2gm_tmpl_n->IsInstance<IntImmNode>())
+            << "copy_ub_to_gm: the inner (column) dimension of the source "
+               "buffer shape must be a compile-time constant, but got "
+            << ub2gm_tmpl_n;
+      }
+      ss << ub2gm_tmpl_n;
       if (src->shape.size() > 1) {
         ss << ", " << compute_blocklen(src, src_extents);
       }
       ss << ">";
     } else if (dst.scope() == "shared.l1") {
       config.virtual_channel = true;
-      ss << "copy_ub_to_l1<"; // real channel is "ub -> gm -> l1"
+      ss << "copy_ub_to_l1<";
       ss << get_dtype(dst) << ", ";
-      ss << src->shape[src->shape.size() - 1];
+      ss << src_extents[src->shape.size() - 1];
       if (src->shape.size() > 1) {
-        ss << ", " << src->shape[src->shape.size() - 2];
+        ss << ", " << compute_blocklen(src, src_extents);
       }
       ss << ">";
     } else if (src.scope() == "wmma.accumulator") {
       config.virtual_channel = true;
       ss << "copy_l0c_to_ub<";
       ss << get_dtype(src) << ", " << get_dtype(dst) << ", ";
-      ss << "layout::RowMajor, "; // real channel is "ub -> gm -> l1", so gm is
+      ss << "layout::RowMajor, "; // In "ub -> gm -> l1" path, gm is
                                   // always row major
       ss << src->shape[src->shape.size() - 2] << ", "
          << src->shape[src->shape.size() - 1];
@@ -332,6 +390,22 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
   auto dst_ptr = dst_new_buffer.access_ptr(
       2, dst_new_buffer->dtype, 1,
       dst_new_buffer.OffsetOf(dst_new_indices).back(), dst_len);
+
+  PrimExpr tmp_ptr;
+  if (tmp.defined()) {
+    auto tmp_new_indices =
+        T.layout_map.count(tmp)
+            ? T.layout_map[tmp]->Forward(build_indices(tmp_range))
+            : build_indices(tmp_range);
+    auto tmp_new_buffer = T.buffer_remap.count(tmp) ? T.buffer_remap[tmp] : tmp;
+    PrimExpr tmp_len = 1;
+    for (auto &shape : tmp_extents) {
+      tmp_len *= shape;
+    }
+    tmp_ptr = tmp_new_buffer.access_ptr(
+        3, tmp_new_buffer->dtype, 1,
+        tmp_new_buffer.OffsetOf(tmp_new_indices).back(), tmp_len);
+  }
 
   auto compute_valid_extent = [](PrimExpr min_val, PrimExpr extent,
                                  PrimExpr shape) -> PrimExpr {
@@ -431,8 +505,27 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
 
   if (config.l0_dst_split) {
     int dst_dim = dst->shape.size();
-    new_args.push_back(dst->shape[dst_dim - 2]);
-    new_args.push_back(dst->shape[dst_dim - 1]);
+    PrimExpr dm = dst->shape[dst_dim - 2];
+    PrimExpr dn = dst->shape[dst_dim - 1];
+    // realK overrides the L0 fractal's K extent so it matches the following
+    // mma's runtime K. K is the trailing dim for matrix_a ([M, K]) and the
+    // leading one for matrix_b ([K, N]). realK == 0 keeps dst->shape, which is
+    // byte-identical for every existing L1->L0 copy.
+    const auto *rk_imm = realK.as<IntImmNode>();
+    if (!(rk_imm && rk_imm->value == 0)) {
+      if (dst.scope() == "wmma.matrix_a") {
+        dn = realK;
+      } else if (dst.scope() == "wmma.matrix_b") {
+        dm = realK;
+      }
+    }
+    // realN overrides matrix_b's N extent, the axis realK does not cover.
+    const auto *rn_imm = realN.as<IntImmNode>();
+    if (!(rn_imm && rn_imm->value == 0) && dst.scope() == "wmma.matrix_b") {
+      dn = realN;
+    }
+    new_args.push_back(dm);
+    new_args.push_back(dn);
   }
 
   if (config.l0c2gm) {
@@ -442,6 +535,11 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     new_args.push_back(src->shape[src->shape.size() - 2]);
     new_args.push_back(src->shape[src->shape.size() - 1]);
     new_args.push_back(Bool(enRelu)); // Add enable_relu parameter
+    // unitFlag goes last, not in call order: this list is shared with the PTO
+    // codegen, which reads several of these by position (the pad enum and the
+    // relu flag among them). The ascendc codegen picks it up off the end and
+    // emits it in the position the C++ helper expects.
+    new_args.push_back(unitFlag);
   }
 
   if (config.gm2l1) {
@@ -479,10 +577,20 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
   }
 
   if (config.virtual_channel) {
-    new_args.push_back(
-        src->shape[src->shape.size() -
-                   1]); // ub/l0c -> gm need realdstN which is equal to srcN in
-                        // virtural channel scenario
+    new_args.push_back(src_extents[src_extents.size() - 1]); // src_N
+    if (src_extents.size() >= 2) {
+      new_args.push_back(src_extents[src_extents.size() - 2]); // src_M
+    } else {
+      new_args.push_back(IntImm(DataType::Int(32), 0)); // 1D: no M dim
+    }
+    new_args.push_back(dst_extents[dst_extents.size() - 2]); // dst_M
+    new_args.push_back(dst_extents[dst_extents.size() - 1]); // dst_N
+    // Add tmp buffer for UB->L1 copy on A5 (for ND->Nz conversion)
+    if (tmp.defined()) {
+      new_args.push_back(tmp_ptr);
+      new_args.push_back(tmp_extents[tmp_extents.size() - 2]); // tmp_M
+      new_args.push_back(tmp_extents[tmp_extents.size() - 1]); // tmp_N
+    }
   }
 
   if (config.ub2ub) {
@@ -653,9 +761,25 @@ Stmt AscendAtomicAdd::Lower(const LowerArgs &T,
          "destination buffer rank";
 
   std::stringstream ss;
+  // Same compile-time-template-arg fix as the GM<->UB copy above (see
+  // AscendCopy::Lower): the inner (column) dim is a template arg, so a runtime
+  // inner-extent -- e.g. atomic_add(A[rows, 0:n], src_ub[:, 0:n]) with a
+  // dynamic n -- would put a non-const expr in the template and emit invalid
+  // C++. Use the source buffer's compile-time shape for the template; the
+  // runtime column count is carried by validCol_dst below, so the DMA still
+  // adds exactly the runtime number of columns. A const extent stays
+  // byte-identical, so every existing caller is unchanged.
+  PrimExpr atomic_tmpl_n = src_extents[src->shape.size() - 1];
+  if (!atomic_tmpl_n->IsInstance<IntImmNode>()) {
+    atomic_tmpl_n = src->shape[src->shape.size() - 1];
+    ICHECK(atomic_tmpl_n->IsInstance<IntImmNode>())
+        << "tl.ascend_atomic_add: the inner (column) dimension of the source "
+           "buffer shape must be a compile-time constant, but got "
+        << atomic_tmpl_n;
+  }
   if (src.scope() == "shared.ub") {
     ss << "tl::ascend::atomic_add_ub_to_gm<";
-    ss << get_dtype(dst) << ", " << src_extents[src->shape.size() - 1];
+    ss << get_dtype(dst) << ", " << atomic_tmpl_n;
     if (src->shape.size() > 1) {
       ss << ", " << compute_blocklen(src, src_extents);
     }
@@ -666,10 +790,9 @@ Stmt AscendAtomicAdd::Lower(const LowerArgs &T,
        << (T.layout_map.count(src) ? T.layout_map[src]->AscendLayoutStr()
                                    : "layout::RowMajor");
     if (src->shape.size() > 1) {
-      ss << ", " << compute_blocklen(src, src_extents) << ", "
-         << src_extents[src->shape.size() - 1];
+      ss << ", " << compute_blocklen(src, src_extents) << ", " << atomic_tmpl_n;
     } else {
-      ss << ", 1, " << src_extents[src->shape.size() - 1];
+      ss << ", 1, " << atomic_tmpl_n;
     }
     ss << ">";
   }
@@ -1173,7 +1296,7 @@ TIR_DEFINE_TL_BUILTIN(ascend_sync_all)
                                Integer(CallEffectKind::kOpaque));
 
 TIR_DEFINE_TL_BUILTIN(ascend_gemm_v0)
-    .set_num_inputs(5)
+    .set_num_inputs(6)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
@@ -1194,16 +1317,6 @@ TIR_DEFINE_TL_BUILTIN(ascend_dump_tensor)
 
 TIR_DEFINE_TL_BUILTIN(ascend_src_code)
     .set_num_inputs(-1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ascend_copy_cv_experiment)
-    .set_num_inputs(3)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ascend_copy_vc_experiment)
-    .set_num_inputs(6)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
@@ -1257,8 +1370,10 @@ TIR_DEFINE_TL_BUILTIN(ascend_use_swizzle)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
+// -1 = variadic: the 6 required args (name, A, B, C, init, K) plus the optional
+// trailing n_actual / unitFlag pair.
 TIR_DEFINE_TL_BUILTIN(ascend_mma)
-    .set_num_inputs(6)
+    .set_num_inputs(-1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
@@ -1359,6 +1474,21 @@ TIR_DEFINE_TL_BUILTIN(ascend_row_expand_sub_experiment)
 
 TIR_DEFINE_TL_BUILTIN(ascend_row_expand_div_experiment)
     .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ascend_exp_experiment)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ascend_copy_cv_experiment)
+    .set_num_inputs(3)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ascend_copy_vc_experiment)
+    .set_num_inputs(6)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 

--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -1518,5 +1518,6 @@ TIR_DEFINE_TL_BUILTIN(ascend_cumsum)
     .set_num_inputs(4)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
+
 } // namespace tl
 } // namespace tvm

--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -1384,12 +1384,9 @@ TIR_DEFINE_TL_BUILTIN(ascend_tail_reduce)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-//////
-
 TIR_DEFINE_TL_BUILTIN(ascend_cumsum)
     .set_num_inputs(4)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
-//////
 } // namespace tl
 } // namespace tvm

--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -57,34 +57,6 @@ AscendCopy::AscendCopy(Array<PrimExpr> args, BufferMap vmap) : args_(args) {
   } else {
     padValue = Integer(0);
   }
-  // Handle tmp parameter: check if it's a valid region (not IntImm(0) marker)
-  if (args.size() >= 6) {
-    auto tmp_expr = args[5];
-    // Check if tmp is a Call (valid region) or IntImm (none marker)
-    if (auto *tmp_call = tmp_expr.as<CallNode>()) {
-      auto tmp_region = RegionOp(tmp_call->args, vmap);
-      this->tmp = tmp_region.GetBuffer();
-      this->tmp_range = tmp_region.GetRanges();
-      this->tmp_extents = tmp_region.GetExtents();
-    }
-    // If tmp_expr is IntImm(0), leave tmp as undefined (default)
-  }
-  // Optional trailing runtime arguments for the kernel-driven cube path. All
-  // default to 0, which reproduces the previous behaviour exactly: unitFlag 0
-  // is a standalone fixpipe, and realK/realN 0 mean "take the extent from the
-  // destination L0 buffer".
-  unitFlag = Integer(0);
-  realK = Integer(0);
-  realN = Integer(0);
-  if (args.size() >= 7) {
-    unitFlag = args[6];
-  }
-  if (args.size() >= 8) {
-    realK = args[7];
-  }
-  if (args.size() >= 9) {
-    realN = args[8];
-  }
   std::tie(this->src, this->dst) = std::tie(bf[0], bf[1]);
   std::tie(this->src_range, this->dst_range) = std::tie(rgs[0], rgs[1]);
   std::tie(this->src_extents, this->dst_extents) = std::tie(ets[0], ets[1]);
@@ -235,27 +207,8 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
 
       ss << "copy_gm_to_ub<";
       ss << get_dtype(src) << ", ";
-      // The column dim is a COMPILE-TIME template arg. A runtime inner-extent
-      // slice (dynamic width, e.g. a softmax's actual window tw_a < buffer
-      // width) would put a non-const expr in the template -> invalid C++ ("use
-      // of undeclared identifier"). Use the buffer's compile-time shape for the
-      // template; the runtime width is already carried by the maskShapeN
-      // function arg (validCol_dst). A const extent stays byte-identical (==
-      // shape for a full copy, or the const slice width), so every existing
-      // caller is unchanged -- only the previously-uncompilable runtime-slice
-      // case changes.
-      PrimExpr gm2ub_tmpl_n = dst_extents[dst->shape.size() - 1];
-      if (!gm2ub_tmpl_n->IsInstance<IntImmNode>()) {
-        gm2ub_tmpl_n = dst->shape[dst->shape.size() - 1];
-        // The shape fallback must itself be a compile-time constant; a buffer
-        // declared with a dynamic inner dim would still emit a non-const
-        // template arg (the invalid-C++ case above), so fail early and clearly.
-        ICHECK(gm2ub_tmpl_n->IsInstance<IntImmNode>())
-            << "copy_gm_to_ub: the inner (column) dimension of the destination "
-               "buffer shape must be a compile-time constant, but got "
-            << gm2ub_tmpl_n;
-      }
-      ss << gm2ub_tmpl_n;
+      ss << dst_extents[dst->shape.size() - 1];
+      // ss << dst->shape[dst->shape.size() - 1];
       if (dst->shape.size() > 1) {
         ss << ", " << compute_blocklen(dst, dst_extents);
       }
@@ -267,37 +220,26 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
 
       ss << "copy_ub_to_gm<";
       ss << get_dtype(dst) << ", ";
-      // See copy_gm_to_ub above: a runtime inner-extent must use the buffer's
-      // compile-time shape for the template col dim (runtime width is carried
-      // by the maskShapeN function arg); const extents are byte-identical.
-      PrimExpr ub2gm_tmpl_n = src_extents[src->shape.size() - 1];
-      if (!ub2gm_tmpl_n->IsInstance<IntImmNode>()) {
-        ub2gm_tmpl_n = src->shape[src->shape.size() - 1];
-        // See copy_gm_to_ub: the shape fallback must itself be compile-time.
-        ICHECK(ub2gm_tmpl_n->IsInstance<IntImmNode>())
-            << "copy_ub_to_gm: the inner (column) dimension of the source "
-               "buffer shape must be a compile-time constant, but got "
-            << ub2gm_tmpl_n;
-      }
-      ss << ub2gm_tmpl_n;
+      ss << src_extents[src->shape.size() - 1];
+      // ss << src->shape[src->shape.size() - 1];
       if (src->shape.size() > 1) {
         ss << ", " << compute_blocklen(src, src_extents);
       }
       ss << ">";
     } else if (dst.scope() == "shared.l1") {
       config.virtual_channel = true;
-      ss << "copy_ub_to_l1<";
+      ss << "copy_ub_to_l1<"; // real channel is "ub -> gm -> l1"
       ss << get_dtype(dst) << ", ";
-      ss << src_extents[src->shape.size() - 1];
+      ss << src->shape[src->shape.size() - 1];
       if (src->shape.size() > 1) {
-        ss << ", " << compute_blocklen(src, src_extents);
+        ss << ", " << src->shape[src->shape.size() - 2];
       }
       ss << ">";
     } else if (src.scope() == "wmma.accumulator") {
       config.virtual_channel = true;
       ss << "copy_l0c_to_ub<";
       ss << get_dtype(src) << ", " << get_dtype(dst) << ", ";
-      ss << "layout::RowMajor, "; // In "ub -> gm -> l1" path, gm is
+      ss << "layout::RowMajor, "; // real channel is "ub -> gm -> l1", so gm is
                                   // always row major
       ss << src->shape[src->shape.size() - 2] << ", "
          << src->shape[src->shape.size() - 1];
@@ -390,22 +332,6 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
   auto dst_ptr = dst_new_buffer.access_ptr(
       2, dst_new_buffer->dtype, 1,
       dst_new_buffer.OffsetOf(dst_new_indices).back(), dst_len);
-
-  PrimExpr tmp_ptr;
-  if (tmp.defined()) {
-    auto tmp_new_indices =
-        T.layout_map.count(tmp)
-            ? T.layout_map[tmp]->Forward(build_indices(tmp_range))
-            : build_indices(tmp_range);
-    auto tmp_new_buffer = T.buffer_remap.count(tmp) ? T.buffer_remap[tmp] : tmp;
-    PrimExpr tmp_len = 1;
-    for (auto &shape : tmp_extents) {
-      tmp_len *= shape;
-    }
-    tmp_ptr = tmp_new_buffer.access_ptr(
-        3, tmp_new_buffer->dtype, 1,
-        tmp_new_buffer.OffsetOf(tmp_new_indices).back(), tmp_len);
-  }
 
   auto compute_valid_extent = [](PrimExpr min_val, PrimExpr extent,
                                  PrimExpr shape) -> PrimExpr {
@@ -505,27 +431,8 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
 
   if (config.l0_dst_split) {
     int dst_dim = dst->shape.size();
-    PrimExpr dm = dst->shape[dst_dim - 2];
-    PrimExpr dn = dst->shape[dst_dim - 1];
-    // realK overrides the L0 fractal's K extent so it matches the following
-    // mma's runtime K. K is the trailing dim for matrix_a ([M, K]) and the
-    // leading one for matrix_b ([K, N]). realK == 0 keeps dst->shape, which is
-    // byte-identical for every existing L1->L0 copy.
-    const auto *rk_imm = realK.as<IntImmNode>();
-    if (!(rk_imm && rk_imm->value == 0)) {
-      if (dst.scope() == "wmma.matrix_a") {
-        dn = realK;
-      } else if (dst.scope() == "wmma.matrix_b") {
-        dm = realK;
-      }
-    }
-    // realN overrides matrix_b's N extent, the axis realK does not cover.
-    const auto *rn_imm = realN.as<IntImmNode>();
-    if (!(rn_imm && rn_imm->value == 0) && dst.scope() == "wmma.matrix_b") {
-      dn = realN;
-    }
-    new_args.push_back(dm);
-    new_args.push_back(dn);
+    new_args.push_back(dst->shape[dst_dim - 2]);
+    new_args.push_back(dst->shape[dst_dim - 1]);
   }
 
   if (config.l0c2gm) {
@@ -535,11 +442,6 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     new_args.push_back(src->shape[src->shape.size() - 2]);
     new_args.push_back(src->shape[src->shape.size() - 1]);
     new_args.push_back(Bool(enRelu)); // Add enable_relu parameter
-    // unitFlag goes last, not in call order: this list is shared with the PTO
-    // codegen, which reads several of these by position (the pad enum and the
-    // relu flag among them). The ascendc codegen picks it up off the end and
-    // emits it in the position the C++ helper expects.
-    new_args.push_back(unitFlag);
   }
 
   if (config.gm2l1) {
@@ -577,20 +479,10 @@ Stmt AscendCopy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
   }
 
   if (config.virtual_channel) {
-    new_args.push_back(src_extents[src_extents.size() - 1]); // src_N
-    if (src_extents.size() >= 2) {
-      new_args.push_back(src_extents[src_extents.size() - 2]); // src_M
-    } else {
-      new_args.push_back(IntImm(DataType::Int(32), 0)); // 1D: no M dim
-    }
-    new_args.push_back(dst_extents[dst_extents.size() - 2]); // dst_M
-    new_args.push_back(dst_extents[dst_extents.size() - 1]); // dst_N
-    // Add tmp buffer for UB->L1 copy on A5 (for ND->Nz conversion)
-    if (tmp.defined()) {
-      new_args.push_back(tmp_ptr);
-      new_args.push_back(tmp_extents[tmp_extents.size() - 2]); // tmp_M
-      new_args.push_back(tmp_extents[tmp_extents.size() - 1]); // tmp_N
-    }
+    new_args.push_back(
+        src->shape[src->shape.size() -
+                   1]); // ub/l0c -> gm need realdstN which is equal to srcN in
+                        // virtural channel scenario
   }
 
   if (config.ub2ub) {
@@ -761,25 +653,9 @@ Stmt AscendAtomicAdd::Lower(const LowerArgs &T,
          "destination buffer rank";
 
   std::stringstream ss;
-  // Same compile-time-template-arg fix as the GM<->UB copy above (see
-  // AscendCopy::Lower): the inner (column) dim is a template arg, so a runtime
-  // inner-extent -- e.g. atomic_add(A[rows, 0:n], src_ub[:, 0:n]) with a
-  // dynamic n -- would put a non-const expr in the template and emit invalid
-  // C++. Use the source buffer's compile-time shape for the template; the
-  // runtime column count is carried by validCol_dst below, so the DMA still
-  // adds exactly the runtime number of columns. A const extent stays
-  // byte-identical, so every existing caller is unchanged.
-  PrimExpr atomic_tmpl_n = src_extents[src->shape.size() - 1];
-  if (!atomic_tmpl_n->IsInstance<IntImmNode>()) {
-    atomic_tmpl_n = src->shape[src->shape.size() - 1];
-    ICHECK(atomic_tmpl_n->IsInstance<IntImmNode>())
-        << "tl.ascend_atomic_add: the inner (column) dimension of the source "
-           "buffer shape must be a compile-time constant, but got "
-        << atomic_tmpl_n;
-  }
   if (src.scope() == "shared.ub") {
     ss << "tl::ascend::atomic_add_ub_to_gm<";
-    ss << get_dtype(dst) << ", " << atomic_tmpl_n;
+    ss << get_dtype(dst) << ", " << src_extents[src->shape.size() - 1];
     if (src->shape.size() > 1) {
       ss << ", " << compute_blocklen(src, src_extents);
     }
@@ -790,9 +666,10 @@ Stmt AscendAtomicAdd::Lower(const LowerArgs &T,
        << (T.layout_map.count(src) ? T.layout_map[src]->AscendLayoutStr()
                                    : "layout::RowMajor");
     if (src->shape.size() > 1) {
-      ss << ", " << compute_blocklen(src, src_extents) << ", " << atomic_tmpl_n;
+      ss << ", " << compute_blocklen(src, src_extents) << ", "
+         << src_extents[src->shape.size() - 1];
     } else {
-      ss << ", 1, " << atomic_tmpl_n;
+      ss << ", 1, " << src_extents[src->shape.size() - 1];
     }
     ss << ">";
   }
@@ -1296,7 +1173,7 @@ TIR_DEFINE_TL_BUILTIN(ascend_sync_all)
                                Integer(CallEffectKind::kOpaque));
 
 TIR_DEFINE_TL_BUILTIN(ascend_gemm_v0)
-    .set_num_inputs(6)
+    .set_num_inputs(5)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
@@ -1317,6 +1194,16 @@ TIR_DEFINE_TL_BUILTIN(ascend_dump_tensor)
 
 TIR_DEFINE_TL_BUILTIN(ascend_src_code)
     .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ascend_copy_cv_experiment)
+    .set_num_inputs(3)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ascend_copy_vc_experiment)
+    .set_num_inputs(6)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
@@ -1370,10 +1257,8 @@ TIR_DEFINE_TL_BUILTIN(ascend_use_swizzle)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-// -1 = variadic: the 6 required args (name, A, B, C, init, K) plus the optional
-// trailing n_actual / unitFlag pair.
 TIR_DEFINE_TL_BUILTIN(ascend_mma)
-    .set_num_inputs(-1)
+    .set_num_inputs(6)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
@@ -1477,21 +1362,6 @@ TIR_DEFINE_TL_BUILTIN(ascend_row_expand_div_experiment)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(ascend_exp_experiment)
-    .set_num_inputs(-1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ascend_copy_cv_experiment)
-    .set_num_inputs(3)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ascend_copy_vc_experiment)
-    .set_num_inputs(6)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
 // Internal tail-aware ops (see ascend.h). Variadic: they carry an AscendC op
 // tag string, buffer pointers, and the runtime tail rect.
 TIR_DEFINE_TL_BUILTIN(ascend_tail_unary)
@@ -1513,5 +1383,13 @@ TIR_DEFINE_TL_BUILTIN(ascend_tail_reduce)
     .set_num_inputs(-1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
+
+//////
+
+TIR_DEFINE_TL_BUILTIN(ascend_cumsum)
+    .set_num_inputs(4)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+//////
 } // namespace tl
 } // namespace tvm

--- a/src/op/ascend.h
+++ b/src/op/ascend.h
@@ -35,6 +35,24 @@ private:
   bool enRelu;
   bool transposeL1;
   PrimExpr padValue;
+  Buffer tmp;
+  Array<Range> tmp_range;
+  Array<PrimExpr> tmp_extents;
+  // L0C->GM fixpipe unitFlag (default 0 = a standalone fixpipe). Threaded into
+  // copy_l0c_to_gm so a kernel-driven fixpipe can pair with the preceding mma's
+  // unitFlag and overlap across an L0C ping-pong.
+  PrimExpr unitFlag;
+  // L1->L0 runtime contraction length (default 0 = take the K extent from the
+  // destination L0 buffer). Overrides copy_l1_to_l0a's dstN / copy_l1_to_l0b's
+  // dstM so the loaded fractal matches a following mma's runtime K -- a
+  // full-width load feeding a shorter mma otherwise reads mismatched fractals.
+  PrimExpr realK;
+  // L1->L0B runtime output width (default 0 = take N from the destination L0
+  // buffer). The other axis of what realK covers: L0B's fractal derives its
+  // K-block stride from the column count, so a full-width load followed by a
+  // shorter mma addresses the wrong K-blocks. Applies to matrix_b only, since
+  // matrix_a is [M, K] and has no N.
+  PrimExpr realN;
 };
 
 class AscendAtomicAdd : public Operator {
@@ -196,10 +214,6 @@ TVM_DLL const Op &ascend_dump_tensor();
 
 TVM_DLL const Op &ascend_src_code();
 
-TVM_DLL const Op &ascend_copy_cv_experiment();
-
-TVM_DLL const Op &ascend_copy_vc_experiment();
-
 TVM_DLL const Op &ascend_bilinear_interpolation();
 
 TVM_DLL const Op &ascend_wholereducemax();
@@ -260,6 +274,8 @@ TVM_DLL const Op &ascend_row_expand_sub_experiment();
 
 TVM_DLL const Op &ascend_row_expand_div_experiment();
 
+TVM_DLL const Op &ascend_exp_experiment();
+
 // ---------------------------------------------------------------------------
 // Internal tail-aware vector ops produced by AscendTailMaskPropagation. These
 // are never emitted by the front-end; the pass rewrites the corresponding
@@ -276,8 +292,11 @@ TVM_DLL const Op &ascend_tail_scalar();
 
 TVM_DLL const Op &ascend_tail_reduce();
 
-TVM_DLL const Op &ascend_cumsum();
+TVM_DLL const Op &ascend_copy_cv_experiment();
 
+TVM_DLL const Op &ascend_copy_vc_experiment();
+
+TVM_DLL const Op &ascend_cumsum();
 } // namespace tl
 } // namespace tvm
 

--- a/src/op/ascend.h
+++ b/src/op/ascend.h
@@ -35,24 +35,6 @@ private:
   bool enRelu;
   bool transposeL1;
   PrimExpr padValue;
-  Buffer tmp;
-  Array<Range> tmp_range;
-  Array<PrimExpr> tmp_extents;
-  // L0C->GM fixpipe unitFlag (default 0 = a standalone fixpipe). Threaded into
-  // copy_l0c_to_gm so a kernel-driven fixpipe can pair with the preceding mma's
-  // unitFlag and overlap across an L0C ping-pong.
-  PrimExpr unitFlag;
-  // L1->L0 runtime contraction length (default 0 = take the K extent from the
-  // destination L0 buffer). Overrides copy_l1_to_l0a's dstN / copy_l1_to_l0b's
-  // dstM so the loaded fractal matches a following mma's runtime K -- a
-  // full-width load feeding a shorter mma otherwise reads mismatched fractals.
-  PrimExpr realK;
-  // L1->L0B runtime output width (default 0 = take N from the destination L0
-  // buffer). The other axis of what realK covers: L0B's fractal derives its
-  // K-block stride from the column count, so a full-width load followed by a
-  // shorter mma addresses the wrong K-blocks. Applies to matrix_b only, since
-  // matrix_a is [M, K] and has no N.
-  PrimExpr realN;
 };
 
 class AscendAtomicAdd : public Operator {
@@ -214,6 +196,10 @@ TVM_DLL const Op &ascend_dump_tensor();
 
 TVM_DLL const Op &ascend_src_code();
 
+TVM_DLL const Op &ascend_copy_cv_experiment();
+
+TVM_DLL const Op &ascend_copy_vc_experiment();
+
 TVM_DLL const Op &ascend_bilinear_interpolation();
 
 TVM_DLL const Op &ascend_wholereducemax();
@@ -274,8 +260,6 @@ TVM_DLL const Op &ascend_row_expand_sub_experiment();
 
 TVM_DLL const Op &ascend_row_expand_div_experiment();
 
-TVM_DLL const Op &ascend_exp_experiment();
-
 // ---------------------------------------------------------------------------
 // Internal tail-aware vector ops produced by AscendTailMaskPropagation. These
 // are never emitted by the front-end; the pass rewrites the corresponding
@@ -292,9 +276,10 @@ TVM_DLL const Op &ascend_tail_scalar();
 
 TVM_DLL const Op &ascend_tail_reduce();
 
-TVM_DLL const Op &ascend_copy_cv_experiment();
+//////
+TVM_DLL const Op &ascend_cumsum();
+//////
 
-TVM_DLL const Op &ascend_copy_vc_experiment();
 } // namespace tl
 } // namespace tvm
 

--- a/src/op/ascend.h
+++ b/src/op/ascend.h
@@ -276,9 +276,7 @@ TVM_DLL const Op &ascend_tail_scalar();
 
 TVM_DLL const Op &ascend_tail_reduce();
 
-//////
 TVM_DLL const Op &ascend_cumsum();
-//////
 
 } // namespace tl
 } // namespace tvm

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -15,6 +15,7 @@
 #include <tvm/tir/expr.h>
 
 #include <cmath>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -479,19 +480,29 @@ void CodeGenTileLangAscend::VisitExpr_(const BufferLoadNode *op,
   if (scope == "local.var") {
     os << var_name;
   } else {
-    os << var_name << ".GetValue(" << PrintExpr(op->indices.back()) << ")";
+    // Flatten every index, not just the innermost one: a scalar access into a
+    // multi-dimensional buffer such as table[b, i] otherwise drops the leading
+    // dimensions and aliases every row onto row 0. OffsetOf is the identity for
+    // a 1-D buffer, so single-dimension accesses are unchanged.
+    os << var_name << ".GetValue("
+       << PrintExpr(op->buffer.OffsetOf(op->indices).back()) << ")";
   }
 }
 
 void CodeGenTileLangAscend::VisitStmt_(const BufferStoreNode *op) {
   auto var_name = var_idmap_[op->buffer->data.get()];
   std::string scope = GetPtrStorageScope(op->buffer->data);
-  this->PrintIndent();
   if (scope == "local.var") {
-    this->stream << var_name << " = " << PrintExpr(op->value) << ";\n";
+    std::string value = PrintExpr(op->value);
+    this->PrintIndent();
+    this->stream << var_name << " = " << value << ";\n";
   } else {
-    this->stream << var_name << ".SetValue(" << PrintExpr(op->indices.back())
-                 << ", " << PrintExpr(op->value) << ");\n";
+    // See VisitExpr_(BufferLoadNode): flatten across all dimensions.
+    std::string index = PrintExpr(op->buffer.OffsetOf(op->indices).back());
+    std::string value = PrintExpr(op->value);
+    this->PrintIndent();
+    this->stream << var_name << ".SetValue(" << index << ", " << value
+                 << ");\n";
   }
 }
 
@@ -638,6 +649,8 @@ void CodeGenTileLangAscend::VisitExpr_(const CallNode *op, std::ostream &os) {
     RowExpandSubExperimentCodegen(op);
   } else if (op->op.same_as(tl::ascend_row_expand_div_experiment())) {
     RowExpandDivExperimentCodegen(op);
+  } else if (op->op.same_as(tl::ascend_exp_experiment())) {
+    ExpExperimentCodegen(op);
   } else if (op->op.same_as(tl::ascend_wait_cross_flag())) {
     PrintOpCall(op, "AscendC::CrossCoreWaitFlag", {0, 0}, {0, 1});
   } else if (op->op.same_as(tl::ascend_set_cross_flag())) {
@@ -656,6 +669,8 @@ void CodeGenTileLangAscend::VisitExpr_(const CallNode *op, std::ostream &os) {
     PrintfOpCodegen(op, "AscendC::PRINTF");
   } else if (op->op.same_as(tl::ascend_dump_tensor())) {
     DumpTensorCodegen(op);
+  } else if (op->op.same_as(tl::ascend_src_code())) {
+    SrcCodeCodegen(op);
   } else if (op->op.same_as(tl::ascend_bilinear_interpolation())) {
     BilinearInterpolationCodegen(op);
   } else if (op->op.same_as(tl::ascend_wholereducemax())) {
@@ -760,20 +775,6 @@ void CodeGenTileLangAscend::VisitStmt_(const AttrStmtNode *op) {
       auto vec_id_ = AllocVarID(iv->var.get());
       this->PrintIndent();
       this->stream << "auto " << vec_id_ << " = AscendC::GetSubBlockIdx();\n";
-    }
-    this->VisitStmt(op->body);
-    return;
-  } else if (op->attr_key == "init_flag" || op->attr_key == "clear_flag") {
-    const StringImmNode *instn = op->value.as<StringImmNode>();
-
-    std::string inst = std::string(instn->value);
-    size_t st = 0;
-    for (size_t i = 0; i < inst.size(); ++i) {
-      if (inst[i] == '\n') {
-        this->PrintIndent();
-        stream << inst.substr(st, i - st) << "\n";
-        st = i + 1;
-      }
     }
     this->VisitStmt(op->body);
     return;
@@ -2019,6 +2020,16 @@ void CodeGenTileLangAscend::ReduceOpCodegen(const CallNode *op) {
 
   bool is_reduce_sum = (op_name.find("reduce_sum") != std::string::npos);
   int buffer_arg_end = static_cast<int>(op->args.size());
+  // Optional trailing physical row width, emitted only when the logical width
+  // is narrower than the row the data sits in (a sliced region, or a real_shape
+  // narrower than the buffer). It follows `clear`, so peel it off first.
+  int64_t physical_row = 0;
+  if (buffer_arg_end > 0 && !op->args[buffer_arg_end - 1].dtype().is_bool()) {
+    if (const auto *row_imm = op->args[buffer_arg_end - 1].as<IntImmNode>()) {
+      physical_row = row_imm->value;
+      buffer_arg_end--;
+    }
+  }
   bool clear = true;
   if (buffer_arg_end > 0 && op->args[buffer_arg_end - 1].dtype().is_bool()) {
     clear = !is_zero(op->args[buffer_arg_end - 1]);
@@ -2033,6 +2044,85 @@ void CodeGenTileLangAscend::ReduceOpCodegen(const CallNode *op) {
   }
 
   this->PrintIndent();
+
+  // Narrow row-reduce: the logical width is only part of a wider physical row,
+  // so the source cannot be walked as one contiguous M x N block. Route to the
+  // WholeReduce* helpers, which take an explicit per-repeat source stride.
+  if (physical_row > 0) {
+    size_t tpos1 = op_name.find("<");
+    size_t tpos2 = op_name.rfind(">");
+    std::string tparams = op_name.substr(tpos1 + 1, tpos2 - tpos1 - 1);
+    size_t c1 = tparams.find(",");
+    size_t c2 = tparams.find(",", c1 + 1);
+    size_t c3 = tparams.find(",", c2 + 1);
+    auto trim = [](std::string s) {
+      size_t b = s.find_first_not_of(" \t");
+      if (b == std::string::npos)
+        return std::string("");
+      return s.substr(b, s.find_last_not_of(" \t") - b + 1);
+    };
+    std::string ndtype = trim(tparams.substr(0, c1));
+    // The front end only attaches a physical row width once it has resolved the
+    // logical extents to constants, so these parse. Guard anyway: a symbolic
+    // extent reaching here would otherwise throw out of std::stoll and take the
+    // compiler down with it.
+    int64_t nm = 0, nn = 0, ndim = 0;
+    try {
+      nm = std::stoll(trim(tparams.substr(c1 + 1, c2 - c1 - 1)));
+      nn = std::stoll(trim(tparams.substr(c2 + 1, c3 - c2 - 1)));
+      ndim = std::stoll(trim(tparams.substr(c3 + 1)));
+    } catch (const std::exception &) {
+      LOG(FATAL) << "narrow reduce needs compile-time extents, but could not "
+                    "parse the template parameters: "
+                 << tparams;
+    }
+
+    // Enumerated rather than defaulted: guessing 4 bytes for an unrecognised
+    // type would silently scale the stride wrong instead of failing.
+    int64_t elem_bytes = 0;
+    if (ndtype == "float" || ndtype == "int32_t" || ndtype == "uint32_t") {
+      elem_bytes = 4;
+    } else if (ndtype == "half" || ndtype == "bfloat16_t" ||
+               ndtype == "int16_t" || ndtype == "uint16_t") {
+      elem_bytes = 2;
+    } else if (ndtype == "int8_t" || ndtype == "uint8_t" ||
+               ndtype == "float8_e4m3_t" || ndtype == "float8_e5m2_t") {
+      elem_bytes = 1;
+    }
+    ICHECK(elem_bytes > 0)
+        << "narrow reduce does not know the element size of '" << ndtype << "'";
+    ICHECK(ndim == -1) << "narrow reduce is only implemented for a row reduce "
+                          "(dim == -1); got dim "
+                       << ndim << " over a logical width of " << nn
+                       << " inside a physical row of " << physical_row;
+    ICHECK(nn * elem_bytes <= 256)
+        << "narrow reduce needs the logical width to fit one vector repeat "
+           "(256 "
+           "bytes); got "
+        << nn << " elements of " << elem_bytes << " bytes. Split the range and "
+        << "combine the partial results.";
+    ICHECK(clear) << "narrow reduce cannot merge into the destination "
+                     "(clear == false); reduce into a scratch and combine.";
+
+    std::string narrow = "reduce_max_narrow";
+    if (is_reduce_sum) {
+      narrow = "reduce_sum_narrow";
+    } else if (op_name.find("reduce_min") != std::string::npos) {
+      narrow = "reduce_min_narrow";
+    }
+    // srcRepStride steps one physical row, counted in 32-byte blocks, so the
+    // row has to be a whole number of them -- otherwise the division truncates
+    // and the reduce walks a stride that is short (or zero).
+    ICHECK((physical_row * elem_bytes) % 32 == 0)
+        << "narrow reduce needs the physical row (" << physical_row
+        << " elements of " << elem_bytes
+        << " bytes) to be a multiple of the 32-byte block";
+    int64_t src_rep_stride = physical_row * elem_bytes / 32;
+    this->stream << "tl::ascend::" << narrow << "<" << ndtype << ">("
+                 << var_names[0] << ", " << var_names[1] << ", " << nn << ", "
+                 << nm << ", " << src_rep_stride << ");\n";
+    return;
+  }
 
   if (is_reduce_sum) {
     size_t pos1 = op_name.find("<");
@@ -2191,11 +2281,10 @@ void CodeGenTileLangAscend::RowExpandDivExperimentCodegen(const CallNode *op) {
 void CodeGenTileLangAscend::RowExpandBinOpExperimentCodegen(
     const CallNode *op, const std::string &mask_op_name) {
   // args[0] = op name string, args[1] = dst, args[2] = src0,
-  // args[3] = src1, args[4] = tmp (required for AscendC)
+  // args[3] = src1, args[4] = optional broadcast workspace.
   //
-  // AscendC path: src1 is 1D [R] scalars, but {mul,sub,div}_mask requires
-  // a 2D [R, elems_per_block] broadcast buffer. Use tmp as intermediate:
-  // brcb(src1 → tmp) then {op}_mask(dst, src0, tmp).
+  // With tmp, src1 is a scalar-linear [R] stream that brcb expands into
+  // [R, elems_per_block]. Without tmp, src1 already contains those blocks.
   DataType dtype = GetAccessPtrDtype(op->args[1].as<CallNode>());
   std::string type_str = getType(dtype);
   int elems_per_block = 32 / (dtype.bits() / 8);
@@ -2215,7 +2304,13 @@ void CodeGenTileLangAscend::RowExpandBinOpExperimentCodegen(
       cols = static_cast<int>(shape[shape.size() - 1].as<IntImmNode>()->value);
     }
   }
+  ICHECK_EQ(cols % elems_per_block, 0)
+      << "RowExpandBinOpExperimentCodegen: physical columns=" << cols
+      << " must be divisible by " << elems_per_block;
   int rep_stride = cols / elems_per_block;
+  ICHECK(rep_stride > 0 && rep_stride <= 255)
+      << "RowExpandBinOpExperimentCodegen: repeat stride=" << rep_stride
+      << " must fit uint8_t";
   int repeat_time = 0;
   if (auto *extent_imm = dst_access->args[3].as<IntImmNode>()) {
     int extent = static_cast<int>(extent_imm->value);
@@ -2232,12 +2327,13 @@ void CodeGenTileLangAscend::RowExpandBinOpExperimentCodegen(
   ICHECK(rows % 8 == 0)
       << "RowExpandBinOpExperimentCodegen: rows=" << rows
       << " must be a multiple of 8 (BRCB processes 8 scalars per repeat)";
+  ICHECK_LE(rows, 255) << "RowExpandBinOpExperimentCodegen: rows=" << rows
+                       << " must fit uint8_t";
   int brcb_repeat = rows / 8;
   ICHECK(rows > 0 && cols > 0)
       << "RowExpandBinOpExperimentCodegen: failed to derive rows/cols";
 
-  uint64_t mask0 = 0xFFFFFFFFFFFFFFFF;
-  uint64_t mask1 = (dtype.bits() == 16) ? 0xFFFFFFFFFFFFFFFF : 0;
+  const char *mask1 = (dtype.bits() == 16) ? "0xFFFFFFFFFFFFFFFF" : "0";
 
   std::string dst_name = PrintBufferOffset(op->args[1].as<CallNode>(), true);
   std::string src0_name = PrintBufferOffset(op->args[2].as<CallNode>(), true);
@@ -2269,6 +2365,57 @@ void CodeGenTileLangAscend::RowExpandBinOpExperimentCodegen(
                  << ", 1, 1, 0, " << rep_stride << ", " << rep_stride
                  << ", 1);\n";
   }
+}
+
+void CodeGenTileLangAscend::ExpExperimentCodegen(const CallNode *op) {
+  // args[0] = op name string, args[1] = dst, args[2] = src.
+  // Unary mirror of RowExpandBinOpExperimentCodegen: exp the `mask` valid
+  // columns of each row in place, striding by the buffer's physical column
+  // count so one call covers all rows of a 64-column (fp32) chunk of a wider
+  // N-strided score buffer. rep_stride = physical_cols / elems_per_block;
+  // repeat_time = extent / (8 * elems_per_block) = one repeat per row when the
+  // slice is a 64-col chunk.
+  DataType dtype = GetAccessPtrDtype(op->args[1].as<CallNode>());
+  std::string type_str = getType(dtype);
+  int elems_per_block = 256 / dtype.bits();
+
+  auto *dst_access = op->args[1].as<CallNode>();
+  Var dst_var = Downcast<Var>(dst_access->args[1]);
+  int cols = 0;
+  if (buffer_shapes_.count(dst_var)) {
+    auto shape = buffer_shapes_.at(dst_var);
+    if (shape.size() >= 1 && shape[shape.size() - 1].as<IntImmNode>()) {
+      cols = static_cast<int>(shape[shape.size() - 1].as<IntImmNode>()->value);
+    }
+  }
+  int rep_stride = cols / elems_per_block;
+  int repeat_time = 0;
+  if (auto *extent_imm = dst_access->args[3].as<IntImmNode>()) {
+    int extent = static_cast<int>(extent_imm->value);
+    int elems_per_repeat = 8 * elems_per_block;
+    ICHECK(extent > 0 && extent % elems_per_repeat == 0)
+        << "ExpExperimentCodegen: extent=" << extent
+        << " must be a positive multiple of " << elems_per_repeat;
+    repeat_time = extent / elems_per_repeat;
+  } else {
+    ICHECK(false) << "ExpExperimentCodegen: dynamic extent not supported";
+  }
+  ICHECK(repeat_time > 0 && cols > 0)
+      << "ExpExperimentCodegen: failed to derive repeat_time/cols";
+  ICHECK(cols % elems_per_block == 0)
+      << "ExpExperimentCodegen: physical columns " << cols
+      << " must be a multiple of elems_per_block " << elems_per_block;
+
+  uint64_t mask1 = (dtype.bits() == 16) ? 0xFFFFFFFFFFFFFFFF : 0;
+
+  std::string dst_name = PrintBufferOffset(op->args[1].as<CallNode>(), true);
+  std::string src_name = PrintBufferOffset(op->args[2].as<CallNode>(), true);
+
+  this->PrintIndent();
+  this->stream << "tl::ascend::exp_mask<" << type_str << ">(" << dst_name
+               << ", " << src_name << ", 0xFFFFFFFFFFFFFFFF, " << mask1 << ", "
+               << repeat_time << ", 1, 1, " << rep_stride << ", " << rep_stride
+               << ");\n";
 }
 
 void CodeGenTileLangAscend::BroadcastOpCodegen(const CallNode *op) {
@@ -2419,7 +2566,7 @@ void CodeGenTileLangAscend::GemmOpCodegen(const CallNode *op) {
   this->stream << op_name << "(" << a_name << "[" << a_offset << "], " << b_name
                << "[" << b_offset << "], " << c_name << "[" << c_offset
                << "], ascend_l0a, ascend_l0b, " << PrintExpr(op->args[4])
-               << ");\n";
+               << ", " << PrintExpr(op->args[5]) << ");\n";
 }
 
 void CodeGenTileLangAscend::PrintfOpCodegen(const CallNode *op,
@@ -2475,6 +2622,18 @@ void CodeGenTileLangAscend::DumpTensorCodegen(const CallNode *op) {
   }
 
   this->stream << ");\n";
+}
+
+void CodeGenTileLangAscend::SrcCodeCodegen(const CallNode *op) {
+  auto *str = op->args[0].as<StringImmNode>();
+  ICHECK(str) << "T._src_code() expects a string literal argument";
+  std::string code = str->value;
+  std::istringstream iss(code);
+  std::string line;
+  while (std::getline(iss, line)) {
+    this->PrintIndent();
+    this->stream << line << "\n";
+  }
 }
 
 void CodeGenTileLangAscend::BilinearInterpolationCodegen(const CallNode *op) {
@@ -2580,8 +2739,13 @@ void CodeGenTileLangAscend::MmaCodegen(const CallNode *op) {
   this->PrintIndent();
   this->stream << op_name << "(" << a_name << "[" << a_offset << "]," << b_name
                << "[" << b_offset << "]," << c_name << "[" << c_offset << "], "
-               << PrintExpr(op->args[4]) << ", " << PrintExpr(op->args[5])
-               << ");\n";
+               << PrintExpr(op->args[4]) << ", " << PrintExpr(op->args[5]);
+  // Optional trailing args (n_actual, unitFlag). Absent for the legacy 6-arg
+  // form, where the template supplies n_actual = N and unitFlag = 0.
+  for (size_t i = 6; i < op->args.size(); ++i) {
+    this->stream << ", " << PrintExpr(op->args[i]);
+  }
+  this->stream << ");\n";
 }
 
 void CodeGenTileLangAscend::CopyCodegen(const CallNode *op) {
@@ -2634,6 +2798,16 @@ void CodeGenTileLangAscend::CopyCodegen(const CallNode *op) {
   }
 
   if (found) {
+    // The count above is the most a call can carry. Not every producer supplies
+    // all of them -- passes that rewrite a copy in place (AscendWorkspace-
+    // Reduction turning copy_l0c_to_ub into copy_l0c_to_gm, say) build their
+    // own argument list and stop at the ones they care about. Every trailing
+    // parameter has a C++ default that reproduces the old behaviour, so emit
+    // what is actually there rather than indexing past the end.
+    int available = static_cast<int>(op->args.size()) - 3;
+    if (extra_args > available) {
+      extra_args = available;
+    }
     std::vector<std::string> var_names;
     for (int i = 0; i < extra_args; ++i) {
       auto expr = op->args[3 + i];
@@ -2658,6 +2832,17 @@ void CodeGenTileLangAscend::CopyCodegen(const CallNode *op) {
     // natural owner of the tail-padding clear.
     if (op_name.find("copy_gm_to_l1") != std::string::npos) {
       this->stream << ", " << (is_zero(dst_offset_expr) ? "true" : "false");
+    }
+
+    // copy_l0c_to_gm's unitFlag rides at the end of the argument list rather
+    // than in call order: the list is shared with the PTO codegen, which reads
+    // the entries in between by position. Emit it where the C++ helper expects
+    // it. A producer that predates it leaves the template default of 0, which
+    // is a standalone fixpipe.
+    constexpr int kL0cToGmArgc = 10;
+    if (op_name.find("copy_l0c_to_gm") != std::string::npos &&
+        static_cast<int>(op->args.size()) >= kL0cToGmArgc) {
+      this->stream << ", " << PrintExpr(op->args[kL0cToGmArgc - 1]);
     }
 
     this->stream << ");\n";

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -15,7 +15,6 @@
 #include <tvm/tir/expr.h>
 
 #include <cmath>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -480,29 +479,19 @@ void CodeGenTileLangAscend::VisitExpr_(const BufferLoadNode *op,
   if (scope == "local.var") {
     os << var_name;
   } else {
-    // Flatten every index, not just the innermost one: a scalar access into a
-    // multi-dimensional buffer such as table[b, i] otherwise drops the leading
-    // dimensions and aliases every row onto row 0. OffsetOf is the identity for
-    // a 1-D buffer, so single-dimension accesses are unchanged.
-    os << var_name << ".GetValue("
-       << PrintExpr(op->buffer.OffsetOf(op->indices).back()) << ")";
+    os << var_name << ".GetValue(" << PrintExpr(op->indices.back()) << ")";
   }
 }
 
 void CodeGenTileLangAscend::VisitStmt_(const BufferStoreNode *op) {
   auto var_name = var_idmap_[op->buffer->data.get()];
   std::string scope = GetPtrStorageScope(op->buffer->data);
+  this->PrintIndent();
   if (scope == "local.var") {
-    std::string value = PrintExpr(op->value);
-    this->PrintIndent();
-    this->stream << var_name << " = " << value << ";\n";
+    this->stream << var_name << " = " << PrintExpr(op->value) << ";\n";
   } else {
-    // See VisitExpr_(BufferLoadNode): flatten across all dimensions.
-    std::string index = PrintExpr(op->buffer.OffsetOf(op->indices).back());
-    std::string value = PrintExpr(op->value);
-    this->PrintIndent();
-    this->stream << var_name << ".SetValue(" << index << ", " << value
-                 << ");\n";
+    this->stream << var_name << ".SetValue(" << PrintExpr(op->indices.back())
+                 << ", " << PrintExpr(op->value) << ");\n";
   }
 }
 
@@ -649,8 +638,6 @@ void CodeGenTileLangAscend::VisitExpr_(const CallNode *op, std::ostream &os) {
     RowExpandSubExperimentCodegen(op);
   } else if (op->op.same_as(tl::ascend_row_expand_div_experiment())) {
     RowExpandDivExperimentCodegen(op);
-  } else if (op->op.same_as(tl::ascend_exp_experiment())) {
-    ExpExperimentCodegen(op);
   } else if (op->op.same_as(tl::ascend_wait_cross_flag())) {
     PrintOpCall(op, "AscendC::CrossCoreWaitFlag", {0, 0}, {0, 1});
   } else if (op->op.same_as(tl::ascend_set_cross_flag())) {
@@ -669,8 +656,6 @@ void CodeGenTileLangAscend::VisitExpr_(const CallNode *op, std::ostream &os) {
     PrintfOpCodegen(op, "AscendC::PRINTF");
   } else if (op->op.same_as(tl::ascend_dump_tensor())) {
     DumpTensorCodegen(op);
-  } else if (op->op.same_as(tl::ascend_src_code())) {
-    SrcCodeCodegen(op);
   } else if (op->op.same_as(tl::ascend_bilinear_interpolation())) {
     BilinearInterpolationCodegen(op);
   } else if (op->op.same_as(tl::ascend_wholereducemax())) {
@@ -727,7 +712,13 @@ void CodeGenTileLangAscend::VisitExpr_(const CallNode *op, std::ostream &os) {
     CreateDatacacheExperimentCodegen(op);
   } else if (op->op.same_as(tl::ascend_brcb_experiment())) {
     BrcbExperimentCodegen(op);
-  } else {
+  }
+  //////
+  else if (op->op.same_as(tl::ascend_cumsum())) {
+    CumSumOpCodegen(op);
+  }
+  //////
+  else {
     // tvm::Dump(op);
     CodeGenC::VisitExpr_(op, os);
   }
@@ -773,6 +764,20 @@ void CodeGenTileLangAscend::VisitStmt_(const AttrStmtNode *op) {
       auto vec_id_ = AllocVarID(iv->var.get());
       this->PrintIndent();
       this->stream << "auto " << vec_id_ << " = AscendC::GetSubBlockIdx();\n";
+    }
+    this->VisitStmt(op->body);
+    return;
+  } else if (op->attr_key == "init_flag" || op->attr_key == "clear_flag") {
+    const StringImmNode *instn = op->value.as<StringImmNode>();
+
+    std::string inst = std::string(instn->value);
+    size_t st = 0;
+    for (size_t i = 0; i < inst.size(); ++i) {
+      if (inst[i] == '\n') {
+        this->PrintIndent();
+        stream << inst.substr(st, i - st) << "\n";
+        st = i + 1;
+      }
     }
     this->VisitStmt(op->body);
     return;
@@ -2018,16 +2023,6 @@ void CodeGenTileLangAscend::ReduceOpCodegen(const CallNode *op) {
 
   bool is_reduce_sum = (op_name.find("reduce_sum") != std::string::npos);
   int buffer_arg_end = static_cast<int>(op->args.size());
-  // Optional trailing physical row width, emitted only when the logical width
-  // is narrower than the row the data sits in (a sliced region, or a real_shape
-  // narrower than the buffer). It follows `clear`, so peel it off first.
-  int64_t physical_row = 0;
-  if (buffer_arg_end > 0 && !op->args[buffer_arg_end - 1].dtype().is_bool()) {
-    if (const auto *row_imm = op->args[buffer_arg_end - 1].as<IntImmNode>()) {
-      physical_row = row_imm->value;
-      buffer_arg_end--;
-    }
-  }
   bool clear = true;
   if (buffer_arg_end > 0 && op->args[buffer_arg_end - 1].dtype().is_bool()) {
     clear = !is_zero(op->args[buffer_arg_end - 1]);
@@ -2042,85 +2037,6 @@ void CodeGenTileLangAscend::ReduceOpCodegen(const CallNode *op) {
   }
 
   this->PrintIndent();
-
-  // Narrow row-reduce: the logical width is only part of a wider physical row,
-  // so the source cannot be walked as one contiguous M x N block. Route to the
-  // WholeReduce* helpers, which take an explicit per-repeat source stride.
-  if (physical_row > 0) {
-    size_t tpos1 = op_name.find("<");
-    size_t tpos2 = op_name.rfind(">");
-    std::string tparams = op_name.substr(tpos1 + 1, tpos2 - tpos1 - 1);
-    size_t c1 = tparams.find(",");
-    size_t c2 = tparams.find(",", c1 + 1);
-    size_t c3 = tparams.find(",", c2 + 1);
-    auto trim = [](std::string s) {
-      size_t b = s.find_first_not_of(" \t");
-      if (b == std::string::npos)
-        return std::string("");
-      return s.substr(b, s.find_last_not_of(" \t") - b + 1);
-    };
-    std::string ndtype = trim(tparams.substr(0, c1));
-    // The front end only attaches a physical row width once it has resolved the
-    // logical extents to constants, so these parse. Guard anyway: a symbolic
-    // extent reaching here would otherwise throw out of std::stoll and take the
-    // compiler down with it.
-    int64_t nm = 0, nn = 0, ndim = 0;
-    try {
-      nm = std::stoll(trim(tparams.substr(c1 + 1, c2 - c1 - 1)));
-      nn = std::stoll(trim(tparams.substr(c2 + 1, c3 - c2 - 1)));
-      ndim = std::stoll(trim(tparams.substr(c3 + 1)));
-    } catch (const std::exception &) {
-      LOG(FATAL) << "narrow reduce needs compile-time extents, but could not "
-                    "parse the template parameters: "
-                 << tparams;
-    }
-
-    // Enumerated rather than defaulted: guessing 4 bytes for an unrecognised
-    // type would silently scale the stride wrong instead of failing.
-    int64_t elem_bytes = 0;
-    if (ndtype == "float" || ndtype == "int32_t" || ndtype == "uint32_t") {
-      elem_bytes = 4;
-    } else if (ndtype == "half" || ndtype == "bfloat16_t" ||
-               ndtype == "int16_t" || ndtype == "uint16_t") {
-      elem_bytes = 2;
-    } else if (ndtype == "int8_t" || ndtype == "uint8_t" ||
-               ndtype == "float8_e4m3_t" || ndtype == "float8_e5m2_t") {
-      elem_bytes = 1;
-    }
-    ICHECK(elem_bytes > 0)
-        << "narrow reduce does not know the element size of '" << ndtype << "'";
-    ICHECK(ndim == -1) << "narrow reduce is only implemented for a row reduce "
-                          "(dim == -1); got dim "
-                       << ndim << " over a logical width of " << nn
-                       << " inside a physical row of " << physical_row;
-    ICHECK(nn * elem_bytes <= 256)
-        << "narrow reduce needs the logical width to fit one vector repeat "
-           "(256 "
-           "bytes); got "
-        << nn << " elements of " << elem_bytes << " bytes. Split the range and "
-        << "combine the partial results.";
-    ICHECK(clear) << "narrow reduce cannot merge into the destination "
-                     "(clear == false); reduce into a scratch and combine.";
-
-    std::string narrow = "reduce_max_narrow";
-    if (is_reduce_sum) {
-      narrow = "reduce_sum_narrow";
-    } else if (op_name.find("reduce_min") != std::string::npos) {
-      narrow = "reduce_min_narrow";
-    }
-    // srcRepStride steps one physical row, counted in 32-byte blocks, so the
-    // row has to be a whole number of them -- otherwise the division truncates
-    // and the reduce walks a stride that is short (or zero).
-    ICHECK((physical_row * elem_bytes) % 32 == 0)
-        << "narrow reduce needs the physical row (" << physical_row
-        << " elements of " << elem_bytes
-        << " bytes) to be a multiple of the 32-byte block";
-    int64_t src_rep_stride = physical_row * elem_bytes / 32;
-    this->stream << "tl::ascend::" << narrow << "<" << ndtype << ">("
-                 << var_names[0] << ", " << var_names[1] << ", " << nn << ", "
-                 << nm << ", " << src_rep_stride << ");\n";
-    return;
-  }
 
   if (is_reduce_sum) {
     size_t pos1 = op_name.find("<");
@@ -2279,10 +2195,11 @@ void CodeGenTileLangAscend::RowExpandDivExperimentCodegen(const CallNode *op) {
 void CodeGenTileLangAscend::RowExpandBinOpExperimentCodegen(
     const CallNode *op, const std::string &mask_op_name) {
   // args[0] = op name string, args[1] = dst, args[2] = src0,
-  // args[3] = src1, args[4] = optional broadcast workspace.
+  // args[3] = src1, args[4] = tmp (required for AscendC)
   //
-  // With tmp, src1 is a scalar-linear [R] stream that brcb expands into
-  // [R, elems_per_block]. Without tmp, src1 already contains those blocks.
+  // AscendC path: src1 is 1D [R] scalars, but {mul,sub,div}_mask requires
+  // a 2D [R, elems_per_block] broadcast buffer. Use tmp as intermediate:
+  // brcb(src1 → tmp) then {op}_mask(dst, src0, tmp).
   DataType dtype = GetAccessPtrDtype(op->args[1].as<CallNode>());
   std::string type_str = getType(dtype);
   int elems_per_block = 32 / (dtype.bits() / 8);
@@ -2302,13 +2219,7 @@ void CodeGenTileLangAscend::RowExpandBinOpExperimentCodegen(
       cols = static_cast<int>(shape[shape.size() - 1].as<IntImmNode>()->value);
     }
   }
-  ICHECK_EQ(cols % elems_per_block, 0)
-      << "RowExpandBinOpExperimentCodegen: physical columns=" << cols
-      << " must be divisible by " << elems_per_block;
   int rep_stride = cols / elems_per_block;
-  ICHECK(rep_stride > 0 && rep_stride <= 255)
-      << "RowExpandBinOpExperimentCodegen: repeat stride=" << rep_stride
-      << " must fit uint8_t";
   int repeat_time = 0;
   if (auto *extent_imm = dst_access->args[3].as<IntImmNode>()) {
     int extent = static_cast<int>(extent_imm->value);
@@ -2325,13 +2236,12 @@ void CodeGenTileLangAscend::RowExpandBinOpExperimentCodegen(
   ICHECK(rows % 8 == 0)
       << "RowExpandBinOpExperimentCodegen: rows=" << rows
       << " must be a multiple of 8 (BRCB processes 8 scalars per repeat)";
-  ICHECK_LE(rows, 255) << "RowExpandBinOpExperimentCodegen: rows=" << rows
-                       << " must fit uint8_t";
   int brcb_repeat = rows / 8;
   ICHECK(rows > 0 && cols > 0)
       << "RowExpandBinOpExperimentCodegen: failed to derive rows/cols";
 
-  const char *mask1 = (dtype.bits() == 16) ? "0xFFFFFFFFFFFFFFFF" : "0";
+  uint64_t mask0 = 0xFFFFFFFFFFFFFFFF;
+  uint64_t mask1 = (dtype.bits() == 16) ? 0xFFFFFFFFFFFFFFFF : 0;
 
   std::string dst_name = PrintBufferOffset(op->args[1].as<CallNode>(), true);
   std::string src0_name = PrintBufferOffset(op->args[2].as<CallNode>(), true);
@@ -2363,57 +2273,6 @@ void CodeGenTileLangAscend::RowExpandBinOpExperimentCodegen(
                  << ", 1, 1, 0, " << rep_stride << ", " << rep_stride
                  << ", 1);\n";
   }
-}
-
-void CodeGenTileLangAscend::ExpExperimentCodegen(const CallNode *op) {
-  // args[0] = op name string, args[1] = dst, args[2] = src.
-  // Unary mirror of RowExpandBinOpExperimentCodegen: exp the `mask` valid
-  // columns of each row in place, striding by the buffer's physical column
-  // count so one call covers all rows of a 64-column (fp32) chunk of a wider
-  // N-strided score buffer. rep_stride = physical_cols / elems_per_block;
-  // repeat_time = extent / (8 * elems_per_block) = one repeat per row when the
-  // slice is a 64-col chunk.
-  DataType dtype = GetAccessPtrDtype(op->args[1].as<CallNode>());
-  std::string type_str = getType(dtype);
-  int elems_per_block = 256 / dtype.bits();
-
-  auto *dst_access = op->args[1].as<CallNode>();
-  Var dst_var = Downcast<Var>(dst_access->args[1]);
-  int cols = 0;
-  if (buffer_shapes_.count(dst_var)) {
-    auto shape = buffer_shapes_.at(dst_var);
-    if (shape.size() >= 1 && shape[shape.size() - 1].as<IntImmNode>()) {
-      cols = static_cast<int>(shape[shape.size() - 1].as<IntImmNode>()->value);
-    }
-  }
-  int rep_stride = cols / elems_per_block;
-  int repeat_time = 0;
-  if (auto *extent_imm = dst_access->args[3].as<IntImmNode>()) {
-    int extent = static_cast<int>(extent_imm->value);
-    int elems_per_repeat = 8 * elems_per_block;
-    ICHECK(extent > 0 && extent % elems_per_repeat == 0)
-        << "ExpExperimentCodegen: extent=" << extent
-        << " must be a positive multiple of " << elems_per_repeat;
-    repeat_time = extent / elems_per_repeat;
-  } else {
-    ICHECK(false) << "ExpExperimentCodegen: dynamic extent not supported";
-  }
-  ICHECK(repeat_time > 0 && cols > 0)
-      << "ExpExperimentCodegen: failed to derive repeat_time/cols";
-  ICHECK(cols % elems_per_block == 0)
-      << "ExpExperimentCodegen: physical columns " << cols
-      << " must be a multiple of elems_per_block " << elems_per_block;
-
-  uint64_t mask1 = (dtype.bits() == 16) ? 0xFFFFFFFFFFFFFFFF : 0;
-
-  std::string dst_name = PrintBufferOffset(op->args[1].as<CallNode>(), true);
-  std::string src_name = PrintBufferOffset(op->args[2].as<CallNode>(), true);
-
-  this->PrintIndent();
-  this->stream << "tl::ascend::exp_mask<" << type_str << ">(" << dst_name
-               << ", " << src_name << ", 0xFFFFFFFFFFFFFFFF, " << mask1 << ", "
-               << repeat_time << ", 1, 1, " << rep_stride << ", " << rep_stride
-               << ");\n";
 }
 
 void CodeGenTileLangAscend::BroadcastOpCodegen(const CallNode *op) {
@@ -2564,7 +2423,7 @@ void CodeGenTileLangAscend::GemmOpCodegen(const CallNode *op) {
   this->stream << op_name << "(" << a_name << "[" << a_offset << "], " << b_name
                << "[" << b_offset << "], " << c_name << "[" << c_offset
                << "], ascend_l0a, ascend_l0b, " << PrintExpr(op->args[4])
-               << ", " << PrintExpr(op->args[5]) << ");\n";
+               << ");\n";
 }
 
 void CodeGenTileLangAscend::PrintfOpCodegen(const CallNode *op,
@@ -2620,18 +2479,6 @@ void CodeGenTileLangAscend::DumpTensorCodegen(const CallNode *op) {
   }
 
   this->stream << ");\n";
-}
-
-void CodeGenTileLangAscend::SrcCodeCodegen(const CallNode *op) {
-  auto *str = op->args[0].as<StringImmNode>();
-  ICHECK(str) << "T._src_code() expects a string literal argument";
-  std::string code = str->value;
-  std::istringstream iss(code);
-  std::string line;
-  while (std::getline(iss, line)) {
-    this->PrintIndent();
-    this->stream << line << "\n";
-  }
 }
 
 void CodeGenTileLangAscend::BilinearInterpolationCodegen(const CallNode *op) {
@@ -2737,13 +2584,8 @@ void CodeGenTileLangAscend::MmaCodegen(const CallNode *op) {
   this->PrintIndent();
   this->stream << op_name << "(" << a_name << "[" << a_offset << "]," << b_name
                << "[" << b_offset << "]," << c_name << "[" << c_offset << "], "
-               << PrintExpr(op->args[4]) << ", " << PrintExpr(op->args[5]);
-  // Optional trailing args (n_actual, unitFlag). Absent for the legacy 6-arg
-  // form, where the template supplies n_actual = N and unitFlag = 0.
-  for (size_t i = 6; i < op->args.size(); ++i) {
-    this->stream << ", " << PrintExpr(op->args[i]);
-  }
-  this->stream << ");\n";
+               << PrintExpr(op->args[4]) << ", " << PrintExpr(op->args[5])
+               << ");\n";
 }
 
 void CodeGenTileLangAscend::CopyCodegen(const CallNode *op) {
@@ -2796,16 +2638,6 @@ void CodeGenTileLangAscend::CopyCodegen(const CallNode *op) {
   }
 
   if (found) {
-    // The count above is the most a call can carry. Not every producer supplies
-    // all of them -- passes that rewrite a copy in place (AscendWorkspace-
-    // Reduction turning copy_l0c_to_ub into copy_l0c_to_gm, say) build their
-    // own argument list and stop at the ones they care about. Every trailing
-    // parameter has a C++ default that reproduces the old behaviour, so emit
-    // what is actually there rather than indexing past the end.
-    int available = static_cast<int>(op->args.size()) - 3;
-    if (extra_args > available) {
-      extra_args = available;
-    }
     std::vector<std::string> var_names;
     for (int i = 0; i < extra_args; ++i) {
       auto expr = op->args[3 + i];
@@ -2830,17 +2662,6 @@ void CodeGenTileLangAscend::CopyCodegen(const CallNode *op) {
     // natural owner of the tail-padding clear.
     if (op_name.find("copy_gm_to_l1") != std::string::npos) {
       this->stream << ", " << (is_zero(dst_offset_expr) ? "true" : "false");
-    }
-
-    // copy_l0c_to_gm's unitFlag rides at the end of the argument list rather
-    // than in call order: the list is shared with the PTO codegen, which reads
-    // the entries in between by position. Emit it where the C++ helper expects
-    // it. A producer that predates it leaves the template default of 0, which
-    // is a standalone fixpipe.
-    constexpr int kL0cToGmArgc = 10;
-    if (op_name.find("copy_l0c_to_gm") != std::string::npos &&
-        static_cast<int>(op->args.size()) >= kL0cToGmArgc) {
-      this->stream << ", " << PrintExpr(op->args[kL0cToGmArgc - 1]);
     }
 
     this->stream << ");\n";
@@ -3001,6 +2822,28 @@ void CodeGenTileLangAscend::BrcbExperimentCodegen(const CallNode *op) {
       "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   PrintOpCall(op, op_name, {1, 3}, {3, 6});
 }
+
+//////
+
+void CodeGenTileLangAscend::CumSumOpCodegen(const CallNode *op) {
+  std::string op_name =
+      "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
+
+  auto dst = PrintBufferOffset(op->args[1].as<CallNode>());
+  auto src = PrintBufferOffset(op->args[2].as<CallNode>());
+  auto tmp = PrintBufferOffset(op->args[3].as<CallNode>());
+  auto last_row = PrintBufferOffset(op->args[4].as<CallNode>());
+  bool reverse = !is_zero(op->args[5]);
+  ICHECK(!reverse) << "AscendC cumsum reverse=True is not implemented yet";
+
+  this->PrintIndent();
+  this->stream << op_name << "("
+               << dst << ", "
+               << last_row << ", "
+               << src << ", "
+               << tmp << ");\n";
+}
+//////
 
 } // namespace codegen
 } // namespace tvm

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -712,13 +712,9 @@ void CodeGenTileLangAscend::VisitExpr_(const CallNode *op, std::ostream &os) {
     CreateDatacacheExperimentCodegen(op);
   } else if (op->op.same_as(tl::ascend_brcb_experiment())) {
     BrcbExperimentCodegen(op);
-  }
-  //////
-  else if (op->op.same_as(tl::ascend_cumsum())) {
+  }else if (op->op.same_as(tl::ascend_cumsum())) {
     CumSumOpCodegen(op);
-  }
-  //////
-  else {
+  }else {
     // tvm::Dump(op);
     CodeGenC::VisitExpr_(op, os);
   }
@@ -2823,8 +2819,6 @@ void CodeGenTileLangAscend::BrcbExperimentCodegen(const CallNode *op) {
   PrintOpCall(op, op_name, {1, 3}, {3, 6});
 }
 
-//////
-
 void CodeGenTileLangAscend::CumSumOpCodegen(const CallNode *op) {
   std::string op_name =
       "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
@@ -2843,7 +2837,6 @@ void CodeGenTileLangAscend::CumSumOpCodegen(const CallNode *op) {
                << src << ", "
                << tmp << ");\n";
 }
-//////
 
 } // namespace codegen
 } // namespace tvm

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -727,9 +727,9 @@ void CodeGenTileLangAscend::VisitExpr_(const CallNode *op, std::ostream &os) {
     CreateDatacacheExperimentCodegen(op);
   } else if (op->op.same_as(tl::ascend_brcb_experiment())) {
     BrcbExperimentCodegen(op);
-  }else if (op->op.same_as(tl::ascend_cumsum())) {
+  } else if (op->op.same_as(tl::ascend_cumsum())) {
     CumSumOpCodegen(op);
-  }else {
+  } else {
     // tvm::Dump(op);
     CodeGenC::VisitExpr_(op, os);
   }
@@ -3016,11 +3016,8 @@ void CodeGenTileLangAscend::CumSumOpCodegen(const CallNode *op) {
   ICHECK(!reverse) << "AscendC cumsum reverse=True is not implemented yet";
 
   this->PrintIndent();
-  this->stream << op_name << "("
-               << dst << ", "
-               << last_row << ", "
-               << src << ", "
-               << tmp << ");\n";
+  this->stream << op_name << "(" << dst << ", " << last_row << ", " << src
+               << ", " << tmp << ");\n";
 }
 
 } // namespace codegen

--- a/src/target/codegen_ascend.h
+++ b/src/target/codegen_ascend.h
@@ -161,6 +161,8 @@ private:
   void RowExpandBinOpExperimentCodegen(const CallNode *op,
                                        const std::string &mask_op_name);
 
+  void ExpExperimentCodegen(const CallNode *op);
+
   void SetCrossFlagCodegen(const CallNode *op);
 
   void FlagOpCodegen(const CallNode *op, std::string op_name);
@@ -172,6 +174,8 @@ private:
   void PrintfOpCodegen(const CallNode *op, const std::string &op_name);
 
   void DumpTensorCodegen(const CallNode *op);
+
+  void SrcCodeCodegen(const CallNode *op);
 
   void BilinearInterpolationCodegen(const CallNode *op);
 

--- a/src/target/codegen_ascend.h
+++ b/src/target/codegen_ascend.h
@@ -223,9 +223,7 @@ private:
 
   void BrcbExperimentCodegen(const CallNode *op);
 
-  //////
   void CumSumOpCodegen(const CallNode *op);
-  //////
 
 private:
   // Whether scope such as "__shared__" or "__constant__"  is part of type.

--- a/src/target/codegen_ascend.h
+++ b/src/target/codegen_ascend.h
@@ -161,8 +161,6 @@ private:
   void RowExpandBinOpExperimentCodegen(const CallNode *op,
                                        const std::string &mask_op_name);
 
-  void ExpExperimentCodegen(const CallNode *op);
-
   void SetCrossFlagCodegen(const CallNode *op);
 
   void FlagOpCodegen(const CallNode *op, std::string op_name);
@@ -174,8 +172,6 @@ private:
   void PrintfOpCodegen(const CallNode *op, const std::string &op_name);
 
   void DumpTensorCodegen(const CallNode *op);
-
-  void SrcCodeCodegen(const CallNode *op);
 
   void BilinearInterpolationCodegen(const CallNode *op);
 
@@ -226,6 +222,10 @@ private:
   void CreateDatacacheExperimentCodegen(const CallNode *op);
 
   void BrcbExperimentCodegen(const CallNode *op);
+
+  //////
+  void CumSumOpCodegen(const CallNode *op);
+  //////
 
 private:
   // Whether scope such as "__shared__" or "__constant__"  is part of type.

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -540,7 +540,6 @@ reduce_sum(LocalTensor<T> const &dstTensor, LocalTensor<T> const &srcTensor,
 }
 
 
-//////
 template <typename T>
 CATLASS_DEVICE void abs_contiguous(LocalTensor<T> dstTensor,
                                    LocalTensor<T> srcTensor,
@@ -565,7 +564,6 @@ CATLASS_DEVICE void abs_contiguous(LocalTensor<T> dstTensor,
         {1, 1, 8, 8});
   }
 }
-
 
 template <typename T, uint32_t M, uint32_t N, int32_t dim>
 CATLASS_DEVICE void reduce_abssum(LocalTensor<T> const &dstTensor,
@@ -656,7 +654,6 @@ CATLASS_DEVICE void cumsum(LocalTensor<T> dstTensor,
         cumSumInfo);
   }
 }
-//////
 
 template <typename T>
 CATLASS_DEVICE T reduce_scalar_max_safe(T lhsValue, T rhsValue) {

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -539,6 +539,125 @@ reduce_sum(LocalTensor<T> const &dstTensor, LocalTensor<T> const &srcTensor,
   }
 }
 
+
+//////
+template <typename T>
+CATLASS_DEVICE void abs_contiguous(LocalTensor<T> dstTensor,
+                                   LocalTensor<T> srcTensor,
+                                   uint32_t count) {
+  constexpr uint32_t kOneRepeatBytes = 256;
+  constexpr uint32_t kOneRepeatElems = kOneRepeatBytes / sizeof(T);
+  uint32_t repeatTime = count / kOneRepeatElems;
+  uint32_t tail = count % kOneRepeatElems;
+
+  if (repeatTime > 0) {
+    uint64_t mask = kOneRepeatElems;
+    AscendC::Abs(dstTensor, srcTensor, mask, repeatTime, {1, 1, 8, 8});
+  }
+
+  if (tail > 0) {
+    uint64_t mask = tail;
+    AscendC::Abs(
+        dstTensor[repeatTime * kOneRepeatElems],
+        srcTensor[repeatTime * kOneRepeatElems],
+        mask,
+        1,
+        {1, 1, 8, 8});
+  }
+}
+
+
+template <typename T, uint32_t M, uint32_t N, int32_t dim>
+CATLASS_DEVICE void reduce_abssum(LocalTensor<T> const &dstTensor,
+                                  LocalTensor<T> const &srcTensor,
+                                  LocalTensor<uint8_t> const &sharedTmpBuffer,
+                                  bool clear = true) {
+  (void)clear;
+
+  constexpr uint32_t srcCount = M * N;
+  constexpr uint32_t absTmpBytes = srcCount * sizeof(T);
+
+  LocalTensor<T> absTmp =
+      const_cast<LocalTensor<uint8_t>&>(sharedTmpBuffer).template ReinterpretCast<T>();
+  LocalTensor<uint8_t> reduceTmp =
+      const_cast<LocalTensor<uint8_t>&>(sharedTmpBuffer)[absTmpBytes];
+
+  abs_contiguous<T>(absTmp, srcTensor, srcCount);
+
+  uint32_t shape[] = {M, N};
+  if constexpr (dim == -1) {
+    AscendC::ReduceSum<T, AscendC::Pattern::Reduce::AR>(
+        dstTensor, absTmp, reduceTmp, shape, true);
+  } else {
+    AscendC::ReduceSum<T, AscendC::Pattern::Reduce::RA>(
+        dstTensor, absTmp, reduceTmp, shape, true);
+  }
+}
+
+template <typename T, uint32_t M, uint32_t N, int32_t dim>
+CATLASS_DEVICE void reduce_absmax(LocalTensor<T> const &dstTensor,
+                                  LocalTensor<T> const &srcTensor,
+                                  LocalTensor<uint8_t> const &sharedTmpBuffer,
+                                  bool clear = true) {
+  (void)clear;
+
+  constexpr uint32_t srcCount = M * N;
+  constexpr uint32_t absTmpBytes = srcCount * sizeof(T);
+
+  LocalTensor<T> absTmp =
+      const_cast<LocalTensor<uint8_t>&>(sharedTmpBuffer).template ReinterpretCast<T>();
+  LocalTensor<uint8_t> reduceTmp =
+      const_cast<LocalTensor<uint8_t>&>(sharedTmpBuffer)[absTmpBytes];
+
+  abs_contiguous<T>(absTmp, srcTensor, srcCount);
+
+  uint32_t shape[] = {M, N};
+  if constexpr (dim == -1) {
+    AscendC::ReduceMax<T, AscendC::Pattern::Reduce::AR>(
+        dstTensor, absTmp, reduceTmp, shape, true);
+  } else {
+    AscendC::ReduceMax<T, AscendC::Pattern::Reduce::RA>(
+        dstTensor, absTmp, reduceTmp, shape, true);
+  }
+}
+
+constexpr AscendC::CumSumConfig kCumSumLastAxisConfig{
+    true,
+    false,
+    true,
+    AscendC::CumSumAlgorithm::CUMSUM_ALGORITHM_LINEBYLINE};
+
+constexpr AscendC::CumSumConfig kCumSumFirstAxisConfig{
+    false,
+    false,
+    true,
+    AscendC::CumSumAlgorithm::CUMSUM_ALGORITHM_LINEBYLINE};
+
+template <typename T, uint32_t M, uint32_t N, int32_t dim>
+CATLASS_DEVICE void cumsum(LocalTensor<T> dstTensor,
+                           LocalTensor<T> lastRowTensor,
+                           LocalTensor<T> srcTensor,
+                           LocalTensor<uint8_t> sharedTmpBuffer) {
+  const AscendC::CumSumInfo cumSumInfo{M, N};
+
+  if constexpr (dim == 1 || dim == -1) {
+    AscendC::CumSum<T, kCumSumLastAxisConfig>(
+        dstTensor,
+        lastRowTensor,
+        srcTensor,
+        sharedTmpBuffer,
+        cumSumInfo);
+  } else {
+    AscendC::CumSum<T, kCumSumFirstAxisConfig>(
+        dstTensor,
+        lastRowTensor,
+        srcTensor,
+        sharedTmpBuffer,
+        cumSumInfo);
+  }
+}
+//////
+
 template <typename T>
 CATLASS_DEVICE T reduce_scalar_max_safe(T lhsValue, T rhsValue) {
   // Bisheng/AICore does not allow scalar half/bfloat16 comparisons inside

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -539,11 +539,9 @@ reduce_sum(LocalTensor<T> const &dstTensor, LocalTensor<T> const &srcTensor,
   }
 }
 
-
 template <typename T>
 CATLASS_DEVICE void abs_contiguous(LocalTensor<T> dstTensor,
-                                   LocalTensor<T> srcTensor,
-                                   uint32_t count) {
+                                   LocalTensor<T> srcTensor, uint32_t count) {
   constexpr uint32_t kOneRepeatBytes = 256;
   constexpr uint32_t kOneRepeatElems = kOneRepeatBytes / sizeof(T);
   uint32_t repeatTime = count / kOneRepeatElems;
@@ -556,102 +554,82 @@ CATLASS_DEVICE void abs_contiguous(LocalTensor<T> dstTensor,
 
   if (tail > 0) {
     uint64_t mask = tail;
-    AscendC::Abs(
-        dstTensor[repeatTime * kOneRepeatElems],
-        srcTensor[repeatTime * kOneRepeatElems],
-        mask,
-        1,
-        {1, 1, 8, 8});
+    AscendC::Abs(dstTensor[repeatTime * kOneRepeatElems],
+                 srcTensor[repeatTime * kOneRepeatElems], mask, 1,
+                 {1, 1, 8, 8});
   }
 }
 
 template <typename T, uint32_t M, uint32_t N, int32_t dim>
-CATLASS_DEVICE void reduce_abssum(LocalTensor<T> const &dstTensor,
-                                  LocalTensor<T> const &srcTensor,
-                                  LocalTensor<uint8_t> const &sharedTmpBuffer,
-                                  bool clear = true) {
+CATLASS_DEVICE void
+reduce_abssum(LocalTensor<T> const &dstTensor, LocalTensor<T> const &srcTensor,
+              LocalTensor<uint8_t> const &sharedTmpBuffer, bool clear = true) {
   (void)clear;
 
   constexpr uint32_t srcCount = M * N;
   constexpr uint32_t absTmpBytes = srcCount * sizeof(T);
 
-  LocalTensor<T> absTmp =
-      const_cast<LocalTensor<uint8_t>&>(sharedTmpBuffer).template ReinterpretCast<T>();
+  LocalTensor<T> absTmp = const_cast<LocalTensor<uint8_t> &>(sharedTmpBuffer)
+                              .template ReinterpretCast<T>();
   LocalTensor<uint8_t> reduceTmp =
-      const_cast<LocalTensor<uint8_t>&>(sharedTmpBuffer)[absTmpBytes];
+      const_cast<LocalTensor<uint8_t> &>(sharedTmpBuffer)[absTmpBytes];
 
   abs_contiguous<T>(absTmp, srcTensor, srcCount);
 
   uint32_t shape[] = {M, N};
   if constexpr (dim == -1) {
-    AscendC::ReduceSum<T, AscendC::Pattern::Reduce::AR>(
-        dstTensor, absTmp, reduceTmp, shape, true);
+    AscendC::ReduceSum<T, AscendC::Pattern::Reduce::AR>(dstTensor, absTmp,
+                                                        reduceTmp, shape, true);
   } else {
-    AscendC::ReduceSum<T, AscendC::Pattern::Reduce::RA>(
-        dstTensor, absTmp, reduceTmp, shape, true);
+    AscendC::ReduceSum<T, AscendC::Pattern::Reduce::RA>(dstTensor, absTmp,
+                                                        reduceTmp, shape, true);
   }
 }
 
 template <typename T, uint32_t M, uint32_t N, int32_t dim>
-CATLASS_DEVICE void reduce_absmax(LocalTensor<T> const &dstTensor,
-                                  LocalTensor<T> const &srcTensor,
-                                  LocalTensor<uint8_t> const &sharedTmpBuffer,
-                                  bool clear = true) {
+CATLASS_DEVICE void
+reduce_absmax(LocalTensor<T> const &dstTensor, LocalTensor<T> const &srcTensor,
+              LocalTensor<uint8_t> const &sharedTmpBuffer, bool clear = true) {
   (void)clear;
 
   constexpr uint32_t srcCount = M * N;
   constexpr uint32_t absTmpBytes = srcCount * sizeof(T);
 
-  LocalTensor<T> absTmp =
-      const_cast<LocalTensor<uint8_t>&>(sharedTmpBuffer).template ReinterpretCast<T>();
+  LocalTensor<T> absTmp = const_cast<LocalTensor<uint8_t> &>(sharedTmpBuffer)
+                              .template ReinterpretCast<T>();
   LocalTensor<uint8_t> reduceTmp =
-      const_cast<LocalTensor<uint8_t>&>(sharedTmpBuffer)[absTmpBytes];
+      const_cast<LocalTensor<uint8_t> &>(sharedTmpBuffer)[absTmpBytes];
 
   abs_contiguous<T>(absTmp, srcTensor, srcCount);
 
   uint32_t shape[] = {M, N};
   if constexpr (dim == -1) {
-    AscendC::ReduceMax<T, AscendC::Pattern::Reduce::AR>(
-        dstTensor, absTmp, reduceTmp, shape, true);
+    AscendC::ReduceMax<T, AscendC::Pattern::Reduce::AR>(dstTensor, absTmp,
+                                                        reduceTmp, shape, true);
   } else {
-    AscendC::ReduceMax<T, AscendC::Pattern::Reduce::RA>(
-        dstTensor, absTmp, reduceTmp, shape, true);
+    AscendC::ReduceMax<T, AscendC::Pattern::Reduce::RA>(dstTensor, absTmp,
+                                                        reduceTmp, shape, true);
   }
 }
 
 constexpr AscendC::CumSumConfig kCumSumLastAxisConfig{
-    true,
-    false,
-    true,
-    AscendC::CumSumAlgorithm::CUMSUM_ALGORITHM_LINEBYLINE};
+    true, false, true, AscendC::CumSumAlgorithm::CUMSUM_ALGORITHM_LINEBYLINE};
 
 constexpr AscendC::CumSumConfig kCumSumFirstAxisConfig{
-    false,
-    false,
-    true,
-    AscendC::CumSumAlgorithm::CUMSUM_ALGORITHM_LINEBYLINE};
+    false, false, true, AscendC::CumSumAlgorithm::CUMSUM_ALGORITHM_LINEBYLINE};
 
 template <typename T, uint32_t M, uint32_t N, int32_t dim>
-CATLASS_DEVICE void cumsum(LocalTensor<T> dstTensor,
-                           LocalTensor<T> lastRowTensor,
-                           LocalTensor<T> srcTensor,
-                           LocalTensor<uint8_t> sharedTmpBuffer) {
+CATLASS_DEVICE void
+cumsum(LocalTensor<T> dstTensor, LocalTensor<T> lastRowTensor,
+       LocalTensor<T> srcTensor, LocalTensor<uint8_t> sharedTmpBuffer) {
   const AscendC::CumSumInfo cumSumInfo{M, N};
 
   if constexpr (dim == 1 || dim == -1) {
     AscendC::CumSum<T, kCumSumLastAxisConfig>(
-        dstTensor,
-        lastRowTensor,
-        srcTensor,
-        sharedTmpBuffer,
-        cumSumInfo);
+        dstTensor, lastRowTensor, srcTensor, sharedTmpBuffer, cumSumInfo);
   } else {
     AscendC::CumSum<T, kCumSumFirstAxisConfig>(
-        dstTensor,
-        lastRowTensor,
-        srcTensor,
-        sharedTmpBuffer,
-        cumSumInfo);
+        dstTensor, lastRowTensor, srcTensor, sharedTmpBuffer, cumSumInfo);
   }
 }
 

--- a/src/transform/allocate_tmp_buffer.cc
+++ b/src/transform/allocate_tmp_buffer.cc
@@ -165,7 +165,7 @@ int64_t ParseStaticInt(const std::string &value, const std::string &op_name) {
   return result;
 }
 
-enum class ReduceKind { kSum, kMax, kMin };
+enum class ReduceKind { kSum, kMax, kMin, kAbsSum, kAbsMax };
 
 struct ReduceTemplateInfo {
   ReduceKind kind;
@@ -195,7 +195,11 @@ ReduceTemplateInfo ParseReduceTemplateInfo(const CallNode *call) {
   ICHECK_EQ(params.size(), 4U) << "Failed to parse reduce template " << op_name;
 
   ReduceKind kind;
-  if (op_name.find("reduce_sum") != std::string::npos) {
+  if (op_name.find("reduce_abssum") != std::string::npos) {
+    kind = ReduceKind::kAbsSum;
+  } else if (op_name.find("reduce_absmax") != std::string::npos) {
+    kind = ReduceKind::kAbsMax;
+  } else if (op_name.find("reduce_sum") != std::string::npos) {
     kind = ReduceKind::kSum;
   } else if (op_name.find("reduce_max") != std::string::npos) {
     kind = ReduceKind::kMax;
@@ -419,6 +423,10 @@ EstimateAscendCReduceWorkspaceBytes(const CallNode *call,
     }
   }
 
+  if (info.kind == ReduceKind::kAbsSum || info.kind == ReduceKind::kAbsMax) {
+    bytes += info.rows * info.cols * dtype_bytes;
+  }
+
   // The current wrapper still has a sharedTmpBuffer parameter even when the
   // selected CANN branch reports zero bytes. Keep one aligned block
   // for implicit calls; explicit arenas are deliberately not size-checked.
@@ -509,7 +517,56 @@ WorkspaceSpec RequireWorkspace(DataType dtype, int64_t bytes) {
   ICHECK_GE(bytes, 0);
   return WorkspaceSpec{true, dtype, bytes, kWorkspaceWriteAccess};
 }
+//////
+struct CumSumWorkspaceLayout {
+  int64_t tmp_bytes;
+  int64_t last_row_offset;
+  int64_t last_row_bytes;
+  DataType last_row_dtype;
+};
 
+CumSumWorkspaceLayout GetCumSumWorkspaceLayout(const CallNode *call) {
+  ICHECK(call->op.same_as(tl::ascend_cumsum()));
+  ICHECK_GE(call->args.size(), 4U) << "Malformed AscendC cumsum call.";
+
+  const std::string op_name = Downcast<StringImm>(call->args[0])->value;
+  const size_t left = op_name.find('<');
+  const size_t right = op_name.rfind('>');
+  ICHECK(left != std::string::npos && right != std::string::npos &&
+         left < right)
+      << "Failed to parse cumsum template " << op_name;
+
+  std::vector<std::string> params;
+  size_t begin = left + 1;
+  while (begin < right) {
+    const size_t comma = op_name.find(',', begin);
+    const size_t end =
+        comma == std::string::npos || comma > right ? right : comma;
+    params.push_back(Trim(op_name.substr(begin, end - begin)));
+    begin = end + 1;
+  }
+  ICHECK_EQ(params.size(), 4U) << "Failed to parse cumsum template " << op_name;
+
+  const int64_t m = ParseStaticInt(params[1], op_name);
+  const int64_t n = ParseStaticInt(params[2], op_name);
+  ICHECK_GT(m, 0);
+  ICHECK_GT(n, 0);
+
+  const DataType src_dtype = GetAccessPtrDtype(call->args[2]);
+  const int64_t src_bytes = GetAccessPtrBytes(call->args[2]);
+
+  // Keep the old first implementation's heuristic:
+  // tmp_ub size = src element bytes * 4.
+  const int64_t tmp_bytes = src_bytes * 4;
+
+  // CANN CumSum lastRowTensor holds the last row/column result.
+  const int64_t last_row_elems = std::max(m, n);
+  const int64_t last_row_offset = AlignUp(tmp_bytes, 32);
+  const int64_t last_row_bytes = last_row_elems * src_dtype.bytes();
+
+  return {tmp_bytes, last_row_offset, last_row_bytes, src_dtype};
+}
+//////
 WorkspaceSpec GetPTOWorkspaceSpec(const CallNode *call,
                                   const Array<Buffer> &alloc_buffers) {
   const DataType byte_dtype = DataType::UInt(8);
@@ -646,6 +703,13 @@ WorkspaceSpec GetAscendCWorkspaceSpec(const CallNode *call,
     return RequireWorkspace(GetAccessPtrDtype(call->args[1]),
                             GetAccessPtrBytes(call->args[1]));
   }
+  //////
+  if (call->op.same_as(tl::ascend_cumsum())) {
+    const CumSumWorkspaceLayout layout = GetCumSumWorkspaceLayout(call);
+    return RequireWorkspace(byte_dtype,
+                            layout.last_row_offset + layout.last_row_bytes);
+  }
+  //////
   if (call->op.same_as(tl::ascend_merge_sort()) ||
       call->op.same_as(tl::ascend_select()) ||
       call->op.same_as(tl::ascend_gather_mask()) ||
@@ -752,6 +816,12 @@ private:
                      ? CallWithoutWorkspaceArgs(op, tmp_buffer_param_offset)
                      : StmtExprMutator::VisitExpr_(op);
         }
+        //////
+        if (op->op.same_as(tl::ascend_cumsum())) {
+          return CallNodeAddCumSumWorkspace(op, tmp_buffer_param_offset, spec,
+                                            has_workspace);
+        }
+        //////
         if (has_workspace) {
           return HandleExistingTmp(op, tmp_buffer_param_offset, spec);
         }
@@ -907,6 +977,37 @@ private:
     return Call(op->dtype, op->op, new_args, Span());
   }
 
+  //////
+  Call CallNodeAddCumSumWorkspace(const CallNode *op,
+                                  int64_t tmp_buffer_param_offset,
+                                  const WorkspaceSpec &spec,
+                                  bool has_workspace) {
+    const CumSumWorkspaceLayout layout = GetCumSumWorkspaceLayout(op);
+    ICHECK_GE(spec.primary_bytes,
+              layout.last_row_offset + layout.last_row_bytes);
+
+    const PrimExpr arena =
+        has_workspace ? op->args[tmp_buffer_param_offset]
+                      : MakeAccessPtrFromBuffer_(tmp_buf_, spec.access_mask);
+
+    Array<PrimExpr> new_args;
+    for (int64_t i = 0; i < tmp_buffer_param_offset; ++i) {
+      new_args.push_back(op->args[i]);
+    }
+
+    new_args.push_back(MakeAccessPtrView(arena, 0, layout.tmp_bytes,
+                                         DataType::UInt(8), spec.access_mask));
+    new_args.push_back(MakeAccessPtrView(arena, layout.last_row_offset,
+                                         layout.last_row_bytes,
+                                         layout.last_row_dtype, 2));
+
+    const size_t skip = has_workspace ? 1 : 0;
+    for (size_t i = tmp_buffer_param_offset + skip; i < op->args.size(); ++i) {
+      new_args.push_back(op->args[i]);
+    }
+    return Call(op->dtype, op->op, new_args, op->span);
+  }
+  //////
   Call CallNodeAddReduceOutputTmp(const CallNode *op,
                                   int64_t tmp_buffer_param_offset,
                                   const WorkspaceSpec &spec) {

--- a/src/transform/common/operation_config.h
+++ b/src/transform/common/operation_config.h
@@ -212,6 +212,7 @@ GetOperationConfig() {
        {{{0, "write"}, {1, "read"}, {2, "read"}}, "PIPE_V"}},
       {"tl.ascend_reduce",
        {{{1, "write"}, {2, "read"}, {3, "read"}}, "PIPE_V"}},
+      {"tl.ascend_cumsum", {{{1, "write"}, {2, "read"}}, "PIPE_V"}},
       {"tl.ascend_block_reduce_max", {{{0, "write"}, {1, "read"}}, "PIPE_V"}},
       {"tl.ascend_block_reduce_min", {{{0, "write"}, {1, "read"}}, "PIPE_V"}},
       {"tl.ascend_block_reduce_sum", {{{0, "write"}, {1, "read"}}, "PIPE_V"}},
@@ -385,6 +386,7 @@ GetWorkspaceOpConfigs() {
           {tl::ascend_select().get(), {3, true, true}},
           {tl::ascend_gather_mask().get(), {4, true, true}},
           {tl::ascend_gather().get(), {5, true, true}},
+          {tl::ascend_cumsum().get(), {3, true, false}},
       };
   return ops;
 }

--- a/testing/python/language/parallel/test_tilelang_ascend_language_parallel.py
+++ b/testing/python/language/parallel/test_tilelang_ascend_language_parallel.py
@@ -419,7 +419,7 @@ class TestTileLangKernels:
 
     def test_shiftright_operation(self, clear_cache, setup_random_seed):
         """Test bitwise right shift kernel"""
-        scalar_value = random.randint(1, 32)
+        scalar_value = random.randint(1, 31)
 
         def kernel_func(M, N, block_M, block_N):
             return self.unary_op_kernel_int(M, N, block_M, block_N, op_func=lambda a: a >> scalar_value, dtype="int32")

--- a/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
+++ b/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
@@ -46,7 +46,6 @@
 
 #     return repo
 
-
 # REPO_ROOT = _bootstrap_repo_paths()
 
 # import tilelang  # noqa: E402

--- a/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
+++ b/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
@@ -12,7 +12,7 @@
 #     python testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py --runtime cumsum ascendc
 
 
-# # What it prints: 
+# # What it prints:
 
 # # * which Python function T.reduce_sum/reduce_abssum/reduce_absmax/cumsum binds to
 # # * the PrimFunc produced by @T.prim_func

--- a/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
+++ b/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
@@ -12,7 +12,7 @@
 #     python testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py --runtime cumsum ascendc
 
 
-# # What it prints:
+# # What it prints: 
 
 # # * which Python function T.reduce_sum/reduce_abssum/reduce_absmax/cumsum binds to
 # # * the PrimFunc produced by @T.prim_func

--- a/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
+++ b/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
@@ -1,0 +1,501 @@
+# """Direct debug script for reduce_abssum/reduce_absmax/cumsum on Ascend.
+
+# This is intentionally not a pytest-style file.  It is meant to be run directly
+# while developing/fixing the issue.
+
+# Examples:
+
+#     python testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
+#     python testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py reduce_abssum ascendc
+#     python testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py --runtime reduce_absmax ascendc
+#     python testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py --runtime reduce_abssum ascendc
+#     python testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py --runtime cumsum ascendc
+
+
+# What it prints:
+
+# * which Python function T.reduce_sum/reduce_abssum/reduce_absmax/cumsum binds to
+# * the PrimFunc produced by @T.prim_func
+# * each important lower pass, especially the pass that fails
+# * generated kernel_source if lowering reaches codegen
+# """
+
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+import traceback
+from pathlib import Path
+from typing import Callable
+
+
+def _bootstrap_repo_paths() -> Path:
+    """Prefer this checkout's Python code and build/libtvm when run directly."""
+
+    repo = Path(__file__).resolve().parents[3]
+    tvm_python = repo / "3rdparty" / "tvm" / "python"
+    tvm_build = repo / "build" / "tvm"
+
+    os.environ.setdefault("TVM_LIBRARY_PATH", str(tvm_build))
+    for path in (repo, tvm_python):
+        path_str = str(path)
+        while path_str in sys.path:
+            sys.path.remove(path_str)
+        sys.path.insert(0, path_str)
+
+    return repo
+
+
+REPO_ROOT = _bootstrap_repo_paths()
+
+import tilelang  # noqa: E402
+import tilelang.transform  # noqa: E402
+from tilelang import language as T  # noqa: E402
+from tilelang.engine.lower import device_codegen, extrac_params  # noqa: E402
+from tilelang.engine.phase import allow_vectorize  # noqa: E402
+from tilelang.utils.target import check_npu_availability, determine_platform  # noqa: E402
+import tvm  # noqa: E402
+from tvm import tir  # noqa: E402
+
+
+REDUCE_OPS = {"reduce_abssum", "reduce_absmax"}
+CONTROL_REDUCE_OPS = {"reduce_sum", "reduce_max", "reduce_min"}
+ALL_OPS = ["reduce_sum", "reduce_max", "reduce_min", "reduce_abssum", "reduce_absmax", "cumsum"]
+ALL_TARGETS = ["ascendc", "pto"]
+
+RUNTIME_PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+def line(title: str) -> None:
+    print("\n" + "=" * 100)
+    print(title)
+    print("=" * 100)
+
+
+def subline(title: str) -> None:
+    print("\n" + "-" * 100)
+    print(title)
+    print("-" * 100)
+
+
+def source_of(obj) -> str:
+    try:
+        return inspect.getsourcefile(obj) or "<unknown>"
+    except TypeError:
+        return "<unknown>"
+
+
+def print_api_binding() -> None:
+    line("API binding: which Python implementation does T.* use?")
+    for name in ALL_OPS:
+        obj = getattr(T, name)
+        print(f"T.{name}")
+        print(f"  object : {obj}")
+        print(f"  module : {getattr(obj, '__module__', '<unknown>')}")
+        print(f"  file   : {source_of(obj)}")
+        try:
+            src = inspect.getsource(obj).strip().splitlines()
+            print("  source :")
+            for src_line in src[:8]:
+                print(f"    {src_line}")
+            if len(src) > 8:
+                print("    ...")
+        except (OSError, TypeError):
+            print("  source : <not available>")
+
+
+def make_reduce_kernel(op_name: str):
+    op = getattr(T, op_name)
+
+    @T.prim_func
+    def main(
+        src: T.Tensor([8, 64], "float"),  # type: ignore
+        out: T.Tensor([8], "float"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (_, vid):
+            src_ub = T.alloc_ub([8, 64], "float")
+            out_ub = T.alloc_ub([8], "float")
+
+            if vid == 0:
+                T.copy(src, src_ub)
+                op(src_ub, out_ub, dim=-1)
+                T.copy(out_ub, out)
+
+    return main
+
+
+def make_cumsum_kernel(dim: int = -1, reverse: bool = False):
+    @T.prim_func
+    def main(
+        src: T.Tensor([8, 64], "float"),  # type: ignore
+        out: T.Tensor([8, 64], "float"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (_, vid):
+            src_ub = T.alloc_ub([8, 64], "float")
+            out_ub = T.alloc_ub([8, 64], "float")
+
+            if vid == 0:
+                T.copy(src, src_ub)
+                T.cumsum(src_ub, out_ub, dim=dim, reverse=reverse)
+                T.copy(out_ub, out)
+
+    return main
+
+
+def make_program(op_name: str):
+    if op_name == "cumsum":
+        return make_cumsum_kernel(dim=-1, reverse=False)
+    if op_name in REDUCE_OPS or op_name in CONTROL_REDUCE_OPS:
+        return make_reduce_kernel(op_name)
+    raise ValueError(f"unknown op: {op_name}")
+
+
+def print_prim_func(func: tir.PrimFunc) -> None:
+    subline("PrimFunc generated by @T.prim_func")
+    print("type:", type(func))
+    print("attrs:", func.attrs)
+    print("params:", list(func.params))
+    print("\nscript:")
+    print(func.script())
+
+
+def print_module(mod: tvm.IRModule, title: str) -> None:
+    subline(title)
+    try:
+        print(mod.script())
+    except Exception:  # pylint: disable=broad-except
+        print(mod)
+
+
+def run_pass(mod: tvm.IRModule, name: str, pass_func: Callable[[tvm.IRModule], tvm.IRModule]):
+    print(f"\n>>> PASS START: {name}")
+    try:
+        new_mod = pass_func(mod)
+    except Exception as err:  # pylint: disable=broad-except
+        print(f"<<< PASS FAILED: {name}")
+        print(f"exception type: {type(err).__name__}")
+        print(f"exception msg : {err}")
+        print("\nPython traceback:")
+        traceback.print_exc(file=sys.stdout)
+        raise
+    print(f"<<< PASS OK: {name}")
+    return new_mod
+
+
+def phase1_passes(target: tvm.target.Target):
+    return [
+        ("InjectTmpBuffer", lambda m: tilelang.transform.InjectTmpBuffer(target)(m)),
+        ("AscendInferBufferScope", lambda m: tilelang.transform.AscendInferBufferScope()(m)),
+        ("AscendVidReduction", lambda m: tilelang.transform.AscendVidReduction()(m)),
+        ("BufferShapeCollector", lambda m: tilelang.transform.BufferShapeCollector()(m)),
+        ("tir.BindTarget", lambda m: tir.transform.BindTarget(target)(m)),
+        ("HostProcesser", lambda m: tilelang.transform.HostProcesser()(m)),
+        ("tir.Simplify before LowerTileOp", lambda m: tir.transform.Simplify()(m)),
+        ("AscendLowerParallelToVector", lambda m: tilelang.transform.AscendLowerParallelToVector()(m)),
+        ("LayoutInference", lambda m: tilelang.transform.LayoutInference()(m)),
+        ("CollectBufferShapes", lambda m: tilelang.transform.CollectBufferShapes()(m)),
+        ("LowerTileOp", lambda m: tilelang.transform.LowerTileOp()(m)),
+        (
+            "AscendTailMaskPropagation",
+            lambda m: tilelang.transform.AscendTailMaskPropagation(
+                rewrite_reduce=target.model in {"ascendc", "pto", "auto"}
+            )(m),
+        ),
+        ("AscendWorkspaceReduction", lambda m: tilelang.transform.AscendWorkspaceReduction()(m)),
+        ("LegalizeVectorizedLoop", lambda m: tilelang.transform.LegalizeVectorizedLoop()(m)),
+        ("LegalizeSafeMemoryAccess", lambda m: tilelang.transform.LegalizeSafeMemoryAccess()(m)),
+        ("tir.Simplify after legalize", lambda m: tir.transform.Simplify()(m)),
+    ]
+
+
+def phase2_passes(target: tvm.target.Target, platform: str):
+    pass_ctx = tilelang.transform.get_pass_context()
+    return [
+        ("tir.PlanAndUpdateBufferAllocationLocation", lambda m: tir.transform.PlanAndUpdateBufferAllocationLocation()(m)),
+        ("CrossCorePipeline", lambda m: tilelang.transform.CrossCorePipeline()(m)),
+        ("CombineCV", lambda m: tilelang.transform.CombineCV()(m)),
+        ("PipelinePlanning", lambda m: tilelang.transform.PipelinePlanning()(m)),
+        ("InjectSoftwarePipeline", lambda m: tilelang.transform.InjectSoftwarePipeline()(m)),
+        ("AscendLowerOpaqueBlock", lambda m: tilelang.transform.AscendLowerOpaqueBlock()(m)),
+        ("tir.NarrowDataType(32)", lambda m: tir.transform.NarrowDataType(32)(m)),
+        ("ConfigIndexBitwidth", lambda m: tilelang.transform.ConfigIndexBitwidth()(m)),
+        ("Flatten2DBuffer", lambda m: tilelang.transform.Flatten2DBuffer()(m)),
+        ("FlattenBuffer", lambda m: tilelang.transform.FlattenBuffer()(m)),
+        ("tir.Simplify before VectorizeLoop", lambda m: tir.transform.Simplify()(m)),
+        (
+            "VectorizeLoop",
+            lambda m: tilelang.transform.VectorizeLoop(
+                enable_vectorize=allow_vectorize(pass_ctx=pass_ctx)
+            )(m),
+        ),
+        (
+            "AscendStorageRewrite",
+            lambda m: tilelang.transform.AscendStorageRewrite(
+                is_npu=check_npu_availability()
+            )(m),
+        ),
+        ("tir.UnrollLoop", lambda m: tir.transform.UnrollLoop()(m)),
+        ("tir.RenormalizeSplitPattern", lambda m: tir.transform.RenormalizeSplitPattern()(m)),
+        ("tir.Simplify after unroll", lambda m: tir.transform.Simplify()(m)),
+        ("tir.RemoveNoOp", lambda m: tir.transform.RemoveNoOp()(m)),
+        ("tir.RewriteUnsafeSelect", lambda m: tir.transform.RewriteUnsafeSelect()(m)),
+        ("tir.HoistIfThenElse", lambda m: tir.transform.HoistIfThenElse()(m)),
+        ("AscendMemoryPlanning", lambda m: tilelang.transform.AscendMemoryPlanning()(m)),
+        ("AscendSyncInsert", lambda m: tilelang.transform.AscendSyncInsert(target, platform)(m)),
+        ("AscendSyncInsertVS", lambda m: tilelang.transform.AscendSyncInsertVS(target, platform)(m)),
+    ]
+
+
+def lower_step_by_step(func: tir.PrimFunc, target_name: str) -> None:
+    target = tvm.target.Target({"kind": "llvm", "model": target_name})
+    platform = determine_platform("auto")
+    params = extrac_params(func)
+    mod = tvm.IRModule({func.attrs["global_symbol"]: func})
+
+    print(f"target  : {target}")
+    print(f"platform: {platform}")
+    print("params  :")
+    for param in params:
+        print(f"  {param}")
+
+    print_module(mod, "Initial IRModule before lowering")
+
+    line("Phase 1: LowerAndLegalize, expanded pass by pass")
+    for name, pass_func in phase1_passes(target):
+        if name == "LowerTileOp":
+            print_module(mod, "IRModule immediately before LowerTileOp")
+        mod = run_pass(mod, name, pass_func)
+        if name == "LowerTileOp":
+            print_module(mod, "IRModule immediately after LowerTileOp")
+
+    line("Phase 2: OptimizeForTarget, expanded pass by pass")
+    for name, pass_func in phase2_passes(target, platform):
+        mod = run_pass(mod, name, pass_func)
+
+    print_module(mod, "IRModule before device_codegen")
+
+    line("Device codegen")
+    try:
+        codegen_mod = device_codegen(mod, target, platform)
+    except Exception as err:  # pylint: disable=broad-except
+        print("device_codegen FAILED")
+        print(f"exception type: {type(err).__name__}")
+        print(f"exception msg : {err}")
+        traceback.print_exc(file=sys.stdout)
+        raise
+
+    source = codegen_mod.get_source()
+    print("device_codegen OK")
+    print("\nGenerated kernel_source:")
+    print(source)
+
+
+def run_case(op_name: str, target_name: str) -> bool:
+    line(f"CASE op={op_name}, target={target_name}")
+    tilelang.cache.clear_cache()
+    func = make_program(op_name)
+    print_prim_func(func)
+
+    try:
+        lower_step_by_step(func, target_name)
+    except Exception:
+        print(f"\nCASE RESULT: FAILED op={op_name}, target={target_name}")
+        return False
+
+    print(f"\nCASE RESULT: OK op={op_name}, target={target_name}")
+    return True
+
+
+def compile_runtime_kernel(op_name: str, target_name: str):
+    """Compile one direct NPU runtime kernel for correctness testing."""
+
+    func = make_program(op_name)
+    return tilelang.compile(
+        func,
+        out_idx=[-1],
+        pass_configs=RUNTIME_PASS_CONFIGS,
+        target=target_name,
+    )
+
+
+def reference_result(op_name: str, src):
+    if op_name == "reduce_sum":
+        return src.sum(dim=-1)
+    if op_name == "reduce_max":
+        return src.max(dim=-1).values
+    if op_name == "reduce_min":
+        return src.min(dim=-1).values
+    if op_name == "reduce_abssum":
+        return src.abs().sum(dim=-1)
+    if op_name == "reduce_absmax":
+        return src.abs().amax(dim=-1)
+    if op_name == "cumsum":
+        return src.cumsum(dim=-1)
+    raise ValueError(f"unknown op: {op_name}")
+
+
+def run_runtime_case(op_name: str, target_name: str) -> bool:
+    """Compile and run the kernel, then compare with PyTorch on NPU."""
+
+    line(f"RUNTIME CASE op={op_name}, target={target_name}")
+    if target_name != "ascendc":
+        print("runtime test is intended for ascendc first; pto codegen can still be checked with the normal mode")
+        return False
+
+    try:
+        import torch  # pylint: disable=import-outside-toplevel
+    except ImportError as err:
+        print(f"torch import failed: {err}")
+        return False
+
+    if not hasattr(torch, "npu") or not torch.npu.is_available():
+        print("torch.npu is not available in this environment")
+        return False
+
+    tilelang.cache.clear_cache()
+    kernel = compile_runtime_kernel(op_name, target_name)
+    print(f"{kernel.get_kernel_source()}")
+    torch.manual_seed(0)
+    src = torch.randn(8, 64, dtype=torch.float32).npu()
+    # Add deterministic edge values so abs reductions check negative and zero data.
+    src[0, 0] = -7.0
+    src[1, 3] = 0.0
+    torch.npu.synchronize()
+
+    got = kernel(src)
+    torch.npu.synchronize()
+    expected = reference_result(op_name, src)
+    print(f"expected: {expected}\n")
+    torch.testing.assert_close(got, expected, rtol=1e-2, atol=1e-2)
+    print("runtime output matched PyTorch reference")
+    print("got shape:", tuple(got.shape))
+    print("got sample:", got.flatten()[:8].detach().cpu())
+    print(f"RUNTIME RESULT: OK op={op_name}, target={target_name}")
+    return True
+
+
+def test_reduce_abssum_runtime():
+    assert run_runtime_case("reduce_abssum", "ascendc")
+
+
+def test_reduce_absmax_runtime():
+    assert run_runtime_case("reduce_absmax", "ascendc")
+
+
+def test_cumsum_runtime():
+    assert run_runtime_case("cumsum", "ascendc")
+
+
+def parse_args() -> tuple[bool, list[str], list[str]]:
+    args = sys.argv[1:]
+    runtime = False
+    if "--runtime" in args:
+        runtime = True
+        args = [arg for arg in args if arg != "--runtime"]
+
+    if not args:
+        return runtime, ["reduce_abssum", "reduce_absmax", "cumsum"], ALL_TARGETS
+    if len(args) != 2:
+        print("Usage:")
+        print(f"  python {Path(__file__).name}")
+        print(f"  python {Path(__file__).name} --runtime reduce_abssum ascendc")
+        print(f"  python {Path(__file__).name} reduce_abssum ascendc")
+        print(f"  python {Path(__file__).name} reduce_absmax pto")
+        print(f"  python {Path(__file__).name} cumsum ascendc")
+        raise SystemExit(2)
+
+    op_name, target_name = args
+    if op_name not in ALL_OPS:
+        raise SystemExit(f"unknown op {op_name}, expected one of {ALL_OPS}")
+    if target_name not in ALL_TARGETS:
+        raise SystemExit(f"unknown target {target_name}, expected one of {ALL_TARGETS}")
+    return runtime, [op_name], [target_name]
+
+
+def main() -> int:
+    print("repo root:", REPO_ROOT)
+    print("tvm python:", tvm.__file__)
+    print("tilelang language:", T.__file__)
+    print("TVM_LIBRARY_PATH:", os.environ.get("TVM_LIBRARY_PATH"))
+
+    print_api_binding()
+
+    runtime, op_names, target_names = parse_args()
+    failed = 0
+    for op_name in op_names:
+        for target_name in target_names:
+            ok = run_runtime_case(op_name, target_name) if runtime else run_case(op_name, target_name)
+            failed += 0 if ok else 1
+    return failed
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+
+
+
+# import tilelang
+# from tilelang import language as T
+
+
+
+# # op_name, target =  "reduce_abssum", "ascendc"
+# # op_name, target =  "reduce_absmax" ,"ascendc"
+# op_name, target =  "cumsum" ,"ascendc"
+
+
+
+
+
+# def make_reduce_kernel():
+#     op = getattr(T, op_name)
+
+#     @T.prim_func
+#     def main(
+#         src: T.Tensor([8, 64], "float"),
+#         out: T.Tensor([8], "float"),
+#     ):
+#         with T.Kernel(1, is_npu=True) as (_, vid):
+#             src_ub = T.alloc_ub([8, 64], "float")
+#             out_ub = T.alloc_ub([8], "float")
+
+#             if vid == 0:
+#                 T.copy(src, src_ub)
+#                 op(src_ub, out_ub, dim=-1)
+#                 T.copy(out_ub, out)
+
+#     return main
+
+
+# def make_cumsum_kernel():
+#     @T.prim_func
+#     def main(
+#         src: T.Tensor([8, 64], "float"),
+#         out: T.Tensor([8, 64], "float"),
+#     ):
+#         with T.Kernel(1, is_npu=True) as (_, vid):
+#             src_ub = T.alloc_ub([8, 64], "float")
+#             out_ub = T.alloc_ub([8, 64], "float")
+
+#             if vid == 0:
+#                 T.copy(src, src_ub)
+#                 T.cumsum(src_ub, out_ub, dim=-1)
+#                 T.copy(out_ub, out)
+
+#     return main
+
+
+# program = (
+#     make_cumsum_kernel()
+#     if op_name == "cumsum"
+#     else make_reduce_kernel()
+# )
+# print(tilelang.lower(program, target=target).kernel_source)

--- a/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
+++ b/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
@@ -1,9 +1,9 @@
-# """Direct debug script for reduce_abssum/reduce_absmax/cumsum on Ascend.
+# # """Direct debug script for reduce_abssum/reduce_absmax/cumsum on Ascend.
 
-# This is intentionally not a pytest-style file.  It is meant to be run directly
-# while developing/fixing the issue.
+# # This is intentionally not a pytest-style file.  It is meant to be run directly
+# # while developing/fixing the issue.
 
-# Examples:
+# # Examples:
 
 #     python testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
 #     python testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py reduce_abssum ascendc
@@ -12,102 +12,102 @@
 #     python testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py --runtime cumsum ascendc
 
 
-# What it prints:
+# # What it prints:
 
-# * which Python function T.reduce_sum/reduce_abssum/reduce_absmax/cumsum binds to
-# * the PrimFunc produced by @T.prim_func
-# * each important lower pass, especially the pass that fails
-# * generated kernel_source if lowering reaches codegen
-# """
+# # * which Python function T.reduce_sum/reduce_abssum/reduce_absmax/cumsum binds to
+# # * the PrimFunc produced by @T.prim_func
+# # * each important lower pass, especially the pass that fails
+# # * generated kernel_source if lowering reaches codegen
+# # """
 
-from __future__ import annotations
+# from __future__ import annotations
 
-import inspect
-import os
-import sys
-import traceback
-from pathlib import Path
-from typing import Callable
-
-
-def _bootstrap_repo_paths() -> Path:
-    """Prefer this checkout's Python code and build/libtvm when run directly."""
-
-    repo = Path(__file__).resolve().parents[3]
-    tvm_python = repo / "3rdparty" / "tvm" / "python"
-    tvm_build = repo / "build" / "tvm"
-
-    os.environ.setdefault("TVM_LIBRARY_PATH", str(tvm_build))
-    for path in (repo, tvm_python):
-        path_str = str(path)
-        while path_str in sys.path:
-            sys.path.remove(path_str)
-        sys.path.insert(0, path_str)
-
-    return repo
+# import inspect
+# import os
+# import sys
+# import traceback
+# from pathlib import Path
+# from typing import Callable
 
 
-REPO_ROOT = _bootstrap_repo_paths()
+# def _bootstrap_repo_paths() -> Path:
+#     """Prefer this checkout's Python code and build/libtvm when run directly."""
 
-import tilelang  # noqa: E402
-import tilelang.transform  # noqa: E402
-from tilelang import language as T  # noqa: E402
-from tilelang.engine.lower import device_codegen, extrac_params  # noqa: E402
-from tilelang.engine.phase import allow_vectorize  # noqa: E402
-from tilelang.utils.target import check_npu_availability, determine_platform  # noqa: E402
-import tvm  # noqa: E402
-from tvm import tir  # noqa: E402
+#     repo = Path(__file__).resolve().parents[3]
+#     tvm_python = repo / "3rdparty" / "tvm" / "python"
+#     tvm_build = repo / "build" / "tvm"
 
+#     os.environ.setdefault("TVM_LIBRARY_PATH", str(tvm_build))
+#     for path in (repo, tvm_python):
+#         path_str = str(path)
+#         while path_str in sys.path:
+#             sys.path.remove(path_str)
+#         sys.path.insert(0, path_str)
 
-REDUCE_OPS = {"reduce_abssum", "reduce_absmax"}
-CONTROL_REDUCE_OPS = {"reduce_sum", "reduce_max", "reduce_min"}
-ALL_OPS = ["reduce_sum", "reduce_max", "reduce_min", "reduce_abssum", "reduce_absmax", "cumsum"]
-ALL_TARGETS = ["ascendc", "pto"]
-
-RUNTIME_PASS_CONFIGS = {
-    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
-    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
-    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
-    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
-}
+#     return repo
 
 
-def line(title: str) -> None:
-    print("\n" + "=" * 100)
-    print(title)
-    print("=" * 100)
+# REPO_ROOT = _bootstrap_repo_paths()
+
+# import tilelang  # noqa: E402
+# import tilelang.transform  # noqa: E402
+# from tilelang import language as T  # noqa: E402
+# from tilelang.engine.lower import device_codegen, extrac_params  # noqa: E402
+# from tilelang.engine.phase import allow_vectorize  # noqa: E402
+# from tilelang.utils.target import check_npu_availability, determine_platform  # noqa: E402
+# import tvm  # noqa: E402
+# from tvm import tir  # noqa: E402
 
 
-def subline(title: str) -> None:
-    print("\n" + "-" * 100)
-    print(title)
-    print("-" * 100)
+# REDUCE_OPS = {"reduce_abssum", "reduce_absmax"}
+# CONTROL_REDUCE_OPS = {"reduce_sum", "reduce_max", "reduce_min"}
+# ALL_OPS = ["reduce_sum", "reduce_max", "reduce_min", "reduce_abssum", "reduce_absmax", "cumsum"]
+# ALL_TARGETS = ["ascendc", "pto"]
+
+# RUNTIME_PASS_CONFIGS = {
+#     tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+#     tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+#     tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+#     tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+# }
 
 
-def source_of(obj) -> str:
-    try:
-        return inspect.getsourcefile(obj) or "<unknown>"
-    except TypeError:
-        return "<unknown>"
+# def line(title: str) -> None:
+#     print("\n" + "=" * 100)
+#     print(title)
+#     print("=" * 100)
 
 
-def print_api_binding() -> None:
-    line("API binding: which Python implementation does T.* use?")
-    for name in ALL_OPS:
-        obj = getattr(T, name)
-        print(f"T.{name}")
-        print(f"  object : {obj}")
-        print(f"  module : {getattr(obj, '__module__', '<unknown>')}")
-        print(f"  file   : {source_of(obj)}")
-        try:
-            src = inspect.getsource(obj).strip().splitlines()
-            print("  source :")
-            for src_line in src[:8]:
-                print(f"    {src_line}")
-            if len(src) > 8:
-                print("    ...")
-        except (OSError, TypeError):
-            print("  source : <not available>")
+# def subline(title: str) -> None:
+#     print("\n" + "-" * 100)
+#     print(title)
+#     print("-" * 100)
+
+
+# def source_of(obj) -> str:
+#     try:
+#         return inspect.getsourcefile(obj) or "<unknown>"
+#     except TypeError:
+#         return "<unknown>"
+
+
+# def print_api_binding() -> None:
+#     line("API binding: which Python implementation does T.* use?")
+#     for name in ALL_OPS:
+#         obj = getattr(T, name)
+#         print(f"T.{name}")
+#         print(f"  object : {obj}")
+#         print(f"  module : {getattr(obj, '__module__', '<unknown>')}")
+#         print(f"  file   : {source_of(obj)}")
+#         try:
+#             src = inspect.getsource(obj).strip().splitlines()
+#             print("  source :")
+#             for src_line in src[:8]:
+#                 print(f"    {src_line}")
+#             if len(src) > 8:
+#                 print("    ...")
+#         except (OSError, TypeError):
+#             print("  source : <not available>")
 
 
 def make_reduce_kernel(op_name: str):
@@ -448,8 +448,8 @@ if __name__ == "__main__":
 
 #     @T.prim_func
 #     def main(
-#         src: T.Tensor([8, 64], "float"),
-#         out: T.Tensor([8], "float"),
+#         src: T.Tensor([8, 64], "float"),  # type: ignore
+#         out: T.Tensor([8], "float"),  # type: ignore
 #     ):
 #         with T.Kernel(1, is_npu=True) as (_, vid):
 #             src_ub = T.alloc_ub([8, 64], "float")
@@ -463,11 +463,11 @@ if __name__ == "__main__":
 #     return main
 
 
-# def make_cumsum_kernel():
+# def make_cumsum_kernel(dim: int = -1, reverse: bool = False):
 #     @T.prim_func
 #     def main(
-#         src: T.Tensor([8, 64], "float"),
-#         out: T.Tensor([8, 64], "float"),
+#         src: T.Tensor([8, 64], "float"),  # type: ignore
+#         out: T.Tensor([8, 64], "float"),  # type: ignore
 #     ):
 #         with T.Kernel(1, is_npu=True) as (_, vid):
 #             src_ub = T.alloc_ub([8, 64], "float")
@@ -475,15 +475,344 @@ if __name__ == "__main__":
 
 #             if vid == 0:
 #                 T.copy(src, src_ub)
-#                 T.cumsum(src_ub, out_ub, dim=-1)
+#                 T.cumsum(src_ub, out_ub, dim=dim, reverse=reverse)
 #                 T.copy(out_ub, out)
 
 #     return main
 
 
-# program = (
-#     make_cumsum_kernel()
-#     if op_name == "cumsum"
-#     else make_reduce_kernel()
-# )
-# print(tilelang.lower(program, target=target).kernel_source)
+# def make_program(op_name: str):
+#     if op_name == "cumsum":
+#         return make_cumsum_kernel(dim=-1, reverse=False)
+#     if op_name in REDUCE_OPS or op_name in CONTROL_REDUCE_OPS:
+#         return make_reduce_kernel(op_name)
+#     raise ValueError(f"unknown op: {op_name}")
+
+
+# def print_prim_func(func: tir.PrimFunc) -> None:
+#     subline("PrimFunc generated by @T.prim_func")
+#     print("type:", type(func))
+#     print("attrs:", func.attrs)
+#     print("params:", list(func.params))
+#     print("\nscript:")
+#     print(func.script())
+
+
+# def print_module(mod: tvm.IRModule, title: str) -> None:
+#     subline(title)
+#     try:
+#         print(mod.script())
+#     except Exception:  # pylint: disable=broad-except
+#         print(mod)
+
+
+# def run_pass(mod: tvm.IRModule, name: str, pass_func: Callable[[tvm.IRModule], tvm.IRModule]):
+#     print(f"\n>>> PASS START: {name}")
+#     try:
+#         new_mod = pass_func(mod)
+#     except Exception as err:  # pylint: disable=broad-except
+#         print(f"<<< PASS FAILED: {name}")
+#         print(f"exception type: {type(err).__name__}")
+#         print(f"exception msg : {err}")
+#         print("\nPython traceback:")
+#         traceback.print_exc(file=sys.stdout)
+#         raise
+#     print(f"<<< PASS OK: {name}")
+#     return new_mod
+
+
+# def phase1_passes(target: tvm.target.Target):
+#     return [
+#         ("InjectTmpBuffer", lambda m: tilelang.transform.InjectTmpBuffer(target)(m)),
+#         ("AscendInferBufferScope", lambda m: tilelang.transform.AscendInferBufferScope()(m)),
+#         ("AscendVidReduction", lambda m: tilelang.transform.AscendVidReduction()(m)),
+#         ("BufferShapeCollector", lambda m: tilelang.transform.BufferShapeCollector()(m)),
+#         ("tir.BindTarget", lambda m: tir.transform.BindTarget(target)(m)),
+#         ("HostProcesser", lambda m: tilelang.transform.HostProcesser()(m)),
+#         ("tir.Simplify before LowerTileOp", lambda m: tir.transform.Simplify()(m)),
+#         ("AscendLowerParallelToVector", lambda m: tilelang.transform.AscendLowerParallelToVector()(m)),
+#         ("LayoutInference", lambda m: tilelang.transform.LayoutInference()(m)),
+#         ("CollectBufferShapes", lambda m: tilelang.transform.CollectBufferShapes()(m)),
+#         ("LowerTileOp", lambda m: tilelang.transform.LowerTileOp()(m)),
+#         (
+#             "AscendTailMaskPropagation",
+#             lambda m: tilelang.transform.AscendTailMaskPropagation(rewrite_reduce=target.model in {"ascendc", "pto", "auto"})(m),
+#         ),
+#         ("AscendWorkspaceReduction", lambda m: tilelang.transform.AscendWorkspaceReduction()(m)),
+#         ("LegalizeVectorizedLoop", lambda m: tilelang.transform.LegalizeVectorizedLoop()(m)),
+#         ("LegalizeSafeMemoryAccess", lambda m: tilelang.transform.LegalizeSafeMemoryAccess()(m)),
+#         ("tir.Simplify after legalize", lambda m: tir.transform.Simplify()(m)),
+#     ]
+
+
+# def phase2_passes(target: tvm.target.Target, platform: str):
+#     pass_ctx = tilelang.transform.get_pass_context()
+#     return [
+#         ("tir.PlanAndUpdateBufferAllocationLocation", lambda m: tir.transform.PlanAndUpdateBufferAllocationLocation()(m)),
+#         ("CrossCorePipeline", lambda m: tilelang.transform.CrossCorePipeline()(m)),
+#         ("CombineCV", lambda m: tilelang.transform.CombineCV()(m)),
+#         ("PipelinePlanning", lambda m: tilelang.transform.PipelinePlanning()(m)),
+#         ("InjectSoftwarePipeline", lambda m: tilelang.transform.InjectSoftwarePipeline()(m)),
+#         ("AscendLowerOpaqueBlock", lambda m: tilelang.transform.AscendLowerOpaqueBlock()(m)),
+#         ("tir.NarrowDataType(32)", lambda m: tir.transform.NarrowDataType(32)(m)),
+#         ("ConfigIndexBitwidth", lambda m: tilelang.transform.ConfigIndexBitwidth()(m)),
+#         ("Flatten2DBuffer", lambda m: tilelang.transform.Flatten2DBuffer()(m)),
+#         ("FlattenBuffer", lambda m: tilelang.transform.FlattenBuffer()(m)),
+#         ("tir.Simplify before VectorizeLoop", lambda m: tir.transform.Simplify()(m)),
+#         (
+#             "VectorizeLoop",
+#             lambda m: tilelang.transform.VectorizeLoop(enable_vectorize=allow_vectorize(pass_ctx=pass_ctx))(m),
+#         ),
+#         (
+#             "AscendStorageRewrite",
+#             lambda m: tilelang.transform.AscendStorageRewrite(is_npu=check_npu_availability())(m),
+#         ),
+#         ("tir.UnrollLoop", lambda m: tir.transform.UnrollLoop()(m)),
+#         ("tir.RenormalizeSplitPattern", lambda m: tir.transform.RenormalizeSplitPattern()(m)),
+#         ("tir.Simplify after unroll", lambda m: tir.transform.Simplify()(m)),
+#         ("tir.RemoveNoOp", lambda m: tir.transform.RemoveNoOp()(m)),
+#         ("tir.RewriteUnsafeSelect", lambda m: tir.transform.RewriteUnsafeSelect()(m)),
+#         ("tir.HoistIfThenElse", lambda m: tir.transform.HoistIfThenElse()(m)),
+#         ("AscendMemoryPlanning", lambda m: tilelang.transform.AscendMemoryPlanning()(m)),
+#         ("AscendSyncInsert", lambda m: tilelang.transform.AscendSyncInsert(target, platform)(m)),
+#         ("AscendSyncInsertVS", lambda m: tilelang.transform.AscendSyncInsertVS(target, platform)(m)),
+#     ]
+
+
+# def lower_step_by_step(func: tir.PrimFunc, target_name: str) -> None:
+#     target = tvm.target.Target({"kind": "llvm", "model": target_name})
+#     platform = determine_platform("auto")
+#     params = extrac_params(func)
+#     mod = tvm.IRModule({func.attrs["global_symbol"]: func})
+
+#     print(f"target  : {target}")
+#     print(f"platform: {platform}")
+#     print("params  :")
+#     for param in params:
+#         print(f"  {param}")
+
+#     print_module(mod, "Initial IRModule before lowering")
+
+#     line("Phase 1: LowerAndLegalize, expanded pass by pass")
+#     for name, pass_func in phase1_passes(target):
+#         if name == "LowerTileOp":
+#             print_module(mod, "IRModule immediately before LowerTileOp")
+#         mod = run_pass(mod, name, pass_func)
+#         if name == "LowerTileOp":
+#             print_module(mod, "IRModule immediately after LowerTileOp")
+
+#     line("Phase 2: OptimizeForTarget, expanded pass by pass")
+#     for name, pass_func in phase2_passes(target, platform):
+#         mod = run_pass(mod, name, pass_func)
+
+#     print_module(mod, "IRModule before device_codegen")
+
+#     line("Device codegen")
+#     try:
+#         codegen_mod = device_codegen(mod, target, platform)
+#     except Exception as err:  # pylint: disable=broad-except
+#         print("device_codegen FAILED")
+#         print(f"exception type: {type(err).__name__}")
+#         print(f"exception msg : {err}")
+#         traceback.print_exc(file=sys.stdout)
+#         raise
+
+#     source = codegen_mod.get_source()
+#     print("device_codegen OK")
+#     print("\nGenerated kernel_source:")
+#     print(source)
+
+
+# def run_case(op_name: str, target_name: str) -> bool:
+#     line(f"CASE op={op_name}, target={target_name}")
+#     tilelang.cache.clear_cache()
+#     func = make_program(op_name)
+#     print_prim_func(func)
+
+#     try:
+#         lower_step_by_step(func, target_name)
+#     except Exception:
+#         print(f"\nCASE RESULT: FAILED op={op_name}, target={target_name}")
+#         return False
+
+#     print(f"\nCASE RESULT: OK op={op_name}, target={target_name}")
+#     return True
+
+
+# def compile_runtime_kernel(op_name: str, target_name: str):
+#     """Compile one direct NPU runtime kernel for correctness testing."""
+
+#     func = make_program(op_name)
+#     return tilelang.compile(
+#         func,
+#         out_idx=[-1],
+#         pass_configs=RUNTIME_PASS_CONFIGS,
+#         target=target_name,
+#     )
+
+
+# def reference_result(op_name: str, src):
+#     if op_name == "reduce_sum":
+#         return src.sum(dim=-1)
+#     if op_name == "reduce_max":
+#         return src.max(dim=-1).values
+#     if op_name == "reduce_min":
+#         return src.min(dim=-1).values
+#     if op_name == "reduce_abssum":
+#         return src.abs().sum(dim=-1)
+#     if op_name == "reduce_absmax":
+#         return src.abs().amax(dim=-1)
+#     if op_name == "cumsum":
+#         return src.cumsum(dim=-1)
+#     raise ValueError(f"unknown op: {op_name}")
+
+
+# def run_runtime_case(op_name: str, target_name: str) -> bool:
+#     """Compile and run the kernel, then compare with PyTorch on NPU."""
+
+#     line(f"RUNTIME CASE op={op_name}, target={target_name}")
+#     if target_name != "ascendc":
+#         print("runtime test is intended for ascendc first; pto codegen can still be checked with the normal mode")
+#         return False
+
+#     try:
+#         import torch  # pylint: disable=import-outside-toplevel
+#     except ImportError as err:
+#         print(f"torch import failed: {err}")
+#         return False
+
+#     if not hasattr(torch, "npu") or not torch.npu.is_available():
+#         print("torch.npu is not available in this environment")
+#         return False
+
+#     tilelang.cache.clear_cache()
+#     kernel = compile_runtime_kernel(op_name, target_name)
+#     print(f"{kernel.get_kernel_source()}")
+#     torch.manual_seed(0)
+#     src = torch.randn(8, 64, dtype=torch.float32).npu()
+#     # Add deterministic edge values so abs reductions check negative and zero data.
+#     src[0, 0] = -7.0
+#     src[1, 3] = 0.0
+#     torch.npu.synchronize()
+
+#     got = kernel(src)
+#     torch.npu.synchronize()
+#     expected = reference_result(op_name, src)
+#     print(f"expected: {expected}\n")
+#     torch.testing.assert_close(got, expected, rtol=1e-2, atol=1e-2)
+#     print("runtime output matched PyTorch reference")
+#     print("got shape:", tuple(got.shape))
+#     print("got sample:", got.flatten()[:8].detach().cpu())
+#     print(f"RUNTIME RESULT: OK op={op_name}, target={target_name}")
+#     return True
+
+
+# def test_reduce_abssum_runtime():
+#     assert run_runtime_case("reduce_abssum", "ascendc")
+
+
+# def test_reduce_absmax_runtime():
+#     assert run_runtime_case("reduce_absmax", "ascendc")
+
+
+# def test_cumsum_runtime():
+#     assert run_runtime_case("cumsum", "ascendc")
+
+
+# def parse_args() -> tuple[bool, list[str], list[str]]:
+#     args = sys.argv[1:]
+#     runtime = False
+#     if "--runtime" in args:
+#         runtime = True
+#         args = [arg for arg in args if arg != "--runtime"]
+
+#     if not args:
+#         return runtime, ["reduce_abssum", "reduce_absmax", "cumsum"], ALL_TARGETS
+#     if len(args) != 2:
+#         print("Usage:")
+#         print(f"  python {Path(__file__).name}")
+#         print(f"  python {Path(__file__).name} --runtime reduce_abssum ascendc")
+#         print(f"  python {Path(__file__).name} reduce_abssum ascendc")
+#         print(f"  python {Path(__file__).name} reduce_absmax pto")
+#         print(f"  python {Path(__file__).name} cumsum ascendc")
+#         raise SystemExit(2)
+
+#     op_name, target_name = args
+#     if op_name not in ALL_OPS:
+#         raise SystemExit(f"unknown op {op_name}, expected one of {ALL_OPS}")
+#     if target_name not in ALL_TARGETS:
+#         raise SystemExit(f"unknown target {target_name}, expected one of {ALL_TARGETS}")
+#     return runtime, [op_name], [target_name]
+
+
+# def main() -> int:
+#     print("repo root:", REPO_ROOT)
+#     print("tvm python:", tvm.__file__)
+#     print("tilelang language:", T.__file__)
+#     print("TVM_LIBRARY_PATH:", os.environ.get("TVM_LIBRARY_PATH"))
+
+#     print_api_binding()
+
+#     runtime, op_names, target_names = parse_args()
+#     failed = 0
+#     for op_name in op_names:
+#         for target_name in target_names:
+#             ok = run_runtime_case(op_name, target_name) if runtime else run_case(op_name, target_name)
+#             failed += 0 if ok else 1
+#     return failed
+
+
+# if __name__ == "__main__":
+#     raise SystemExit(main())
+
+
+# 复现原issue的代码
+import tilelang
+from tilelang import language as T
+
+
+op_name, target = "reduce_abssum", "ascendc"
+op_name, target = "reduce_absmax", "ascendc"
+op_name, target = "cumsum", "ascendc"
+
+
+def make_reduce_kernel():
+    op = getattr(T, op_name)
+
+    @T.prim_func
+    def main(
+        src: T.Tensor([8, 64], "float"),
+        out: T.Tensor([8], "float"),
+    ):
+        with T.Kernel(1, is_npu=True) as (_, vid):
+            src_ub = T.alloc_ub([8, 64], "float")
+            out_ub = T.alloc_ub([8], "float")
+
+            if vid == 0:
+                T.copy(src, src_ub)
+                op(src_ub, out_ub, dim=-1)
+                T.copy(out_ub, out)
+
+    return main
+
+
+def make_cumsum_kernel():
+    @T.prim_func
+    def main(
+        src: T.Tensor([8, 64], "float"),
+        out: T.Tensor([8, 64], "float"),
+    ):
+        with T.Kernel(1, is_npu=True) as (_, vid):
+            src_ub = T.alloc_ub([8, 64], "float")
+            out_ub = T.alloc_ub([8, 64], "float")
+
+            if vid == 0:
+                T.copy(src, src_ub)
+                T.cumsum(src_ub, out_ub, dim=-1)
+                T.copy(out_ub, out)
+
+    return main
+
+
+program = make_cumsum_kernel() if op_name == "cumsum" else make_reduce_kernel()
+print(tilelang.lower(program, target=target).kernel_source)

--- a/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
+++ b/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
@@ -58,11 +58,11 @@ from tilelang.utils.target import check_npu_availability, determine_platform  # 
 import tvm  # noqa: E402
 from tvm import tir  # noqa: E402
 
-
+ALL_TARGETS = ["ascendc", "pto"]
 REDUCE_OPS = {"reduce_abssum", "reduce_absmax"}
 CONTROL_REDUCE_OPS = {"reduce_sum", "reduce_max", "reduce_min"}
 ALL_OPS = ["reduce_sum", "reduce_max", "reduce_min", "reduce_abssum", "reduce_absmax", "cumsum"]
-ALL_TARGETS = ["ascendc", "pto"]
+
 
 RUNTIME_PASS_CONFIGS = {
     tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,

--- a/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
+++ b/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
@@ -433,6 +433,7 @@ if __name__ == "__main__":
     raise SystemExit(main())
 
 
+## 复现原issue的代码
 # import tilelang
 # from tilelang import language as T
 

--- a/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
+++ b/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
@@ -22,9 +22,9 @@
 
 from __future__ import annotations
 
-import inspect
 import os
 import sys
+import inspect
 import traceback
 from pathlib import Path
 from typing import Callable

--- a/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
+++ b/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
@@ -203,9 +203,7 @@ def phase1_passes(target: tvm.target.Target):
         ("LowerTileOp", lambda m: tilelang.transform.LowerTileOp()(m)),
         (
             "AscendTailMaskPropagation",
-            lambda m: tilelang.transform.AscendTailMaskPropagation(
-                rewrite_reduce=target.model in {"ascendc", "pto", "auto"}
-            )(m),
+            lambda m: tilelang.transform.AscendTailMaskPropagation(rewrite_reduce=target.model in {"ascendc", "pto", "auto"})(m),
         ),
         ("AscendWorkspaceReduction", lambda m: tilelang.transform.AscendWorkspaceReduction()(m)),
         ("LegalizeVectorizedLoop", lambda m: tilelang.transform.LegalizeVectorizedLoop()(m)),
@@ -230,15 +228,11 @@ def phase2_passes(target: tvm.target.Target, platform: str):
         ("tir.Simplify before VectorizeLoop", lambda m: tir.transform.Simplify()(m)),
         (
             "VectorizeLoop",
-            lambda m: tilelang.transform.VectorizeLoop(
-                enable_vectorize=allow_vectorize(pass_ctx=pass_ctx)
-            )(m),
+            lambda m: tilelang.transform.VectorizeLoop(enable_vectorize=allow_vectorize(pass_ctx=pass_ctx))(m),
         ),
         (
             "AscendStorageRewrite",
-            lambda m: tilelang.transform.AscendStorageRewrite(
-                is_npu=check_npu_availability()
-            )(m),
+            lambda m: tilelang.transform.AscendStorageRewrite(is_npu=check_npu_availability())(m),
         ),
         ("tir.UnrollLoop", lambda m: tir.transform.UnrollLoop()(m)),
         ("tir.RenormalizeSplitPattern", lambda m: tir.transform.RenormalizeSplitPattern()(m)),
@@ -439,20 +433,13 @@ if __name__ == "__main__":
     raise SystemExit(main())
 
 
-
-
-
 # import tilelang
 # from tilelang import language as T
-
 
 
 # # op_name, target =  "reduce_abssum", "ascendc"
 # # op_name, target =  "reduce_absmax" ,"ascendc"
 # op_name, target =  "cumsum" ,"ascendc"
-
-
-
 
 
 # def make_reduce_kernel():

--- a/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
+++ b/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py
@@ -20,93 +20,94 @@
 # # * generated kernel_source if lowering reaches codegen
 # # """
 
-# from __future__ import annotations
+from __future__ import annotations
 
-# import inspect
-# import os
-# import sys
-# import traceback
-# from pathlib import Path
-# from typing import Callable
-
-
-# def _bootstrap_repo_paths() -> Path:
-#     """Prefer this checkout's Python code and build/libtvm when run directly."""
-
-#     repo = Path(__file__).resolve().parents[3]
-#     tvm_python = repo / "3rdparty" / "tvm" / "python"
-#     tvm_build = repo / "build" / "tvm"
-
-#     os.environ.setdefault("TVM_LIBRARY_PATH", str(tvm_build))
-#     for path in (repo, tvm_python):
-#         path_str = str(path)
-#         while path_str in sys.path:
-#             sys.path.remove(path_str)
-#         sys.path.insert(0, path_str)
-
-#     return repo
-
-# REPO_ROOT = _bootstrap_repo_paths()
-
-# import tilelang  # noqa: E402
-# import tilelang.transform  # noqa: E402
-# from tilelang import language as T  # noqa: E402
-# from tilelang.engine.lower import device_codegen, extrac_params  # noqa: E402
-# from tilelang.engine.phase import allow_vectorize  # noqa: E402
-# from tilelang.utils.target import check_npu_availability, determine_platform  # noqa: E402
-# import tvm  # noqa: E402
-# from tvm import tir  # noqa: E402
+import inspect
+import os
+import sys
+import traceback
+from pathlib import Path
+from typing import Callable
 
 
-# REDUCE_OPS = {"reduce_abssum", "reduce_absmax"}
-# CONTROL_REDUCE_OPS = {"reduce_sum", "reduce_max", "reduce_min"}
-# ALL_OPS = ["reduce_sum", "reduce_max", "reduce_min", "reduce_abssum", "reduce_absmax", "cumsum"]
-# ALL_TARGETS = ["ascendc", "pto"]
+def _bootstrap_repo_paths() -> Path:
+    """Prefer this checkout's Python code and build/libtvm when run directly."""
 
-# RUNTIME_PASS_CONFIGS = {
-#     tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
-#     tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
-#     tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
-#     tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
-# }
+    repo = Path(__file__).resolve().parents[3]
+    tvm_python = repo / "3rdparty" / "tvm" / "python"
+    tvm_build = repo / "build" / "tvm"
 
+    os.environ.setdefault("TVM_LIBRARY_PATH", str(tvm_build))
+    for path in (repo, tvm_python):
+        path_str = str(path)
+        while path_str in sys.path:
+            sys.path.remove(path_str)
+        sys.path.insert(0, path_str)
 
-# def line(title: str) -> None:
-#     print("\n" + "=" * 100)
-#     print(title)
-#     print("=" * 100)
+    return repo
 
 
-# def subline(title: str) -> None:
-#     print("\n" + "-" * 100)
-#     print(title)
-#     print("-" * 100)
+REPO_ROOT = _bootstrap_repo_paths()
+
+import tilelang  # noqa: E402
+import tilelang.transform  # noqa: E402
+from tilelang import language as T  # noqa: E402
+from tilelang.engine.lower import device_codegen, extrac_params  # noqa: E402
+from tilelang.engine.phase import allow_vectorize  # noqa: E402
+from tilelang.utils.target import check_npu_availability, determine_platform  # noqa: E402
+import tvm  # noqa: E402
+from tvm import tir  # noqa: E402
 
 
-# def source_of(obj) -> str:
-#     try:
-#         return inspect.getsourcefile(obj) or "<unknown>"
-#     except TypeError:
-#         return "<unknown>"
+REDUCE_OPS = {"reduce_abssum", "reduce_absmax"}
+CONTROL_REDUCE_OPS = {"reduce_sum", "reduce_max", "reduce_min"}
+ALL_OPS = ["reduce_sum", "reduce_max", "reduce_min", "reduce_abssum", "reduce_absmax", "cumsum"]
+ALL_TARGETS = ["ascendc", "pto"]
+
+RUNTIME_PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
 
 
-# def print_api_binding() -> None:
-#     line("API binding: which Python implementation does T.* use?")
-#     for name in ALL_OPS:
-#         obj = getattr(T, name)
-#         print(f"T.{name}")
-#         print(f"  object : {obj}")
-#         print(f"  module : {getattr(obj, '__module__', '<unknown>')}")
-#         print(f"  file   : {source_of(obj)}")
-#         try:
-#             src = inspect.getsource(obj).strip().splitlines()
-#             print("  source :")
-#             for src_line in src[:8]:
-#                 print(f"    {src_line}")
-#             if len(src) > 8:
-#                 print("    ...")
-#         except (OSError, TypeError):
-#             print("  source : <not available>")
+def line(title: str) -> None:
+    print("\n" + "=" * 100)
+    print(title)
+    print("=" * 100)
+
+
+def subline(title: str) -> None:
+    print("\n" + "-" * 100)
+    print(title)
+    print("-" * 100)
+
+
+def source_of(obj) -> str:
+    try:
+        return inspect.getsourcefile(obj) or "<unknown>"
+    except TypeError:
+        return "<unknown>"
+
+
+def print_api_binding() -> None:
+    line("API binding: which Python implementation does T.* use?")
+    for name in ALL_OPS:
+        obj = getattr(T, name)
+        print(f"T.{name}")
+        print(f"  object : {obj}")
+        print(f"  module : {getattr(obj, '__module__', '<unknown>')}")
+        print(f"  file   : {source_of(obj)}")
+        try:
+            src = inspect.getsource(obj).strip().splitlines()
+            print("  source :")
+            for src_line in src[:8]:
+                print(f"    {src_line}")
+            if len(src) > 8:
+                print("    ...")
+        except (OSError, TypeError):
+            print("  source : <not available>")
 
 
 def make_reduce_kernel(op_name: str):
@@ -432,14 +433,14 @@ if __name__ == "__main__":
     raise SystemExit(main())
 
 
-## 复现原issue的代码
+# # 复现原issue的代码
 # import tilelang
 # from tilelang import language as T
 
 
-# # op_name, target =  "reduce_abssum", "ascendc"
-# # op_name, target =  "reduce_absmax" ,"ascendc"
-# op_name, target =  "cumsum" ,"ascendc"
+# op_name, target = "reduce_abssum", "ascendc"
+# op_name, target = "reduce_absmax", "ascendc"
+# op_name, target = "cumsum", "ascendc"
 
 
 # def make_reduce_kernel():
@@ -447,8 +448,8 @@ if __name__ == "__main__":
 
 #     @T.prim_func
 #     def main(
-#         src: T.Tensor([8, 64], "float"),  # type: ignore
-#         out: T.Tensor([8], "float"),  # type: ignore
+#         src: T.Tensor([8, 64], "float"),
+#         out: T.Tensor([8], "float"),
 #     ):
 #         with T.Kernel(1, is_npu=True) as (_, vid):
 #             src_ub = T.alloc_ub([8, 64], "float")
@@ -462,11 +463,11 @@ if __name__ == "__main__":
 #     return main
 
 
-# def make_cumsum_kernel(dim: int = -1, reverse: bool = False):
+# def make_cumsum_kernel():
 #     @T.prim_func
 #     def main(
-#         src: T.Tensor([8, 64], "float"),  # type: ignore
-#         out: T.Tensor([8, 64], "float"),  # type: ignore
+#         src: T.Tensor([8, 64], "float"),
+#         out: T.Tensor([8, 64], "float"),
 #     ):
 #         with T.Kernel(1, is_npu=True) as (_, vid):
 #             src_ub = T.alloc_ub([8, 64], "float")
@@ -474,344 +475,11 @@ if __name__ == "__main__":
 
 #             if vid == 0:
 #                 T.copy(src, src_ub)
-#                 T.cumsum(src_ub, out_ub, dim=dim, reverse=reverse)
+#                 T.cumsum(src_ub, out_ub, dim=-1)
 #                 T.copy(out_ub, out)
 
 #     return main
 
 
-# def make_program(op_name: str):
-#     if op_name == "cumsum":
-#         return make_cumsum_kernel(dim=-1, reverse=False)
-#     if op_name in REDUCE_OPS or op_name in CONTROL_REDUCE_OPS:
-#         return make_reduce_kernel(op_name)
-#     raise ValueError(f"unknown op: {op_name}")
-
-
-# def print_prim_func(func: tir.PrimFunc) -> None:
-#     subline("PrimFunc generated by @T.prim_func")
-#     print("type:", type(func))
-#     print("attrs:", func.attrs)
-#     print("params:", list(func.params))
-#     print("\nscript:")
-#     print(func.script())
-
-
-# def print_module(mod: tvm.IRModule, title: str) -> None:
-#     subline(title)
-#     try:
-#         print(mod.script())
-#     except Exception:  # pylint: disable=broad-except
-#         print(mod)
-
-
-# def run_pass(mod: tvm.IRModule, name: str, pass_func: Callable[[tvm.IRModule], tvm.IRModule]):
-#     print(f"\n>>> PASS START: {name}")
-#     try:
-#         new_mod = pass_func(mod)
-#     except Exception as err:  # pylint: disable=broad-except
-#         print(f"<<< PASS FAILED: {name}")
-#         print(f"exception type: {type(err).__name__}")
-#         print(f"exception msg : {err}")
-#         print("\nPython traceback:")
-#         traceback.print_exc(file=sys.stdout)
-#         raise
-#     print(f"<<< PASS OK: {name}")
-#     return new_mod
-
-
-# def phase1_passes(target: tvm.target.Target):
-#     return [
-#         ("InjectTmpBuffer", lambda m: tilelang.transform.InjectTmpBuffer(target)(m)),
-#         ("AscendInferBufferScope", lambda m: tilelang.transform.AscendInferBufferScope()(m)),
-#         ("AscendVidReduction", lambda m: tilelang.transform.AscendVidReduction()(m)),
-#         ("BufferShapeCollector", lambda m: tilelang.transform.BufferShapeCollector()(m)),
-#         ("tir.BindTarget", lambda m: tir.transform.BindTarget(target)(m)),
-#         ("HostProcesser", lambda m: tilelang.transform.HostProcesser()(m)),
-#         ("tir.Simplify before LowerTileOp", lambda m: tir.transform.Simplify()(m)),
-#         ("AscendLowerParallelToVector", lambda m: tilelang.transform.AscendLowerParallelToVector()(m)),
-#         ("LayoutInference", lambda m: tilelang.transform.LayoutInference()(m)),
-#         ("CollectBufferShapes", lambda m: tilelang.transform.CollectBufferShapes()(m)),
-#         ("LowerTileOp", lambda m: tilelang.transform.LowerTileOp()(m)),
-#         (
-#             "AscendTailMaskPropagation",
-#             lambda m: tilelang.transform.AscendTailMaskPropagation(rewrite_reduce=target.model in {"ascendc", "pto", "auto"})(m),
-#         ),
-#         ("AscendWorkspaceReduction", lambda m: tilelang.transform.AscendWorkspaceReduction()(m)),
-#         ("LegalizeVectorizedLoop", lambda m: tilelang.transform.LegalizeVectorizedLoop()(m)),
-#         ("LegalizeSafeMemoryAccess", lambda m: tilelang.transform.LegalizeSafeMemoryAccess()(m)),
-#         ("tir.Simplify after legalize", lambda m: tir.transform.Simplify()(m)),
-#     ]
-
-
-# def phase2_passes(target: tvm.target.Target, platform: str):
-#     pass_ctx = tilelang.transform.get_pass_context()
-#     return [
-#         ("tir.PlanAndUpdateBufferAllocationLocation", lambda m: tir.transform.PlanAndUpdateBufferAllocationLocation()(m)),
-#         ("CrossCorePipeline", lambda m: tilelang.transform.CrossCorePipeline()(m)),
-#         ("CombineCV", lambda m: tilelang.transform.CombineCV()(m)),
-#         ("PipelinePlanning", lambda m: tilelang.transform.PipelinePlanning()(m)),
-#         ("InjectSoftwarePipeline", lambda m: tilelang.transform.InjectSoftwarePipeline()(m)),
-#         ("AscendLowerOpaqueBlock", lambda m: tilelang.transform.AscendLowerOpaqueBlock()(m)),
-#         ("tir.NarrowDataType(32)", lambda m: tir.transform.NarrowDataType(32)(m)),
-#         ("ConfigIndexBitwidth", lambda m: tilelang.transform.ConfigIndexBitwidth()(m)),
-#         ("Flatten2DBuffer", lambda m: tilelang.transform.Flatten2DBuffer()(m)),
-#         ("FlattenBuffer", lambda m: tilelang.transform.FlattenBuffer()(m)),
-#         ("tir.Simplify before VectorizeLoop", lambda m: tir.transform.Simplify()(m)),
-#         (
-#             "VectorizeLoop",
-#             lambda m: tilelang.transform.VectorizeLoop(enable_vectorize=allow_vectorize(pass_ctx=pass_ctx))(m),
-#         ),
-#         (
-#             "AscendStorageRewrite",
-#             lambda m: tilelang.transform.AscendStorageRewrite(is_npu=check_npu_availability())(m),
-#         ),
-#         ("tir.UnrollLoop", lambda m: tir.transform.UnrollLoop()(m)),
-#         ("tir.RenormalizeSplitPattern", lambda m: tir.transform.RenormalizeSplitPattern()(m)),
-#         ("tir.Simplify after unroll", lambda m: tir.transform.Simplify()(m)),
-#         ("tir.RemoveNoOp", lambda m: tir.transform.RemoveNoOp()(m)),
-#         ("tir.RewriteUnsafeSelect", lambda m: tir.transform.RewriteUnsafeSelect()(m)),
-#         ("tir.HoistIfThenElse", lambda m: tir.transform.HoistIfThenElse()(m)),
-#         ("AscendMemoryPlanning", lambda m: tilelang.transform.AscendMemoryPlanning()(m)),
-#         ("AscendSyncInsert", lambda m: tilelang.transform.AscendSyncInsert(target, platform)(m)),
-#         ("AscendSyncInsertVS", lambda m: tilelang.transform.AscendSyncInsertVS(target, platform)(m)),
-#     ]
-
-
-# def lower_step_by_step(func: tir.PrimFunc, target_name: str) -> None:
-#     target = tvm.target.Target({"kind": "llvm", "model": target_name})
-#     platform = determine_platform("auto")
-#     params = extrac_params(func)
-#     mod = tvm.IRModule({func.attrs["global_symbol"]: func})
-
-#     print(f"target  : {target}")
-#     print(f"platform: {platform}")
-#     print("params  :")
-#     for param in params:
-#         print(f"  {param}")
-
-#     print_module(mod, "Initial IRModule before lowering")
-
-#     line("Phase 1: LowerAndLegalize, expanded pass by pass")
-#     for name, pass_func in phase1_passes(target):
-#         if name == "LowerTileOp":
-#             print_module(mod, "IRModule immediately before LowerTileOp")
-#         mod = run_pass(mod, name, pass_func)
-#         if name == "LowerTileOp":
-#             print_module(mod, "IRModule immediately after LowerTileOp")
-
-#     line("Phase 2: OptimizeForTarget, expanded pass by pass")
-#     for name, pass_func in phase2_passes(target, platform):
-#         mod = run_pass(mod, name, pass_func)
-
-#     print_module(mod, "IRModule before device_codegen")
-
-#     line("Device codegen")
-#     try:
-#         codegen_mod = device_codegen(mod, target, platform)
-#     except Exception as err:  # pylint: disable=broad-except
-#         print("device_codegen FAILED")
-#         print(f"exception type: {type(err).__name__}")
-#         print(f"exception msg : {err}")
-#         traceback.print_exc(file=sys.stdout)
-#         raise
-
-#     source = codegen_mod.get_source()
-#     print("device_codegen OK")
-#     print("\nGenerated kernel_source:")
-#     print(source)
-
-
-# def run_case(op_name: str, target_name: str) -> bool:
-#     line(f"CASE op={op_name}, target={target_name}")
-#     tilelang.cache.clear_cache()
-#     func = make_program(op_name)
-#     print_prim_func(func)
-
-#     try:
-#         lower_step_by_step(func, target_name)
-#     except Exception:
-#         print(f"\nCASE RESULT: FAILED op={op_name}, target={target_name}")
-#         return False
-
-#     print(f"\nCASE RESULT: OK op={op_name}, target={target_name}")
-#     return True
-
-
-# def compile_runtime_kernel(op_name: str, target_name: str):
-#     """Compile one direct NPU runtime kernel for correctness testing."""
-
-#     func = make_program(op_name)
-#     return tilelang.compile(
-#         func,
-#         out_idx=[-1],
-#         pass_configs=RUNTIME_PASS_CONFIGS,
-#         target=target_name,
-#     )
-
-
-# def reference_result(op_name: str, src):
-#     if op_name == "reduce_sum":
-#         return src.sum(dim=-1)
-#     if op_name == "reduce_max":
-#         return src.max(dim=-1).values
-#     if op_name == "reduce_min":
-#         return src.min(dim=-1).values
-#     if op_name == "reduce_abssum":
-#         return src.abs().sum(dim=-1)
-#     if op_name == "reduce_absmax":
-#         return src.abs().amax(dim=-1)
-#     if op_name == "cumsum":
-#         return src.cumsum(dim=-1)
-#     raise ValueError(f"unknown op: {op_name}")
-
-
-# def run_runtime_case(op_name: str, target_name: str) -> bool:
-#     """Compile and run the kernel, then compare with PyTorch on NPU."""
-
-#     line(f"RUNTIME CASE op={op_name}, target={target_name}")
-#     if target_name != "ascendc":
-#         print("runtime test is intended for ascendc first; pto codegen can still be checked with the normal mode")
-#         return False
-
-#     try:
-#         import torch  # pylint: disable=import-outside-toplevel
-#     except ImportError as err:
-#         print(f"torch import failed: {err}")
-#         return False
-
-#     if not hasattr(torch, "npu") or not torch.npu.is_available():
-#         print("torch.npu is not available in this environment")
-#         return False
-
-#     tilelang.cache.clear_cache()
-#     kernel = compile_runtime_kernel(op_name, target_name)
-#     print(f"{kernel.get_kernel_source()}")
-#     torch.manual_seed(0)
-#     src = torch.randn(8, 64, dtype=torch.float32).npu()
-#     # Add deterministic edge values so abs reductions check negative and zero data.
-#     src[0, 0] = -7.0
-#     src[1, 3] = 0.0
-#     torch.npu.synchronize()
-
-#     got = kernel(src)
-#     torch.npu.synchronize()
-#     expected = reference_result(op_name, src)
-#     print(f"expected: {expected}\n")
-#     torch.testing.assert_close(got, expected, rtol=1e-2, atol=1e-2)
-#     print("runtime output matched PyTorch reference")
-#     print("got shape:", tuple(got.shape))
-#     print("got sample:", got.flatten()[:8].detach().cpu())
-#     print(f"RUNTIME RESULT: OK op={op_name}, target={target_name}")
-#     return True
-
-
-# def test_reduce_abssum_runtime():
-#     assert run_runtime_case("reduce_abssum", "ascendc")
-
-
-# def test_reduce_absmax_runtime():
-#     assert run_runtime_case("reduce_absmax", "ascendc")
-
-
-# def test_cumsum_runtime():
-#     assert run_runtime_case("cumsum", "ascendc")
-
-
-# def parse_args() -> tuple[bool, list[str], list[str]]:
-#     args = sys.argv[1:]
-#     runtime = False
-#     if "--runtime" in args:
-#         runtime = True
-#         args = [arg for arg in args if arg != "--runtime"]
-
-#     if not args:
-#         return runtime, ["reduce_abssum", "reduce_absmax", "cumsum"], ALL_TARGETS
-#     if len(args) != 2:
-#         print("Usage:")
-#         print(f"  python {Path(__file__).name}")
-#         print(f"  python {Path(__file__).name} --runtime reduce_abssum ascendc")
-#         print(f"  python {Path(__file__).name} reduce_abssum ascendc")
-#         print(f"  python {Path(__file__).name} reduce_absmax pto")
-#         print(f"  python {Path(__file__).name} cumsum ascendc")
-#         raise SystemExit(2)
-
-#     op_name, target_name = args
-#     if op_name not in ALL_OPS:
-#         raise SystemExit(f"unknown op {op_name}, expected one of {ALL_OPS}")
-#     if target_name not in ALL_TARGETS:
-#         raise SystemExit(f"unknown target {target_name}, expected one of {ALL_TARGETS}")
-#     return runtime, [op_name], [target_name]
-
-
-# def main() -> int:
-#     print("repo root:", REPO_ROOT)
-#     print("tvm python:", tvm.__file__)
-#     print("tilelang language:", T.__file__)
-#     print("TVM_LIBRARY_PATH:", os.environ.get("TVM_LIBRARY_PATH"))
-
-#     print_api_binding()
-
-#     runtime, op_names, target_names = parse_args()
-#     failed = 0
-#     for op_name in op_names:
-#         for target_name in target_names:
-#             ok = run_runtime_case(op_name, target_name) if runtime else run_case(op_name, target_name)
-#             failed += 0 if ok else 1
-#     return failed
-
-
-# if __name__ == "__main__":
-#     raise SystemExit(main())
-
-
-# 复现原issue的代码
-import tilelang
-from tilelang import language as T
-
-
-op_name, target = "reduce_abssum", "ascendc"
-op_name, target = "reduce_absmax", "ascendc"
-op_name, target = "cumsum", "ascendc"
-
-
-def make_reduce_kernel():
-    op = getattr(T, op_name)
-
-    @T.prim_func
-    def main(
-        src: T.Tensor([8, 64], "float"),
-        out: T.Tensor([8], "float"),
-    ):
-        with T.Kernel(1, is_npu=True) as (_, vid):
-            src_ub = T.alloc_ub([8, 64], "float")
-            out_ub = T.alloc_ub([8], "float")
-
-            if vid == 0:
-                T.copy(src, src_ub)
-                op(src_ub, out_ub, dim=-1)
-                T.copy(out_ub, out)
-
-    return main
-
-
-def make_cumsum_kernel():
-    @T.prim_func
-    def main(
-        src: T.Tensor([8, 64], "float"),
-        out: T.Tensor([8, 64], "float"),
-    ):
-        with T.Kernel(1, is_npu=True) as (_, vid):
-            src_ub = T.alloc_ub([8, 64], "float")
-            out_ub = T.alloc_ub([8, 64], "float")
-
-            if vid == 0:
-                T.copy(src, src_ub)
-                T.cumsum(src_ub, out_ub, dim=-1)
-                T.copy(out_ub, out)
-
-    return main
-
-
-program = make_cumsum_kernel() if op_name == "cumsum" else make_reduce_kernel()
-print(tilelang.lower(program, target=target).kernel_source)
+# program = make_cumsum_kernel() if op_name == "cumsum" else make_reduce_kernel()
+# print(tilelang.lower(program, target=target).kernel_source)

--- a/tilelang/language/reduce_ascend.py
+++ b/tilelang/language/reduce_ascend.py
@@ -518,7 +518,7 @@ def reduce_absmax(
     dim: int = -1,
     *args,
     clear=_REDUCE_KWARG_SENTINEL,
-    real_shape=_REDUCE_KWARG_SENTINEL
+    real_shape=_REDUCE_KWARG_SENTINEL,
 ):
     """Perform absolute-max reduction on the current Ascend fast-path."""
     parsed_clear, parsed_real_shape = _parse_reduce_optional_args(

--- a/tilelang/language/reduce_ascend.py
+++ b/tilelang/language/reduce_ascend.py
@@ -10,7 +10,8 @@ from .ascend import _dtype, _get_tmp_arena_access_ptr, _retrieve_shape
 
 _REDUCE_KWARG_SENTINEL = object()
 
-__all__ = ["reduce","reduce_sum","reduce_max","reduce_min", "reduce_abssum", "reduce_absmax","cumsum"]
+__all__ = ["reduce", "reduce_sum", "reduce_max", "reduce_min", "reduce_abssum", "reduce_absmax", "cumsum"]
+
 
 def _get_buffer_extent(object: Buffer | BufferRegion) -> list[int]:
     return list(_retrieve_shape(object))
@@ -475,6 +476,7 @@ def reduce_sum(
     legalized_dim = _legalize_reduce_dim(_get_buffer_extent(buffer), dim)
     return _reduce_with_clear(buffer, out, "reduce_sum", legalized_dim, parsed_clear, parsed_real_shape)
 
+
 def reduce_abssum(
     buffer: Buffer | BufferRegion,
     out: Buffer | BufferRegion,
@@ -500,7 +502,8 @@ def reduce_abssum(
         True,
         parsed_real_shape,
     )
-    
+
+
 def reduce_absmax(
     buffer: Buffer | BufferRegion,
     out: Buffer | BufferRegion,
@@ -527,7 +530,8 @@ def reduce_absmax(
         parsed_clear,
         parsed_real_shape,
     )
-    
+
+
 def cumsum(
     src: Buffer | BufferRegion,
     dst: Buffer | BufferRegion | None = None,

--- a/tilelang/language/reduce_ascend.py
+++ b/tilelang/language/reduce_ascend.py
@@ -474,7 +474,15 @@ def reduce_sum(
     """
     parsed_clear, parsed_real_shape = _parse_reduce_optional_args("reduce_sum", args, clear=clear, real_shape=real_shape)
     legalized_dim = _legalize_reduce_dim(_get_buffer_extent(buffer), dim)
-    return _reduce_with_clear(buffer, out, "reduce_sum", legalized_dim, parsed_clear, parsed_real_shape)
+    return _reduce_with_clear(
+        buffer,
+        out,
+        "reduce_sum",
+        legalized_dim,
+        parsed_clear,
+        parsed_real_shape,
+        tmp=tmp,
+    )
 
 
 def reduce_abssum(

--- a/tilelang/language/reduce_ascend.py
+++ b/tilelang/language/reduce_ascend.py
@@ -518,7 +518,7 @@ def reduce_absmax(
     dim: int = -1,
     *args,
     clear=_REDUCE_KWARG_SENTINEL,
-    real_shape=_REDUCE_KWARG_SENTINEL,
+    real_shape=_REDUCE_KWARG_SENTINEL
 ):
     """Perform absolute-max reduction on the current Ascend fast-path."""
     parsed_clear, parsed_real_shape = _parse_reduce_optional_args(

--- a/tilelang/language/reduce_ascend.py
+++ b/tilelang/language/reduce_ascend.py
@@ -10,8 +10,7 @@ from .ascend import _dtype, _get_tmp_arena_access_ptr, _retrieve_shape
 
 _REDUCE_KWARG_SENTINEL = object()
 
-__all__ = ["reduce", "reduce_sum", "reduce_max", "reduce_min"]
-
+__all__ = ["reduce","reduce_sum","reduce_max","reduce_min", "reduce_abssum", "reduce_absmax","cumsum"]
 
 def _get_buffer_extent(object: Buffer | BufferRegion) -> list[int]:
     return list(_retrieve_shape(object))
@@ -474,12 +473,87 @@ def reduce_sum(
     """
     parsed_clear, parsed_real_shape = _parse_reduce_optional_args("reduce_sum", args, clear=clear, real_shape=real_shape)
     legalized_dim = _legalize_reduce_dim(_get_buffer_extent(buffer), dim)
+    return _reduce_with_clear(buffer, out, "reduce_sum", legalized_dim, parsed_clear, parsed_real_shape)
+
+def reduce_abssum(
+    buffer: Buffer | BufferRegion,
+    out: Buffer | BufferRegion,
+    dim: int = -1,
+    *args,
+    real_shape=_REDUCE_KWARG_SENTINEL,
+):
+    """Perform absolute-sum reduction on the current Ascend fast-path."""
+    parsed_clear, parsed_real_shape = _parse_reduce_optional_args(
+        "reduce_abssum",
+        args,
+        clear=True,
+        real_shape=real_shape,
+    )
+    if parsed_clear is not True:
+        raise ValueError("reduce_abssum requires clear=True in the first implementation")
+    legalized_dim = _legalize_reduce_dim(_get_buffer_extent(buffer), dim)
     return _reduce_with_clear(
         buffer,
         out,
-        "reduce_sum",
+        "reduce_abssum",
+        legalized_dim,
+        True,
+        parsed_real_shape,
+    )
+    
+def reduce_absmax(
+    buffer: Buffer | BufferRegion,
+    out: Buffer | BufferRegion,
+    dim: int = -1,
+    *args,
+    clear=_REDUCE_KWARG_SENTINEL,
+    real_shape=_REDUCE_KWARG_SENTINEL,
+):
+    """Perform absolute-max reduction on the current Ascend fast-path."""
+    parsed_clear, parsed_real_shape = _parse_reduce_optional_args(
+        "reduce_absmax",
+        args,
+        clear=clear,
+        real_shape=real_shape,
+    )
+    if parsed_clear is not True:
+        raise ValueError("reduce_absmax requires clear=True in the first implementation")
+    legalized_dim = _legalize_reduce_dim(_get_buffer_extent(buffer), dim)
+    return _reduce_with_clear(
+        buffer,
+        out,
+        "reduce_absmax",
         legalized_dim,
         parsed_clear,
         parsed_real_shape,
-        tmp=tmp,
+    )
+    
+def cumsum(
+    src: Buffer | BufferRegion,
+    dst: Buffer | BufferRegion | None = None,
+    dim: int = 0,
+    reverse: bool = False,
+):
+    if dst is None:
+        dst = src
+
+    shape = _get_buffer_extent(src)
+    if len(shape) != 2:
+        raise ValueError("Ascend cumsum first implementation only supports 2D UB tensor")
+    if dim < 0:
+        dim = len(shape) + dim
+    if dim not in (0, 1):
+        raise ValueError("Ascend cumsum only supports dim=0/-2 or dim=1/-1")
+    if reverse:
+        raise ValueError("Ascend cumsum reverse=True is not implemented in the first version")
+
+    dtype = _dtype(src)
+    op_name = f"cumsum<{dtype}, {shape[0]}, {shape[1]}, {dim}>"
+    return tir.call_intrin(
+        "handle",
+        tir.op.Op.get("tl.ascend_cumsum"),
+        op_name,
+        dst.access_ptr("w"),
+        src.access_ptr("r"),
+        reverse,
     )


### PR DESCRIPTION
Regarding Issue #1519 [Bug] T.reduce_abssum、T.reduce_absmax 和 T.cumsum 缺少 Ascend 后端支持

Add Ascend T.reduce_abssum、T.reduce_absmax 、T.cumsum support

使用Issue的复现代码
```
import sys

import tilelang
from tilelang import language as T

op_name, target = sys.argv[1:3]


def make_reduce_kernel():
    op = getattr(T, op_name)

    @T.prim_func
    def main(
        src: T.Tensor([8, 64], "float"),
        out: T.Tensor([8], "float"),
    ):
        with T.Kernel(1, is_npu=True) as (_, vid):
            src_ub = T.alloc_ub([8, 64], "float")
            out_ub = T.alloc_ub([8], "float")

            if vid == 0:
                T.copy(src, src_ub)
                op(src_ub, out_ub, dim=-1)
                T.copy(out_ub, out)

    return main


def make_cumsum_kernel():
    @T.prim_func
    def main(
        src: T.Tensor([8, 64], "float"),
        out: T.Tensor([8, 64], "float"),
    ):
        with T.Kernel(1, is_npu=True) as (_, vid):
            src_ub = T.alloc_ub([8, 64], "float")
            out_ub = T.alloc_ub([8, 64], "float")

            if vid == 0:
                T.copy(src, src_ub)
                T.cumsum(src_ub, out_ub, dim=-1)
                T.copy(out_ub, out)

    return main


program = (
    make_cumsum_kernel()
    if op_name == "cumsum"
    else make_reduce_kernel()
)
print(tilelang.lower(program, target=target).kernel_source)
```


运行：

```
python repro.py reduce_abssum ascendc
python repro.py reduce_absmax ascendc
python repro.py cumsum ascendc
```


生成结果
reduce_abssum ascendc:
```
    tl::ascend::copy_gm_to_ub<float, 64, 8>(src_ub[0], src[0], 64, 8, 64, 0.000000e+00f);
    tl::ascend::reduce_abssum<float, 8, 64, -1>(out_ub[0], src_ub[0], tmp_ub[0], true);
    tl::ascend::copy_ub_to_gm<float, 8>(out[0], out_ub[0], 8, 1, 8);
```
reduce_absmax ascendc:
```
    tl::ascend::copy_gm_to_ub<float, 64, 8>(src_ub[0], src[0], 64, 8, 64, 0.000000e+00f);
    tl::ascend::reduce_absmax<float, 8, 64, -1>(out_ub[0], src_ub[0], tmp_ub[0], true);
    tl::ascend::copy_ub_to_gm<float, 8>(out[0], out_ub[0], 8, 1, 8);
```
cumsum ascendc:
```
    tl::ascend::copy_gm_to_ub<float, 64, 8>(src_ub[0], src[0], 64, 8, 64, 0.000000e+00f);
    tl::ascend::cumsum<float, 8, 64, 1>(out_ub[0], cumsum_last_row[0], src_ub[0], tmp_ub[0]);
    tl::ascend::copy_ub_to_gm<float, 64, 8>(out[0], out_ub[0], 64, 8, 64);
```

T.reduce_abssum、T.reduce_absmax 和 T.cumsum均正确接入ascend后端

同时进行了精度和效果测试，
复现代码见： tilelang-ascend/testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py

测试命令
```

python testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py --runtime reduce_abssum ascendc
python testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py --runtime reduce_absmax ascendc
python testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py --runtime cumsum ascendc

```
```
例：python testing/python/language/test_tilelang_ascend_language_reduce_abssum_absmax_cumsum_issue.py --runtime reduce_absmax ascendc

运行结果
expected: tensor([7.0000, 2.6133, 1.9507, 1.9029, 2.0655, 3.9300, 4.1015, 3.4028],
       device='npu:0')

runtime output matched PyTorch reference
got shape: (8,)
got sample: tensor([7.0000, 2.6133, 1.9507, 1.9029, 2.0655, 3.9300, 4.1015, 3.4028])
```

