### PR TITLE
[Test]: add non-intrusive pytest coverage for example kernels 

### DIFF
--- a/examples/deepseek_v4/test_act_quant.py
+++ b/examples/deepseek_v4/test_act_quant.py
@@ -1,0 +1,41 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_act_quant_example() -> ModuleType:
+    source = Path(__file__).with_name("act_quant.py")
+    spec = importlib.util.spec_from_file_location("_act_quant_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+    return module
+
+
+def test_act_quant_accuracy() -> None:
+    import torch
+
+    example = _load_act_quant_example()
+
+    m = 128
+    n = 1024
+
+    torch.manual_seed(42)
+    x_bf16 = torch.randn(m, n, dtype=torch.bfloat16, device="npu")
+
+    kernel = example.act_quant_kernel_int8_optimized(n, block_M=16, block_N=n, round_scale=False)
+
+    actual, scales = kernel(x_bf16)
+    expected, expected_scales = example.validate_act_quant_kernel(x_bf16, m, n)
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1)
+    torch.testing.assert_close(scales.reshape(m), expected_scales.reshape(m), rtol=1e-2, atol=1e-2)

--- a/examples/deepseek_v4/test_hc_split_sinkhorn.py
+++ b/examples/deepseek_v4/test_hc_split_sinkhorn.py
@@ -1,0 +1,62 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_hc_split_sinkhorn_example() -> ModuleType:
+    source = Path(__file__).with_name("hc_split_sinkhorn.py")
+    spec = importlib.util.spec_from_file_location("_hc_split_sinkhorn_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+    return module
+
+
+def test_hc_split_sinkhorn_accuracy() -> None:
+    import torch
+
+    example = _load_hc_split_sinkhorn_example()
+
+    dtype = torch.float32
+    batch = 1
+    seq_len = 5
+    hc_mult = 4
+    sinkhorn_iters = 20
+    eps = 1e-6
+    mix_hc = (2 + hc_mult) * hc_mult
+    n = batch * seq_len
+
+    torch.manual_seed(42)
+    mixes = torch.rand((n, mix_hc), dtype=dtype, device="npu")
+    hc_scale = torch.rand(3, dtype=dtype, device="npu")
+    hc_base = torch.rand(mix_hc, dtype=dtype, device="npu")
+
+    pre = torch.empty((n, hc_mult), dtype=dtype, device="npu")
+    post = torch.empty((n, hc_mult), dtype=dtype, device="npu")
+    comb = torch.empty((n, hc_mult, hc_mult), dtype=dtype, device="npu")
+    torch.npu.synchronize()
+
+    kernel = example.hc_split_sinkhorn(hc=hc_mult, sinkhorn_iters=sinkhorn_iters, eps=eps)
+
+    pre, post, comb = kernel(mixes, hc_scale, hc_base)
+    pre_ref, post_ref, comb_ref = example.hc_split_sinkhorn_ref(
+        mixes,
+        hc_scale,
+        hc_base,
+        hc_mult,
+        sinkhorn_iters,
+        eps,
+    )
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(pre_ref, pre, rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(post_ref, post, rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(comb_ref, comb, rtol=1e-2, atol=1e-2)

--- a/examples/deepseek_v4/test_int8_gemm.py
+++ b/examples/deepseek_v4/test_int8_gemm.py
@@ -1,0 +1,70 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_int8_gemm_example() -> ModuleType:
+    source = Path(__file__).with_name("int8_gemm.py")
+    spec = importlib.util.spec_from_file_location("_int8_gemm_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+    return module
+
+
+def test_int8_gemm_accuracy() -> None:
+    import torch
+
+    example = _load_int8_gemm_example()
+
+    m = 1024
+    n = 1024
+    k = 1024
+
+    torch.manual_seed(42)
+    a_bf16 = torch.randn(m, k, dtype=torch.bfloat16, device="npu")
+    a_fp32 = a_bf16.float()
+    a_abs_max = torch.max(torch.abs(a_fp32), dim=1, keepdim=True)[0]
+    a_abs_max = torch.clamp(a_abs_max, min=1e-4)
+    a_scales = a_abs_max / 127.0
+    a_scaled = a_fp32 / a_scales
+    a_int8 = torch.clamp(a_scaled, -128, 127).round().to(torch.int8)
+
+    b_bf16 = torch.randn(n, k, dtype=torch.bfloat16, device="npu")
+    b_fp32 = b_bf16.float()
+    b_abs_max = torch.max(torch.abs(b_fp32), dim=1, keepdim=True)[0]
+    b_abs_max = torch.clamp(b_abs_max, min=1e-4)
+    b_scales = b_abs_max / 127.0
+    b_scaled = b_fp32 / b_scales
+    b_int8 = torch.clamp(b_scaled, -128, 127).round().to(torch.int8)
+
+    kernel = example.int8_gemm_kernel_corrected(
+        n,
+        k,
+        block_M=64,
+        block_N=64,
+        block_K=64,
+        out_dtype=example.BF16,
+    )
+
+    actual = kernel(a_int8, b_int8, a_scales, b_scales)
+    torch.npu.synchronize()
+
+    expected = example.int8_gemm_torch_optimized(
+        a_int8,
+        a_scales,
+        b_int8,
+        b_scales,
+        out_dtype=torch.bfloat16,
+    )
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)

--- a/examples/deepseek_v4/test_sparse_attention.py
+++ b/examples/deepseek_v4/test_sparse_attention.py
@@ -1,0 +1,49 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_sparse_attention_example() -> ModuleType:
+    source = Path(__file__).with_name("sparse_attention.py")
+    spec = importlib.util.spec_from_file_location("_sparse_attention_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+    return module
+
+
+def test_sparse_attention_accuracy() -> None:
+    import torch
+
+    example = _load_sparse_attention_example()
+
+    dtype = torch.bfloat16
+    batch = 1
+    query_len = 256
+    kv_len = 256
+    heads = 64
+    head_dim = 512
+    topk = 128
+
+    torch.manual_seed(42)
+    inputs = example.make_random_test_inputs(batch, query_len, kv_len, heads, head_dim, topk, dtype)
+    query = inputs["q"]
+    kv = inputs["kv"]
+    attn_sink = inputs["attn_sink"]
+    topk_idxs = inputs["topk_idxs"]
+    softmax_scale = head_dim**-0.5
+
+    kernel = example.sparse_attn_kernel(h=heads, d=head_dim, scale=softmax_scale)
+    actual = kernel(query, kv, attn_sink, topk_idxs)
+    torch.npu.synchronize()
+
+    expected = example.sparse_attn(query, kv, attn_sink, topk_idxs, softmax_scale)
+    torch.testing.assert_close(expected, actual, rtol=1e-2, atol=1e-2)

--- a/examples/pos_embedding/test_rms_norm_pos_embedding.py
+++ b/examples/pos_embedding/test_rms_norm_pos_embedding.py
@@ -1,0 +1,36 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_rms_norm_example() -> ModuleType:
+    source = Path(__file__).with_name("rms_norm.py")
+    spec = importlib.util.spec_from_file_location("_rms_norm_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+    return module
+
+
+def test_rms_norm_accuracy() -> None:
+    import torch
+
+    example = _load_rms_norm_example()
+
+    variance_epsilon = 1e-6
+
+    torch.manual_seed(0)
+    q = torch.randn(16, 64, 512, dtype=torch.float16, device="npu")
+
+    actual = example.tilelang_q_rms(q, variance_epsilon)
+    expected = example.rms_norm_reference(q, variance_epsilon)
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-2, atol=1e-2)

--- a/examples/pos_embedding/test_rms_rope_fused.py
+++ b/examples/pos_embedding/test_rms_rope_fused.py
@@ -1,0 +1,56 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_rms_rope_fused_example() -> ModuleType:
+    source = Path(__file__).with_name("rms_rope_fused.py")
+    spec = importlib.util.spec_from_file_location("_rms_rope_fused_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+    return module
+
+
+def test_rms_rope_fused_accuracy() -> None:
+    import torch
+
+    example = _load_rms_rope_fused_example()
+
+    batch_size = 16
+    head_num = 64
+    head_dim = 512
+    rope_dim = 256
+    eps = 1e-6
+
+    torch.manual_seed(42)
+    example.tilelang.disable_cache()
+
+    dtype = torch.float16
+    device = "npu"
+    example.device = device
+
+    q = torch.randn((batch_size, head_num, head_dim), device=device, dtype=dtype)
+    sin = torch.randn((batch_size, rope_dim), device=device, dtype=dtype)
+    cos = torch.randn((batch_size, rope_dim), device=device, dtype=dtype)
+
+    dim_start = head_dim - rope_dim
+    expected = example.rms_norm_reference(q, head_dim, eps)
+    expected_part = expected[..., dim_start:]
+    expected[..., dim_start:] = example.rope_reference(
+        expected_part.to(torch.float32),
+        cos.to(torch.float32),
+        sin.to(torch.float32),
+    )
+
+    actual = example.tilelang_rms_rope_fused(q.clone(), sin, cos, eps)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)

--- a/examples/pos_embedding/test_rms_rope_fused_mask.py
+++ b/examples/pos_embedding/test_rms_rope_fused_mask.py
@@ -1,0 +1,56 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_rms_rope_fused_mask_example() -> ModuleType:
+    source = Path(__file__).with_name("rms_rope_fused_mask.py")
+    spec = importlib.util.spec_from_file_location("_rms_rope_fused_mask_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+    return module
+
+
+def test_rms_rope_fused_mask_accuracy() -> None:
+    import torch
+
+    example = _load_rms_rope_fused_mask_example()
+
+    batch_size = 16
+    head_num = 64
+    head_dim = 512
+    rope_dim = 256
+    eps = 1e-6
+
+    torch.manual_seed(42)
+    example.tilelang.disable_cache()
+
+    dtype = torch.float16
+    device = "npu"
+    example.device = device
+
+    q = torch.randn((batch_size, head_num, head_dim), device=device, dtype=dtype)
+    sin = torch.randn((batch_size, rope_dim), device=device, dtype=dtype)
+    cos = torch.randn((batch_size, rope_dim), device=device, dtype=dtype)
+
+    dim_start = head_dim - rope_dim
+    expected = example.rms_norm_reference(q, head_dim, eps)
+    expected_part = expected[..., dim_start:]
+    expected[..., dim_start:] = example.rope_reference(
+        expected_part.to(torch.float32),
+        cos.to(torch.float32),
+        sin.to(torch.float32),
+    )
+
+    actual = example.tilelang_rms_rope_fused(q.clone(), sin, cos, eps)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)

--- a/examples/pos_embedding/test_rope.py
+++ b/examples/pos_embedding/test_rope.py
@@ -1,0 +1,55 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_rope_example() -> ModuleType:
+    source = Path(__file__).with_name("rope.py")
+    spec = importlib.util.spec_from_file_location("_pos_rope_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+    return module
+
+
+def test_rope_accuracy() -> None:
+    import torch
+
+    example = _load_rope_example()
+
+    batch_size = 16
+    head_num = 64
+    hidden_size = 512
+    rope_dim = 256
+
+    torch.manual_seed(42)
+    example.tilelang.disable_cache()
+
+    dtype = torch.float16
+    device = "npu"
+
+    x = torch.randn((batch_size, head_num, hidden_size), device=device, dtype=dtype)
+    sin = torch.randn((batch_size, rope_dim), device=device, dtype=dtype)
+    cos = torch.randn((batch_size, rope_dim), device=device, dtype=dtype)
+
+    dim_start = hidden_size - rope_dim
+    expected = x.clone()
+    expected_part = expected[..., dim_start:]
+    expected[..., dim_start:] = example.torch_rope_ref(
+        expected_part.to(torch.float32),
+        sin.to(torch.float32),
+        cos.to(torch.float32),
+    )
+
+    actual = x.clone()
+    example.tilelang_apply_rope_partial_in_place(actual, sin, cos)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-3, atol=1e-3)

--- a/examples/pos_embedding/test_rope_mask.py
+++ b/examples/pos_embedding/test_rope_mask.py
@@ -1,0 +1,55 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_rope_mask_example() -> ModuleType:
+    source = Path(__file__).with_name("rope_mask.py")
+    spec = importlib.util.spec_from_file_location("_rope_mask_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+    return module
+
+
+def test_rope_mask_accuracy() -> None:
+    import torch
+
+    example = _load_rope_mask_example()
+
+    batch_size = 16
+    head_num = 64
+    hidden_size = 512
+    rope_dim = 256
+
+    torch.manual_seed(42)
+    example.tilelang.disable_cache()
+
+    dtype = torch.float16
+    device = "npu"
+
+    x = torch.randn((batch_size, head_num, hidden_size), device=device, dtype=dtype)
+    sin = torch.randn((batch_size, rope_dim), device=device, dtype=dtype)
+    cos = torch.randn((batch_size, rope_dim), device=device, dtype=dtype)
+
+    dim_start = hidden_size - rope_dim
+    expected = x.clone()
+    expected_part = expected[..., dim_start:]
+    expected[..., dim_start:] = example.torch_rope_ref(
+        expected_part.to(torch.float32),
+        sin.to(torch.float32),
+        cos.to(torch.float32),
+    )
+
+    actual = x.clone()
+    example.tilelang_apply_rope_partial_in_place(actual, sin, cos)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-3, atol=1e-3)

--- a/examples/pos_embedding/test_rope_mask_bwd.py
+++ b/examples/pos_embedding/test_rope_mask_bwd.py
@@ -1,0 +1,57 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+ROPE_MASK_BWD_LAYOUT_CASES = [
+    pytest.param("tnd", id="tnd"),
+    pytest.param("bsnd", id="bsnd"),
+]
+
+ROPE_MASK_BWD_VARIANT_CASES = [
+    pytest.param(dtype, rotary_mode, id=f"{dtype}_{rotary_mode}")
+    for rotary_mode in ["interleave", "half"]
+    for dtype in ["float16", "bfloat16", "float"]
+]
+
+
+def _load_rope_mask_bwd_example() -> ModuleType:
+    source = Path(__file__).with_name("rope_mask_bwd.py")
+    spec = importlib.util.spec_from_file_location("_rope_mask_bwd_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+    return module
+
+
+@pytest.mark.parametrize("layout", ROPE_MASK_BWD_LAYOUT_CASES)
+@pytest.mark.parametrize(("dtype", "rotary_mode"), ROPE_MASK_BWD_VARIANT_CASES)
+def test_rope_mask_bwd_accuracy(layout: str, dtype: str, rotary_mode: str) -> None:
+    import torch
+
+    example = _load_rope_mask_bwd_example()
+
+    batch_size = 16
+    head_num = 64
+    hidden_size = 512
+    rope_dim = 256
+
+    torch.manual_seed(42)
+    example.tilelang.disable_cache()
+
+    if layout == "tnd":
+        example.check_case_tnd(batch_size, head_num, hidden_size, rope_dim, dtype, rotary_mode)
+    else:
+        batch = 4
+        seq_len = batch_size // 4 if batch_size >= 4 else batch_size
+        example.check_case_bsnd(batch, seq_len, head_num, hidden_size, rope_dim, dtype, rotary_mode)

--- a/examples/xllm_kernels/test_fused_gdn_gating.py
+++ b/examples/xllm_kernels/test_fused_gdn_gating.py
@@ -1,0 +1,56 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+FUSED_GDN_GATING_NUM_BATCHES = [
+    pytest.param(1, id="batch1"),
+    pytest.param(16, id="batch16"),
+    pytest.param(275, id="batch275"),
+    pytest.param(4096, id="batch4096"),
+    pytest.param(65536, id="batch65536"),
+]
+
+FUSED_GDN_GATING_NUM_HEADS = [
+    pytest.param(4, id="heads4"),
+    pytest.param(8, id="heads8"),
+    pytest.param(16, id="heads16"),
+    pytest.param(24, id="heads24"),
+]
+
+
+def _load_fused_gdn_gating_example() -> ModuleType:
+    source = Path(__file__).with_name("fused_gdn_gating.py")
+    spec = importlib.util.spec_from_file_location("_fused_gdn_gating_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    original_sys_path = list(sys.path)
+    try:
+        sys.argv = [str(source)]
+        sys.path.insert(0, str(source.parent))
+        sys.path.insert(0, str(source.parents[2]))
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+        sys.path[:] = original_sys_path
+    return module
+
+
+@pytest.mark.parametrize("num_batches", FUSED_GDN_GATING_NUM_BATCHES)
+@pytest.mark.parametrize("num_heads", FUSED_GDN_GATING_NUM_HEADS)
+def test_fused_gdn_gating_accuracy(num_batches: int, num_heads: int) -> None:
+    example = _load_fused_gdn_gating_example()
+
+    example._run_ref_check(
+        num_batches=num_batches,
+        num_heads=num_heads,
+        compile_max_batch=example.DEFAULT_MAX_BATCH,
+        softplus_beta=1.0,
+        softplus_threshold=20.0,
+    )

--- a/examples/xllm_kernels/test_rope_xllm_kernels.py
+++ b/examples/xllm_kernels/test_rope_xllm_kernels.py
@@ -1,0 +1,78 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+XLLM_ROPE_CASES = [
+    pytest.param(16, 4, 128, 128, 0, 20260213, id="tokens16_heads4_dim128_rope128_start0"),
+    pytest.param(2051, 2, 128, 128, 0, 20260214, id="tokens2051_heads2_dim128_rope128_start0"),
+    pytest.param(1, 1, 128, 128, 0, 101, id="tokens1_heads1_dim128_rope128_start0"),
+    pytest.param(7, 3, 128, 128, 0, 102, id="tokens7_heads3_dim128_rope128_start0"),
+    pytest.param(64, 4, 128, 128, 0, 107, id="tokens64_heads4_dim128_rope128_start0"),
+    pytest.param(8, 5, 128, 128, 0, 103, id="tokens8_heads5_dim128_rope128_start0"),
+    pytest.param(9, 5, 128, 128, 0, 104, id="tokens9_heads5_dim128_rope128_start0"),
+    pytest.param(4, 64, 128, 128, 0, 108, id="tokens4_heads64_dim128_rope128_start0"),
+    pytest.param(127, 8, 128, 128, 0, 105, id="tokens127_heads8_dim128_rope128_start0"),
+    pytest.param(33, 16, 128, 128, 0, 106, id="tokens33_heads16_dim128_rope128_start0"),
+    pytest.param(1, 1, 576, 64, 512, 20260226, id="tokens1_heads1_dim576_rope64_start512"),
+    pytest.param(8, 1, 576, 64, 512, 20260227, id="tokens8_heads1_dim576_rope64_start512"),
+    pytest.param(47, 1, 576, 64, 512, 20260301, id="tokens47_heads1_dim576_rope64_start512"),
+    pytest.param(48, 1, 576, 64, 512, 20260302, id="tokens48_heads1_dim576_rope64_start512"),
+    pytest.param(49, 1, 576, 64, 512, 20260303, id="tokens49_heads1_dim576_rope64_start512"),
+    pytest.param(95, 1, 576, 64, 512, 20260304, id="tokens95_heads1_dim576_rope64_start512"),
+    pytest.param(96, 1, 576, 64, 512, 20260305, id="tokens96_heads1_dim576_rope64_start512"),
+    pytest.param(97, 1, 576, 64, 512, 20260306, id="tokens97_heads1_dim576_rope64_start512"),
+    pytest.param(128, 1, 576, 64, 512, 20260228, id="tokens128_heads1_dim576_rope64_start512"),
+    pytest.param(512, 1, 576, 64, 512, 20260307, id="tokens512_heads1_dim576_rope64_start512"),
+    pytest.param(1024, 1, 576, 64, 512, 20260308, id="tokens1024_heads1_dim576_rope64_start512"),
+    pytest.param(2048, 1, 576, 64, 512, 20260225, id="tokens2048_heads1_dim576_rope64_start512"),
+]
+
+
+def _load_rope_example() -> ModuleType:
+    source = Path(__file__).with_name("rope.py")
+    spec = importlib.util.spec_from_file_location("_xllm_rope_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    original_sys_path = list(sys.path)
+    try:
+        sys.argv = [str(source)]
+        sys.path.insert(0, str(source.parent))
+        sys.path.insert(0, str(source.parents[2]))
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+        sys.path[:] = original_sys_path
+    return module
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "num_heads", "head_dim", "rope_dim", "start_dim", "seed"),
+    XLLM_ROPE_CASES,
+)
+def test_rope_accuracy(
+    num_tokens: int,
+    num_heads: int,
+    head_dim: int,
+    rope_dim: int,
+    start_dim: int,
+    seed: int,
+) -> None:
+    example = _load_rope_example()
+
+    example._run_ref_check(
+        num_tokens=num_tokens,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        rope_dim=rope_dim,
+        start_dim=start_dim,
+        seed=seed,
+        vec_core_num=example.detect_vec_core_num(),
+        ub_buffer_bytes=example.FIXED_UB_BUFFER_BYTES,
+    )

--- a/examples/xllm_kernels/test_split_qkv_rmsnorm_mrope.py
+++ b/examples/xllm_kernels/test_split_qkv_rmsnorm_mrope.py
@@ -1,0 +1,85 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+HEAD_CONFIGS = [
+    (32, 2),
+    (24, 4),
+    (16, 4),
+    (16, 2),
+    (16, 1),
+    (12, 2),
+    (8, 2),
+    (8, 1),
+    (6, 1),
+    (4, 1),
+    (3, 1),
+    (2, 1),
+    (1, 1),
+]
+
+SPLIT_QKV_RMSNORM_MROPE_CASES = [
+    pytest.param(16, num_q_heads, num_kv_heads, True, id=f"tokens16_q{num_q_heads}_kv{num_kv_heads}_interleaved")
+    for num_q_heads, num_kv_heads in HEAD_CONFIGS
+]
+SPLIT_QKV_RMSNORM_MROPE_CASES += [
+    pytest.param(num_tokens, num_q_heads, num_kv_heads, True, id=f"tokens{num_tokens}_q{num_q_heads}_kv{num_kv_heads}_interleaved")
+    for num_tokens in [1, 17, 4097]
+    for num_q_heads, num_kv_heads in [(32, 2), (24, 4), (16, 2)]
+]
+SPLIT_QKV_RMSNORM_MROPE_CASES += [
+    pytest.param(
+        num_tokens, 16, 4, is_interleaved, id=f"tokens{num_tokens}_q16_kv4_{'interleaved' if is_interleaved else 'noninterleaved'}"
+    )
+    for num_tokens in [4097, 8192]
+    for is_interleaved in [True, False]
+]
+
+
+def _load_split_qkv_rmsnorm_mrope_example() -> ModuleType:
+    source = Path(__file__).with_name("split_qkv_rmsnorm_mrope.py")
+    spec = importlib.util.spec_from_file_location("_split_qkv_rmsnorm_mrope_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    original_sys_path = list(sys.path)
+    try:
+        sys.argv = [str(source)]
+        sys.path.insert(0, str(source.parent))
+        sys.path.insert(0, str(source.parents[2]))
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+        sys.path[:] = original_sys_path
+    return module
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "num_q_heads", "num_kv_heads", "is_interleaved"),
+    SPLIT_QKV_RMSNORM_MROPE_CASES,
+)
+def test_split_qkv_rmsnorm_mrope_accuracy(
+    num_tokens: int,
+    num_q_heads: int,
+    num_kv_heads: int,
+    is_interleaved: bool,
+) -> None:
+    example = _load_split_qkv_rmsnorm_mrope_example()
+    head_size, rope_dim = example.SUPPORTED_HEAD_SPECS[0]
+
+    example._run_ref_check(
+        num_tokens=num_tokens,
+        num_q_heads=num_q_heads,
+        num_kv_heads=num_kv_heads,
+        head_size=head_size,
+        rope_dim=rope_dim,
+        eps=example.REF_CHECK_EPS,
+        mrope_section=tuple(example.DEFAULT_MROPE_SECTION),
+        is_interleaved=is_interleaved,
+    )

--- a/examples_experiment/blocksparse_gemm/test_example_blocksparse_gemm.py
+++ b/examples_experiment/blocksparse_gemm/test_example_blocksparse_gemm.py
@@ -1,0 +1,46 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+BLOCKSPARSE_GEMM_CASES = [
+    pytest.param("basic", id="basic"),
+    pytest.param("typical", id="typical"),
+    pytest.param("boundary_dense", id="boundary_dense"),
+    pytest.param("boundary_sparse", id="boundary_sparse"),
+]
+
+
+def _load_blocksparse_gemm_example() -> ModuleType:
+    source = Path(__file__).with_name("example_blocksparse_gemm.py")
+    spec = importlib.util.spec_from_file_location("_blocksparse_gemm_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+    return module
+
+
+@pytest.mark.parametrize("case_name", BLOCKSPARSE_GEMM_CASES)
+def test_blocksparse_gemm_accuracy(case_name: str) -> None:
+    example = _load_blocksparse_gemm_example()
+
+    if case_name == "basic":
+        example.test_basic()
+    elif case_name == "typical":
+        example.test_typical()
+    elif case_name == "boundary_dense":
+        example.test_boundary_dense()
+    elif case_name == "boundary_sparse":
+        example.test_boundary_sparse()
+    else:
+        raise AssertionError(f"Unknown blocksparse_gemm case: {case_name}")

--- a/examples_experiment/convolution/test_example_convolution.py
+++ b/examples_experiment/convolution/test_example_convolution.py
@@ -1,0 +1,64 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+CONVOLUTION_CASES = [
+    pytest.param("perfect_alignment", 2, 2, 15, 15, 128, 8, 8, 1, 0, id="perfect_alignment"),
+    pytest.param("m_padding", 1, 2, 32, 32, 50, 3, 3, 1, 0, id="m_padding"),
+    pytest.param("n_padding", 1, 4, 17, 17, 128, 3, 3, 1, 0, id="n_padding"),
+    pytest.param("k_padding", 2, 3, 28, 28, 128, 3, 3, 2, 1, id="k_padding"),
+    pytest.param("all_dim_padding", 1, 3, 17, 17, 64, 3, 3, 1, 0, id="all_dim_padding"),
+    pytest.param("multi_block", 4, 8, 28, 28, 256, 5, 5, 1, 0, id="multi_block"),
+]
+
+
+def _load_convolution_example() -> ModuleType:
+    source = Path(__file__).with_name("example_convolution.py")
+    spec = importlib.util.spec_from_file_location("_convolution_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+    return module
+
+
+@pytest.mark.parametrize(
+    ("name", "batch", "channels", "height", "width", "out_channels", "kernel_h", "kernel_w", "stride", "padding"),
+    CONVOLUTION_CASES,
+)
+def test_convolution_accuracy(
+    name: str,
+    batch: int,
+    channels: int,
+    height: int,
+    width: int,
+    out_channels: int,
+    kernel_h: int,
+    kernel_w: int,
+    stride: int,
+    padding: int,
+) -> None:
+    example = _load_convolution_example()
+
+    example.run_test(
+        name,
+        batch,
+        channels,
+        height,
+        width,
+        out_channels,
+        kernel_h,
+        kernel_w,
+        stride,
+        padding,
+    )

--- a/examples_experiment/convolution/test_example_convolution_autotune.py
+++ b/examples_experiment/convolution/test_example_convolution_autotune.py
@@ -1,0 +1,65 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+CONVOLUTION_AUTOTUNE_CASES = [
+    pytest.param("perfect_alignment", 2, 2, 15, 15, 128, 8, 8, 1, 0, id="perfect_alignment"),
+    pytest.param("m_padding", 1, 2, 32, 32, 50, 3, 3, 1, 0, id="m_padding"),
+    pytest.param("n_padding", 1, 4, 17, 17, 128, 3, 3, 1, 0, id="n_padding"),
+    pytest.param("k_padding", 2, 3, 28, 28, 128, 3, 3, 2, 1, id="k_padding"),
+    pytest.param("all_dim_padding", 1, 3, 17, 17, 64, 3, 3, 1, 0, id="all_dim_padding"),
+    pytest.param("multi_block", 4, 8, 28, 28, 256, 5, 5, 1, 0, id="multi_block"),
+]
+
+
+def _load_convolution_autotune_example() -> ModuleType:
+    source = Path(__file__).with_name("example_convolution_autotune.py")
+    spec = importlib.util.spec_from_file_location("_convolution_autotune_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+    return module
+
+
+@pytest.mark.parametrize(
+    ("name", "batch", "channels", "height", "width", "out_channels", "kernel_h", "kernel_w", "stride", "padding"),
+    CONVOLUTION_AUTOTUNE_CASES,
+)
+def test_convolution_autotune_accuracy(
+    name: str,
+    batch: int,
+    channels: int,
+    height: int,
+    width: int,
+    out_channels: int,
+    kernel_h: int,
+    kernel_w: int,
+    stride: int,
+    padding: int,
+) -> None:
+    example = _load_convolution_autotune_example()
+
+    example.run_test(
+        name,
+        batch,
+        channels,
+        height,
+        width,
+        out_channels,
+        kernel_h,
+        kernel_w,
+        stride,
+        padding,
+        use_autotune=True,
+    )

--- a/examples_experiment/dequantize_gemm/test_example_dequant_gemm_fine_grained.py
+++ b/examples_experiment/dequantize_gemm/test_example_dequant_gemm_fine_grained.py
@@ -1,0 +1,90 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+DEQUANT_GEMM_FP16_CASES = [
+    pytest.param(256, 256, 256, "float16", "float16", id="fp16_256"),
+    pytest.param(512, 512, 512, "float16", "float16", id="fp16_512"),
+    pytest.param(1024, 1024, 1024, "float16", "float16", id="fp16_1024"),
+    pytest.param(512, 512, 512, "bfloat16", "bfloat16", id="bf16_512"),
+]
+
+DEQUANT_GEMM_INT8_CASES = [
+    pytest.param(256, 256, 256, "int32", id="int8_256_int32"),
+    pytest.param(512, 512, 512, "int32", id="int8_512_int32"),
+    pytest.param(1024, 1024, 1024, "int32", id="int8_1024_int32"),
+    pytest.param(512, 512, 512, "float16", id="int8_512_float16"),
+]
+
+
+def _load_dequant_gemm_fine_grained_example() -> ModuleType:
+    source = Path(__file__).with_name("example_dequant_gemm_fine_grained.py")
+    spec = importlib.util.spec_from_file_location("_dequant_gemm_fine_grained_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+    return module
+
+
+def test_dequant_gemm_fine_grained_unpack_accuracy() -> None:
+    example = _load_dequant_gemm_fine_grained_example()
+    example.check_unpack_functions()
+
+
+@pytest.mark.parametrize(("m", "n", "k", "input_dtype", "output_dtype"), DEQUANT_GEMM_FP16_CASES)
+def test_dequant_gemm_fine_grained_fp16_accuracy(
+    m: int,
+    n: int,
+    k: int,
+    input_dtype: str,
+    output_dtype: str,
+) -> None:
+    import torch
+
+    example = _load_dequant_gemm_fine_grained_example()
+
+    torch.manual_seed(0)
+    example.check_case_fp16(
+        m,
+        n,
+        k,
+        block_M=128,
+        block_N=256,
+        block_K=64,
+        input_dtype=input_dtype,
+        output_dtype=output_dtype,
+    )
+
+
+@pytest.mark.parametrize(("m", "n", "k", "output_dtype"), DEQUANT_GEMM_INT8_CASES)
+def test_dequant_gemm_fine_grained_int8_accuracy(
+    m: int,
+    n: int,
+    k: int,
+    output_dtype: str,
+) -> None:
+    import torch
+
+    example = _load_dequant_gemm_fine_grained_example()
+
+    torch.manual_seed(0)
+    example.check_case_int8(
+        m,
+        n,
+        k,
+        block_M=128,
+        block_N=128,
+        block_K=64,
+        output_dtype=output_dtype,
+    )

--- a/examples_experiment/dequantize_gemm/test_example_dequant_gemm_w4a8.py
+++ b/examples_experiment/dequantize_gemm/test_example_dequant_gemm_w4a8.py
@@ -1,0 +1,40 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+DEQUANT_GEMM_W4A8_CASES = [
+    pytest.param(64, 64, 256, id="M64_N64_K256"),
+    pytest.param(128, 128, 512, id="M128_N128_K512"),
+    pytest.param(256, 256, 1024, id="M256_N256_K1024"),
+]
+
+
+def _load_dequant_gemm_w4a8_example() -> ModuleType:
+    source = Path(__file__).with_name("example_dequant_gemm_w4a8.py")
+    spec = importlib.util.spec_from_file_location("_dequant_gemm_w4a8_example_for_test", source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load example module: {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+    return module
+
+
+@pytest.mark.parametrize(("m", "n", "k"), DEQUANT_GEMM_W4A8_CASES)
+def test_dequant_gemm_w4a8_accuracy(m: int, n: int, k: int) -> None:
+    import torch
+
+    example = _load_dequant_gemm_w4a8_example()
+
+    example.tilelang.disable_cache()
+    torch.manual_seed(42)
+    example.test(m, n, k)


### PR DESCRIPTION
* [Test]: add non-intrusive pytest coverage for example kernels

Add pytest wrappers for deepseek_v4, xllm_kernels, pos_embedding, and examples_experiment kernels. The tests load example modules via importlib with argv isolation, preserve original kernel/reference flows, and expose built-in case suites through pytest parametrization.

Covered examples include examples/deepseek_v4, examples/pos_embedding, examples/xllm_kernels,
 as well as examples_experiment/blocksparse_gemm, examples_experiment/dequantize_gemm, and examples_experiment/convolution.

* fix: apply ruff format auto wrap

* fix: delete files with same name:example/pos_embedding/test_rope.py

* fix: re-add example/pos_embedding/test_rope.py
Since PR #1497 fixed the issue that test files with identical names under different subdirectories in example could not be distinguished, we reintroduce the test file with naming conflict: example/pos_embedding/test_rope.py.

* fix: rename files with same name(#1493) iiiii fidsdfthe chsdasfsdfsadfasdsdfasfanges in ci/operator_test_manifest.yaml(#1497), the file names corresponding to the name has been modified.

---------