### PR TITLE
[Example] Add rms_norm with cann-bench 20 cases and perf-optimization…

### DIFF
--- a/.agents/skills/tilelang-perf-optimization/SKILL.md
+++ b/.agents/skills/tilelang-perf-optimization/SKILL.md
@@ -133,7 +133,8 @@ Edit 调用方、dispatch 或 planner 前，再写 `[KERNEL-REUSE-AUDIT]` 复核
 
 | 算子类型 | 文档 | 核心优化技术 |
 |---------|------|-------------|
-| Vector 型 | [RoPE 优化](references/best-practices/rope-developer-mode.md)、[归约遍数融合](references/vector-practices/vector_reduce_pass_fusion.md) | | NPU 内动态生成 Mask、Tile API 向量化、参数简化 |
+| Vector 型 | [RoPE 优化](references/best-practices/rope-developer-mode.md)、[归约遍数融合](references/vector-practices/vector_reduce_pass_fusion.md) | NPU 内动态生成 Mask、Tile API 向量化、参数简化 |
+| Vector 型（归一化） | optimization-guide.md §2.18 + §2.19 | 自适应 tiling、单遍扫描、output_ub 分离、rsqrt Newton、Pass 2 Double Buffer、双 kernel 策略 |
 | Cube 型 | [GEMM Intrinsic](references/best-practices/gemm_intrinsic_optimize.md) | 多缓冲流水线、细粒度 Flag 同步、MMA intrinsic、L0 分块、负载均衡 |
 | CV 融合型 | [Flash Attention](references/best-practices/flash_attn_optimize.md) | num_stages 流水线、批量 Softmax、Cross-core Semaphore、数据布局优化；**多 shape 适配**（BSND 免转置、Sq==1 decode 窄块、加性 mask 屏蔽变长 Skv） |
 

--- a/.agents/skills/tilelang-perf-optimization/SKILL.md
+++ b/.agents/skills/tilelang-perf-optimization/SKILL.md
@@ -134,7 +134,7 @@ Edit 调用方、dispatch 或 planner 前，再写 `[KERNEL-REUSE-AUDIT]` 复核
 | 算子类型 | 文档 | 核心优化技术 |
 |---------|------|-------------|
 | Vector 型 | [RoPE 优化](references/best-practices/rope-developer-mode.md)、[归约遍数融合](references/vector-practices/vector_reduce_pass_fusion.md) | NPU 内动态生成 Mask、Tile API 向量化、参数简化 |
-| Vector 型（归一化） | optimization-guide.md §2.18 + §2.19 | 自适应 tiling、单遍扫描、output_ub 分离、rsqrt Newton、Pass 2 Double Buffer、双 kernel 策略 |
+| Vector 型（归一化） | [两遍扫描归一化](references/vector-practices/reduction/two_pass_normalization.md) | 自适应 tiling、单遍扫描、output_ub 分离、rsqrt Newton、Pass 2 Double Buffer、双 kernel 策略 |
 | Cube 型 | [GEMM Intrinsic](references/best-practices/gemm_intrinsic_optimize.md) | 多缓冲流水线、细粒度 Flag 同步、MMA intrinsic、L0 分块、负载均衡 |
 | CV 融合型 | [Flash Attention](references/best-practices/flash_attn_optimize.md) | num_stages 流水线、批量 Softmax、Cross-core Semaphore、数据布局优化；**多 shape 适配**（BSND 免转置、Sq==1 decode 窄块、加性 mask 屏蔽变长 Skv） |
 

--- a/.agents/skills/tilelang-perf-optimization/references/optimization-guide.md
+++ b/.agents/skills/tilelang-perf-optimization/references/optimization-guide.md
@@ -290,6 +290,21 @@ T.wait_flag("mte3", "mte2", 1)
 >
 > **自检方法**：每个 `[2, ...]` buffer 必须能找到对应的 `T.copy(GM_buf, ...)` 或 `T.copy(..., GM_buf)` 语句。找不到 → 该 buffer 改为单份。
 
+#### 2.2.2 Pass 1 vs Pass 2 双缓冲可行性差异（两遍扫描算子）
+
+> **适用场景**：RMSNorm / LayerNorm 等两遍扫描算子。
+
+**关键约束**：Pass 1 和 Pass 2 的双缓冲可行性完全不同：
+
+| Pass | MTE3 写回 | 双缓冲可行性 | 原因 |
+|------|----------|------------|------|
+| Pass 2（归一化+写回） | ✅ 有 | **可行** | MTE3 写回后通过 `mte3→mte2` flag 释放 buffer，形成 `MTE2→V→MTE3→MTE2` 完整闭环 |
+| Pass 1（累加统计量） | ❌ 无 | **不可行** | 无 MTE3 中继，`v→mte2` flag 在 AIV Vector 硬件上**不可用**（死锁），只能用 `barrier_all()` |
+
+**AIV Vector 硬件 flag 通道限制**：`mte3→mte2` ✅、`mte2→v` ✅、`v→mte3` ✅、`v→mte2` ❌（不可用，死锁）。
+
+**T.Pipelined 在 Pass 1 的表现**：`AUTO_SYNC=False` 下不自动插入 MTE2→V 同步（全 NaN）；配合 `barrier_all` 时同步所有引擎，无重叠。
+
 ### 2.3 MTE2 预取优化（Cube 核）
 
 **适用场景**：
@@ -507,6 +522,16 @@ with T.Kernel(core_num, is_npu=True) as (cid, vid):
         ...
         T.copy(result, workspace[cid, :, :])  # workspace[cid] 被复用
 ```
+
+**失效条件**（实测确认）：
+
+| 失效场景 | 原因 | 实测案例 |
+|---------|------|---------|
+| D 极小（≤8）+ S 极大 | 软件循环开销 > launch 节省；硬件 block scheduler 更高效 | RMSNorm D=2 S=1000003：Fixed Core 慢 42% |
+| 每 block 计算量极小 | 软件 `T.serial` scalar 开销占比高 | 同上 |
+| block 间无数据依赖 | 硬件 scheduler 自动流水线化 | Vector 算子 |
+
+> **判断准则**：Fixed Core 适用于"每 block 有大量计算 + workspace 复用"。对"计算量小 + 无依赖"场景会变慢。实测下降 >5% 立即回退。
 
 ### 2.10 pass_configs 调优（最后手段）
 
@@ -1687,3 +1712,100 @@ for i in range(n):
 | reduce_sum 编译报错 `Invalid reduce output shape` | 输出用了 `[rows, 1]` 2D buffer 而非 1D `[rows]` | output 改为 `alloc_ub([rows], dtype)` 纯 1D，见 §2.13 P1 |
 | cpg 较大时 aicore exception（UB 越界） | 固定 block_S=256 导致多行 tile buffer 溢出 UB | 使用 `find_block_S()` 动态计算 + 开启 `MEMORY_PLANNING`，见 §2.13 |
 | `T.copy` 编译报 `StructuralEqual check failed` | 试图用 copy 做 1D↔2D shape 转换 | 改用 `T.tile.fill` 跨维度值传递，见 §2.13 P4 |
+| `mul_add_dst` 性能反不如 `mul+add` | Ascend 910B3/910C 上 `mul_add_dst` 指令延迟可能高于独立 `mul+add` | 实测对比，若 `mul_add_dst` 变慢则回退为 `mul+add`，见 §2.18 |
+| `T.tile.rsqrt` 精度不足（~1e-3） | Ascend 硬件 rsqrt 指令是查表近似，精度约 1e-3 | 加 Newton 迭代 `y1 = y0 * (1.5 - 0.5 * x * y0²)`，精度提升到 ~1e-6，见 §2.18 |
+| UB buffer 命名 `tmp_ub` 导致编译报 "Duplicate buffer name" | `AscendMemoryPlanning` pass 内部临时 buffer 也用 `tmp_ub` 命名 | 避免使用 `tmp_ub`，用语义化命名如 `newton_ub`/`accum_ub`，见 §2.18 |
+| `T.copy(UB→UB)` 性能无提升 | `T.copy(UB→UB)` 生成 `copy_ub_to_ub` 走 MTE2 引擎（非 V），无法与 GM→UB 重叠 | gamma 预加载等 UB→UB 优化无效；保持 GM→UB 原路径，见 §2.18 |
+| cann-bench profiler 报 `OSError: could not get source code` | profiler 子进程清除 `linecache.cache`，`@T.prim_func` 的 `inspect.getsourcelines` 失败 | 在 `_get_kernel` 中调 `_ensure_source_cached()` 预缓存源代码，见 §2.19 |
+
+---
+
+## 五、算子类专属优化
+
+### 2.18 两遍扫描归一化算子优化（RMSNorm / LayerNorm）
+
+**适用场景**：RMSNorm、LayerNorm 等"Pass 1 累加统计量 + Pass 2 归一化+写回"的两遍扫描归一化算子。纯 Vector 型（无 Cube 操作）。
+
+**优化模式清单**（按实施顺序）：
+
+#### 优化 1：自适应 tiling（host 侧 `_select_tiling`）
+
+**适用条件**：所有 case（无限制）
+
+**实现**：host 侧根据 S、D、dtype 动态选择 block_M / block_N，按 UB 预算反推。候选 block_M: (1024, 512, 256, 128, 64, 32, 16)。评分公式: `n_num * 100000 + m_penalty`（n_num 优先减少 GM 读取，m_num ∈ [24, 48] 避免空闲核和过多 launch）。
+
+**收益**：RMSNorm 实测 0.43x → 0.58x（+35%）
+
+#### 优化 2：单遍扫描（n_num=1 时 Pass 2 跳过 GM 读取）
+
+**适用条件**：`n_num == 1`（block_N ≥ D）
+
+**实现**：Pass 1 只读 a_ub（cast 到 a_cal），不修改 a_ub。Pass 2 可跳过 `T.copy(A, a_ub)`，复用 Pass 1 的 a_ub。jit 闭包加 `single_pass = (n_num_int == 1)` 编译期常量。
+
+**收益**：n_num=1 的 case 减少 1 次 GM→UB 读取，+2-3%
+
+#### 优化 3：output_ub 分离 a_ub 双重写入
+
+**适用条件**：fp16/bf16 dtype（需 cast back 到低精度）
+
+**问题**：Pass 2 中 `T.tile.cast(a_ub, a_cal, CAST_RINT)` 让 a_ub 被 V 写入，与 MTE2 写入冲突，阻止 Double Buffer。
+
+**实现**：引入独立 output_ub 做 cast back，使 a_ub 只被 MTE2 写入。
+
+**收益**：为 Pass 2 Double Buffer 铺路
+
+#### 优化 4：rsqrt Newton 迭代（精度修复）
+
+**适用条件**：使用 `T.tile.rsqrt` 且精度要求 rtol < 1e-3
+
+**问题**：`T.tile.rsqrt` 精度约 1e-3（查表近似），对 fp32 rtol=1e-4 不足。
+
+**实现**：`y1 = y0 * (1.5 - 0.5 * x * y0²)`，精度提升到 ~1e-6。
+
+> **UB buffer 命名约束**：不能命名为 `tmp_ub`（与 `AscendMemoryPlanning` pass 内部临时 buffer 冲突），用 `newton_ub` 等语义化命名。
+
+#### 优化 5：gamma 1D→2D 广播乘
+
+用 `T.tile.broadcast + T.tile.mul`，不要用 `T.Parallel` 赋值与 `T.tile.*` 混用。
+
+#### 优化 6：T.copy(UB→UB) 走 MTE2 的限制
+
+`T.copy(UB→UB)` 生成 `copy_ub_to_ub` 走 MTE2 引擎，不能与 GM→UB 重叠。gamma 预加载类优化**无效**。
+
+#### 优化 7：mul_add_dst 硬件性能反转
+
+`mul_add_dst` 在 910B3/910C 上可能比 `mul+add` **更慢**。必须实测验证，不更快则回退。
+
+#### 优化 8：Pass 2 Double Buffer（Expert 模式）
+
+**适用条件**：n_num > 1 + Expert 模式（AUTO_SYNC=False）
+
+**前置条件**：已实施优化 3（output_ub 分离）；Pass 2 无跨迭代累加器；inv_rms_tile 在循环外计算。
+
+**实现**：参考 §2.2 Vector 核三阶段流水 + §2.2.0 同步决策表。Pass 1 不可双缓冲（见 §2.2.2）。
+
+**收益**：大 D case 耗时下降 10-17%
+
+#### 完整优化检查清单
+
+- [ ] 自适应 tiling 已实施？
+- [ ] 单遍扫描已实施（n_num=1）？
+- [ ] output_ub 已分离（fp16/bf16）？
+- [ ] rsqrt Newton 迭代已加？
+- [ ] gamma 广播用 `broadcast + mul`？
+- [ ] UB buffer 无 `tmp_ub` 命名？
+- [ ] mul_add_dst 已实测验证？
+- [ ] Pass 2 Double Buffer 已实施（n_num>1）？
+- [ ] Pass 1 保持串行（barrier_all）？
+
+---
+
+### 2.19 双 kernel 策略（n_num 自适应模式选择）
+
+**适用场景**：同一算子在不同 shape 下有截然不同的最优 pass_configs，且 pass_configs 不能在 jit 闭包内动态切换。
+
+**实现**：定义两个 jit 函数（Hybrid + Expert），host 侧按 n_num 选择。详见 SKILL.md 最佳实践表。
+
+#### cann-bench profiler linecache 适配
+
+profiler 子进程清除 `linecache.cache`，导致 `OSError: could not get source code`。在 `_get_kernel` 中调 `_ensure_source_cached()` 预缓存源代码。

--- a/.agents/skills/tilelang-perf-optimization/references/optimization-guide.md
+++ b/.agents/skills/tilelang-perf-optimization/references/optimization-guide.md
@@ -305,6 +305,8 @@ T.wait_flag("mte3", "mte2", 1)
 
 **T.Pipelined 在 Pass 1 的表现**：`AUTO_SYNC=False` 下不自动插入 MTE2→V 同步（全 NaN）；配合 `barrier_all` 时同步所有引擎，无重叠。
 
+> 两遍扫描归一化算子（RMSNorm / LayerNorm 等）基于本节机制的完整优化实践，见 [vector-practices/reduction/two_pass_normalization.md](vector-practices/reduction/two_pass_normalization.md)。
+
 ### 2.3 MTE2 预取优化（Cube 核）
 
 **适用场景**：
@@ -1712,100 +1714,13 @@ for i in range(n):
 | reduce_sum 编译报错 `Invalid reduce output shape` | 输出用了 `[rows, 1]` 2D buffer 而非 1D `[rows]` | output 改为 `alloc_ub([rows], dtype)` 纯 1D，见 §2.13 P1 |
 | cpg 较大时 aicore exception（UB 越界） | 固定 block_S=256 导致多行 tile buffer 溢出 UB | 使用 `find_block_S()` 动态计算 + 开启 `MEMORY_PLANNING`，见 §2.13 |
 | `T.copy` 编译报 `StructuralEqual check failed` | 试图用 copy 做 1D↔2D shape 转换 | 改用 `T.tile.fill` 跨维度值传递，见 §2.13 P4 |
-| `mul_add_dst` 性能反不如 `mul+add` | Ascend 910B3/910C 上 `mul_add_dst` 指令延迟可能高于独立 `mul+add` | 实测对比，若 `mul_add_dst` 变慢则回退为 `mul+add`，见 §2.18 |
-| `T.tile.rsqrt` 精度不足（~1e-3） | Ascend 硬件 rsqrt 指令是查表近似，精度约 1e-3 | 加 Newton 迭代 `y1 = y0 * (1.5 - 0.5 * x * y0²)`，精度提升到 ~1e-6，见 §2.18 |
-| UB buffer 命名 `tmp_ub` 导致编译报 "Duplicate buffer name" | `AscendMemoryPlanning` pass 内部临时 buffer 也用 `tmp_ub` 命名 | 避免使用 `tmp_ub`，用语义化命名如 `newton_ub`/`accum_ub`，见 §2.18 |
-| `T.copy(UB→UB)` 性能无提升 | `T.copy(UB→UB)` 生成 `copy_ub_to_ub` 走 MTE2 引擎（非 V），无法与 GM→UB 重叠 | gamma 预加载等 UB→UB 优化无效；保持 GM→UB 原路径，见 §2.18 |
-| cann-bench profiler 报 `OSError: could not get source code` | profiler 子进程清除 `linecache.cache`，`@T.prim_func` 的 `inspect.getsourcelines` 失败 | 在 `_get_kernel` 中调 `_ensure_source_cached()` 预缓存源代码，见 §2.19 |
+| `mul_add_dst` 性能反不如 `mul+add` | Ascend 910B3/910C 上 `mul_add_dst` 指令延迟可能高于独立 `mul+add` | 实测对比，若 `mul_add_dst` 变慢则回退为 `mul+add`，见 vector-practices/reduction/two_pass_normalization.md 优化 7 |
+| `T.tile.rsqrt` 精度不足（~1e-3） | Ascend 硬件 rsqrt 指令是查表近似，精度约 1e-3 | 加 Newton 迭代 `y1 = y0 * (1.5 - 0.5 * x * y0²)`，精度提升到 ~1e-6，见 vector-practices/reduction/two_pass_normalization.md 优化 4 |
+| UB buffer 命名 `tmp_ub` 导致编译报 "Duplicate buffer name" | `AscendMemoryPlanning` pass 内部临时 buffer 也用 `tmp_ub` 命名 | 避免使用 `tmp_ub`，用语义化命名如 `newton_ub`/`accum_ub`，见 vector-practices/reduction/two_pass_normalization.md 优化 4 |
+| `T.copy(UB→UB)` 性能无提升 | `T.copy(UB→UB)` 生成 `copy_ub_to_ub` 走 MTE2 引擎（非 V），无法与 GM→UB 重叠 | gamma 预加载等 UB→UB 优化无效；保持 GM→UB 原路径，见 vector-practices/reduction/two_pass_normalization.md 优化 6 |
+| cann-bench profiler 报 `OSError: could not get source code` | profiler 子进程清除 `linecache.cache`，`@T.prim_func` 的 `inspect.getsourcelines` 失败 | 在 `_get_kernel` 中调 `_ensure_source_cached()` 预缓存源代码，见 vector-practices/reduction/two_pass_normalization.md 双 kernel 策略 |
 
 ---
 
-## 五、算子类专属优化
+> 算子类专属优化已按类组织为独立文档，见 [vector-practices/](vector-practices/)（规约类：[reduction/two_pass_normalization.md](vector-practices/reduction/two_pass_normalization.md)）。新增算子类优化请按 `vector-practices/<类别>/<模式>.md` 组织，不再向本文件追加章节。
 
-### 2.18 两遍扫描归一化算子优化（RMSNorm / LayerNorm）
-
-**适用场景**：RMSNorm、LayerNorm 等"Pass 1 累加统计量 + Pass 2 归一化+写回"的两遍扫描归一化算子。纯 Vector 型（无 Cube 操作）。
-
-**优化模式清单**（按实施顺序）：
-
-#### 优化 1：自适应 tiling（host 侧 `_select_tiling`）
-
-**适用条件**：所有 case（无限制）
-
-**实现**：host 侧根据 S、D、dtype 动态选择 block_M / block_N，按 UB 预算反推。候选 block_M: (1024, 512, 256, 128, 64, 32, 16)。评分公式: `n_num * 100000 + m_penalty`（n_num 优先减少 GM 读取，m_num ∈ [24, 48] 避免空闲核和过多 launch）。
-
-**收益**：RMSNorm 实测 0.43x → 0.58x（+35%）
-
-#### 优化 2：单遍扫描（n_num=1 时 Pass 2 跳过 GM 读取）
-
-**适用条件**：`n_num == 1`（block_N ≥ D）
-
-**实现**：Pass 1 只读 a_ub（cast 到 a_cal），不修改 a_ub。Pass 2 可跳过 `T.copy(A, a_ub)`，复用 Pass 1 的 a_ub。jit 闭包加 `single_pass = (n_num_int == 1)` 编译期常量。
-
-**收益**：n_num=1 的 case 减少 1 次 GM→UB 读取，+2-3%
-
-#### 优化 3：output_ub 分离 a_ub 双重写入
-
-**适用条件**：fp16/bf16 dtype（需 cast back 到低精度）
-
-**问题**：Pass 2 中 `T.tile.cast(a_ub, a_cal, CAST_RINT)` 让 a_ub 被 V 写入，与 MTE2 写入冲突，阻止 Double Buffer。
-
-**实现**：引入独立 output_ub 做 cast back，使 a_ub 只被 MTE2 写入。
-
-**收益**：为 Pass 2 Double Buffer 铺路
-
-#### 优化 4：rsqrt Newton 迭代（精度修复）
-
-**适用条件**：使用 `T.tile.rsqrt` 且精度要求 rtol < 1e-3
-
-**问题**：`T.tile.rsqrt` 精度约 1e-3（查表近似），对 fp32 rtol=1e-4 不足。
-
-**实现**：`y1 = y0 * (1.5 - 0.5 * x * y0²)`，精度提升到 ~1e-6。
-
-> **UB buffer 命名约束**：不能命名为 `tmp_ub`（与 `AscendMemoryPlanning` pass 内部临时 buffer 冲突），用 `newton_ub` 等语义化命名。
-
-#### 优化 5：gamma 1D→2D 广播乘
-
-用 `T.tile.broadcast + T.tile.mul`，不要用 `T.Parallel` 赋值与 `T.tile.*` 混用。
-
-#### 优化 6：T.copy(UB→UB) 走 MTE2 的限制
-
-`T.copy(UB→UB)` 生成 `copy_ub_to_ub` 走 MTE2 引擎，不能与 GM→UB 重叠。gamma 预加载类优化**无效**。
-
-#### 优化 7：mul_add_dst 硬件性能反转
-
-`mul_add_dst` 在 910B3/910C 上可能比 `mul+add` **更慢**。必须实测验证，不更快则回退。
-
-#### 优化 8：Pass 2 Double Buffer（Expert 模式）
-
-**适用条件**：n_num > 1 + Expert 模式（AUTO_SYNC=False）
-
-**前置条件**：已实施优化 3（output_ub 分离）；Pass 2 无跨迭代累加器；inv_rms_tile 在循环外计算。
-
-**实现**：参考 §2.2 Vector 核三阶段流水 + §2.2.0 同步决策表。Pass 1 不可双缓冲（见 §2.2.2）。
-
-**收益**：大 D case 耗时下降 10-17%
-
-#### 完整优化检查清单
-
-- [ ] 自适应 tiling 已实施？
-- [ ] 单遍扫描已实施（n_num=1）？
-- [ ] output_ub 已分离（fp16/bf16）？
-- [ ] rsqrt Newton 迭代已加？
-- [ ] gamma 广播用 `broadcast + mul`？
-- [ ] UB buffer 无 `tmp_ub` 命名？
-- [ ] mul_add_dst 已实测验证？
-- [ ] Pass 2 Double Buffer 已实施（n_num>1）？
-- [ ] Pass 1 保持串行（barrier_all）？
-
----
-
-### 2.19 双 kernel 策略（n_num 自适应模式选择）
-
-**适用场景**：同一算子在不同 shape 下有截然不同的最优 pass_configs，且 pass_configs 不能在 jit 闭包内动态切换。
-
-**实现**：定义两个 jit 函数（Hybrid + Expert），host 侧按 n_num 选择。详见 SKILL.md 最佳实践表。
-
-#### cann-bench profiler linecache 适配
-
-profiler 子进程清除 `linecache.cache`，导致 `OSError: could not get source code`。在 `_get_kernel` 中调 `_ensure_source_cached()` 预缓存源代码。

--- a/.agents/skills/tilelang-perf-optimization/references/performance-antipatterns.md
+++ b/.agents/skills/tilelang-perf-optimization/references/performance-antipatterns.md
@@ -417,20 +417,60 @@ T.reduce_sum(row_buf, result, dim=-1)  # [rows] → scalar
 
 ---
 
-## 正交轴串行化（Scalar Scan on Parallelizable Axis）
+**检查点**：
+- `get_kernel_source()` 是否只有 `IS_ASCEND_AIV`（纯 Vector）？
+- pass_configs 是否开了 `AUTO_CV_COMBINE`？
+- kernel 内是否使用了 `T.alloc_var`？
+- 三者同时满足 → 检查生成代码中变量定义/使用的核归属；仅在确认误分核后关闭
+  `AUTO_CV_COMBINE`
 
-**识别特征**：两层嵌套循环中，外层遍历正交轴（如行），内层沿扫描轴逐元素处理，且外层各迭代独立无依赖。内层操作是标量（`if`/`GetValue`/`SetValue`），而非 `T.tile` 向量操作。
+---
 
-```python
-# ❌ 正交轴被串行化，内层是标量操作
-for r in range(sub_block_R):
-    for i in range(1, L):
-        if a[r, i] <= v[r, i - 1]:    # 标量 if-else
-            v[r, i] = a[r, i]
-            idx[r, i] = i
-        else:
-            v[r, i] = v[r, i - 1]
-            idx[r, i] = idx[r, i - 1]
+## T.copy(UB→UB) 走 MTE2 导致 gamma 预加载无效
+
+**识别特征**：尝试"gamma 预加载常驻 UB"——循环前一次性 `T.copy(G[0:D], gamma_ub_full)`，循环内用 UB→UB 切片替代 GM 读取。
+
+**性能原因**：`T.copy(UB→UB)` 生成 `copy_ub_to_ub` 走 **MTE2 引擎**（DMA），不能与 GM→UB 重叠。MTE2 总字节数从 D 翻倍到 D + n_num×block_N，无带宽节省。
+
+**替代方案**：保持原路径（循环内每轮从 GM 读 gamma 分块）。
+
+---
+
+## mul_add_dst 硬件性能反转
+
+**识别特征**：用 `T.tile.mul_add_dst` 替代 `mul + add`，期望减少指令数。
+
+**性能原因**：910B3/910C 上 `mul_add_dst` 延迟可能**高于**独立 `mul+add`。fp16/bf16 case 回归 5-8%。
+
+**替代方案**：必须实测验证，不更快则回退为 `mul+add`。
+
+---
+
+## UB buffer 命名 tmp_ub 导致 AscendMemoryPlanning 冲突
+
+**识别特征**：buffer 命名为 `tmp_ub`，编译报 "Duplicate buffer name"。
+
+**替代方案**：用语义化命名（`newton_ub`、`accum_ub`）。
+
+---
+
+## Pass 1（无 MTE3 写回）双缓冲不可行
+
+**识别特征**：两遍扫描算子的 Pass 1 尝试 Double Buffer/T.Pipelined，性能无提升或精度失败。
+
+**性能原因**：Pass 1 只有 MTE2→V 两路（无 MTE3），`v→mte2` flag 在 AIV 不可用（死锁）。只能用 `barrier_all()`，但同步所有引擎阻止重叠。
+
+**替代方案**：Pass 1 保持串行，集中优化 Pass 2（有 MTE3 可形成闭环）。
+
+---
+
+## Fixed Core 在小 D + 大 S 场景反而变慢
+
+**识别特征**：D≤8 + S>100000，Fixed Core 模式性能下降。
+
+**性能原因**：软件循环开销 > launch 节省；硬件 block scheduler 更高效。
+
+**替代方案**：保持按逻辑任务数 launch，让硬件 scheduler 调度。
 ```
 
 **性能原因**：扫描轴有真依赖无法消除，但正交轴各元素独立——串行处理正交轴浪费了向量化的并行能力。标量操作导致指令数和 icache miss 随并行轴规模线性增长。
@@ -482,6 +522,54 @@ PASS_CONFIGS = {
 - kernel 内是否使用了 `T.alloc_var`？
 - 三者同时满足 → 检查生成代码中变量定义/使用的核归属；仅在确认误分核后关闭
   `AUTO_CV_COMBINE`
+
+---
+
+## T.copy(UB→UB) 走 MTE2 导致 gamma 预加载无效
+
+**识别特征**：尝试"gamma 预加载常驻 UB"——循环前一次性 `T.copy(G[0:D], gamma_ub_full)`，循环内用 UB→UB 切片替代 GM 读取。
+
+**性能原因**：`T.copy(UB→UB)` 生成 `copy_ub_to_ub` 走 **MTE2 引擎**（DMA），不能与 GM→UB 重叠。MTE2 总字节数从 D 翻倍到 D + n_num×block_N，无带宽节省。
+
+**替代方案**：保持原路径（循环内每轮从 GM 读 gamma 分块）。
+
+---
+
+## mul_add_dst 硬件性能反转
+
+**识别特征**：用 `T.tile.mul_add_dst` 替代 `mul + add`，期望减少指令数。
+
+**性能原因**：910B3/910C 上 `mul_add_dst` 延迟可能**高于**独立 `mul+add`。fp16/bf16 case 回归 5-8%。
+
+**替代方案**：必须实测验证，不更快则回退为 `mul+add`。
+
+---
+
+## UB buffer 命名 tmp_ub 导致 AscendMemoryPlanning 冲突
+
+**识别特征**：buffer 命名为 `tmp_ub`，编译报 "Duplicate buffer name"。
+
+**替代方案**：用语义化命名（`newton_ub`、`accum_ub`）。
+
+---
+
+## Pass 1（无 MTE3 写回）双缓冲不可行
+
+**识别特征**：两遍扫描算子的 Pass 1 尝试 Double Buffer/T.Pipelined，性能无提升或精度失败。
+
+**性能原因**：Pass 1 只有 MTE2→V 两路（无 MTE3），`v→mte2` flag 在 AIV 不可用（死锁）。只能用 `barrier_all()`，但同步所有引擎阻止重叠。
+
+**替代方案**：Pass 1 保持串行，集中优化 Pass 2（有 MTE3 可形成闭环）。
+
+---
+
+## Fixed Core 在小 D + 大 S 场景反而变慢
+
+**识别特征**：D≤8 + S>100000，Fixed Core 模式性能下降。
+
+**性能原因**：软件循环开销 > launch 节省；硬件 block scheduler 更高效。
+
+**替代方案**：保持按逻辑任务数 launch，让硬件 scheduler 调度。
 
 ---
 

--- a/.agents/skills/tilelang-perf-optimization/references/performance-antipatterns.md
+++ b/.agents/skills/tilelang-perf-optimization/references/performance-antipatterns.md
@@ -13,7 +13,14 @@
 - [tile size 过小导致片上内存浪费](#tile-size-过小导致片上内存浪费)
 - [AIC/AIV 混合算子未开启 CV overlap](#aicaiv-混合算子未开启-cv-overlap)
 - [纯 AIV memory bound 算子未做流水/双 buffer](#纯-aiv-memory-bound-算子未做流水双-buffer)
+- [多行 tile 循环内逐块归约](#多行-tile-循环内逐块归约)
 - [正交轴串行化（Scalar Scan on Parallelizable Axis）](#正交轴串行化scalar-scan-on-parallelizable-axis)
+- [T.copy(UB→UB) 走 MTE2 导致 gamma 预加载无效](#tcopyubub-走-mte2-导致-gamma-预加载无效)
+- [mul_add_dst 硬件性能反转](#mul_add_dst-硬件性能反转)
+- [UB buffer 命名 tmp_ub 导致 AscendMemoryPlanning 冲突](#ub-buffer-命名-tmp_ub-导致-ascendmemoryplanning-冲突)
+- [Pass 1（无 MTE3 写回）双缓冲不可行](#pass-1无-mte3-写回双缓冲不可行)
+- [Fixed Core 在小 D + 大 S 场景反而变慢](#fixed-core-在最小-d-大-s-场景反而变慢)
+- [纯 Vector 算子的 AUTO_CV_COMBINE 误分核风险](#纯-vector-算子的-auto_cv_combine-误分核风险)
 - [评审记录模板](#评审记录模板)
 
 ---
@@ -417,60 +424,20 @@ T.reduce_sum(row_buf, result, dim=-1)  # [rows] → scalar
 
 ---
 
-**检查点**：
-- `get_kernel_source()` 是否只有 `IS_ASCEND_AIV`（纯 Vector）？
-- pass_configs 是否开了 `AUTO_CV_COMBINE`？
-- kernel 内是否使用了 `T.alloc_var`？
-- 三者同时满足 → 检查生成代码中变量定义/使用的核归属；仅在确认误分核后关闭
-  `AUTO_CV_COMBINE`
+## 正交轴串行化（Scalar Scan on Parallelizable Axis）
 
----
+**识别特征**：两层嵌套循环中，外层遍历正交轴（如行），内层沿扫描轴逐元素处理，且外层各迭代独立无依赖。内层操作是标量（`if`/`GetValue`/`SetValue`），而非 `T.tile` 向量操作。
 
-## T.copy(UB→UB) 走 MTE2 导致 gamma 预加载无效
-
-**识别特征**：尝试"gamma 预加载常驻 UB"——循环前一次性 `T.copy(G[0:D], gamma_ub_full)`，循环内用 UB→UB 切片替代 GM 读取。
-
-**性能原因**：`T.copy(UB→UB)` 生成 `copy_ub_to_ub` 走 **MTE2 引擎**（DMA），不能与 GM→UB 重叠。MTE2 总字节数从 D 翻倍到 D + n_num×block_N，无带宽节省。
-
-**替代方案**：保持原路径（循环内每轮从 GM 读 gamma 分块）。
-
----
-
-## mul_add_dst 硬件性能反转
-
-**识别特征**：用 `T.tile.mul_add_dst` 替代 `mul + add`，期望减少指令数。
-
-**性能原因**：910B3/910C 上 `mul_add_dst` 延迟可能**高于**独立 `mul+add`。fp16/bf16 case 回归 5-8%。
-
-**替代方案**：必须实测验证，不更快则回退为 `mul+add`。
-
----
-
-## UB buffer 命名 tmp_ub 导致 AscendMemoryPlanning 冲突
-
-**识别特征**：buffer 命名为 `tmp_ub`，编译报 "Duplicate buffer name"。
-
-**替代方案**：用语义化命名（`newton_ub`、`accum_ub`）。
-
----
-
-## Pass 1（无 MTE3 写回）双缓冲不可行
-
-**识别特征**：两遍扫描算子的 Pass 1 尝试 Double Buffer/T.Pipelined，性能无提升或精度失败。
-
-**性能原因**：Pass 1 只有 MTE2→V 两路（无 MTE3），`v→mte2` flag 在 AIV 不可用（死锁）。只能用 `barrier_all()`，但同步所有引擎阻止重叠。
-
-**替代方案**：Pass 1 保持串行，集中优化 Pass 2（有 MTE3 可形成闭环）。
-
----
-
-## Fixed Core 在小 D + 大 S 场景反而变慢
-
-**识别特征**：D≤8 + S>100000，Fixed Core 模式性能下降。
-
-**性能原因**：软件循环开销 > launch 节省；硬件 block scheduler 更高效。
-
-**替代方案**：保持按逻辑任务数 launch，让硬件 scheduler 调度。
+```python
+# ❌ 正交轴被串行化，内层是标量操作
+for r in range(sub_block_R):
+    for i in range(1, L):
+        if a[r, i] <= v[r, i - 1]:    # 标量 if-else
+            v[r, i] = a[r, i]
+            idx[r, i] = i
+        else:
+            v[r, i] = v[r, i - 1]
+            idx[r, i] = idx[r, i - 1]
 ```
 
 **性能原因**：扫描轴有真依赖无法消除，但正交轴各元素独立——串行处理正交轴浪费了向量化的并行能力。标量操作导致指令数和 icache miss 随并行轴规模线性增长。
@@ -498,6 +465,54 @@ for j in range(1, L):
 
 ---
 
+## T.copy(UB→UB) 走 MTE2 导致 gamma 预加载无效
+
+**识别特征**：尝试"gamma 预加载常驻 UB"——循环前一次性 `T.copy(G[0:D], gamma_ub_full)`，循环内用 UB→UB 切片替代 GM 读取。
+
+**性能原因**：`T.copy(UB→UB)` 生成 `copy_ub_to_ub` 走 **MTE2 引擎**（DMA），不能与 GM→UB 重叠。MTE2 总字节数从 D 翻倍到 D + n_num×block_N，无带宽节省。
+
+**替代方案**：保持原路径（循环内每轮从 GM 读 gamma 分块）。详见 [vector-practices/reduction/two_pass_normalization.md](vector-practices/reduction/two_pass_normalization.md) 优化 6。
+
+---
+
+## mul_add_dst 硬件性能反转
+
+**识别特征**：用 `T.tile.mul_add_dst` 替代 `mul + add`，期望减少指令数。
+
+**性能原因**：910B3/910C 上 `mul_add_dst` 延迟可能**高于**独立 `mul+add`。fp16/bf16 case 回归 5-8%。
+
+**替代方案**：必须实测验证，不更快则回退为 `mul+add`。详见 [vector-practices/reduction/two_pass_normalization.md](vector-practices/reduction/two_pass_normalization.md) 优化 7。
+
+---
+
+## UB buffer 命名 tmp_ub 导致 AscendMemoryPlanning 冲突
+
+**识别特征**：buffer 命名为 `tmp_ub`，编译报 "Duplicate buffer name"。
+
+**替代方案**：用语义化命名（`newton_ub`、`accum_ub`）。详见 [vector-practices/reduction/two_pass_normalization.md](vector-practices/reduction/two_pass_normalization.md) 优化 4。
+
+---
+
+## Pass 1（无 MTE3 写回）双缓冲不可行
+
+**识别特征**：两遍扫描算子的 Pass 1 尝试 Double Buffer/T.Pipelined，性能无提升或精度失败。
+
+**性能原因**：Pass 1 只有 MTE2→V 两路（无 MTE3），`v→mte2` flag 在 AIV 不可用（死锁）。只能用 `barrier_all()`，但同步所有引擎阻止重叠。
+
+**替代方案**：Pass 1 保持串行，集中优化 Pass 2（有 MTE3 可形成闭环）。详见 optimization-guide.md §2.2.2 及 [vector-practices/reduction/two_pass_normalization.md](vector-practices/reduction/two_pass_normalization.md) 优化 8。
+
+---
+
+## Fixed Core 在小 D + 大 S 场景反而变慢
+
+**识别特征**：D≤8 + S>100000，Fixed Core 模式性能下降。
+
+**性能原因**：软件循环开销 > launch 节省；硬件 block scheduler 更高效。
+
+**替代方案**：保持按逻辑任务数 launch，让硬件 scheduler 调度。详见 optimization-guide.md §2.9 失效条件。
+
+---
+
 ## 纯 Vector 算子的 AUTO_CV_COMBINE 误分核风险
 
 **识别特征**：纯 Vector 算子（`get_kernel_source()` 只有 `IS_ASCEND_AIV`），pass_configs 中开了 `TL_ASCEND_AUTO_CV_COMBINE: True`，且 kernel 内使用了 `T.alloc_var`。
@@ -522,54 +537,6 @@ PASS_CONFIGS = {
 - kernel 内是否使用了 `T.alloc_var`？
 - 三者同时满足 → 检查生成代码中变量定义/使用的核归属；仅在确认误分核后关闭
   `AUTO_CV_COMBINE`
-
----
-
-## T.copy(UB→UB) 走 MTE2 导致 gamma 预加载无效
-
-**识别特征**：尝试"gamma 预加载常驻 UB"——循环前一次性 `T.copy(G[0:D], gamma_ub_full)`，循环内用 UB→UB 切片替代 GM 读取。
-
-**性能原因**：`T.copy(UB→UB)` 生成 `copy_ub_to_ub` 走 **MTE2 引擎**（DMA），不能与 GM→UB 重叠。MTE2 总字节数从 D 翻倍到 D + n_num×block_N，无带宽节省。
-
-**替代方案**：保持原路径（循环内每轮从 GM 读 gamma 分块）。
-
----
-
-## mul_add_dst 硬件性能反转
-
-**识别特征**：用 `T.tile.mul_add_dst` 替代 `mul + add`，期望减少指令数。
-
-**性能原因**：910B3/910C 上 `mul_add_dst` 延迟可能**高于**独立 `mul+add`。fp16/bf16 case 回归 5-8%。
-
-**替代方案**：必须实测验证，不更快则回退为 `mul+add`。
-
----
-
-## UB buffer 命名 tmp_ub 导致 AscendMemoryPlanning 冲突
-
-**识别特征**：buffer 命名为 `tmp_ub`，编译报 "Duplicate buffer name"。
-
-**替代方案**：用语义化命名（`newton_ub`、`accum_ub`）。
-
----
-
-## Pass 1（无 MTE3 写回）双缓冲不可行
-
-**识别特征**：两遍扫描算子的 Pass 1 尝试 Double Buffer/T.Pipelined，性能无提升或精度失败。
-
-**性能原因**：Pass 1 只有 MTE2→V 两路（无 MTE3），`v→mte2` flag 在 AIV 不可用（死锁）。只能用 `barrier_all()`，但同步所有引擎阻止重叠。
-
-**替代方案**：Pass 1 保持串行，集中优化 Pass 2（有 MTE3 可形成闭环）。
-
----
-
-## Fixed Core 在小 D + 大 S 场景反而变慢
-
-**识别特征**：D≤8 + S>100000，Fixed Core 模式性能下降。
-
-**性能原因**：软件循环开销 > launch 节省；硬件 block scheduler 更高效。
-
-**替代方案**：保持按逻辑任务数 launch，让硬件 scheduler 调度。
 
 ---
 

--- a/.agents/skills/tilelang-perf-optimization/references/vector-practices/reduction/two_pass_normalization.md
+++ b/.agents/skills/tilelang-perf-optimization/references/vector-practices/reduction/two_pass_normalization.md
@@ -1,0 +1,154 @@
+# 两遍扫描归一化算子优化（Two-Pass Normalization）
+
+本文档介绍 Vector 型两遍扫描归一化算子的完整优化模式。此类算子的核心结构为"Pass 1 归约求统计量（mean/rms 等）+ Pass 2 逐元素应用统计量并写回"，属于纯 Vector 型（无 Cube 操作）。
+
+参考实现：`examples/cann-bench/rms_norm/example_rms_norm.py`
+
+---
+
+## 适用场景
+
+### 适用条件（全部满足）
+
+| 编号 | 条件 | 说明 |
+|------|------|------|
+| C1 | 算子类型为 Vector（`IS_ASCEND_AIV`） | 归约维度沿列方向，数据需分块从 GM 搬入 UB |
+| C2 | 统计量需分块累加 | 归约维度 D 大于 UB 单次容量，Pass 1 必须分块扫描累加 |
+| C3 | Pass 2 需写回 GM | 存在 MTE3 写回，为 Double Buffer 闭环提供条件 |
+| C4 | 两遍之间存在数据依赖 | Pass 2 依赖 Pass 1 的统计量，无法合并为单遍 |
+
+### 不适用条件
+
+| 编号 | 条件 | 原因 |
+|------|------|------|
+| X1 | `n_num == 1`（block_N ≥ D） | 无流水空间，Hybrid 单 kernel 自动同步更快，见"双 kernel 策略" |
+| X2 | D 极小（≤8）+ S 极大 | 每块计算量过小，软件循环开销占比高，见 optimization-guide.md §2.9 失效条件 |
+
+### 可泛化的算子模式
+
+| 算子 | Pass 1 统计量 | Pass 2 应用 |
+|------|--------------|------------|
+| RMSNorm | sum of squares → rsqrt(mean) | x × inv_rms × gamma |
+| LayerNorm | mean + variance → rsqrt(var) | (x − mean) × inv_std × gamma + beta |
+| GroupNorm | 组内 mean + variance | 同 LayerNorm（按组归约） |
+| 任何"归约统计量 → 逐元素应用"算子 | 分块累加统计量 | 广播应用 |
+
+---
+
+## 约束条件
+
+### 硬件约束
+
+| 约束 | 说明 |
+|------|------|
+| UB 容量 | A2/A3 的 UB 预算为 192 KB，按预算公式反推 block_M / block_N（见优化 1） |
+| 对齐要求 | 所有 UB buffer 需 32B 对齐（fp32 为 8 元素，fp16/bf16 为 16 元素） |
+| AIV flag 通道 | `mte3→mte2` ✅、`mte2→v` ✅、`v→mte3` ✅、`v→mte2` ❌（不可用，死锁）——决定 Pass 1 不可双缓冲 |
+| `T.copy(UB→UB)` | 走 MTE2 引擎（DMA），不能与 GM→UB 重叠（见优化 6） |
+
+### 算法约束
+
+| 约束 | 说明 |
+|------|------|
+| 中间计算精度 | fp16/bf16 输入必须 cast 到 fp32 计算，否则无法满足 MERE/MARE 阈值 |
+| rsqrt 精度 | `T.tile.rsqrt` 为查表近似，精度约 1e-3；fp32 rtol=1e-4 需加 Newton 迭代（见优化 4） |
+| pass_configs 编译期固定 | `pass_configs` 是 decorator 参数，jit 闭包内不能动态切换（催生双 kernel 策略） |
+
+---
+
+## 优化模式清单（按实施顺序）
+
+### 优化 1：自适应 tiling（host 侧 `_select_tiling`）
+
+**适用条件**：所有 case（无限制）
+
+**实现**：host 侧根据 S、D、dtype 动态选择 block_M / block_N，按 UB 预算反推。候选 block_M: (1024, 512, 256, 128, 64, 32, 16)。评分公式: `n_num * 100000 + m_penalty`（n_num 优先减少 GM 读取，m_num ∈ [24, 48] 避免空闲核和过多 launch）。
+
+**收益**：RMSNorm 实测 0.43x → 0.58x（+35%）
+
+### 优化 2：单遍扫描（n_num=1 时 Pass 2 跳过 GM 读取）
+
+**适用条件**：`n_num == 1`（block_N ≥ D）
+
+**实现**：Pass 1 只读 a_ub（cast 到 a_cal），不修改 a_ub。Pass 2 可跳过 `T.copy(A, a_ub)`，复用 Pass 1 的 a_ub。jit 闭包加 `single_pass = (n_num_int == 1)` 编译期常量。
+
+**收益**：n_num=1 的 case 减少 1 次 GM→UB 读取，+2-3%
+
+### 优化 3：output_ub 分离 a_ub 双重写入
+
+**适用条件**：fp16/bf16 dtype（需 cast back 到低精度）
+
+**问题**：Pass 2 中 `T.tile.cast(a_ub, a_cal, CAST_RINT)` 让 a_ub 被 V 写入，与 MTE2 写入冲突，阻止 Double Buffer。
+
+**实现**：引入独立 output_ub 做 cast back，使 a_ub 只被 MTE2 写入。
+
+**收益**：为 Pass 2 Double Buffer 铺路
+
+### 优化 4：rsqrt Newton 迭代（精度修复）
+
+**适用条件**：使用 `T.tile.rsqrt` 且精度要求 rtol < 1e-3
+
+**问题**：`T.tile.rsqrt` 精度约 1e-3（查表近似），对 fp32 rtol=1e-4 不足。
+
+**实现**：`y1 = y0 * (1.5 - 0.5 * x * y0²)`，精度提升到 ~1e-6。
+
+> **UB buffer 命名约束**：不能命名为 `tmp_ub`（与 `AscendMemoryPlanning` pass 内部临时 buffer 冲突），用 `newton_ub` 等语义化命名。
+
+### 优化 5：gamma 1D→2D 广播乘
+
+用 `T.tile.broadcast + T.tile.mul`，不要用 `T.Parallel` 赋值与 `T.tile.*` 混用。
+
+### 优化 6：T.copy(UB→UB) 走 MTE2 的限制
+
+`T.copy(UB→UB)` 生成 `copy_ub_to_ub` 走 MTE2 引擎，不能与 GM→UB 重叠。gamma 预加载类优化**无效**。
+
+### 优化 7：mul_add_dst 硬件性能反转
+
+`mul_add_dst` 在 910B3/910C 上可能比 `mul+add` **更慢**。必须实测验证，不更快则回退。
+
+### 优化 8：Pass 2 Double Buffer（Expert 模式）
+
+**适用条件**：n_num > 1 + Expert 模式（AUTO_SYNC=False）
+
+**前置条件**：已实施优化 3（output_ub 分离）；Pass 2 无跨迭代累加器；inv_rms_tile 在循环外计算。
+
+**实现**：参考 optimization-guide.md §2.2 Vector 核三阶段流水 + §2.2.0 同步决策表。Pass 1 不可双缓冲（见 optimization-guide.md §2.2.2）。
+
+**收益**：大 D case 耗时下降 10-17%
+
+---
+
+## 双 kernel 策略（n_num 自适应模式选择）
+
+**适用场景**：同一算子在不同 shape 下有截然不同的最优 pass_configs，且 pass_configs 不能在 jit 闭包内动态切换。
+
+**实现**：定义两个 jit 函数（Hybrid + Expert），host 侧按 n_num 选择：
+
+- `n_num=1`：Hybrid（AUTO_SYNC=True）——无流水空间，自动同步避免 barrier 开销，且可实施优化 2 单遍扫描；
+- `n_num>1`：Expert（AUTO_SYNC=False + Pass 2 Double Buffer）——MTE2/V/MTE3 三路重叠收益大于手动同步成本。
+
+### cann-bench profiler linecache 适配
+
+profiler 子进程清除 `linecache.cache`，导致 `OSError: could not get source code`。在 `_get_kernel` 中调 `_ensure_source_cached()` 预缓存源代码。
+
+---
+
+## 完整优化检查清单
+
+- [ ] 自适应 tiling 已实施？
+- [ ] 单遍扫描已实施（n_num=1）？
+- [ ] output_ub 已分离（fp16/bf16）？
+- [ ] rsqrt Newton 迭代已加？
+- [ ] gamma 广播用 `broadcast + mul`？
+- [ ] UB buffer 无 `tmp_ub` 命名？
+- [ ] mul_add_dst 已实测验证？
+- [ ] Pass 2 Double Buffer 已实施（n_num>1）？
+- [ ] Pass 1 保持串行（barrier_all）？
+
+---
+
+## 关联文档
+
+- 反模式自查：[performance-antipatterns.md](../../performance-antipatterns.md)（T.copy(UB→UB) 走 MTE2、mul_add_dst 性能反转、tmp_ub 命名冲突、Pass 1 双缓冲不可行、Fixed Core 小 D 大 S 失效）
+- 同步机制：[optimization-guide.md](../../optimization-guide.md) §2.2（三阶段流水）、§2.2.0（同步决策表）、§2.2.2（Pass 1 vs Pass 2 双缓冲可行性）、§2.9（Fixed Core 失效条件）
+- 同族优化：[vector_reduce_pass_fusion.md](../vector_reduce_pass_fusion.md)（归约遍数融合，Online Softmax 3-pass → 2-pass）

--- a/examples/cann-bench/rms_norm/example_rms_norm.py
+++ b/examples/cann-bench/rms_norm/example_rms_norm.py
@@ -1,0 +1,668 @@
+"""RMSNorm example — multi-case optimized version with cann-bench 20 cases.
+
+Two-pass RMS normalization with dual-kernel strategy (Hybrid simple + Expert pipeline)
+for arbitrary shape, dtype, and epsilon. Targets cann-bench multi-case evaluation.
+
+Algorithm:
+    y = x / sqrt(mean(x^2) + eps) * gamma
+
+Reference: torch.nn.functional.rms_norm (PyTorch >= 2.4)
+
+Key optimizations:
+- Dual-kernel: n_num=1 uses Hybrid (AUTO_SYNC=True), n_num>1 uses Expert
+  (AUTO_SYNC=False + double buffer + three-way flag pipeline)
+- Adaptive tiling via UB budget formula
+- Newton iteration for rsqrt precision (~1e-3 -> ~1e-6)
+- output_ub separation keeps a_ub MTE2-write-only (enables double buffer)
+"""
+
+import argparse
+import sys
+
+import torch
+
+import tilelang
+from tilelang import language as T
+
+
+# ========== JIT Configuration ==========
+EXPERT_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False,
+}
+
+HYBRID_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+CAST_NONE = "CAST_NONE"
+CAST_RINT = "CAST_RINT"
+
+_DTYPE_MAP = {
+    "float16": torch.float16,
+    "float32": torch.float32,
+    "bfloat16": torch.bfloat16,
+}
+
+# cann-bench precision thresholds (MERE = mean relative error, MARE = max relative error)
+_CANNBENCH_THRESHOLDS = {
+    "float16": 2**-10,
+    "bfloat16": 2**-7,
+    "float32": 2**-13,
+}
+
+
+# ========== Kernel: Simple (n_num=1, Hybrid mode) ==========
+@tilelang.jit(out_idx=[2], pass_configs=HYBRID_CONFIGS)
+def _rms_norm_simple(S, D, block_M, block_N, eps=1e-6, dtype="float16"):
+    """Hybrid mode RMS Norm for n_num=1 (single tile covers D)."""
+    VEC_NUM = 2
+    ROWS = block_M // VEC_NUM
+    m_num = T.ceildiv(S, block_M)
+    need_cast = dtype not in ("float", "float32")
+    acc_dtype = "float32" if need_cast else dtype
+
+    @T.prim_func
+    def tilelang_rms_norm(
+        A: T.Tensor((S, D), dtype),  # type: ignore
+        G: T.Tensor((D,), dtype),  # type: ignore
+        B: T.Tensor((S, D), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num, is_npu=True) as (cid, vid):
+            row_start = cid * block_M + vid * ROWS
+
+            a_ub = T.alloc_ub([ROWS, block_N], dtype)
+            a_cal = T.alloc_ub([ROWS, block_N], acc_dtype)
+            output_ub = T.alloc_ub([ROWS, block_N], dtype)
+            sum_sq_acc = T.alloc_ub([ROWS, block_N], acc_dtype)
+            sum_sq_row = T.alloc_ub([ROWS, 1], acc_dtype)
+            inv_rms_ub = T.alloc_ub([ROWS, 1], acc_dtype)
+            inv_rms_tile = T.alloc_ub([ROWS, block_N], acc_dtype)
+            gamma_ub = T.alloc_ub([block_N], dtype)
+            gamma_cal = T.alloc_ub([block_N if need_cast else 1], acc_dtype)
+            gamma_tile = T.alloc_ub([ROWS, block_N], acc_dtype)
+            newton_ub = T.alloc_ub([ROWS, 1], acc_dtype)
+
+            # Pass 1: accumulate x^2
+            T.tile.fill(sum_sq_acc, 0.0)
+            T.copy(A[row_start : row_start + ROWS, 0:block_N], a_ub)
+            if need_cast:
+                T.tile.cast(a_cal, a_ub, CAST_NONE, ROWS * block_N)
+                T.tile.mul(a_cal, a_cal, a_cal)
+                T.tile.add(sum_sq_acc, sum_sq_acc, a_cal)
+            else:
+                T.tile.mul(a_cal, a_ub, a_ub)
+                T.tile.add(sum_sq_acc, sum_sq_acc, a_cal)
+
+            # reduce + inv_rms (Newton iteration for precision)
+            T.reduce_sum(sum_sq_acc, sum_sq_row, dim=-1)
+            inv_n = T.cast(1.0 / D, acc_dtype)
+            eps_val = T.cast(eps, acc_dtype)
+            T.tile.mul(sum_sq_row, sum_sq_row, inv_n)
+            T.tile.add(sum_sq_row, sum_sq_row, eps_val)
+            T.tile.rsqrt(inv_rms_ub, sum_sq_row)
+            T.tile.mul(newton_ub, inv_rms_ub, inv_rms_ub)
+            T.tile.mul(newton_ub, newton_ub, sum_sq_row)
+            half_neg = T.cast(-0.5, acc_dtype)
+            T.tile.mul(newton_ub, newton_ub, half_neg)
+            three_half = T.cast(1.5, acc_dtype)
+            T.tile.add(newton_ub, newton_ub, three_half)
+            T.tile.mul(inv_rms_ub, inv_rms_ub, newton_ub)
+            T.tile.broadcast(inv_rms_tile, inv_rms_ub)
+
+            # Pass 2: normalize + gamma + write back (n_num=1: reuse a_ub)
+            if need_cast:
+                T.tile.cast(a_cal, a_ub, CAST_NONE, ROWS * block_N)
+                T.tile.mul(a_cal, a_cal, inv_rms_tile)
+            else:
+                T.tile.mul(a_cal, a_ub, inv_rms_tile)
+
+            T.copy(G[0:block_N], gamma_ub)
+            if need_cast:
+                T.tile.cast(gamma_cal, gamma_ub, CAST_NONE, block_N)
+                T.tile.broadcast(gamma_tile, gamma_cal)
+            else:
+                T.tile.broadcast(gamma_tile, gamma_ub)
+            T.tile.mul(a_cal, a_cal, gamma_tile)
+
+            if need_cast:
+                T.tile.cast(output_ub, a_cal, CAST_RINT, ROWS * block_N)
+                T.copy(output_ub, B[row_start : row_start + ROWS, 0:block_N])
+            else:
+                T.copy(a_cal, B[row_start : row_start + ROWS, 0:block_N])
+
+    return tilelang_rms_norm
+
+
+# ========== Kernel: Pipeline (n_num>1, Expert mode with double buffer) ==========
+@tilelang.jit(out_idx=[2], pass_configs=EXPERT_CONFIGS)
+def _rms_norm_pipeline(S, D, block_M, block_N, eps=1e-6, dtype="float16"):
+    """Expert mode RMS Norm for n_num>1 with double buffer pipeline.
+
+    Pass 2 uses three-way flag pipeline (mte3->mte2, mte2->v, v->mte3).
+    Pass 1 uses barrier_all (no MTE3 in Pass 1, v->mte2 flag unavailable).
+    """
+    VEC_NUM = 2
+    ROWS = block_M // VEC_NUM
+    m_num = T.ceildiv(S, block_M)
+    n_num = T.ceildiv(D, block_N)
+    need_cast = dtype not in ("float", "float32")
+    acc_dtype = "float32" if need_cast else dtype
+
+    @T.prim_func
+    def tilelang_rms_norm(
+        A: T.Tensor((S, D), dtype),  # type: ignore
+        G: T.Tensor((D,), dtype),  # type: ignore
+        B: T.Tensor((S, D), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num, is_npu=True) as (cid, vid):
+            row_start = cid * block_M + vid * ROWS
+
+            a_ub_db = T.alloc_ub([2, ROWS, block_N], dtype)
+            gamma_ub_db = T.alloc_ub([2, block_N], dtype)
+            a_cal = T.alloc_ub([ROWS, block_N], acc_dtype)
+            sum_sq_acc = T.alloc_ub([ROWS, block_N], acc_dtype)
+            sum_sq_row = T.alloc_ub([ROWS, 1], acc_dtype)
+            inv_rms_ub = T.alloc_ub([ROWS, 1], acc_dtype)
+            inv_rms_tile = T.alloc_ub([ROWS, block_N], acc_dtype)
+            gamma_cal = T.alloc_ub([block_N if need_cast else 1], acc_dtype)
+            gamma_tile = T.alloc_ub([ROWS, block_N], acc_dtype)
+            newton_ub = T.alloc_ub([ROWS, 1], acc_dtype)
+
+            with T.Scope("V"):
+                # Pass 1: accumulate x^2 (single buffer, barrier_all per iteration)
+                T.tile.fill(sum_sq_acc, 0.0)
+                for by in T.serial(n_num):
+                    col_off = by * block_N
+                    T.copy(
+                        A[row_start : row_start + ROWS, col_off : col_off + block_N],
+                        a_ub_db[0, :, :],
+                    )
+                    T.barrier_all()
+                    if need_cast:
+                        T.tile.cast(a_cal, a_ub_db[0, :, :], CAST_NONE, ROWS * block_N)
+                        T.tile.mul(a_cal, a_cal, a_cal)
+                        T.tile.add(sum_sq_acc, sum_sq_acc, a_cal)
+                    else:
+                        T.tile.mul(a_cal, a_ub_db[0, :, :], a_ub_db[0, :, :])
+                        T.tile.add(sum_sq_acc, sum_sq_acc, a_cal)
+
+                # reduce + inv_rms (Newton iteration)
+                T.reduce_sum(sum_sq_acc, sum_sq_row, dim=-1)
+                inv_n = T.cast(1.0 / D, acc_dtype)
+                eps_val = T.cast(eps, acc_dtype)
+                T.tile.mul(sum_sq_row, sum_sq_row, inv_n)
+                T.tile.add(sum_sq_row, sum_sq_row, eps_val)
+                T.tile.rsqrt(inv_rms_ub, sum_sq_row)
+                T.tile.mul(newton_ub, inv_rms_ub, inv_rms_ub)
+                T.tile.mul(newton_ub, newton_ub, sum_sq_row)
+                half_neg = T.cast(-0.5, acc_dtype)
+                T.tile.mul(newton_ub, newton_ub, half_neg)
+                three_half = T.cast(1.5, acc_dtype)
+                T.tile.add(newton_ub, newton_ub, three_half)
+                T.tile.mul(inv_rms_ub, inv_rms_ub, newton_ub)
+                T.tile.broadcast(inv_rms_tile, inv_rms_ub)
+
+                T.barrier_all()
+
+                # Pass 2: double buffer pipeline (three-way flag)
+                T.set_flag("mte3", "mte2", 0)
+                T.set_flag("mte3", "mte2", 1)
+
+                # Prefetch tile 0
+                T.wait_flag("mte3", "mte2", 0)
+                T.copy(A[row_start : row_start + ROWS, 0:block_N], a_ub_db[0, :, :])
+                T.copy(G[0:block_N], gamma_ub_db[0, :])
+                T.set_flag("mte2", "v", 0)
+
+                # Main body
+                for tile in T.serial(0, n_num - 1):
+                    cur = tile % 2
+                    nxt = (tile + 1) % 2
+                    col_cur = tile * block_N
+                    col_nxt = (tile + 1) * block_N
+
+                    T.wait_flag("mte3", "mte2", nxt)
+                    T.copy(
+                        A[row_start : row_start + ROWS, col_nxt : col_nxt + block_N],
+                        a_ub_db[nxt, :, :],
+                    )
+                    T.copy(G[col_nxt : col_nxt + block_N], gamma_ub_db[nxt, :])
+                    T.set_flag("mte2", "v", nxt)
+
+                    T.wait_flag("mte2", "v", cur)
+                    if need_cast:
+                        T.tile.cast(a_cal, a_ub_db[cur, :, :], CAST_NONE, ROWS * block_N)
+                        T.tile.mul(a_cal, a_cal, inv_rms_tile)
+                        T.tile.cast(gamma_cal, gamma_ub_db[cur, :], CAST_NONE, block_N)
+                        T.tile.broadcast(gamma_tile, gamma_cal)
+                        T.tile.mul(a_cal, a_cal, gamma_tile)
+                        T.tile.cast(a_ub_db[cur, :, :], a_cal, CAST_RINT, ROWS * block_N)
+                    else:
+                        T.tile.mul(a_ub_db[cur, :, :], a_ub_db[cur, :, :], inv_rms_tile)
+                        T.tile.broadcast(gamma_tile, gamma_ub_db[cur, :])
+                        T.tile.mul(a_ub_db[cur, :, :], a_ub_db[cur, :, :], gamma_tile)
+                    T.set_flag("v", "mte3", cur)
+
+                    T.wait_flag("v", "mte3", cur)
+                    T.copy(
+                        a_ub_db[cur, :, :],
+                        B[row_start : row_start + ROWS, col_cur : col_cur + block_N],
+                    )
+                    T.set_flag("mte3", "mte2", cur)
+
+                # Epilogue
+                last_tile = n_num - 1
+                last_stage = last_tile % 2
+                col_last = last_tile * block_N
+
+                T.wait_flag("mte2", "v", last_stage)
+                if need_cast:
+                    T.tile.cast(a_cal, a_ub_db[last_stage, :, :], CAST_NONE, ROWS * block_N)
+                    T.tile.mul(a_cal, a_cal, inv_rms_tile)
+                    T.tile.cast(gamma_cal, gamma_ub_db[last_stage, :], CAST_NONE, block_N)
+                    T.tile.broadcast(gamma_tile, gamma_cal)
+                    T.tile.mul(a_cal, a_cal, gamma_tile)
+                    T.tile.cast(a_ub_db[last_stage, :, :], a_cal, CAST_RINT, ROWS * block_N)
+                else:
+                    T.tile.mul(a_ub_db[last_stage, :, :], a_ub_db[last_stage, :, :], inv_rms_tile)
+                    T.tile.broadcast(gamma_tile, gamma_ub_db[last_stage, :])
+                    T.tile.mul(a_ub_db[last_stage, :, :], a_ub_db[last_stage, :, :], gamma_tile)
+                T.set_flag("v", "mte3", last_stage)
+
+                T.wait_flag("v", "mte3", last_stage)
+                T.copy(
+                    a_ub_db[last_stage, :, :],
+                    B[row_start : row_start + ROWS, col_last : col_last + block_N],
+                )
+                T.set_flag("mte3", "mte2", last_stage)
+
+                T.wait_flag("mte3", "mte2", 0)
+                T.wait_flag("mte3", "mte2", 1)
+
+    return tilelang_rms_norm
+
+
+# ========== Golden Reference ==========
+def golden_rms_norm(x, gamma, epsilon=1e-6):
+    """Golden reference using torch.nn.functional.rms_norm (CPU fp32)."""
+    return torch.nn.functional.rms_norm(x, normalized_shape=gamma.shape, weight=gamma, eps=epsilon)
+
+
+# ========== Tiling Selection ==========
+_BN_CANDIDATES = [2048, 1024, 768, 512, 384, 256, 192, 128, 64, 32, 16]
+_BN_POW2 = [1024, 512, 256, 128, 64, 32, 16]
+
+
+def _find_best_block_n(D, max_bn):
+    for bn in _BN_CANDIDATES:
+        if bn <= max_bn and bn <= D and D % bn == 0:
+            return bn
+    for bn in _BN_POW2:
+        if bn <= max_bn:
+            return bn
+    return 16
+
+
+def _select_tiling(S, D, dtype_str):
+    """Select block_M, block_N adaptively based on S, D, dtype."""
+    VEC_NUM = 2
+    CORE_NUM = 24
+    UB_BUDGET = 170 * 1024
+    is_low_prec = dtype_str in ("float16", "bfloat16")
+    per_unit = 18 if is_low_prec else 16
+    D_aligned = max(((D + 15) // 16) * 16, 16)
+
+    best_score = float("inf")
+    best_bm, best_bn = 64, 128
+
+    for block_M in (1024, 512, 256, 128, 64, 32, 16):
+        if block_M % VEC_NUM != 0:
+            continue
+        rows = block_M // VEC_NUM
+        max_bn = UB_BUDGET // (rows * per_unit)
+        max_bn = (max_bn // 16) * 16
+        max_bn = max(max_bn, 16)
+
+        if D_aligned <= max_bn:
+            block_N = D_aligned
+        else:
+            block_N = _find_best_block_n(D, max_bn)
+
+        n_num = (D + block_N - 1) // block_N
+        m_num = (S + block_M - 1) // block_M
+
+        if m_num < CORE_NUM:
+            m_penalty = (CORE_NUM - m_num) * 1000
+        else:
+            m_penalty = max(0, m_num - 2 * CORE_NUM) * 1
+        score = n_num * 100000 + m_penalty
+
+        if score < best_score:
+            best_score = score
+            best_bm, best_bn = block_M, block_N
+
+    n_num_check = (D + best_bn - 1) // best_bn
+    if n_num_check > 1:
+        per_unit_pipeline = 20
+        rows = best_bm // VEC_NUM
+        max_bn = UB_BUDGET // (rows * per_unit_pipeline)
+        max_bn = (max_bn // 16) * 16
+        max_bn = max(max_bn, 16)
+        if D_aligned > max_bn:
+            best_bn = _find_best_block_n(D, max_bn)
+
+    return best_bm, best_bn
+
+
+# ========== Host Wrapper ==========
+def rms_norm_host(x, gamma, eps=1e-6):
+    """Host-side wrapper: flatten (..., D) -> (S, D), call kernel, reshape back."""
+    original_shape = x.shape
+    D = original_shape[-1]
+    S = 1
+    for d in original_shape[:-1]:
+        S *= d
+    x_2d = x.reshape(S, D)
+    dtype_str = str(x.dtype).replace("torch.", "")
+    block_M, block_N = _select_tiling(S, D, dtype_str)
+    n_num = (D + block_N - 1) // block_N
+    if n_num > 1:
+        func = _rms_norm_pipeline(S, D, block_M=block_M, block_N=block_N, eps=eps, dtype=dtype_str)
+    else:
+        func = _rms_norm_simple(S, D, block_M=block_M, block_N=block_N, eps=eps, dtype=dtype_str)
+    y_2d = func(x_2d, gamma)
+    return y_2d.reshape(original_shape)
+
+
+# ========== Precision Standards ==========
+def get_precision(dtype):
+    """Normalization-class precision standards (L0 threshold)."""
+    precision_map = {
+        "float16": (1e-3, 1e-3),
+        "float32": (1e-4, 1e-4),
+        "bfloat16": (1e-2, 5e-3),
+    }
+    return precision_map[dtype]
+
+
+# ========== cann-bench Precision Checker ==========
+def _mere_mare(actual, golden):
+    """Compute MERE (mean relative error) and MARE (max relative error).
+
+    Formula (cann-bench standard):
+        relative_error = abs(actual - golden) / (abs(golden) + 1e-7)
+    """
+    diff = (actual.float() - golden.float()).abs()
+    denom = golden.float().abs() + 1e-7
+    rel_err = diff / denom
+    # Handle NaN/Inf: positions where both are NaN/Inf are considered matching
+    both_nan = torch.isnan(actual.float()) & torch.isnan(golden.float())
+    both_inf = torch.isinf(actual.float()) & torch.isinf(golden.float())
+    rel_err = torch.where(both_nan | both_inf, torch.zeros_like(rel_err), rel_err)
+    mere = rel_err.mean().item()
+    mare = rel_err.max().item()
+    return mere, mare
+
+
+def check_precision(actual, golden, dtype_str, label=""):
+    """Check precision against cann-bench thresholds."""
+    mere, mare = _mere_mare(actual, golden)
+    threshold = _CANNBENCH_THRESHOLDS[dtype_str]
+    mare_threshold = 10 * threshold
+    passed = mere < threshold and mare < mare_threshold
+    status = "PASS" if passed else "FAIL"
+    tag = f"[{'PRECISION_PASS' if passed else 'PRECISION_FAIL'}]"
+    print(f"{tag} {label} dtype={dtype_str} MERE={mere:.6e} MARE={mare:.6e} threshold={threshold:.6e} -> {status}")
+    return passed
+
+
+# ========== Input Generation ==========
+def _gen_input(shape, dtype, value_range, seed_offset=0):
+    """Generate input tensor with specified value range."""
+    torch.manual_seed(42 + seed_offset)
+    torch_dtype = _DTYPE_MAP[dtype] if isinstance(dtype, str) else dtype
+    dtype_str = dtype if isinstance(dtype, str) else str(dtype).replace("torch.", "")
+
+    if value_range == "inf":
+        x = torch.randn(shape, dtype=torch.float32).uniform_(-1, 1)
+        x[0, 0] = float("inf")
+        x[1, 0] = float("-inf")
+    elif value_range == "nan":
+        x = torch.randn(shape, dtype=torch.float32).uniform_(-1, 1)
+        x[0, 0] = float("nan")
+    elif value_range == "zero":
+        x = torch.zeros(shape, dtype=torch.float32)
+    else:
+        lo, hi = value_range
+        x = torch.empty(shape, dtype=torch.float32).uniform_(lo, hi)
+
+    return x.to(torch_dtype).npu(), dtype_str
+
+
+def _gen_gamma(D, dtype_str):
+    """Generate gamma (ones, as per cann-bench standard golden)."""
+    torch_dtype = _DTYPE_MAP[dtype_str]
+    return torch.ones(D, dtype=torch_dtype).npu()
+
+
+# ========== Test Runner ==========
+def _run_case(name, shape, dtype, eps, value_range, level="cann-bench"):
+    """Run a single test case: generate input -> kernel -> golden -> check."""
+    dtype_str = dtype if isinstance(dtype, str) else str(dtype).replace("torch.", "")
+    D = shape[-1]
+
+    x, dtype_str = _gen_input(shape, dtype_str, value_range, seed_offset=hash(name) % 1000)
+    gamma = _gen_gamma(D, dtype_str)
+
+    # Kernel
+    y = rms_norm_host(x, gamma, eps)
+
+    # Golden (CPU fp32, cast back to original dtype)
+    ref = golden_rms_norm(x.cpu().float(), gamma.cpu().float(), eps).to(_DTYPE_MAP[dtype_str])
+
+    # Precision check
+    if level in ("l0", "l1"):
+        # Use torch.testing.assert_close for L0/L1
+        atol, rtol = get_precision(dtype_str)
+        max_diff = (y.cpu().float() - ref.float()).abs().max().item()
+        try:
+            torch.testing.assert_close(y.cpu(), ref, atol=atol, rtol=rtol)
+            print(f"[PRECISION_PASS] {level} {name} shape={shape} dtype={dtype_str} max_diff={max_diff:.6e}")
+            return True
+        except Exception as e:
+            print(f"[PRECISION_FAIL] {level} {name} shape={shape} dtype={dtype_str} max_diff={max_diff:.6e}: {e}")
+            return False
+    else:
+        # Use cann-bench MERE/MARE for cann-bench cases
+        return check_precision(y.cpu(), ref, dtype_str, label=f"{level} {name} shape={shape}")
+
+
+def _run_boundary(level, name, fn):
+    """L2/Boundary single case: PASS -> [BOUNDARY_PASS], FAIL -> [BOUNDARY_WARN]."""
+    try:
+        fn()
+        print(f"[BOUNDARY_PASS] {level} {name}")
+    except Exception as e:
+        print(f"[BOUNDARY_WARN] {level} {name}: {e}")
+
+
+# ========== L0 Tests ==========
+def test_rms_norm_l0():
+    """L0 threshold tests: 4 cases covering 3 dtypes + aligned/unaligned shapes."""
+    configs = [
+        ("l0-1", [32, 128, 768], "float16", 1e-6, (-1, 1)),
+        ("l0-2", [32, 128, 1024], "float32", 1e-6, (-2, 2)),
+        ("l0-3", [32, 128, 2048], "bfloat16", 1e-6, (-3, 3)),
+        ("l0-4", [63, 67, 1023], "float16", 1e-6, (-1, 1)),
+    ]
+    ok = True
+    for name, shape, dtype, eps, vrange in configs:
+        ok &= _run_case(name, shape, dtype, eps, vrange, level="l0")
+    return ok
+
+
+# ========== L1 Functional Tests ==========
+def test_rms_norm_l1():
+    """L1 functional tests: dtype x shape x gamma combinations."""
+    configs = [
+        ("l1-1", [128, 256], "float16", 1e-6, (-1, 1)),
+        ("l1-2", [128, 256], "float32", 1e-6, (-2, 2)),
+        ("l1-3", [128, 256], "bfloat16", 1e-6, (-3, 3)),
+        ("l1-4", [256, 512], "float16", 1e-6, (-1, 1)),
+        ("l1-5", [100, 100], "float16", 1e-6, (-1, 1)),
+        ("l1-6", [65, 129], "float16", 1e-6, (-1, 1)),
+        ("l1-7", [4, 32, 128], "float16", 1e-6, (-1, 1)),
+        ("l1-8", [2, 4, 8, 256], "float32", 1e-6, (-2, 2)),
+    ]
+    ok = True
+    for name, shape, dtype, eps, vrange in configs:
+        ok &= _run_case(name, shape, dtype, eps, vrange, level="l1")
+    return ok
+
+
+# ========== L2 Exception Tests ==========
+def test_rms_norm_l2():
+    """L2 exception tests: unsupported dtype, gamma mismatch, large S, D=1."""
+
+    def test_unsupported_dtype():
+        x = torch.ones(64, 128, dtype=torch.int32).npu()
+        gamma = torch.ones(128, dtype=torch.int32).npu()
+        rms_norm_host(x, gamma, 1e-6)
+
+    def test_gamma_mismatch():
+        x = torch.ones(64, 128, dtype=torch.float16).npu()
+        gamma = torch.ones(64, dtype=torch.float16).npu()
+        rms_norm_host(x, gamma, 1e-6)
+
+    def test_large_s():
+        x = torch.randn(100003, 128, dtype=torch.float16).npu()
+        gamma = torch.ones(128, dtype=torch.float16).npu()
+        y = rms_norm_host(x, gamma, 1e-6)
+        ref = golden_rms_norm(x.cpu().float(), gamma.cpu().float(), 1e-6).to(torch.float16)
+        torch.testing.assert_close(y.cpu(), ref, atol=1e-3, rtol=1e-3)
+
+    def test_d_equals_1():
+        x = torch.randn(64, 1, dtype=torch.float16).npu()
+        gamma = torch.ones(1, dtype=torch.float16).npu()
+        y = rms_norm_host(x, gamma, 1e-6)
+        ref = golden_rms_norm(x.cpu().float(), gamma.cpu().float(), 1e-6).to(torch.float16)
+        torch.testing.assert_close(y.cpu(), ref, atol=1e-3, rtol=1e-3)
+
+    _run_boundary("l2", "unsupported_dtype_int32", test_unsupported_dtype)
+    _run_boundary("l2", "gamma_dim_mismatch", test_gamma_mismatch)
+    _run_boundary("l2", "large_s_100003", test_large_s)
+    _run_boundary("l2", "d_equals_1", test_d_equals_1)
+
+
+# ========== Boundary Tests ==========
+def test_rms_norm_boundary():
+    """Boundary tests: INF, NAN, all-zeros, extreme values."""
+
+    def test_inf_input():
+        x = torch.randn(64, 128, dtype=torch.float16).npu()
+        x[0, 0] = float("inf")
+        gamma = torch.ones(128, dtype=torch.float16).npu()
+        y = rms_norm_host(x, gamma, 1e-6)
+        assert torch.isinf(y.cpu()).any() or torch.isnan(y.cpu()).any()
+
+    def test_nan_input():
+        x = torch.randn(64, 128, dtype=torch.float16).npu()
+        x[0, 0] = float("nan")
+        gamma = torch.ones(128, dtype=torch.float16).npu()
+        y = rms_norm_host(x, gamma, 1e-6)
+        assert torch.isnan(y.cpu()).any()
+
+    def test_all_zeros():
+        x = torch.zeros(64, 128, dtype=torch.float16).npu()
+        gamma = torch.ones(128, dtype=torch.float16).npu()
+        y = rms_norm_host(x, gamma, 1e-6)
+        ref = golden_rms_norm(x.cpu().float(), gamma.cpu().float(), 1e-6).to(torch.float16)
+        torch.testing.assert_close(y.cpu(), ref, atol=1e-3, rtol=1e-3)
+
+    def test_extreme_values():
+        x = torch.empty(64, 128, dtype=torch.float32).uniform_(-65504, 65504).to(torch.float16).npu()
+        gamma = torch.ones(128, dtype=torch.float16).npu()
+        y = rms_norm_host(x, gamma, 1e-6)
+        ref = golden_rms_norm(x.cpu().float(), gamma.cpu().float(), 1e-6).to(torch.float16)
+        torch.testing.assert_close(y.cpu(), ref, atol=1e-2, rtol=1e-2)
+
+    _run_boundary("boundary", "inf_input", test_inf_input)
+    _run_boundary("boundary", "nan_input", test_nan_input)
+    _run_boundary("boundary", "all_zeros", test_all_zeros)
+    _run_boundary("boundary", "extreme_values_fp16max", test_extreme_values)
+
+
+# ========== cann-bench 20 Cases ==========
+def test_rms_norm_cann_bench():
+    """cann-bench level2/rms_norm official 20 cases.
+
+    Source: cann-bench/tasks/level2/rms_norm/cases.yaml
+    Precision: MERE < threshold, MARE < 10*threshold (cann-bench standard)
+    """
+    configs = [
+        # (name, shape, dtype, eps, value_range)
+        ("cann-bench-1", [32, 128, 768], "float16", 1e-6, (-1, 1)),
+        ("cann-bench-2", [32, 128, 1024], "float32", 1e-6, (-2, 2)),
+        ("cann-bench-3", [32, 128, 2048], "bfloat16", 1e-6, (-3, 3)),
+        ("cann-bench-4", [16, 256, 4096], "float16", 1e-6, (-10, 10)),
+        ("cann-bench-5", [8, 512, 8192], "float32", 1e-6, (-100, 100)),
+        ("cann-bench-6", [4, 1023, 4097], "bfloat16", 1e-5, (-5, 5)),
+        ("cann-bench-7", [63, 67, 1023], "float16", 1e-8, (-0.1, 0.1)),
+        ("cann-bench-8", [16, 511, 2049], "float32", 1e-4, (-1, 1)),
+        ("cann-bench-9", [8, 1021, 4099], "bfloat16", 1e-12, (-0.5, 0.5)),
+        ("cann-bench-10", [33, 127, 769], "float16", 1e-6, (-1, 2)),
+        ("cann-bench-11", [31, 129, 2049], "float32", 1e-6, (-50, 100)),
+        ("cann-bench-12", [17, 255, 4097], "bfloat16", 1e-6, (-3, 6)),
+        ("cann-bench-13", [7, 1009, 1021], "float16", 1e-7, (-1, 1)),
+        ("cann-bench-14", [11, 367, 373], "float32", 1e-5, (-10, 10)),
+        ("cann-bench-15", [1000003, 2], "bfloat16", 1e-6, "inf"),
+        ("cann-bench-16", [11, 13, 17, 67], "float16", 1e-8, "nan"),
+        ("cann-bench-17", [3, 7, 11, 4096], "float32", 1e-4, "zero"),
+        ("cann-bench-18", [2, 511, 8192], "bfloat16", 1e-6, (-0.2, 0.2)),
+        ("cann-bench-19", [4, 255, 4096], "float16", 1e-3, (-65504, 65504)),
+        ("cann-bench-20", [2, 3, 17, 1024, 128], "float32", 1e-6, (-20, 40)),
+    ]
+    ok = True
+    for name, shape, dtype, eps, vrange in configs:
+        ok &= _run_case(name, shape, dtype, eps, vrange, level="cann-bench")
+    return ok
+
+
+# ========== Main ==========
+def main():
+    parser = argparse.ArgumentParser(description="RMSNorm example with cann-bench 20 cases")
+    parser.add_argument(
+        "--level",
+        default="l0",
+        choices=["l0", "l1", "l2", "boundary", "cann-bench", "all"],
+        help="Test level to run (default: l0)",
+    )
+    args = parser.parse_args()
+
+    tilelang.disable_cache()
+    torch.manual_seed(0)
+
+    blocking_ok = True
+    if args.level in ("l0", "all"):
+        blocking_ok &= test_rms_norm_l0()
+    if args.level in ("l1", "all"):
+        blocking_ok &= test_rms_norm_l1()
+    if args.level in ("l2", "all"):
+        test_rms_norm_l2()
+    if args.level in ("boundary", "all"):
+        test_rms_norm_boundary()
+    if args.level in ("cann-bench", "all"):
+        blocking_ok &= test_rms_norm_cann_bench()
+
+    if blocking_ok:
+        print("Test Passed!")
+        sys.exit(0)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Add rms_norm example — multi-case optimized version with cann-bench 20 cases

Two-pass RMS normalization with dual-kernel strategy (Hybrid simple + Expert pipeline) for arbitrary shape, dtype, and epsilon. Targets cann-bench multi-case evaluation.

### Features

- Supports float16, float32, bfloat16
- Arbitrary input shape (2D to 5D) via host-side flatten to (S, D)
- Non-aligned D handled automatically by T.copy dynamic slicing (no host-side padding)
- fp16/bf16 use float32 compute internally (meets cann-bench MERE/MARE thresholds)
- Newton iteration for rsqrt precision (~1e-3 → ~1e-6, required for fp32 rtol=1e-4)

### Optimizations

- **Dual-kernel strategy**: n_num=1 uses Hybrid (AUTO_SYNC=True), n_num>1 uses Expert (AUTO_SYNC=False + double buffer). Reason: `pass_configs` is a decorator parameter fixed at compile time; n_num=1 has no pipeline space (auto sync is faster), n_num>1 benefits from MTE2/V/MTE3 overlap.
- **Adaptive tiling** via UB budget formula (block_M candidates: 1024→16, block_N from D divisors)
- **Single-pass scan**: n_num=1 reuses Pass 1's a_ub in Pass 2 (skips redundant GM read)
- **output_ub separation**: fp16/bf16 cast-back to dedicated buffer, keeping a_ub MTE2-write-only (enables double buffer)
- **Pass 2 Double Buffer**: three-way flag pipeline (mte3→mte2, mte2→v, v→mte3) for n_num>1
- **rsqrt Newton iteration**: `y1 = y0 * (1.5 - 0.5 * x * y0²)` improves precision from ~1e-3 to ~1e-6
- **gamma broadcast**: `T.tile.broadcast + T.tile.mul` (not T.Parallel assignment)

### About AUTO_SYNC=False (Pass 2 Double Buffer)

Pass 2 uses `AUTO_SYNC=False` with manual `set_flag`/`wait_flag` for MTE2→V and V→MTE3 dependencies. The three-stage pipeline works as follows:

1. **Prefetch**: Load tile 0 into stage 0 buffer → `set_flag("mte2", "v", 0)`
2. **Main loop** (per tile):
   - Prefetch next tile into `nxt` stage → `set_flag("mte2", "v", nxt)`
   - Consume current `cur` stage: cast → mul(inv_rms) → gamma → cast_back → `set_flag("v", "mte3", cur)`
   - Store current: `wait_flag("v", "mte3", cur)` → copy to GM → `set_flag("mte3", "mte2", cur)` (release buffer)
3. **Epilogue**: Consume and store last prefetched tile

Flag chain: `mte3→mte2` (buffer released) → `mte2→v` (input ready) → `v→mte3` (output ready)

Pass 1 (which has cross-iteration accumulator `sum_sq_acc`) uses `T.barrier_all()` — Pass 1 double buffer is **not feasible** because:
- Pass 1 has no MTE3 writeback (only accumulates to UB)
- `v→mte2` flag is unavailable on AIV Vector hardware (causes deadlock)
- Without MTE3, the three-way flag chain cannot form a closed loop (`MTE2→V→MTE3→MTE2`)

### Relationship with existing `examples/normalization/rms_norm.py`

| File | Lines | Description |
|------|-------|-------------|
| `examples/normalization/rms_norm.py` | 330 | Original Expert-mode demo (no gamma, fixed tiling) |
| `examples/cann-bench/rms_norm/example_rms_norm.py` | ~570 | This PR — multi-case optimized version with gamma, cann-bench 20 cases, dual-kernel strategy |

The original `examples/normalization/rms_norm.py` is **not modified or overwritten**.

### Backend: AscendC (not PTO)

This PR uses the **AscendC backend** (`target="auto"`). The PTO backend (`target="pto"`) was tested locally but encountered a **compilation segfault** in the PTO codegen path (`tilelang_ascend_pto`).

### Performance Anti-pattern Self-check

| Anti-pattern | Status | Note |
|---|---|---|
| launch core count too high (A) | Tested, not adopted | Fixed Core tested on case 15 (D=2, S=1000003), 42% slower than hardware scheduler |
| Vector per-row for loop | Not present | All operations use tile-level broadcast + vectorized instructions |
| Redundant global sync | Minimized | Pass 2 uses flag sync; Pass 1 uses barrier_all (unavoidable, no MTE3 in Pass 1) |
| Unfused instructions | Tested, reverted | `mul_add_dst` tested but slower than `mul+add` on 910B3/910C — reverted |
| Tile size too small | Optimized | UB budget formula dynamically computes max block_N (up to 2048) |
| AIC/AIV CV overlap | N/A | Pure AIV operator |
| AIV memory bound without pipeline | Optimized | Pass 2 Double Buffer with three-stage pipeline |
| UB→UB copy for gamma preload | Tested, ineffective | `T.copy(UB→UB)` uses MTE2 engine, doubles MTE2 bandwidth — reverted |
| UB buffer naming `tmp_ub` | Avoided | Uses `newton_ub` (AscendMemoryPlanning internal buffer conflicts with `tmp_ub`) |

### Operator Evaluation Report

**Local cann-bench (Ascend910B3, CANN 9.1.0)**:

| Metric | Value |
|--------|-------|
| pass_cases | 20/20 (100%) |
| avg_speedup | 0.67x |
| compilation_score | 20.00 / 20 |
| function_score | 30.00 / 30 |
| performance_score | 18.27 / 50 |
| total_score | 68.27 / 100 |

**Per-case speedup (local, Ascend910B3)**:

| Case | Shape | dtype | eps | speedup | n_num | kernel |
|------|-------|-------|-----|---------|-------|--------|
| 1 | [32,128,768] | fp16 | 1e-6 | 0.65x | 1 | simple |
| 2 | [32,128,1024] | fp32 | 1e-6 | 0.84x | 1 | simple |
| 3 | [32,128,2048] | bf16 | 1e-6 | 1.04x | 2 | pipeline |
| 4 | [16,256,4096] | fp16 | 1e-6 | 0.74x | 1 | simple |
| 5 | [8,512,8192] | fp32 | 1e-6 | 0.69x | 8 | pipeline |
| 6 | [4,1023,4097] | bf16 | 1e-5 | 0.56x | 5 | pipeline |
| 7 | [63,67,1023] | fp16 | 1e-8 | 0.41x | 1 | simple |
| 8 | [16,511,2049] | fp32 | 1e-4 | 0.66x | 3 | pipeline |
| 9 | [8,1021,4099] | bf16 | 1e-12 | 0.55x | 5 | pipeline |
| 10 | [33,127,769] | fp16 | 1e-6 | 0.66x | 1 | simple |
| 11 | [31,129,2049] | fp32 | 1e-6 | 0.67x | 3 | pipeline |
| 12 | [17,255,4097] | bf16 | 1e-6 | 0.55x | 5 | pipeline |
| 13 | [7,1009,1021] | fp16 | 1e-7 | 0.33x | 1 | simple |
| 14 | [11,367,373] | fp32 | 1e-5 | 0.73x | 1 | simple |
| 15 | [1000003,2] | bf16 | 1e-6 | 0.01x | 1 | simple |
| 16 | [11,13,17,67] | fp16 | 1e-8 | 1.25x | 1 | simple |
| 17 | [3,7,11,4096] | fp32 | 1e-4 | 1.07x | 1 | simple |
| 18 | [2,511,8192] | bf16 | 1e-6 | 0.48x | 8 | pipeline |
| 19 | [4,255,4096] | fp16 | 1e-3 | 0.74x | 1 | simple |
| 20 | [2,3,17,1024,128] | fp32 | 1e-6 | 0.61x | 1 | simple |

Profiling:

<img width="1148" height="474" alt="Screenshot 2026-08-06 at 4 34 46 PM" src="https://github.com/user-attachments/assets/1b350aa1-0b7f-4fa2-b21a-907b930d2974" />


### Known limitations

- **Case 15** `[1000003,2] bf16` (speedup 0.01x): D=2 is extremely small, DMA 32B alignment wastes 87.5%. Fixed Core was tested but 42% slower than hardware block scheduler. Left as future work.
- **Pass 1 double buffer**: Not feasible — Pass 1 has no MTE3 writeback, `v→mte2` flag unavailable on AIV Vector hardware. Pass 1 uses `barrier_all()` (acceptable, ~45% of total time).
- **T.Pipelined**: Not usable — does not auto-double-buffer MTE2-written buffers, causes data corruption.
- **mul_add_dst**: Tested but slower than `mul+add` on 910B3/910C — reverted.
- **gamma preload (UB→UB)**: `T.copy(UB→UB)` uses MTE2 engine, doubles MTE2 bandwidth — ineffective, reverted.
- **PTO backend**: Not supported (compilation segfault in codegen). Uses AscendC backend.
