### PR TITLE
[Fix] Reduce cython adapter host launch overhead

### DIFF
--- a/tilelang/jit/adapter/cython/cython_wrapper.pyx
+++ b/tilelang/jit/adapter/cython/cython_wrapper.pyx
@@ -3,6 +3,7 @@
 # cython: language_level=3
 
 import torch
+import torch_npu
 cimport cython
 import ctypes
 from libc.stdint cimport int64_t, uintptr_t
@@ -11,6 +12,20 @@ from tvm import tir
 from tvm.tir import stmt_functor
 from tvm.arith import Analyzer
 from tilelang.utils.tensor import map_torch_type
+
+# Lazily-created process-wide Analyzer singleton. Constructing an Analyzer
+# costs ~170us (17 FFI calls) and it is only needed to simplify dynamic-shape
+# PrimExprs, so do not pay it on every kernel launch. simplify() on expressions
+# without Bind() does not mutate analyzer state, so sharing one instance is safe.
+_GLOBAL_ANALYZER = None
+
+
+def _get_analyzer():
+    global _GLOBAL_ANALYZER
+    if _GLOBAL_ANALYZER is None:
+        _GLOBAL_ANALYZER = Analyzer()
+    return _GLOBAL_ANALYZER
+
 
 cdef class CythonKernelWrapper:
     # Class attributes to store kernel configuration and library reference
@@ -83,16 +98,22 @@ cdef class CythonKernelWrapper:
 
         # Ensure the number of inputs matches expected parameter count
 
-        if stream == -1: 
+        if stream == -1:
             if torch.npu.is_available():
-                stream = torch.npu.current_stream().npu_stream
+                # _npu_getCurrentRawStream (~0.6us) returns the same raw
+                # aclrtStream handle as torch.npu.current_stream().npu_stream
+                # (~24us); it is what torch_npu uses for inductor codegen.
+                _get_raw_stream = getattr(torch_npu._C, "_npu_getCurrentRawStream", None)
+                if _get_raw_stream is not None:
+                    stream = _get_raw_stream(torch.npu.current_device())
+                else:
+                    stream = torch.npu.current_stream().npu_stream
             else:
                 stream = 0
 
         cdef int ins_idx = 0
         cdef list tensor_list = []
 
-        analyzer = Analyzer()
         sym_val_by_name = {}
         for key, (ref_tensor_idx, ref_shape_idx) in self.dynamic_symbolic_map.items():
             val = int(inputs[ref_tensor_idx].shape[ref_shape_idx])
@@ -117,7 +138,7 @@ cdef class CythonKernelWrapper:
                                 raise KeyError(f"Unfounded symbolic var: {str(v)}")
                             vmap[v] = tir.IntImm(v.dtype, sym_val_by_name[v])
                         ss = stmt_functor.substitute(s, vmap)
-                        ss = analyzer.simplify(ss)
+                        ss = _get_analyzer().simplify(ss)
                         if isinstance(ss, tir.IntImm):
                             res = int(ss.value)
                         else:


### PR DESCRIPTION
## Summary

Reduce the per-call host overhead of the cython execution backend from ~306us to ~42us (7.2x) on Ascend NPU.

`CythonKernelWrapper.forward` repeatedly performed work on every kernel launch that can be done once (or avoided entirely):
- A fresh `tvm.arith.Analyzer` was constructed on **every** call (~170us: 1 `CreateAnalyzer` FFI building 5 stateful sub-analyzers + 16 FFI method-handle lookups), but it is only ever used to `simplify()` dynamic-shape `PrimExpr`s. Static-shape kernels never use it.
- The current stream was resolved through `torch.npu.current_stream().npu_stream` (~24us: `_lazy_init` check + device-index resolution + `Stream` object construction), although torch_npu exposes the raw handle directly.

## Changes

- `tilelang/jit/adapter/cython/cython_wrapper.pyx`
  - Create the `Analyzer` lazily as a process-wide singleton (`_get_analyzer()`), only on the dynamic-shape path. Sharing one instance is safe here because `simplify()` on expressions without `Bind()` does not mutate analyzer state (same usage pattern as TVM passes).
  - Resolve the current stream via `torch_npu._C._npu_getCurrentRawStream(device)` (~0.6us) — the same API torch_npu uses for inductor/dynamo codegen (`torch_npu/utils/_inductor.py`) — with fallback to the public `torch.npu.current_stream().npu_stream` if the private API is unavailable.

## Measurement (Ascend 910B4-1, tiny 256-float add kernel, 2000-call loop)

| path | before | after |
|---|---|---|
| `kernel(x, y)` full wrapper | 305.7 us/call | **42.2 us/call** |
| `torch_function(x, y, stream=...)` | 233.3 us/call | **31.8 us/call** |
| raw `lib.call` (device launch, unchanged) | 4.3 us/call | 4.3 us/call |

Component cost before the fix: `Analyzer()` ctor ~167us, `current_stream()` ~24us, output alloc ~7us, remainder ~60-110us.

## Testing

- Static-shape kernel correctness: PASS
- Dynamic-shape kernel (exercises the singleton Analyzer path): PASS
- `examples/flash_attention/flash_attn_bhsd.py` (workspace_idx path): Test Passed
- `examples/elementwise/elementwise_add.py`: Kernel Output Match
- `torch.npu.NPUGraph` capture/replay compatibility: PASS (raw-stream API returns an identical handle under both default and non-default stream contexts)
