### PR TITLE
refine T.tile.sort docstring, add test cases and API documentation

### DIFF
--- a/docs/api_docs/T.tile.select.md
+++ b/docs/api_docs/T.tile.select.md
@@ -1,0 +1,107 @@
+# T.tile.select
+
+## 1. Description
+
+Selects elements from `src0` or `src1` based on `selMask` bit values and writes the result to `dst`: `dst[i] = selMask.bit[i] ? src0[i] : src1[i]`
+
+## 2. Function Prototype
+
+### 2.1 Function Definition
+
+```python
+def select(
+    dst: Buffer | BufferRegion,
+    selMask: Buffer,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferLoad | PrimExpr,
+    selMode: str,
+)
+```
+
+### 2.2 Parameters
+
+| Parameter | Input/Output | Description | Type | Required/Optional |
+|-----------|-------------|-------------|------|-------------------|
+| dst | Output | Stores the selection result | tensor | Required |
+| selMask | Input | Selection mask; each bit controls the source of one element (bit=1 selects from src0, bit=0 selects from src1) | tensor (bit-packed, dtype uint8) | Required |
+| src0 | Input | Source selected when bit=1 | tensor | Required |
+| src1 | Input | Source selected when bit=0; supports tensor or scalar | tensor / scalar | Required |
+| selMode | Input | Selection mode; determines how selMask is interpreted and the type of src1 | string, see [2.3.3 selMode](#233-selmode) | Required |
+
+> **Type Notes**:
+> - **tensor**: A buffer (Buffer) allocated via `T.alloc_ub`, `T.alloc_shared`, etc., or its slice (BufferRegion)
+> - **scalar**: A Python scalar or expression (PrimExpr), e.g. `1.0`, `0.0`
+
+### 2.3 Specifications
+
+#### 2.3.1 DataType Support
+
+| Platform | dst | src0 | src1 | selMask |
+|----------|:---:|:----:|:----:|:-------:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 | float16, float32 | uint8 |
+
+- When src1 is a scalar, its dtype must match src0
+- All three selMode values support the same set of dtypes
+
+#### 2.3.2 Shape Support
+
+- Supports 1D and 2D
+- Higher-dimensional buffers must be passed as 1D/2D BufferRegion via slicing
+
+#### 2.3.3 selMode
+
+selMode determines how selMask is interpreted. There are 3 modes:
+
+| selMode | Description | Use Case |
+|---------|-------------|----------|
+| `"VSEL_CMPMASK_SPR"` | bit-packed mask, reused across iterations | Used with `T.tile.compare` results; mask comes from comparison output |
+| `"VSEL_TENSOR_SCALAR_MODE"` | mask stored contiguously, consumed across iterations; src1 is a scalar | src0 is a tensor, src1 is a constant value |
+| `"VSEL_TENSOR_TENSOR_MODE"` | mask stored contiguously, consumed across iterations; src1 is a tensor | Both src0 and src1 are tensors |
+
+**src1 type and selMode correspondence**:
+- src1 is `PrimExpr` / `float` (scalar) → must use `"VSEL_TENSOR_SCALAR_MODE"`
+- src1 is `Buffer` / `BufferRegion` (tensor) → must use `"VSEL_CMPMASK_SPR"` or `"VSEL_TENSOR_TENSOR_MODE"`
+- src1 as `BufferLoad` (single element access) is currently not supported
+
+### 2.4 Constraints
+
+1. dst and src0 must have the same shape
+2. When src1 is a tensor, its shape must match src0
+3. selMask is a bit-packed mask; dtype must be uint8, element count = data element count / 8
+4. Operand addresses must be 32-byte aligned (hardware constraint)
+5. src1 supports only tensor (Buffer/BufferRegion) or scalar (PrimExpr/float); BufferLoad (single element access) is currently not supported
+6. `"VSEL_CMPMASK_SPR"` mode reuses the compare mask register; the maximum element count per call is `256 / sizeof(T)` (128 for float16, 64 for float32). Exceeding this causes precision errors (hardware constraint)
+7. `"VSEL_TENSOR_SCALAR_MODE"` and `"VSEL_TENSOR_TENSOR_MODE"` modes require reserving the last 8KB of Unified Buffer as temporary space (hardware constraint)
+
+## 3. Examples
+
+**Example 1: tensor-tensor mode (selMode = "VSEL_TENSOR_TENSOR_MODE")**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+src1 = T.alloc_ub((256,), "float16")
+mask = T.alloc_ub((32,),  "uint8")   # 256 elements / 8 bits/byte = 32 bytes
+dst  = T.alloc_ub((256,), "float16")
+T.tile.select(dst, mask, src0, src1, "VSEL_TENSOR_TENSOR_MODE")
+```
+
+**Example 2: tensor-scalar mode (selMode = "VSEL_TENSOR_SCALAR_MODE")**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+mask = T.alloc_ub((32,),  "uint8")
+dst  = T.alloc_ub((256,), "float16")
+T.tile.select(dst, mask, src0, 0.0, "VSEL_TENSOR_SCALAR_MODE")  # src1 = 0.0
+```
+
+**Example 3: Used with T.tile.compare (selMode = "VSEL_CMPMASK_SPR")**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+src1 = T.alloc_ub((256,), "float16")
+cmp_mask = T.alloc_ub((32,), "uint8")  # bit-packed result from T.tile.compare
+dst = T.alloc_ub((256,), "float16")
+
+T.tile.compare(cmp_mask, src0, src1, "GT")                       # bit=1 where src0 > src1
+T.tile.select(dst, cmp_mask, src0, src1, "VSEL_CMPMASK_SPR")     # select the larger value -> equivalent to max(src0, src1)
+```

--- a/docs/api_docs/T.tile.sort.md
+++ b/docs/api_docs/T.tile.sort.md
@@ -1,0 +1,105 @@
+# T.tile.sort
+
+## 1. Description
+
+Performs a full sort on the input data and outputs the results in descending order as interleaved (value, index) pairs: `dst = [val0, idx0, val1, idx1, ...]`, where `idx` is the 0-based position in the aligned buffer before sorting (including -inf padding positions). Internally, each 32-element block is sorted via sort32, then all sorted blocks are merged via merge_sort.
+
+## 2. Function Prototype
+
+### 2.1 Function Definition
+
+```python
+def sort(
+    dst: Buffer,
+    src: Buffer,
+    actual_num: PrimExpr,
+)
+```
+
+### 2.2 Parameters
+
+| Parameter | Direction | Description | Type | Required/Optional |
+|-----------|-----------|-------------|------|-------------------|
+| dst | Output | Stores the sort result as interleaved (value, index) pairs. Must have at least `2 × aligned_count` elements (`aligned_count = ((actual_num + 31) // 32) × 32`) | tensor | Required |
+| src | Input/Output | Source data to be sorted. For float32, the positions from `actual_num` to `aligned_count` are padded with -inf in-place; for float16, `src` is not modified (it is internally cast to float32 and padded in a temporary buffer) | tensor | Required |
+| actual_num | Input | Number of valid elements in `src`. When less than `aligned_count`, the remaining positions are automatically padded with -inf before sorting | integer expression (PrimExpr) | Required |
+
+> **Type notes**:
+> - **tensor**: A buffer allocated via `T.alloc_ub`, `T.alloc_shared`, etc. This API does not accept BufferRegion slices.
+
+### 2.3 Parameter Specifications
+
+#### 2.3.1 DataType Support
+
+| Platform | dst | src |
+|----------|:---:|:---:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 |
+
+#### 2.3.2 Shape Support
+
+- Supports 1D and 2D
+- A 2D buffer is **flattened into a single 1D array** in row-major order and sorted as a whole; it is **not** sorted row by row
+- This API only accepts Buffer type. Higher-dimensional buffers must first be copied into a 1D/2D Buffer via `T.copy` before being passed in
+
+#### 2.3.3 actual_num Description
+
+| Value | Meaning | Use Case |
+|-------|---------|----------|
+| Equal to aligned_count | All elements participate in sorting, no padding needed | Data exactly fills a 32-aligned buffer |
+| Less than aligned_count | Only the first actual_num elements are valid; the remaining positions are automatically padded with -inf and participate in sorting | Valid data is smaller than one 32-aligned block |
+
+> `aligned_count = ((actual_num + 31) // 32) × 32`, i.e., actual_num rounded up to a multiple of 32.
+
+#### 2.3.4 Output Data Format
+
+dst stores interleaved (value, index) pairs, where both value and index use the dtype of dst, laid out as follows:
+
+| dst dtype | Storage Layout | Bytes per Pair |
+|-----------|----------------|:--------------:|
+| float32 | `[value(float32), index(float32)]`. The bit pattern of index is identical to uint32 (stored as uint32 internally, read as float in the output) | 8 Bytes |
+| float16 | `[value(float16), index(float16)]`. Sorted internally as float32, then rounded back to float16 via CAST_RINT | 4 Bytes |
+
+> The float16 index is an internally generated 0-based sequence (0.0, 1.0, 2.0, ...), sorted as float32 and then cast back to float16. Index values beyond 2048 may lose exactness due to half-precision rounding.
+
+### 2.4 Constraints
+
+1. dst and src must have the same dtype
+2. `aligned_count = ((actual_num + 31) // 32) × 32`; dst must have at least `2 × aligned_count` elements (for storing value-index interleaved pairs)
+3. src must have at least `aligned_count` elements
+4. actual_num must satisfy `1 ≤ actual_num ≤ min(src buffer size, 8160)` (actual_num=0 triggers a hardware exception; when actual_num exceeds the buffer size, the hardware does not report an error but the result is unpredictable)
+5. `repeatTimes = (actual_num + 31) // 32`, repeatTimes ∈ [1, 255], i.e., the upper limit of actual_num is 255 × 32 = 8160 (hardware constraint; repeatTimes=0 triggers an aicore exception)
+6. Large actual_num is limited by UB capacity: dst requires `2 × aligned_count` elements, src requires `aligned_count` elements, and the internal temporary buffer is of the same order of magnitude; the sum of all three must not exceed UB capacity (the practically usable actual_num is far smaller than 8160)
+7. Whether src is modified in-place depends on the dtype: for float32, positions from `actual_num` to `aligned_count` are padded with -inf, so src is modified; for float16, src is not modified (it is internally cast to float32 and operated on in a temporary buffer). For float32, copy src beforehand if you need to preserve the original data
+8. src and dst addresses must not overlap (dst is written to, and the internal merge process ping-pongs between dst and tmp; src is read/modified for float32)
+9. The sort direction is fixed to descending order
+10. All buffer addresses must be 32-byte aligned (hardware constraint)
+
+## 3. Example Code
+
+**Example 1: 1D sort (actual_num equals buffer size)**
+
+```python
+src = T.alloc_ub((256,), "float16")
+dst = T.alloc_ub((512,), "float16")
+T.tile.sort(dst, src, 256)
+```
+
+**Example 2: 1D sort (actual_num smaller than buffer size)**
+
+```python
+ub_N = ((131 + 31) // 32) * 32  # 160
+src = T.alloc_ub((ub_N,), "float16")
+dst = T.alloc_ub((ub_N * 2,), "float16")
+T.tile.sort(dst, src, 131)
+```
+
+**Example 3: 2D sort (flattened and sorted as a whole)**
+
+```python
+M = 4
+per_row_N = 128
+ub_N = per_row_N  # 128 is already a multiple of 32
+src = T.alloc_ub((M, ub_N), "float16")    # 512 elements in total
+dst = T.alloc_ub((M, ub_N * 2), "float16") # 1024 elements in total
+T.tile.sort(dst, src, M * per_row_N)       # actual_num = 512, flattened single sort
+```

--- a/testing/python/language/test_tilelang_ascend_language_select.py
+++ b/testing/python/language/test_tilelang_ascend_language_select.py
@@ -4,18 +4,31 @@ import tilelang.language as T
 import torch
 import argparse
 
+TORCH_DTYPE = {"float16": torch.float16, "float32": torch.float32}
+RTOL = {"float16": 1e-3, "float32": 1e-4}
+ATOL = {"float16": 1e-3, "float32": 1e-4}
+CMPMASK_SPR_MAX = {"float16": 128, "float32": 64}
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
 
 def bit_pack_mask_cpu(mask_bool: torch.Tensor) -> torch.Tensor:
-    """Pack Bool mask into uint8 on CPU (8 bits per byte)"""
-    M, N = mask_bool.shape
-    mask_reshaped = mask_bool.view(M, N // 8, 8)
-    mask_packed = torch.zeros((M, N // 8), dtype=torch.uint8)
+    """Pack Bool mask into uint8 on CPU (8 bits per byte, bit i controls element i)"""
+    last = mask_bool.shape[-1]
+    leading = mask_bool.shape[:-1]
+    reshaped = mask_bool.reshape(-1, last // 8, 8)
+    packed = torch.zeros(reshaped.shape[:2], dtype=torch.uint8)
     for i in range(8):
-        bit_val = mask_reshaped[..., i].to(torch.uint8)
-        mask_packed |= bit_val << i
-    return mask_packed
+        packed |= reshaped[:, :, i].to(torch.uint8) << i
+    return packed.reshape(*leading, last // 8)
 
 
+# -----------------------------------------------------------------------------
+# 2D Kernels
+# -----------------------------------------------------------------------------
 def select_kernel_mod1(M, N, block_M, block_N, dtype="float16"):
     m_num, n_num = M // block_M, N // block_N
     mask_width = N // 8
@@ -42,20 +55,15 @@ def select_kernel_mod1(M, N, block_M, block_N, dtype="float16"):
             offset_n = by * block_N
             offset_mask_n = offset_n // 8
 
-            with T.Scope("V"):
-                # 1. Copy data from GM to UB
-                T.copy(A[offset_m : offset_m + sub_block_m, offset_n : offset_n + block_N], a_ub)
-                T.copy(Mask[offset_m : offset_m + sub_block_m, offset_mask_n : offset_mask_n + block_mask_width], mask_ub)
+            # 1. Copy data from GM to UB
+            T.copy(A[offset_m : offset_m + sub_block_m, offset_n : offset_n + block_N], a_ub)
+            T.copy(Mask[offset_m : offset_m + sub_block_m, offset_mask_n : offset_mask_n + block_mask_width], mask_ub)
 
-                T.barrier_all()
+            # 2. Execute Select instruction: select src0(A) or scalar src1 based on bits
+            T.tile.select(c_ub, mask_ub, a_ub, 1.0, "VSEL_TENSOR_SCALAR_MODE")
 
-                # 2. Execute Select instruction: select src0(A) or src1(B) based on bits
-                T.tile.select(c_ub, mask_ub, a_ub, 1.0, "VSEL_TENSOR_SCALAR_MODE")
-
-                T.barrier_all()
-
-                # 3. Copy results back to GM
-                T.copy(c_ub, C[offset_m : offset_m + sub_block_m, offset_n : offset_n + block_N])
+            # 3. Copy results back to GM
+            T.copy(c_ub, C[offset_m : offset_m + sub_block_m, offset_n : offset_n + block_N])
 
     return main
 
@@ -88,37 +96,119 @@ def select_kernel_mod2(M, N, block_M, block_N, dtype="float16"):
             offset_n = by * block_N
             offset_mask_n = offset_n // 8
 
-            with T.Scope("V"):
-                # 1. Copy data from GM to UB
-                T.copy(A[offset_m : offset_m + sub_block_m, offset_n : offset_n + block_N], a_ub)
-                T.copy(B[offset_m : offset_m + sub_block_m, offset_n : offset_n + block_N], b_ub)
-                T.copy(Mask[offset_m : offset_m + sub_block_m, offset_mask_n : offset_mask_n + block_mask_width], mask_ub)
+            # 1. Copy data from GM to UB
+            T.copy(A[offset_m : offset_m + sub_block_m, offset_n : offset_n + block_N], a_ub)
+            T.copy(B[offset_m : offset_m + sub_block_m, offset_n : offset_n + block_N], b_ub)
+            T.copy(Mask[offset_m : offset_m + sub_block_m, offset_mask_n : offset_mask_n + block_mask_width], mask_ub)
 
-                T.barrier_all()
+            # 2. Execute Select instruction: select src0(A) or src1(B) based on bits
+            T.tile.select(c_ub, mask_ub, a_ub, b_ub, "VSEL_TENSOR_TENSOR_MODE")
 
-                # 2. Execute Select instruction: select src0(A) or src1(B) based on bits
-                T.tile.select(c_ub, mask_ub, a_ub, b_ub, "VSEL_TENSOR_TENSOR_MODE")
-
-                T.barrier_all()
-
-                # 3. Copy results back to GM
-                T.copy(c_ub, C[offset_m : offset_m + sub_block_m, offset_n : offset_n + block_N])
+            # 3. Copy results back to GM
+            T.copy(c_ub, C[offset_m : offset_m + sub_block_m, offset_n : offset_n + block_N])
 
     return main
 
 
-def run_test_mod1(M, N, block_M, block_N, target):
+# -----------------------------------------------------------------------------
+# 1D Kernels
+# -----------------------------------------------------------------------------
+def select_kernel_1d_scalar(N, dtype="float16"):
+    mask_width = N // 8
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),  # type: ignore
+        Mask: T.Tensor((mask_width,), "uint8"),  # type: ignore
+        C: T.Tensor((N,), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((N,), dtype)
+            c_ub = T.alloc_ub((N,), dtype)
+            mask_ub = T.alloc_ub((mask_width,), "uint8")
+
+            T.copy(A, a_ub)
+            T.copy(Mask, mask_ub)
+
+            T.tile.select(c_ub, mask_ub, a_ub, 1.0, "VSEL_TENSOR_SCALAR_MODE")
+
+            T.copy(c_ub, C)
+
+    return main
+
+
+def select_kernel_1d_tensor(N, dtype="float16"):
+    mask_width = N // 8
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),  # type: ignore
+        B: T.Tensor((N,), dtype),  # type: ignore
+        Mask: T.Tensor((mask_width,), "uint8"),  # type: ignore
+        C: T.Tensor((N,), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((N,), dtype)
+            b_ub = T.alloc_ub((N,), dtype)
+            c_ub = T.alloc_ub((N,), dtype)
+            mask_ub = T.alloc_ub((mask_width,), "uint8")
+
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            T.copy(Mask, mask_ub)
+
+            T.tile.select(c_ub, mask_ub, a_ub, b_ub, "VSEL_TENSOR_TENSOR_MODE")
+
+            T.copy(c_ub, C)
+
+    return main
+
+
+# -----------------------------------------------------------------------------
+# CMPMASK Kernel (VSEL_CMPMASK_SPR + T.tile.compare)
+# -----------------------------------------------------------------------------
+def select_kernel_mod3(N, dtype="float16"):
+    mask_width = N // 8
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),  # type: ignore
+        B: T.Tensor((N,), dtype),  # type: ignore
+        C: T.Tensor((N,), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((N,), dtype)
+            b_ub = T.alloc_ub((N,), dtype)
+            c_ub = T.alloc_ub((N,), dtype)
+            cmp_ub = T.alloc_ub((mask_width,), "uint8")
+
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+
+            T.tile.compare(cmp_ub, a_ub, b_ub, "GT")
+            T.tile.select(c_ub, cmp_ub, a_ub, b_ub, "VSEL_CMPMASK_SPR")
+
+            T.copy(c_ub, C)
+
+    return main
+
+
+# -----------------------------------------------------------------------------
+# Run functions
+# -----------------------------------------------------------------------------
+def run_test_mod1(M, N, block_M, block_N, dtype, target):
     device = "npu"
     torch.manual_seed(0)
     tilelang.cache.clear_cache()
 
     # 1. Compile the operator
-    func_def = select_kernel_mod1(M, N, block_M, block_N, dtype="float16")
-    func = tilelang.compile(func_def, out_idx=[-1], target=target)
+    func_def = select_kernel_mod1(M, N, block_M, block_N, dtype=dtype)
+    func = tilelang.compile(func_def, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
 
     # 2. Prepare data
-    a = torch.randn(M, N).to(device).half()
-    b = torch.ones(M, N).to(device).half()
+    tdtype = TORCH_DTYPE[dtype]
+    a = torch.randn(M, N).to(device).to(tdtype)
+    b = torch.ones(M, N).to(device).to(tdtype)
 
     # Generate and pack Mask on CPU to avoid NPU bitwise operation limitations
     raw_mask_bool_cpu = torch.randint(0, 2, (M, N)).bool()
@@ -130,22 +220,23 @@ def run_test_mod1(M, N, block_M, block_N, target):
 
     # 4. Verify accuracy
     ref_c = torch.where(raw_mask_bool_cpu.to(device), a, b)
-    torch.testing.assert_close(c, ref_c, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(c, ref_c, rtol=RTOL[dtype], atol=ATOL[dtype])
     print("Test Passed")
 
 
-def run_test_mod2(M, N, block_M, block_N, target):
+def run_test_mod2(M, N, block_M, block_N, dtype, target):
     device = "npu"
     torch.manual_seed(0)
     tilelang.cache.clear_cache()
 
     # 1. Compile the operator
-    func_def = select_kernel_mod2(M, N, block_M, block_N, dtype="float16")
-    func = tilelang.compile(func_def, out_idx=[-1], target=target)
+    func_def = select_kernel_mod2(M, N, block_M, block_N, dtype=dtype)
+    func = tilelang.compile(func_def, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
 
     # 2. Prepare data
-    a = torch.randn(M, N).to(device).half()
-    b = torch.randn(M, N).to(device).half()
+    tdtype = TORCH_DTYPE[dtype]
+    a = torch.randn(M, N).to(device).to(tdtype)
+    b = torch.randn(M, N).to(device).to(tdtype)
 
     # Generate and pack Mask on CPU to avoid NPU bitwise operation limitations
     raw_mask_bool_cpu = torch.randint(0, 2, (M, N)).bool()
@@ -157,31 +248,147 @@ def run_test_mod2(M, N, block_M, block_N, target):
 
     # 4. Verify accuracy
     ref_c = torch.where(raw_mask_bool_cpu.to(device), a, b)
-    torch.testing.assert_close(c, ref_c, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(c, ref_c, rtol=RTOL[dtype], atol=ATOL[dtype])
+    print("Test Passed")
+
+
+def run_test_1d_scalar(N, dtype, target):
+    device = "npu"
+    torch.manual_seed(0)
+    tilelang.cache.clear_cache()
+
+    # 1. Compile the operator
+    func_def = select_kernel_1d_scalar(N, dtype=dtype)
+    func = tilelang.compile(func_def, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+
+    # 2. Prepare data
+    tdtype = TORCH_DTYPE[dtype]
+    a = torch.randn(N).to(device).to(tdtype)
+    b = torch.ones(N, dtype=tdtype, device=device)
+
+    # Generate and pack Mask on CPU to avoid NPU bitwise operation limitations
+    raw_mask_bool_cpu = torch.randint(0, 2, (N,)).bool()
+    mask_packed = bit_pack_mask_cpu(raw_mask_bool_cpu).to(device)
+
+    # 3. Run the operator
+    torch.npu.synchronize()
+    c = func(a, mask_packed)
+
+    # 4. Verify accuracy
+    ref_c = torch.where(raw_mask_bool_cpu.to(device), a, b)
+    torch.testing.assert_close(c, ref_c, rtol=RTOL[dtype], atol=ATOL[dtype])
+    print("Test Passed")
+
+
+def run_test_1d_tensor(N, dtype, target):
+    device = "npu"
+    torch.manual_seed(0)
+    tilelang.cache.clear_cache()
+
+    # 1. Compile the operator
+    func_def = select_kernel_1d_tensor(N, dtype=dtype)
+    func = tilelang.compile(func_def, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+
+    # 2. Prepare data
+    tdtype = TORCH_DTYPE[dtype]
+    a = torch.randn(N).to(device).to(tdtype)
+    b = torch.randn(N).to(device).to(tdtype)
+
+    # Generate and pack Mask on CPU to avoid NPU bitwise operation limitations
+    raw_mask_bool_cpu = torch.randint(0, 2, (N,)).bool()
+    mask_packed = bit_pack_mask_cpu(raw_mask_bool_cpu).to(device)
+
+    # 3. Run the operator
+    torch.npu.synchronize()
+    c = func(a, b, mask_packed)
+
+    # 4. Verify accuracy
+    ref_c = torch.where(raw_mask_bool_cpu.to(device), a, b)
+    torch.testing.assert_close(c, ref_c, rtol=RTOL[dtype], atol=ATOL[dtype])
+    print("Test Passed")
+
+
+def run_test_mod3(dtype, target):
+    device = "npu"
+    torch.manual_seed(0)
+    tilelang.cache.clear_cache()
+
+    # 1. Compile the operator
+    N = CMPMASK_SPR_MAX[dtype]
+    func_def = select_kernel_mod3(N, dtype=dtype)
+    func = tilelang.compile(func_def, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+
+    # 2. Prepare data
+    tdtype = TORCH_DTYPE[dtype]
+    a = torch.randn(N).to(device).to(tdtype)
+    b = torch.randn(N).to(device).to(tdtype)
+
+    # 3. Run the operator
+    torch.npu.synchronize()
+    c = func(a, b)
+
+    # 4. Verify accuracy (select larger element via compare GT + VSEL_CMPMASK_SPR)
+    ref_c = torch.where(a > b, a, b)
+    torch.testing.assert_close(c, ref_c, rtol=RTOL[dtype], atol=ATOL[dtype])
     print("Test Passed")
 
 
 # -----------------------------------------------------------------------------
 # Pytest entry point
 # -----------------------------------------------------------------------------
-@pytest.mark.parametrize("target", ["ascendc", "pto"])
-@pytest.mark.parametrize("shape", [(1024, 1024), (512, 256)])
-def test_select_tensor_op(target, shape):
-    M, N = shape
-    # Alignment check for N dimension
-    if N % 8 != 0:
-        pytest.skip("N must be multiple of 8")
-    run_test_mod2(M, N, 128, 256, target=target)
+BLOCK_M = {"float16": 128, "float32": 32}
+BLOCK_N = {"float16": 256, "float32": 256}
 
 
-@pytest.mark.parametrize("target", ["ascendc", "pto"])
-@pytest.mark.parametrize("shape", [(1024, 1024), (512, 256)])
-def test_select_scalar_op(target, shape):
-    M, N = shape
-    # Alignment check for N dimension
-    if N % 8 != 0:
-        pytest.skip("N must be multiple of 8")
-    run_test_mod1(M, N, 128, 256, target=target)
+@pytest.mark.parametrize("dtype", ["float16", "float32"])
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+@pytest.mark.parametrize("shape", [(1024, 1024), (512, 256), (256,)])
+def test_select_tensor_op(dtype, target, shape):
+    if len(shape) == 1:
+        N = shape[0]
+        if N % 8 != 0:
+            pytest.skip("N must be multiple of 8")
+        run_test_1d_tensor(N, dtype, target)
+    else:
+        M, N = shape
+        if N % 8 != 0:
+            pytest.skip("N must be multiple of 8")
+        run_test_mod2(M, N, BLOCK_M[dtype], BLOCK_N[dtype], dtype, target)
+
+
+@pytest.mark.parametrize("dtype", ["float16", "float32"])
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+@pytest.mark.parametrize("shape", [(1024, 1024), (512, 256), (256,)])
+def test_select_scalar_op(dtype, target, shape):
+    if len(shape) == 1:
+        N = shape[0]
+        if N % 8 != 0:
+            pytest.skip("N must be multiple of 8")
+        run_test_1d_scalar(N, dtype, target)
+    else:
+        M, N = shape
+        if N % 8 != 0:
+            pytest.skip("N must be multiple of 8")
+        run_test_mod1(M, N, BLOCK_M[dtype], BLOCK_N[dtype], dtype, target)
+
+
+@pytest.mark.low_priority
+@pytest.mark.parametrize("dtype", ["float16", "float32"])
+@pytest.mark.parametrize(
+    "target",
+    [
+        "ascendc",
+        pytest.param("pto", marks=pytest.mark.ci_skip),
+    ],
+)
+def test_select_cmpmask_op(dtype, target):
+    run_test_mod3(dtype, target)
 
 
 # -----------------------------------------------------------------------------
@@ -191,10 +398,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--m", type=int, default=1024)
     parser.add_argument("--n", type=int, default=1024)
+    parser.add_argument("--dtype", type=str, choices=["float16", "float32"], default="float16")
     parser.add_argument("--target", type=str, choices=["ascendc", "pto"], default="ascendc")
     args = parser.parse_args()
 
     # Align N to a multiple of 8
     final_n = args.n if args.n % 8 == 0 else (args.n // 8 + 1) * 8
-    run_test_mod1(args.m, final_n, 128, 256, target=args.target)
-    run_test_mod2(args.m, final_n, 128, 256, target=args.target)
+    run_test_mod1(args.m, final_n, BLOCK_M[args.dtype], BLOCK_N[args.dtype], dtype=args.dtype, target=args.target)
+    run_test_mod2(args.m, final_n, BLOCK_M[args.dtype], BLOCK_N[args.dtype], dtype=args.dtype, target=args.target)
+    run_test_mod3(args.dtype, args.target)

--- a/testing/python/language/test_tilelang_ascend_language_sort.py
+++ b/testing/python/language/test_tilelang_ascend_language_sort.py
@@ -1,0 +1,532 @@
+import argparse
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+
+"""
+Test suite for T.tile.sort API.
+
+Covers:
+  - Basic functionality: dtype (float16/float32) × actual_num (aligned/non-aligned)
+  - 2D buffer support
+  - Boundary cases: actual_num=1 (min), actual_num=4096 (large, repeatTimes=128;
+    8160 max repeatTimes=255 exceeds practical UB capacity and segfaults)
+  - src in-place modification verification
+  - float16 index precision loss for actual_num > 2048 (known limitation)
+  - Output format: interleaved (value, index) pairs, both of dst dtype
+
+Reference: docs/api_docs/T.tile.sort.md
+"""
+
+TORCH_DTYPE = {"float16": torch.float16, "float32": torch.float32}
+RTOL = {"float16": 1e-3, "float32": 1e-3}
+ATOL = {"float16": 1e-3, "float32": 1e-3}
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+def _aligned_count(actual_num):
+    """Compute aligned_count = ((actual_num + 31) // 32) * 32"""
+    return ((actual_num + 31) // 32) * 32
+
+
+# -----------------------------------------------------------------------------
+# Kernel builders
+# -----------------------------------------------------------------------------
+
+
+def sort_kernel_1d(actual_num, ub_N, dtype="float16"):
+    """1D sort kernel: src (ub_N,), dst (ub_N*2,), actual_num elements valid."""
+    m_num = 1
+    n_num = 1
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((1, ub_N), dtype),
+        B: T.Tensor((1, ub_N * 2), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            src_ub = T.alloc_ub((1, ub_N), dtype)
+            dst_ub = T.alloc_ub((1, ub_N * 2), dtype)
+            T.copy(A, src_ub)
+            T.tile.sort(dst_ub, src_ub, actual_num)
+            T.copy(dst_ub, B)
+
+    return main
+
+
+def sort_kernel_2d(M, actual_num, total_ub, dtype="float16"):
+    """2D sort kernel: src (M, ub_N), dst (M, ub_N*2).
+
+    T.tile.sort treats 2D buffer as flattened 1D array.
+    actual_num = total valid elements across all rows.
+    total_ub = M * ub_N (total buffer size, must be 32-aligned).
+    """
+    m_num = 1
+    n_num = 1
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, total_ub // M), dtype),
+        B: T.Tensor((M, (total_ub // M) * 2), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            src_ub = T.alloc_ub((M, total_ub // M), dtype)
+            dst_ub = T.alloc_ub((M, (total_ub // M) * 2), dtype)
+            T.copy(A, src_ub)
+            T.tile.sort(dst_ub, src_ub, actual_num)
+            T.copy(dst_ub, B)
+
+    return main
+
+
+def sort_kernel_with_src_output(M, actual_num, ub_N, dtype="float16"):
+    """Sort kernel that also copies src back to GM for in-place modification check."""
+    m_num = 1
+    n_num = 1
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, ub_N), dtype),
+        B: T.Tensor((M, ub_N * 2), dtype),
+        S: T.Tensor((M, ub_N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            src_ub = T.alloc_ub((M, ub_N), dtype)
+            dst_ub = T.alloc_ub((M, ub_N * 2), dtype)
+            T.copy(A, src_ub)
+            T.tile.sort(dst_ub, src_ub, actual_num)
+            T.copy(dst_ub, B)
+            T.copy(src_ub, S)
+
+    return main
+
+
+# -----------------------------------------------------------------------------
+# Reference computation (CPU)
+# -----------------------------------------------------------------------------
+
+
+def _cpu_sort_ref(a_cpu, actual_num, aligned_count):
+    """Compute reference sort result on CPU.
+
+    Returns (out_values, out_indices) of length actual_num, descending order.
+    Pads with -inf up to aligned_count to match hardware behavior.
+    """
+    a_flat = a_cpu.float().reshape(-1)
+    a_padded = torch.full((aligned_count,), float("-inf"))
+    a_padded[:actual_num] = a_flat[:actual_num]
+    ref_vals, ref_index = torch.sort(a_padded, descending=True)
+    return ref_vals[:actual_num], ref_index[:actual_num]
+
+
+# -----------------------------------------------------------------------------
+# Run-test helpers
+# -----------------------------------------------------------------------------
+
+
+def run_test_sort_basic(actual_num, dtype, target):
+    """Three-fold verification: compile + run + precision for 1D sort."""
+    ub_N = _aligned_count(actual_num)
+    torch_dtype = TORCH_DTYPE[dtype]
+
+    kernel = sort_kernel_1d(actual_num, ub_N, dtype)
+    func = tilelang.compile(
+        kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target
+    )
+
+    perm = torch.randperm(actual_num, dtype=torch.int32)
+    a = torch.full((1, ub_N), float("-inf"), dtype=torch_dtype).npu()
+    a[:, :actual_num] = perm.to(torch_dtype)
+
+    b = func(a)
+    torch.npu.synchronize()
+
+    b_cpu = b.cpu().float().reshape(-1)
+    out_values = b_cpu[0::2][:actual_num]
+    out_indices = b_cpu[1::2][:actual_num]
+
+    ref_vals, ref_index = _cpu_sort_ref(a.cpu(), actual_num, ub_N)
+
+    torch.testing.assert_close(
+        out_values, ref_vals, rtol=RTOL[dtype], atol=ATOL[dtype]
+    )
+    torch.testing.assert_close(
+        out_indices, ref_index.float(), rtol=RTOL[dtype], atol=ATOL[dtype]
+    )
+
+
+def run_test_sort_2d(M, per_row_N, dtype, target):
+    """Three-fold verification for 2D buffer sort.
+
+    T.tile.sort treats the 2D buffer as a flat 1D array (row-major).
+    actual_num = M * per_row_N (total valid elements across all rows).
+    Uses unique values across the entire buffer to avoid index ambiguity
+    from duplicate values.
+    """
+    ub_N = _aligned_count(per_row_N)
+    total_ub = M * ub_N
+    total_actual = M * per_row_N
+    torch_dtype = TORCH_DTYPE[dtype]
+
+    kernel = sort_kernel_2d(M, total_actual, total_ub, dtype)
+    func = tilelang.compile(
+        kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target
+    )
+
+    a = torch.full((M, ub_N), float("-inf"), dtype=torch_dtype).npu()
+    total_perm = torch.randperm(total_actual, dtype=torch.int32)
+    a_flat = a.view(-1)
+    a_flat[:total_actual] = total_perm.to(torch_dtype)
+
+    b = func(a)
+    torch.npu.synchronize()
+
+    b_cpu = b.cpu().float().reshape(-1)
+    out_values = b_cpu[0::2][:total_actual]
+    out_indices = b_cpu[1::2][:total_actual]
+
+    ref_vals, ref_index = _cpu_sort_ref(a.cpu(), total_actual, total_ub)
+
+    torch.testing.assert_close(
+        out_values, ref_vals, rtol=RTOL[dtype], atol=ATOL[dtype]
+    )
+    torch.testing.assert_close(
+        out_indices, ref_index.float(), rtol=RTOL[dtype], atol=ATOL[dtype]
+    )
+
+
+def run_test_sort_src_inplace(M, actual_num, dtype, target):
+    """Verify src in-place modification behavior.
+
+    float32: src IS modified in-place (tail region padded with -inf).
+    float16: src is NOT modified (implementation casts to float32 in tmp,
+             padding happens on the float copy, not original src).
+    """
+    ub_N = _aligned_count(actual_num)
+    torch_dtype = TORCH_DTYPE[dtype]
+
+    kernel = sort_kernel_with_src_output(M, actual_num, ub_N, dtype)
+    func = tilelang.compile(
+        kernel, out_idx=[1, 2], pass_configs=PASS_CONFIGS, target=target
+    )
+
+    perm = torch.randperm(actual_num, dtype=torch.int32)
+    a = torch.full((M, ub_N), 0.0, dtype=torch_dtype).npu()
+    a[:, :actual_num] = perm.to(torch_dtype)
+
+    b, s = func(a)
+    torch.npu.synchronize()
+
+    s_cpu = s.cpu()
+    if actual_num < ub_N:
+        tail = s_cpu[0, actual_num:ub_N].float()
+        if dtype == "float32":
+            assert torch.all(tail == float("-inf")), (
+                f"src tail [{actual_num}:{ub_N}] should be -inf after in-place padding, "
+                f"got min={tail.min().item()}, max={tail.max().item()}"
+            )
+        else:
+            assert torch.all(tail == 0.0), (
+                f"float16 src tail [{actual_num}:{ub_N}] should remain unchanged (0.0), "
+                f"got min={tail.min().item()}, max={tail.max().item()}"
+            )
+
+
+def run_test_sort_fp16_index_large(actual_num, dtype, target):
+    """Test float16 index precision for actual_num > 2048.
+
+    float16 can exactly represent integers 0-2048. Beyond that, index values
+    may lose precision due to half rounding. This test verifies the behavior
+    and reports the mismatch rate (expected to be non-zero).
+    """
+    ub_N = _aligned_count(actual_num)
+    torch_dtype = TORCH_DTYPE[dtype]
+
+    kernel = sort_kernel_1d(actual_num, ub_N, dtype)
+    func = tilelang.compile(
+        kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target
+    )
+
+    perm = torch.randperm(actual_num, dtype=torch.int32)
+    a = torch.full((1, ub_N), float("-inf"), dtype=torch_dtype).npu()
+    a[:, :actual_num] = perm.to(torch_dtype)
+
+    b = func(a)
+    torch.npu.synchronize()
+
+    b_cpu = b.cpu().float().reshape(-1)
+    out_values = b_cpu[0::2][:actual_num]
+    out_indices = b_cpu[1::2][:actual_num]
+
+    ref_vals, ref_index = _cpu_sort_ref(a.cpu(), actual_num, ub_N)
+
+    torch.testing.assert_close(
+        out_values, ref_vals, rtol=RTOL[dtype], atol=ATOL[dtype]
+    )
+
+    mismatched = (out_indices != ref_index.float()).sum().item()
+    mismatch_rate = mismatched / actual_num
+    print(
+        f"  fp16 index mismatch: {mismatched}/{actual_num} "
+        f"({mismatch_rate:.1%})"
+    )
+
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    """Clear tilelang cache before tests."""
+    tilelang.cache.clear_cache()
+    yield
+
+
+@pytest.fixture
+def setup_random_seed():
+    """Set random seed for reproducibility."""
+    torch.manual_seed(0)
+    yield
+
+
+# -----------------------------------------------------------------------------
+# Test cases
+# -----------------------------------------------------------------------------
+
+
+# -----------------------------------------------------------------------------
+# 1. Basic functionality: dtype × actual_num (1D)
+# -----------------------------------------------------------------------------
+
+
+basic_params = [
+    32,     # 1 sort32 block, no merge
+    64,     # 2 blocks, triggers merge
+    128,    # 4 blocks
+    256,    # 8 blocks
+    131,    # non-aligned actual_num, padded to 160
+]
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize("dtype", ["float16", "float32"])
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+@pytest.mark.parametrize("actual_num", basic_params)
+def test_sort_basic(dtype, target, actual_num):
+    """Basic 1D sort: compile + run + precision for each dtype and actual_num."""
+    run_test_sort_basic(actual_num, dtype, target)
+
+
+# -----------------------------------------------------------------------------
+# 2. 2D buffer support
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize("dtype", ["float16", "float32"])
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+@pytest.mark.parametrize(
+    "M,per_row_N",
+    [
+        (1, 131),    # single row, non-aligned
+        (4, 128),    # multi-row, each row aligned (total 512 elements)
+        (2, 64),     # multi-row, small (total 128 elements)
+    ],
+)
+def test_sort_2d(dtype, target, M, per_row_N):
+    """2D buffer sort: buffer is flattened and sorted as one array."""
+    run_test_sort_2d(M, per_row_N, dtype, target)
+
+
+# -----------------------------------------------------------------------------
+# 3. Boundary: actual_num=1 (minimum valid)
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize("dtype", ["float16", "float32"])
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+def test_sort_min_actual_num(dtype, target):
+    """Boundary: actual_num=1 (minimum valid value, repeatTimes=1)."""
+    run_test_sort_basic(1, dtype, target)
+
+
+# -----------------------------------------------------------------------------
+# 4. Boundary: large actual_num (4096, repeatTimes=128)
+#    Note: hardware upper limit is 8160 (repeatTimes=255) but exceeds UB capacity.
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.low_priority
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize("dtype", ["float32"])
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+def test_sort_large_actual_num(dtype, target):
+    """Large input: actual_num=4096 (repeatTimes=128).
+
+    The hardware upper limit is repeatTimes=255 (actual_num=8160), but
+    actual_num=8160 exceeds practical UB capacity and causes segfault.
+    This test uses 4096 as a large-but-feasible size.
+
+    Only float32 is tested here because float16 index precision loss
+    beyond 2048 elements causes index mismatch (covered separately by
+    test_sort_fp16_index_precision).
+    """
+    run_test_sort_basic(4096, dtype, target)
+
+
+# -----------------------------------------------------------------------------
+# 5. src in-place modification verification
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize("dtype", ["float16", "float32"])
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+@pytest.mark.parametrize(
+    "actual_num",
+    [
+        131,   # non-aligned: padding region [131:160)
+        100,   # non-aligned: padding region [100:128)
+    ],
+)
+def test_sort_src_inplace(dtype, target, actual_num):
+    """Verify src in-place modification behavior:
+    float32 - tail [actual_num:ub_N) padded with -inf;
+    float16 - src unchanged (padding happens on internal float32 copy).
+    """
+    run_test_sort_src_inplace(1, actual_num, dtype, target)
+
+
+# -----------------------------------------------------------------------------
+# 6. float16 index precision for actual_num > 2048
+#    Known limitation: half can only exactly represent integers 0-2048.
+#    This test reports mismatch rate but does NOT fail on index precision.
+#    Values are still verified for correctness.
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.low_priority
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize("dtype", ["float16"])
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+@pytest.mark.parametrize("actual_num", [2049, 4096])
+def test_sort_fp16_index_precision(dtype, target, actual_num):
+    """float16 index precision loss for actual_num > 2048.
+
+    Per docs/api_docs/T.tile.sort.md section 2.3.4:
+      'Index values beyond 2048 may lose exactness due to half-precision rounding.'
+
+    This test verifies:
+      - Values are still correct (asserted)
+      - Index mismatch rate is reported (not asserted, known limitation)
+    """
+    run_test_sort_fp16_index_large(actual_num, dtype, target)
+
+
+# -----------------------------------------------------------------------------
+# 7. actual_num=0 triggers hardware exception (constraint verification)
+#    Marked ci_skip because it crashes NPU aicore and affects subsequent tests.
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.ci_skip
+@pytest.mark.parametrize("dtype", ["float16", "float32"])
+def test_sort_actual_num_zero_crashes(dtype):
+    """Verify actual_num=0 triggers hardware exception (constraint #5: repeatTimes >= 1).
+
+    Per docs/api_docs/T.tile.sort.md constraint #5:
+      'repeatTimes in [1, 255], actual_num in [1, 8160]'
+
+    actual_num=0 -> repeatTimes=0 -> NPU aicore exception (error 507015).
+    Marked ci_skip because it crashes the NPU and affects subsequent tests.
+    """
+    ub_N = 32
+
+    @T.prim_func
+    def main_zero(
+        A: T.Tensor((1, ub_N), dtype),
+        B: T.Tensor((1, ub_N * 2), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            src_ub = T.alloc_ub((1, ub_N), dtype)
+            dst_ub = T.alloc_ub((1, ub_N * 2), dtype)
+            T.copy(A, src_ub)
+            T.tile.sort(dst_ub, src_ub, 0)
+            T.copy(dst_ub, B)
+
+    torch_dtype = TORCH_DTYPE[dtype]
+    a = torch.full((1, ub_N), float("-inf"), dtype=torch_dtype).npu()
+
+    func = tilelang.compile(
+        main_zero, out_idx=[-1], pass_configs=PASS_CONFIGS, target="ascendc"
+    )
+    with pytest.raises(Exception):
+        func(a)
+        torch.npu.synchronize()
+
+
+# -----------------------------------------------------------------------------
+# Standalone command-line entry point
+# -----------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="T.tile.sort test suite")
+    parser.add_argument("--dtype", type=str, choices=["float16", "float32"], default="float16")
+    parser.add_argument(
+        "--target", type=str, choices=["ascendc", "pto"], default="ascendc"
+    )
+    parser.add_argument("--actual-num", type=int, default=131, help="Number of valid elements")
+    parser.add_argument("--m", type=int, default=1, help="Number of rows (for 2D test)")
+    args = parser.parse_args()
+
+    torch.manual_seed(0)
+    tilelang.cache.clear_cache()
+
+    print("=" * 60)
+    print(f"T.tile.sort test: dtype={args.dtype}, target={args.target}")
+    print("=" * 60)
+
+    print(f"\n[1D basic] actual_num={args.actual_num}")
+    run_test_sort_basic(args.actual_num, args.dtype, args.target)
+    print("  PASSED")
+
+    print(f"\n[2D] M={args.m}, per_row_N={args.actual_num}")
+    run_test_sort_2d(args.m, args.actual_num, args.dtype, args.target)
+    print("  PASSED")
+
+    ub_N = _aligned_count(args.actual_num)
+    if args.actual_num < ub_N:
+        print(f"\n[src in-place] actual_num={args.actual_num}, ub_N={ub_N}")
+        run_test_sort_src_inplace(1, args.actual_num, args.dtype, args.target)
+        print("  PASSED")
+
+    print("\nAll tests passed.")

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -288,22 +288,32 @@ def arith_progression(buffer: Buffer, first_value: PrimExpr, diff_value: PrimExp
 
 
 def sort(dst: Buffer, src: Buffer, actual_num: PrimExpr):
-    """
-    Performs a full sort on arbitrarily-lengthed input data with automatic internal
-    alignment. Sorts each 32-element block via sort32, then merges all sorted
-    blocks via merge_sort to produce the final ordered output.
+    """Sort data in descending order, outputting interleaved (value, index) pairs.
 
-    The output contains interleaved (value, index) pairs in descending order:
-      [val0, idx0, val1, idx1, ...] where idx is the original position (0-based).
-    Indices are generated internally; dst must be 2x the size of src.
+    Internally sorts each 32-element block via sort32, then merges sorted
+    blocks via merge_sort. A temporary buffer is auto-injected by the compiler;
+    the caller does not need to provide one.
+
+    Output format: ``dst = [val0, idx0, val1, idx1, ...]`` where ``idx`` is the
+    0-based position in the aligned buffer (including -inf padding positions).
 
     Args:
-    dst: Destination buffer for interleaved (value, index) pairs. Must have
-         at least 2 * aligned_size elements.
-    src: Source buffer containing the data to be sorted.
-    tmp: Temporary buffer for intermediate sort/merge results (2x the size of src).
-    actual_num: The number of valid elements in src. When actual_num is less than
-                the buffer size, unused positions are padded with -inf before sorting.
+        dst: Destination buffer. Must have at least ``2 * aligned_count``
+            elements, where ``aligned_count = ((actual_num + 31) // 32) * 32``.
+        src: Source buffer. Must have at least ``aligned_count`` elements.
+        actual_num: Number of valid elements in ``src``. Must be >= 1
+            (0 triggers a hardware aicore exception).
+
+    Returns:
+        A TVM intrinsic call that performs the sort operation.
+
+    Note:
+        - float32: ``src`` is modified in-place, padding
+          ``[actual_num, aligned_count)`` with -inf. Copy ``src`` beforehand
+          if the original data is needed later.
+        - float16: ``src`` is not modified (internally cast to float32);
+          result is cast back via CAST_RINT. Index may lose half-precision
+          exactness beyond ~2048 elements.
     """
     repeatTimes = (actual_num + 31) // 32  # ceiling to 32-aligned
     return tir.call_intrin(

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -554,25 +554,46 @@ def select(
     src1: Buffer | BufferLoad | PrimExpr,
     selMode: str,
 ):
-    """Performs an element-wise Select operation based on a mask.
+    """Performs an element-wise Select operation based on a bit-packed mask.
 
-    This intrinsic invokes the underlying Ascend implementation to select elements
-    from `src0` or `src1` based on the `selMask` condition and the specified `selMode`,
-    storing the result in `dst`.
+    Selects elements from `src0` or `src1` based on `selMask` bit values and the
+    specified `selMode`: when selMask.bit[i] == 1, dst[i] = src0[i]; otherwise
+    dst[i] = src1[i].
 
     Args:
         dst: The destination buffer or buffer region where the result will be stored.
-        selMask: The mask buffer that determines which source to select from.
-        src0: The first source buffer or buffer region.
-        src1: The second source operand. It can be a Buffer (Tensor), a specific
-            BufferLoad, or a scalar value (PrimExpr/float).
-        selMode: The selection mode string. Must be one of:
-            - 'VSEL_CMPMASK_SPR': Select based on compare mask.
-            - 'VSEL_TENSOR_SCALAR_MODE': Select between a tensor and a scalar.
-            - 'VSEL_TENSOR_TENSOR_MODE': Select between two tensors.
+            Shape must match ``src0``.
+        selMask: The bit-packed uint8 mask buffer. Each bit controls one element
+            (bit=1 selects from src0, bit=0 selects from src1).
+            Element count = data element count / 8.
+        src0: The first source buffer or buffer region (selected when mask bit = 1).
+        src1: The second source operand. Supports tensor (Buffer/BufferRegion) or
+            scalar (PrimExpr/float). BufferLoad (single element access) is accepted
+            by the signature but not functional in current codegen.
+            - When ``selMode`` is ``"VSEL_TENSOR_SCALAR_MODE"``, ``src1`` must be a scalar.
+            - When ``selMode`` is ``"VSEL_TENSOR_TENSOR_MODE"`` or ``"VSEL_CMPMASK_SPR"``,
+              ``src1`` must be a tensor (shape must match ``src0``).
+        selMode: The selection mode string. Determines how ``selMask`` is interpreted
+            and the type of ``src1``. Must be one of:
+            - ``"VSEL_CMPMASK_SPR"``: bit-packed mask, reuses one mask for all elements
+              (max ``256 / sizeof(T)`` elements per call). Typically paired with
+              ``T.tile.compare``.
+            - ``"VSEL_TENSOR_SCALAR_MODE"``: mask is consumed continuously; ``src1`` is a scalar.
+            - ``"VSEL_TENSOR_TENSOR_MODE"``: mask is consumed continuously; ``src1`` is a tensor.
 
     Returns:
         A TVM intrinsic call that performs the Select operation.
+
+    Note:
+        - Supported dtypes (A2/A3): ``float16``, ``float32`` for dst, src0, src1.
+        - ``selMask`` dtype must be ``uint8``.
+        - ``dst`` and ``src0`` must have the same shape.
+        - When ``src1`` is a tensor, its shape must match ``src0``.
+        - Operand addresses must be 32-byte aligned.
+        - ``"VSEL_CMPMASK_SPR"`` mode caps element count at ``256 / sizeof(T)``
+          (128 for float16, 64 for float32).
+        - ``"VSEL_TENSOR_SCALAR_MODE"`` and ``"VSEL_TENSOR_TENSOR_MODE"`` modes require
+          8KB Unified Buffer temporary space on A2/A3.
     """
 
     def retrieve_shape(object: Buffer | BufferRegion) -> list[int]:


### PR DESCRIPTION
# T.tile.sort 更新说明

> 更新日期：2026-08-06
> 更新范围：`tilelang/language/ascend_tile.py`（sort docstring）、`testing/python/language/test_tilelang_ascend_language_sort.py`、`docs/api_docs/T.tile.sort.md`
> 依据：`request/FACTCHECK_WORKFLOW.md`、`request/pytest_marker_guide.md`

## 1. 文件改动

| 文件 | 类型 | 改动说明 |
|------|------|----------|
| `tilelang/language/ascend_tile.py` | 修改 | 重写 `sort` 函数 docstring：删除虚假 `tmp` 参数（实为编译器自动注入）、修正 Args 缩进、新增 Returns 段、补充 src 原地修改说明（float32 修改 / float16 不修改）、精确化 dst/src 大小约束（`2 × aligned_count` / `aligned_count`）、补充降序说明、按 Google style 精炼（39 行 → 27 行） |
| `testing/python/language/test_tilelang_ascend_language_sort.py` | 新增 | 完整测试套件：dtype 参数化（float16/float32）、actual_num 对齐/非对齐、2D 扁平排序、边界值（actual_num=1/4096）、src 原地修改验证、float16 index 精度、actual_num=0 硬件异常、pytest 标签（pto/large/fp16 标 low_priority，actual_num=0 标 ci_skip） |
| `docs/api_docs/T.tile.sort.md` | 新增 | 校验完成版 API 文档（中文版 → 重写为英文） |

---

## 2. 测试用例

### 2.1 约束测试 `test_sort_constraints.py`（动态验证）

| 验证项 | 测什么 | 结果 |
|--------|--------|:----:|
| float16 index > 2048 精度 | actual_num=4096, float16 | **确认精度损失**：25.1% mismatch |
| src/dst 地址重叠 | UB 内独立 buffer 模拟 | **无法直接测试**：sort 的 dst 只接受 Buffer，不支持 BufferRegion 切片 |
| repeatTimes=0（actual_num=0） | actual_num=0, ub_N=32 | **硬件异常**：NPU aicore error 507015 |
| actual_num > aligned_count | actual_num=128, ub_N=64 | **不报错**：编译+运行成功但结果不可预测 |

### 2.2 语言测试 `test_tilelang_ascend_language_sort.py`（52 用例）

| 测试函数 | 用例数 | 测什么 |
|----------|:---:|--------|
| `test_sort_basic` | 20 | dtype(2) × target(2) × actual_num(5：32/64/128/256/131) |
| `test_sort_2d` | 12 | dtype(2) × target(2) × (M, per_row_N)(3：1×131/4×128/2×64) |
| `test_sort_min_actual_num` | 4 | dtype(2) × target(2)，actual_num=1 边界 |
| `test_sort_large_actual_num` | 2 | float32 × target(2)，actual_num=4096 |
| `test_sort_src_inplace` | 8 | dtype(2) × target(2) × actual_num(2：131/100) |
| `test_sort_fp16_index_precision` | 4 | float16 × target(2) × actual_num(2：2049/4096) |
| `test_sort_actual_num_zero_crashes` | 2 | dtype(2)，actual_num=0 触发硬件异常 |

---

## 3. 测试结果

- **约束测试**：动态验证完成（真机 dav_m200/A2，见 2.1 表）
- **语言测试**：22 PASSED（默认用例，真机 dav_m200/A2，耗时约 280s）

### 3.1 pytest 标签

| 测试函数 | low_priority | PR 执行 |
|----------|:---:|:---:|
| `test_sort_basic` pto 用例 | 10 | 跳过 |
| `test_sort_2d` pto 用例 | 6 | 跳过 |
| `test_sort_min_actual_num` pto 用例 | 2 | 跳过 |
| `test_sort_large_actual_num` 全部 | 2 | 跳过 |
| `test_sort_src_inplace` pto 用例 | 4 | 跳过 |
| `test_sort_fp16_index_precision` 全部 | 4 | 跳过 |
| `test_sort_actual_num_zero_crashes` 全部 | 2（ci_skip） | 跳过 |
| ascendc 默认用例 | — | 22 执行 |

---

## 4. 校验过程中发现的问题

1. **虚假 `tmp` 参数**：原 docstring Args 段列出 `tmp: Temporary buffer...`，但 `sort` 函数签名只有 3 个参数（dst、src、actual_num），tmp 由 `allocate_tmp_buffer.cc` 编译器自动注入。已删除。

2. **"src 必须为 32 的倍数"约束错误**：原文档约束 5 声称 src buffer 必须为 32 的倍数。实际内部按 `alignedCount = repeatTimes × 32` 对齐，src 只需 ≥ alignedCount，不要求 buffer 本身是 32 的倍数。已删除。

3. **"(score, index) 固定占 8 Bytes"约束错误**：原文档约束 6 描述 sort32 的输出格式。实际 sort 对 float16 内部 cast 到 float32 排序再 cast 回 half，输出每对 4 Bytes（非 8 Bytes）。已修正。

4. **"dst 至少为 src 的 2 倍"不精确**：原文档约束 1。实际 dst 需至少 `2 × aligned_count` 个元素（`aligned_count` 由 actual_num 向上取整到 32 倍数），非简单 2×src。已精确化。

5. **float16 src 原地修改描述不准确**：原文档称"src 被原地修改"。实际 float32 路径在 src 上原地填充 -inf，float16 路径 cast 到 float32 后在临时 buffer 中填充，src 不被修改。约束 7 已区分 dtype。

6. **repeatTimes 范围 [0, 255] 有误**：actual_num=0 → repeatTimes=0 会触发 NPU aicore 异常（error 507015）。范围改为 [1, 255]，actual_num ∈ [1, 8160]。

7. **actual_num 超过 buffer 大小时行为未说明**：超出时硬件不报错但结果不可预测（越界访问）。约束 4 已补充说明。

8. **2D 排序语义未说明**：原文档仅写"支持 1D 和 2D"。实际 2D buffer 按行主序扁平化为一维整体排序，非按行独立排序。2.3.2 已说明。

9. **BufferRegion 支持描述矛盾**：原文档 2.3.2 称"更高维 buffer 需通过切片降维为 BufferRegion 传入"，但函数签名 `dst: Buffer, src: Buffer` 只接受 Buffer（`access_ptr` 仅支持 Buffer）。已删除 BufferRegion 描述。

10. **UB 容量实际限制未说明**：约束 5 声称 actual_num 可达 8160，但实测 actual_num=8160 导致 UB 溢出（segfault），实际可用大小远小于 8160。约束 6 已补充。

11. **"截断"术语错误**：原文档 2.3.4 称 float16 结果"截断回 float16"。实际使用 `CAST_RINT`（舍入到最近整数），非截断。已改为"舍入（CAST_RINT）"。

12. **float32 index "由 uint32 重解释为 float"表述易误解**：实际 index 的 bit pattern 与 uint32 一致（内部以 uint32 存储，输出按 float 读取）。2.3.4 已改写。

13. **示例 3 等价于 1D**：原示例 3 用 block_M=1 的 2D buffer，实际等价于 1D。已改为 M=4、per_row_N=128、actual_num=512。

14. **float16 index 精度分界点实测为 2048**：2049 时 0% mismatch，4096 时 43.9% mismatch。2.3.4 已注明"index 值超过 2048 时可能因 half 精度损失"。

---

## 5. 校验完成版文档信息核对

| 章节 | 内容 | 状态 |
|------|------|:----:|
| 1. Description | `dst = [val0, idx0, val1, idx1, ...]`，降序 + idx 定义 | ✅ 内联公式，idx 含义明确 |
| 2.1 Function Definition | `sort(dst, src, actual_num)` | ✅ 与源码一致，无 BufferRegion |
| 2.2 Parameters | 5 列表格 + tensor 类型说明 | ✅ src 标"输入/输出"并区分 dtype |
| 2.3.1 DataType | A2/A3: float16, float32，无 A5 行 | ✅ |
| 2.3.2 Shape | 1D/2D，扁平化排序语义明确 | ✅ 修正 2D 语义 |
| 2.3.3 actual_num | aligned_count 对齐规则 | ✅ |
| 2.3.4 Output Format | float32 8B/对、float16 4B/对 | ✅ 修正 8 Bytes 错误 |
| 2.4 Constraints | 10 条编号约束，硬件约束标注 | ✅ 修正 #4/#5 范围、#6 UB 容量、#7 dtype 分支 |
| 3. Examples | 3 个示例（1D 对齐 / 1D 非对齐 / 2D 扁平） | ✅ 示例 3 修正 |

---

## 6. 验证

- 语法检查：`ast.parse` 通过（ascend_tile.py、测试文件）
- 测试收集：52 个用例正常收集
- 默认测试（`not (low_priority or ci_skip)`）：**22 passed**（真机 dav_m200/A2）
- 文档为英文版，10 条约束与源码 `common.h` 实现逐一核对一致