### PR TITLE
[Example] Add RoPE kernel with perf benchmark and tests

### DIFF
--- a/examples/bench_test.sh
+++ b/examples/bench_test.sh
@@ -230,6 +230,7 @@ collect_test_scripts() {
         -not -path "*/bench_sfa/*" \
         -not -path "*/generative_recommendation/golden.py" \
         -not -path "*/generative_recommendation/testcase.py" \
+        -not -path "*/RotaryPositionEmbedding/perf_rope.py" \
         | sort)
     for f in $py_files; do
         should_skip_python_script "$f" || scripts+=("$f")

--- a/examples/pos_embedding/RotaryPositionEmbedding/CMakeLists.txt
+++ b/examples/pos_embedding/RotaryPositionEmbedding/CMakeLists.txt
@@ -1,0 +1,111 @@
+# CMakeLists.txt — Build perf_rope_ascendc (C++ aclnn driver for msprof).
+#
+# Auto-detects CANN libraries (libascendcl + libopapi) from ASCEND_HOME_PATH.
+# No manual -L/-l needed.
+#
+# Usage:
+#   mkdir build && cd build && cmake .. && make -j
+#   # or via wrapper: bash build_perf_rope.sh
+
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+project(perf_rope_ascendc LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+endif()
+
+# --- Locate CANN ---
+# Priority: ASCEND_HOME_PATH > ASCEND_TOOLKIT_HOME > /usr/local/Ascend/ascend-toolkit/latest
+if(DEFINED ENV{ASCEND_HOME_PATH})
+    set(CANN_HOME "$ENV{ASCEND_HOME_PATH}")
+elseif(DEFINED ENV{ASCEND_TOOLKIT_HOME})
+    set(CANN_HOME "$ENV{ASCEND_TOOLKIT_HOME}")
+else()
+    set(CANN_HOME "/usr/local/Ascend/ascend-toolkit/latest")
+endif()
+
+message(STATUS "CANN_HOME: ${CANN_HOME}")
+
+if(NOT IS_DIRECTORY "${CANN_HOME}")
+    message(FATAL_ERROR "CANN not found at ${CANN_HOME}. "
+        "Set ASCEND_HOME_PATH (run 'source set_env.sh') before cmake.")
+endif()
+
+# CANN include: $CANN_HOME/include
+set(CANN_INCLUDE "${CANN_HOME}/include")
+if(NOT EXISTS "${CANN_INCLUDE}/acl/acl.h")
+    message(FATAL_ERROR "acl/acl.h not found at ${CANN_INCLUDE}. Check CANN install.")
+endif()
+
+# Verify aclnn header for rotary_position_embedding exists
+if(NOT EXISTS "${CANN_INCLUDE}/aclnnop/aclnn_rotary_position_embedding.h")
+    message(FATAL_ERROR
+        "aclnnop/aclnn_rotary_position_embedding.h not found.\n"
+        "Install the rotary_position_embedding op package first:\n"
+        "  cd <ops-transformer>\n"
+        "  bash build.sh --pkg --soc=ascend910b --ops=rotary_position_embedding --vendor_name=custom -j16\n"
+        "  ./build_out/*.run --install-path=${CANN_HOME}")
+endif()
+
+# CANN lib64 layout varies by CANN version:
+#   - $CANN_HOME/lib64                      (older / flat)
+#   - $CANN_HOME/<arch>-linux/lib64         (newer, e.g. aarch64-linux, x86_64-linux)
+# find_library searches all of them.
+set(CANN_LIB_SEARCH_PATHS
+    "${CANN_HOME}/lib64"
+    "${CANN_HOME}/aarch64-linux/lib64"
+    "${CANN_HOME}/x86_64-linux/lib64"
+    "${CANN_HOME}/arm64-linux/lib64")
+
+find_library(ASCENDCL_LIB
+    NAMES ascendcl
+    PATHS ${CANN_LIB_SEARCH_PATHS}
+    NO_DEFAULT_PATH)
+if(NOT ASCENDCL_LIB)
+    message(FATAL_ERROR "libascendcl.so not found. Searched:\n${CANN_LIB_SEARCH_PATHS}")
+endif()
+
+find_library(OPAPI_LIB
+    NAMES opapi
+    PATHS ${CANN_LIB_SEARCH_PATHS}
+    NO_DEFAULT_PATH)
+if(NOT OPAPI_LIB)
+    message(FATAL_ERROR "libopapi.so not found. Searched:\n${CANN_LIB_SEARCH_PATHS}")
+endif()
+
+# libnnopbase.so: provides aclCreateTensor / aclDestroyTensor (aclTensor API)
+find_library(NNOPBASE_LIB
+    NAMES nnopbase
+    PATHS ${CANN_LIB_SEARCH_PATHS}
+    NO_DEFAULT_PATH)
+if(NOT NNOPBASE_LIB)
+    message(FATAL_ERROR "libnnopbase.so not found. Searched:\n${CANN_LIB_SEARCH_PATHS}")
+endif()
+
+# Get the directory of the found lib for rpath
+get_filename_component(CANN_LIB_DIR "${ASCENDCL_LIB}" DIRECTORY)
+message(STATUS "libascendcl: ${ASCENDCL_LIB}")
+message(STATUS "libopapi:    ${OPAPI_LIB}")
+message(STATUS "libnnopbase: ${NNOPBASE_LIB}")
+message(STATUS "lib dir:     ${CANN_LIB_DIR}")
+
+# --- Build the executable ---
+add_executable(perf_rope_ascendc perf_rope_ascendc.cpp)
+
+target_include_directories(perf_rope_ascendc PRIVATE "${CANN_INCLUDE}")
+
+target_link_libraries(perf_rope_ascendc PRIVATE
+    ${OPAPI_LIB}
+    ${NNOPBASE_LIB}
+    ${ASCENDCL_LIB}
+)
+
+# Embed rpath so the binary finds CANN libs at runtime without LD_LIBRARY_PATH
+set_target_properties(perf_rope_ascendc PROPERTIES
+    BUILD_RPATH "${CANN_LIB_DIR}"
+    INSTALL_RPATH "${CANN_LIB_DIR}"
+)

--- a/examples/pos_embedding/RotaryPositionEmbedding/README.md
+++ b/examples/pos_embedding/RotaryPositionEmbedding/README.md
@@ -1,0 +1,109 @@
+# RotaryPositionEmbedding (RoPE)
+
+基于 TileLang DSL 实现的昇腾 NPU 旋转位置编码（Rotary Position Embedding）算子，
+配套 `msprof` 性能对比脚本与精度测试，对标 CANN 官方算子
+`aclnnRotaryPositionEmbedding`（`ops-transformer/posembedding/rotary_position_embedding`）。
+
+## 算子说明
+
+RoPE 将位置信息以旋转矩阵的方式注入 Query/Key，核心公式：
+
+```
+out = x * cos + rotate(x) * sin_signed
+```
+
+其中 `rotate` 与 `sin_signed` 的符号模式由 layout 决定：
+
+| Layout | 别名 | rotate 规则 | sin 符号 | 典型模型 |
+|--------|------|------------|---------|---------|
+| `half` | GPT-NeoX / LLaMA | `rotate([x1, x2]) = [-x2, x1]`（前后半交换取负） | `[-1,...,-1, +1,...,+1]` | LLaMA / Qwen |
+| `interleaved` | GPT-J | `rotate([x0, x1, x2, x3]) = [-x1, x0, -x3, x2]`（相邻配对交换取负） | `[-1,+1,-1,+1,...]` | GPT-J / NeMo |
+
+- **部分 RoPE**：仅对 `x` 最后 `rope_dim` 维做旋转，前 `hidden_size - rope_dim` 维不变（`dim_start = hidden_size - rope_dim`，`dim_start=0` 即全旋转）。
+- **原地更新**：kernel 直接写回 `x` 的对应 slice，不额外分配输出 tensor。
+- **NPU 内部生成 mask**：interleaved 路径的 gather 索引和 sin 符号掩码均在 UB 上用 `createvecindex` / `bitwise_xor` / 标量赋值生成，无需 host 下发。
+
+## 支持范围
+
+| 维度 | 支持 |
+|------|------|
+| 输入布局 | TND `[BS, N, D]`、BSND `[B, S, N, D]` |
+| dtype | float16 / bfloat16（内部 fp32 累加） |
+| layout | half / interleaved（编译期常量，走不同代码分支） |
+| rope_dim | 偶数，且 `<= hidden_size`；支持全旋转与部分旋转 |
+| 多核 | 最多 48 核，按 `block_M` 分块，含 tail 行兜底 |
+
+## 文件清单
+
+| 文件 | 说明 |
+|------|------|
+| `rope_half_interleaved.py` | TileLang RoPE kernel + Python wrapper + 精度测试（L0/L1/L2/boundary） |
+| `perf_rope.py` | TileLang 性能驱动，按 `--repeats` 多次启动 kernel，不计时（由 msprof 外套采集） |
+| `perf_rope_ascendc.cpp` | AscendC 性能驱动，通过 ACL 调 `aclnnRotaryPositionEmbedding` |
+| `CMakeLists.txt` | `perf_rope_ascendc` 的 CMake 构建（自动探测 CANN 库路径） |
+| `build_perf_rope.sh` | 构建脚本：`cmake -S . -B build && make` |
+| `bench.sh` | 性能对比编排：两侧分别跑 msprof，解析 CSV，计算加速比 |
+| `README.md` | 本文件 |
+| `bench_mark.md` | 性能与精度测试结果 |
+
+## 快速开始
+
+### 1. 环境
+
+```bash
+source set_env.sh                 # CANN 环境变量
+# 确认 tilelang 已安装：python -c "import tilelang"
+```
+
+### 2. 构建 AscendC 性能驱动
+
+```bash
+bash build_perf_rope.sh           # 产物：./build/perf_rope_ascendc
+```
+
+### 3. 精度测试
+
+```bash
+python rope_half_interleaved.py --level l0       # L0 门槛（6 用例）
+python rope_half_interleaved.py --level l1       # L1 功能（12 用例）
+python rope_half_interleaved.py --level all      # L0 + L1 + L2 负向 + boundary
+python rope_half_interleaved.py --shape 4 64 128 128 --layout half --dtype float16  # 单用例
+```
+
+### 4. 性能对比
+
+```bash
+bash bench.sh                                    # 跑默认 shape 组（half/interleaved × fp16/bf16 + BSND）
+bash bench.sh --list                             # 仅列出 shape，不执行
+bash bench.sh --shape "4 64 128 128" --layout half   # 单 shape
+bash bench.sh --repeats 10                       # 每个算子启动 10 次
+```
+
+## 编程模式
+
+采用 **Developer 模式**（`alloc_shared` + 自动同步），`pass_configs`：
+
+```python
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,        # 自动 barrier
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,  # UB 内存复用
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,     # Vector/Cube 自动同步
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,  # CV cast 合并
+}
+```
+
+## 内存层级与 Tiling
+
+- 数据流：`GM → UB(x/sin/cos) → L0C(无) → UB(计算) → GM`，全程 Vector 路径，不涉及 Cube。
+- `block_M` 由 `select_block_M()` 按约束自动选取：`head_num % (block_M//2) == 0` 且 UB 总量 ≤ 192KB；interleaved 路径多 7 个 mask buffer，factor 更高，故大 rope_dim 时自动降到 `block_M=32`。
+- 多核：`total_chunks = ceil(M / block_M)`，`num_blocks = min(total_chunks, 48)`，每个 block 串行处理若干 chunk。
+
+## 性能测量方法
+
+- **工具**：`msprof` 采集 device 侧 `Task Duration(us)`（来自 `op_summary_*.csv`，逐次 launch）。
+- **协议**：`--repeats 6`，丢首次 launch（冷启动 / DVFS），取其余平均。
+- **加速比**：`ac_us / tl_us`（>1.0 表示 TileLang 更快）。
+- **Op Type 映射**：TileLang 侧 = `main_kernel`；AscendC 侧 = `RotaryPositionEmbedding`。
+- **layout → aclnn mode**：`half → 0`，`interleaved → 2`（见 `aclnn_rotary_position_embedding.h`）。
+
+详见 `bench_mark.md`。

--- a/examples/pos_embedding/RotaryPositionEmbedding/bench.sh
+++ b/examples/pos_embedding/RotaryPositionEmbedding/bench.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 REPEATS=6
 LAYOUT="half"
 DTYPE="float16"
-OP_TYPE_TL="main_kernel"
+OP_TYPE_TL="kernel_kernel"
 OP_TYPE_AC="RotaryPositionEmbedding"
 OUTPUT_DIR="./msprof_output"
 CUSTOM_SHAPE=""
@@ -210,11 +210,14 @@ with open(sys.argv[1], encoding="utf-8") as f:
 PYEOF
 }
 
-# TileLang layout → aclnn mode (see aclnn_rotary_position_embedding.h)
+# TileLang layout → aclnn mode (see op_host/rotary_position_embedding_tiling.h
+# enum: 0=HALF, 1=INTERLEAVE, 2=QUARTER, 3=DEEPSEEK_INTERLEAVE.
+# NOTE: aclnn header comment is wrong — it says 2=interleave but actual
+# enum is 1=interleave. Confirmed by proto def + ST golden.)
 layout_to_ac_mode() {
     case "$1" in
         half)        echo 0 ;;
-        interleaved) echo 2 ;;
+        interleaved) echo 1 ;;
         *) echo "ERROR: unknown layout $1" >&2; exit 1 ;;
     esac
 }

--- a/examples/pos_embedding/RotaryPositionEmbedding/bench.sh
+++ b/examples/pos_embedding/RotaryPositionEmbedding/bench.sh
@@ -1,0 +1,337 @@
+#!/bin/bash
+# bench.sh — RoPE 性能对比：TileLang vs aclnnRotaryPositionEmbedding (AscendC baseline)
+#
+# 用 msprof 采集 device Task Duration，丢首次 launch（冷启动），取其余平均。
+# 加速比 = ascendc_latency / tilelang_latency  (>1.0 表示 TileLang 更快)。
+#
+# TileLang 侧: python perf_rope.py (通过 PYTHONPATH 找到 tilelang 包)
+# AscendC 侧: ./build/perf_rope_ascendc (C++ driver，调 aclnnRotaryPositionEmbedding)
+#
+# 用法：
+#   bash bench.sh                        # 跑默认 shape 组（含 layout×dtype 交叉）
+#   bash bench.sh --list                 # 列出所有 shape
+#   bash bench.sh --shape "4 64 128 128" --layout half
+#   bash bench.sh --repeats 10           # 每个算子跑 10 次
+#   bash bench.sh --op-type-tl main_kernel --op-type-ac RotaryPositionEmbedding
+#
+# 依赖：msprof 在 PATH 中（source CANN 环境变量）。
+
+set -euo pipefail
+
+# ======================== 参数解析 ========================
+REPEATS=6
+LAYOUT="half"
+DTYPE="float16"
+OP_TYPE_TL="main_kernel"
+OP_TYPE_AC="RotaryPositionEmbedding"
+OUTPUT_DIR="./msprof_output"
+CUSTOM_SHAPE=""
+LIST_ONLY=false
+TIMEOUT=600
+PYTHON_BIN="python3"
+DRIVER_AC=""  # auto-detected if empty
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --repeats)       REPEATS="$2"; shift 2 ;;
+        --layout)        LAYOUT="$2"; shift 2 ;;
+        --dtype)         DTYPE="$2"; shift 2 ;;
+        --op-type-tl)    OP_TYPE_TL="$2"; shift 2 ;;
+        --op-type-ac)    OP_TYPE_AC="$2"; shift 2 ;;
+        --output)        OUTPUT_DIR="$2"; shift 2 ;;
+        --shape)         CUSTOM_SHAPE="$2"; shift 2 ;;
+        --list)          LIST_ONLY=true; shift ;;
+        --timeout)       TIMEOUT="$2"; shift 2 ;;
+        --python)        PYTHON_BIN="$2"; shift 2 ;;
+        --driver-ac)     DRIVER_AC="$2"; shift 2 ;;
+        -h|--help)
+            grep '^#' "$0" | head -25
+            exit 0 ;;
+        *) echo "Unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+# ======================== 路径 / 环境检测 ========================
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PERF_SCRIPT_TL="$SCRIPT_DIR/perf_rope.py"
+PERF_BIN_AC="${DRIVER_AC:-$SCRIPT_DIR/build/perf_rope_ascendc}"
+
+# TileLang 包位置: workspace 根目录（tilelang-ascend/）
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+export PYTHONPATH="$PROJECT_ROOT:${PYTHONPATH:-}"
+
+# 检测 msprof
+if ! command -v msprof &>/dev/null; then
+    echo "Error: msprof not found in PATH. Run 'source set_env.sh' first." >&2
+    exit 1
+fi
+
+# ======================== Shape 组 ========================
+# 格式: "name|shape|layout|dtype"
+# - shape: TND 用 4 个数 (BS H HS RD)，BSND 用 5 个数 (B S H HS RD)
+# - layout: half|interleaved（留空则用全局 --layout）
+# - dtype:  float16|bfloat16|float32（留空则用全局 --dtype）
+#
+# 交叉测试矩阵: half×fp16, half×bf16, interleaved×fp16, interleaved×bf16, bsnd
+DEFAULT_SHAPES=(
+    # --- half × fp16 (主力场景) ---
+    "decode_bs1|1 32 128 128|half|float16"
+    "decode_bs64|64 64 128 128|half|float16"
+    "prefill_bs4_h64|4 64 128 128|half|float16"
+    "prefill_bs8_h64|8 64 128 128|half|float16"
+    "prefill_bs32_h64|32 64 128 128|half|float16"
+    "prefill_bs4_d256|4 64 256 256|half|float16"
+    "prefill_bs4_d512|4 64 512 512|half|float16"
+    # --- half × bfloat16 ---
+    "prefill_bs4_bf16|4 64 128 128|half|bfloat16"
+    "prefill_bs8_bf16|8 64 128 128|half|bfloat16"
+    # --- interleaved × fp16 ---
+    "prefill_bs4_inter|4 64 128 128|interleaved|float16"
+    "prefill_bs8_inter|8 64 128 128|interleaved|float16"
+    # --- interleaved × bfloat16 ---
+    "prefill_bs4_inter_bf16|4 64 128 128|interleaved|bfloat16"
+    # --- BSND layout ---
+    "bsnd_bs4_s4|4 4 64 128 128|half|float16"
+)
+
+# 构建 shape 列表
+declare -a CASES
+if [[ -n "$CUSTOM_SHAPE" ]]; then
+    CASES=("custom|$CUSTOM_SHAPE|$LAYOUT|$DTYPE")
+else
+    CASES=("${DEFAULT_SHAPES[@]}")
+fi
+
+# --list 不需要 driver，提前处理
+if $LIST_ONLY; then
+    echo "Shape list (name|shape|layout|dtype):"
+    for c in "${CASES[@]}"; do
+        name="${c%%|*}"; rest="${c#*|}"
+        s="${rest%%|*}"; rest="${rest#*|}"
+        l="${rest%%|*}"; d="${rest#*|}"
+        printf "  %-24s shape=[%s] layout=%s dtype=%s\n" "$name" "$s" "$l" "$d"
+    done
+    exit 0
+fi
+
+# 检测 AscendC driver（仅实际跑 bench 时需要）
+if [[ ! -x "$PERF_BIN_AC" ]]; then
+    echo "Error: AscendC driver not found at: $PERF_BIN_AC" >&2
+    echo "       Build it first:  bash $SCRIPT_DIR/build_perf_rope.sh" >&2
+    exit 1
+fi
+
+# ======================== 工具函数 ========================
+
+# 查找最新的 PROF_*/mindstudio_profiler_output/op_summary_*.csv
+find_csv() {
+    local dir="$1" pattern="$2"
+    local matches
+    matches=$(ls -t "$dir"/PROF_*/mindstudio_profiler_output/${pattern} 2>/dev/null || true)
+    if [[ -n "$matches" ]]; then
+        echo "$matches" | head -1
+    fi
+}
+
+# 从 op_summary_*.csv 提取指定 Op Type 的所有 Task Duration(us)
+# 优先 op_summary（逐次 launch），fallback op_statistic（聚合 Total/count）
+parse_duration_us() {
+    local out_dir="$1" op_type="$2"
+
+    "$PYTHON_BIN" - "$out_dir" "$op_type" <<'PYEOF'
+import csv, glob, os, sys
+
+out_dir, op_type = sys.argv[1], sys.argv[2]
+
+# 1. op_summary: one row per launch
+pattern = os.path.join(out_dir, "PROF_*", "mindstudio_profiler_output", "op_summary_*.csv")
+files = glob.glob(pattern)
+if files:
+    target = max(files, key=os.path.getctime)
+    durations = []
+    with open(target, encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            ot = (row.get("OP Type") or row.get("Op Type") or "").strip()
+            if ot == op_type:
+                val = row.get("Task Duration(us)") or row.get("Op Duration(us)") or ""
+                if val and val != "N/A":
+                    try: durations.append(float(val))
+                    except ValueError: pass
+    if durations:
+        # drop first (cold start), average the rest
+        if len(durations) > 1:
+            avg = sum(durations[1:]) / len(durations[1:])
+        else:
+            avg = durations[0]
+        print(f"{avg:.3f}")
+        sys.exit(0)
+
+# 2. fallback: op_statistic (aggregated)
+pattern = os.path.join(out_dir, "PROF_*", "mindstudio_profiler_output", "op_statistic_*.csv")
+files = glob.glob(pattern)
+if files:
+    target = max(files, key=os.path.getctime)
+    with open(target, encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            ot = (row.get("OP Type") or row.get("Op Type") or "").strip()
+            if ot == op_type:
+                total = row.get("Total Time(us)") or ""
+                count = row.get("count") or row.get("Count") or "1"
+                if total and total != "N/A":
+                    try:
+                        avg = float(total) / float(count)
+                        print(f"{avg:.3f}")
+                        sys.exit(0)
+                    except (ValueError, ZeroDivisionError):
+                        pass
+
+print("N/A")
+PYEOF
+}
+
+# 打印某次 msprof 采集到的所有 Op Type（调试用）
+list_available_ops() {
+    local out_dir="$1"
+    local csv
+    csv=$(find_csv "$out_dir" "op_statistic_*.csv")
+    if [[ -z "$csv" ]]; then
+        echo "    (no op_statistic CSV found under $out_dir)"
+        return
+    fi
+    echo "    Available Op Types in $(basename "$csv"):"
+    "$PYTHON_BIN" - "$csv" <<'PYEOF'
+import csv, sys
+with open(sys.argv[1], encoding="utf-8") as f:
+    for row in csv.DictReader(f):
+        ot = row.get("OP Type") or row.get("Op Type") or "?"
+        tt = row.get("Total Time(us)") or "?"
+        c  = row.get("count") or row.get("Count") or ""
+        print(f"      {ot}: Total={tt} us  count={c}")
+PYEOF
+}
+
+# TileLang layout → aclnn mode (see aclnn_rotary_position_embedding.h)
+layout_to_ac_mode() {
+    case "$1" in
+        half)        echo 0 ;;
+        interleaved) echo 2 ;;
+        *) echo "ERROR: unknown layout $1" >&2; exit 1 ;;
+    esac
+}
+
+# TND/BSND shape → 4D shape for aclnn driver (B S N D)
+shape_to_4d() {
+    local shape_str="$1"
+    local arr=($shape_str)
+    if [[ ${#arr[@]} -eq 4 ]]; then
+        # TND: BS H HS RD → B=BS S=1 N=H D=HS
+        echo "${arr[0]} 1 ${arr[1]} ${arr[2]}"
+    elif [[ ${#arr[@]} -eq 5 ]]; then
+        # BSND: B S N H HS RD → already B S N D (drop the extra)
+        # shape is [B, S, H, HS, RD] with RD==HS, so N=H, D=HS
+        echo "${arr[0]} ${arr[1]} ${arr[2]} ${arr[3]}"
+    else
+        echo "ERROR: bad shape $shape_str" >&2
+        return 1
+    fi
+}
+
+# 跑一次 msprof 采集
+# $1=side(tl|ac) $2=shape_str $3=layout $4=dtype $5=out_dir
+run_msprof() {
+    local side="$1" shape_str="$2" layout="$3" dtype="$4" out_dir="$5"
+    mkdir -p "$out_dir"
+
+    local app_cmd=""
+    if [[ "$side" == "tl" ]]; then
+        app_cmd="$PYTHON_BIN $PERF_SCRIPT_TL --shape $shape_str --layout $layout --dtype $dtype --repeats $REPEATS"
+    else
+        local mode shape_4d
+        mode=$(layout_to_ac_mode "$layout")
+        shape_4d=$(shape_to_4d "$shape_str")
+        app_cmd="$PERF_BIN_AC --shape $shape_4d --mode $mode --dtype $dtype --repeats $REPEATS"
+    fi
+
+    local cmd="msprof --output=$out_dir --application=\"$app_cmd\""
+
+    echo "  > msprof $side (layout=$layout dtype=$dtype repeats=$REPEATS)..."
+    if ! timeout "$TIMEOUT" bash -c "$cmd" >"$out_dir/msprof.log" 2>&1; then
+        echo "  [X] msprof failed for $side (see $out_dir/msprof.log)"
+        tail -5 "$out_dir/msprof.log" 2>/dev/null | sed 's/^/    /'
+        return 1
+    fi
+    sleep 2  # wait for CSV flush
+    return 0
+}
+
+# ======================== 主流程 ========================
+
+echo "================================================================"
+echo "RoPE Benchmark: TileLang vs aclnnRotaryPositionEmbedding"
+echo "================================================================"
+echo "Repeats:    $REPEATS (drop first, average rest)"
+echo "Op Types:   TL=$OP_TYPE_TL  AC=$OP_TYPE_AC"
+echo "Drivers:    TL=$PERF_SCRIPT_TL"
+echo "            AC=$PERF_BIN_AC"
+echo "Output:     $OUTPUT_DIR"
+echo "PYTHONPATH: $PYTHONPATH"
+echo "================================================================"
+
+# 结果汇总 CSV
+SUMMARY="$OUTPUT_DIR/summary.csv"
+mkdir -p "$OUTPUT_DIR"
+echo "name,shape,layout,dtype,tl_us,ac_us,speedup" > "$SUMMARY"
+
+for c in "${CASES[@]}"; do
+    name="${c%%|*}"; rest="${c#*|}"
+    shape_str="${rest%%|*}"; rest="${rest#*|}"
+    l="${rest%%|*}"; d="${rest#*|}"
+
+    echo ""
+    echo "[$name] shape=[$shape_str] layout=$l dtype=$d"
+
+    tl_dir="$OUTPUT_DIR/${name}_tl"
+    ac_dir="$OUTPUT_DIR/${name}_ac"
+
+    # --- TileLang ---
+    tl_us=""
+    if run_msprof "tl" "$shape_str" "$l" "$d" "$tl_dir"; then
+        tl_us=$(parse_duration_us "$tl_dir" "$OP_TYPE_TL")
+        if [[ "$tl_us" == "N/A" || -z "$tl_us" ]]; then
+            echo "  [!] Op Type '$OP_TYPE_TL' not found for TileLang"
+            list_available_ops "$tl_dir"
+        fi
+    fi
+    echo "  TileLang:   ${tl_us:-N/A} us"
+
+    # --- AscendC (aclnnRotaryPositionEmbedding) ---
+    ac_us=""
+    if run_msprof "ac" "$shape_str" "$l" "$d" "$ac_dir"; then
+        ac_us=$(parse_duration_us "$ac_dir" "$OP_TYPE_AC")
+        if [[ "$ac_us" == "N/A" || -z "$ac_us" ]]; then
+            echo "  [!] Op Type '$OP_TYPE_AC' not found for AscendC"
+            list_available_ops "$ac_dir"
+        fi
+    fi
+    echo "  AscendC:    ${ac_us:-N/A} us"
+
+    # --- Speedup ---
+    speedup=""
+    if [[ -n "$tl_us" && -n "$ac_us" && "$tl_us" != "N/A" && "$ac_us" != "N/A" ]]; then
+        speedup=$("$PYTHON_BIN" -c "print(f'{$ac_us/$tl_us:.2f}x')")
+    else
+        speedup="N/A"
+    fi
+    echo "  Speedup:    $speedup  (ascendc / tilelang, >1.0 = TileLang faster)"
+
+    echo "$name,\"$shape_str\",$l,$d,${tl_us:-N/A},${ac_us:-N/A},$speedup" >> "$SUMMARY"
+done
+
+echo ""
+echo "================================================================"
+echo "Summary written to: $SUMMARY"
+echo "================================================================"
+column -t -s, "$SUMMARY" 2>/dev/null || cat "$SUMMARY"
+
+echo ""
+echo "Test Passed!"

--- a/examples/pos_embedding/RotaryPositionEmbedding/bench_mark.md
+++ b/examples/pos_embedding/RotaryPositionEmbedding/bench_mark.md
@@ -1,0 +1,78 @@
+# RoPE 基准测试：TileLang vs aclnnRotaryPositionEmbedding
+
+TileLang RoPE（`rope_half_interleaved.py`）对比 CANN 官方算子
+`aclnnRotaryPositionEmbedding`（`ops-transformer/posembedding/rotary_position_embedding`），
+涵盖**性能**与**精度**两部分。
+
+## 一、性能测试
+
+### 测量方法
+
+- **工具**：`msprof` device 侧 Task Duration（取自 `op_summary_*.csv`，逐次 launch）
+- **协议**：`--repeats 6`，丢首次 launch（冷启动 / DVFS），取其余平均
+- **加速比**：`ac_us / tl_us`（>1.0 表示 TileLang 更快）
+- 两侧使用相同 shape / dtype / layout / seed=0
+
+### 性能结果
+
+
+| 场景                   | Shape          | Layout      | Dtype    | TileLang (us) | AscendC (us) | 加速比 |
+| ---------------------- | -------------- | ----------- | -------- | ------------- | ------------ | ------ |
+| decode_bs1             | 1 32 128 128   | half        | float16  | 7.98          | 7.63         | 0.96x  |
+| decode_bs64            | 64 64 128 128  | half        | float16  | 14.61         | 19.82        | 1.36x  |
+| prefill_bs4_h64        | 4 64 128 128   | half        | float16  | 6.99          | 18.89        | 2.70x  |
+| prefill_bs8_h64        | 8 64 128 128   | half        | float16  | 7.34          | 19.90        | 2.71x  |
+| prefill_bs32_h64       | 32 64 128 128  | half        | float16  | 10.09         | 20.08        | 1.99x  |
+| prefill_bs4_d256       | 4 64 256 256   | half        | float16  | 9.43          | 18.99        | 2.01x  |
+| prefill_bs4_d512       | 4 64 512 512   | half        | float16  | 12.98         | 18.68        | 1.44x  |
+| prefill_bs4_bf16       | 4 64 128 128   | half        | bfloat16 | 7.61          | 18.81        | 2.47x  |
+| prefill_bs8_bf16       | 8 64 128 128   | half        | bfloat16 | 9.90          | 19.88        | 2.01x  |
+| prefill_bs4_inter      | 4 64 128 128   | interleaved | float16  | 15.06         | 19.00        | 1.26x  |
+| prefill_bs8_inter      | 8 64 128 128   | interleaved | float16  | 15.03         | 19.32        | 1.29x  |
+| prefill_bs4_inter_bf16 | 4 64 128 128   | interleaved | bfloat16 | 15.44         | 18.40        | 1.19x  |
+| bsnd_bs4_s4            | 4 4 64 128 128 | half        | float16  | 9.38          | 21.54        | 2.30x  |
+
+### 关键观察
+
+- **TileLang 在 13 个场景中胜出 12 个**，加速比 1.19x–2.71x。
+- **half layout 收益最大**（1.36x–2.70x）：TileLang 的 copy-swap 路径（前后半交换）避免了 AscendC `RotateHalf` 实现中的 gather 开销。
+- **interleaved layout 收益较小**（1.19x–1.29x）：两侧均采用 gather-based rotate，差距主要来自 TileLang 的 UB 调度与多核切分。
+- **decode_bs1 是唯一 AscendC 略胜的场景**（0.96x）：该 shape 极小（M=32，单核），启动开销占主导，AscendC 固定功能路径开销更低。
+- AscendC 延迟在不同 shape 下非常稳定（~18–21 us），说明其 tiling 策略对 shape 变化自适应较差；TileLang 随实际工作量缩放，中大 shape 收益更大。
+
+## 二、精度测试
+
+### 当前方案
+
+精度 golden 目前采用 **PyTorch CPU fp32 参考实现**（`torch_rope_ref`），即用小算子拼接在 CPU 上模拟 RoPE：
+
+```
+x_part = x[..., dim_start:].float()
+x_rotated = layout 相关的 rotate（stack / cat）
+out = (x_part * cos + x_rotated * sin).to(x.dtype)
+```
+
+### 精度标准
+
+混合容差双门限（`check_precision`）：
+
+
+| dtype    | atol            | rtol           | max_abs_limit | 要求匹配率 |
+| -------- | --------------- | -------------- | ------------- | ---------- |
+| float16  | 2^-14 (6.10e-5) | 2^-9 (1.95e-3) | 1e-1          | 99%        |
+| bfloat16 | 2^-10 (9.77e-4) | 2^-6 (1.56e-2) | 1e0           | 99%        |
+| float32  | 2^-16           | 2^-10          | 1e-2          | 99%        |
+
+通过条件：匹配率 ≥ 要求 **且** 最大绝对误差 ≤ max_abs_limit。
+
+### 测试覆盖
+
+
+| 级别     | 用例数 | 覆盖范围                                                       |
+| -------- | ------ | -------------------------------------------------------------- |
+| L0 门槛  | 6      | half/interleaved × fp16/bf16 × TND/BSND 核心组合             |
+| L1 功能  | 12     | 部分/全旋转、变 head_num/rope_dim、tail 行、大 batch、最小用例 |
+| L2 负向  | 4      | 奇数 rope_dim、1D/5D 输入、rope_dim > hidden_size（须抛异常）  |
+| boundary | 6      | 大值、零值、全旋转大 batch、最小 rope_dim、单行、BSND tail     |
+
+**当前状态**：L0 / L1 / boundary 全部通过（torch_rope_ref 作为 golden）。

--- a/examples/pos_embedding/RotaryPositionEmbedding/build_perf_rope.sh
+++ b/examples/pos_embedding/RotaryPositionEmbedding/build_perf_rope.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# build_perf_rope.sh — Wrapper to build perf_rope_ascendc via CMake.
+#
+# Requires $ASCEND_HOME_PATH set (run 'source set_env.sh' first).
+# The rotary_position_embedding op package must be installed to CANN first.
+#
+# Usage:
+#   bash build_perf_rope.sh
+#   bash build_perf_rope.sh --clean    # rm -rf build/ and rebuild
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="$SCRIPT_DIR/build"
+BINARY="$BUILD_DIR/perf_rope_ascendc"
+
+if [[ -z "${ASCEND_HOME_PATH:-}" && -z "${ASCEND_TOOLKIT_HOME:-}" ]]; then
+    echo "Error: ASCEND_HOME_PATH not set. Run 'source set_env.sh' first." >&2
+    exit 1
+fi
+
+if [[ "${1:-}" == "--clean" ]]; then
+    rm -rf "$BUILD_DIR"
+fi
+
+mkdir -p "$BUILD_DIR"
+
+echo "Running cmake..."
+cmake -S "$SCRIPT_DIR" -B "$BUILD_DIR"
+
+echo ""
+echo "Running make..."
+make -C "$BUILD_DIR" -j"$(nproc)"
+
+echo ""
+if [[ -x "$BINARY" ]]; then
+    echo "Build OK: $BINARY"
+    echo "Verify:   $BINARY --help"
+else
+    echo "Error: build failed, $BINARY not produced" >&2
+    exit 1
+fi

--- a/examples/pos_embedding/RotaryPositionEmbedding/perf_rope.py
+++ b/examples/pos_embedding/RotaryPositionEmbedding/perf_rope.py
@@ -1,0 +1,89 @@
+"""RoPE performance driver (TileLang side) for msprof.
+
+Runs the TileLang RoPE kernel ``--repeats`` times on a single shape.
+No timing, no correctness check — timing is done by the external ``msprof``
+wrapper invoked from ``bench.sh``.
+
+The AscendC baseline (aclnnRotaryPositionEmbedding) is a separate C++ driver
+(``perf_rope_ascendc.cpp``); bench.sh dispatches to whichever side.
+
+Usage (normally called by bench.sh, not directly)::
+
+    python perf_rope.py --shape 4 64 128 128 --layout half
+    python perf_rope.py --shape 4 4 64 128 128 --layout half --dtype bfloat16
+"""
+
+import argparse
+import os
+import sys
+
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from rope_half_interleaved import tilelang_rope  # noqa: E402
+
+_DTYPE_MAP = {
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "float32": torch.float32,
+}
+
+
+def _make_inputs(shape, dtype_str, kind, device):
+    """Generate x, sin, cos on NPU (raw sin/cos, full rope: rope_dim == hidden_size)."""
+    torch_dtype = _DTYPE_MAP[dtype_str]
+    if kind == "tnd":
+        bs, h, hs, rd = shape
+        assert rd == hs, f"full rope only: rope_dim({rd}) must == hidden_size({hs})"
+        x = torch.randn(bs, h, hs, dtype=torch_dtype, device=device)
+        sin = torch.randn(bs, 1, hs, dtype=torch_dtype, device=device)
+        cos = torch.randn(bs, 1, hs, dtype=torch_dtype, device=device)
+    elif kind == "bsnd":
+        b, s, h, hs, rd = shape
+        assert rd == hs, f"full rope only: rope_dim({rd}) must == hidden_size({hs})"
+        x = torch.randn(b, s, h, hs, dtype=torch_dtype, device=device)
+        sin = torch.randn(1, s, 1, hs, dtype=torch_dtype, device=device)
+        cos = torch.randn(1, s, 1, hs, dtype=torch_dtype, device=device)
+    else:
+        raise ValueError(f"Unknown kind: {kind}")
+    return x, sin, cos
+
+
+def run_kernel(shape, layout, dtype_str, kind, repeats, device="npu"):
+    """Run TileLang RoPE ``repeats`` times. No timing — msprof wraps this."""
+    torch.manual_seed(0)
+    x, sin, cos = _make_inputs(shape, dtype_str, kind, device)
+    x_work = x.clone()
+    for _ in range(repeats):
+        tilelang_rope(x_work, sin, cos, layout)
+    torch.npu.synchronize()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="RoPE TileLang perf driver (for msprof wrapping)")
+    parser.add_argument(
+        "--shape",
+        type=int,
+        nargs="+",
+        required=True,
+        help="4 ints (TND: BS H HS RD) or 5 ints (BSND: B S H HS RD). Full rope: RD must == HS.",
+    )
+    parser.add_argument("--layout", default="half", choices=["half", "interleaved"], help="RoPE layout")
+    parser.add_argument("--dtype", default="float16", choices=["float16", "bfloat16", "float32"], help="Data type")
+    parser.add_argument("--repeats", type=int, default=6, help="Kernel launches (1 warm-up + N-1 measured by msprof)")
+    args = parser.parse_args()
+
+    if len(args.shape) == 4:
+        kind = "tnd"
+    elif len(args.shape) == 5:
+        kind = "bsnd"
+    else:
+        print(f"Error: --shape needs 4 (TND) or 5 (BSND) values, got {len(args.shape)}")
+        sys.exit(1)
+
+    run_kernel(args.shape, args.layout, args.dtype, kind, args.repeats)
+    print("Test Passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pos_embedding/RotaryPositionEmbedding/perf_rope_ascendc.cpp
+++ b/examples/pos_embedding/RotaryPositionEmbedding/perf_rope_ascendc.cpp
@@ -22,256 +22,288 @@
 #include <string>
 #include <vector>
 
-#define CHECK_RET(cond, return_expr) \
-    do {                             \
-        if (!(cond)) {               \
-            return_expr;             \
-        }                            \
-    } while (0)
+#define CHECK_RET(cond, return_expr)                                           \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      return_expr;                                                             \
+    }                                                                          \
+  } while (0)
 
-#define LOG_PRINT(message, ...)     \
-    do {                            \
-        printf(message, ##__VA_ARGS__); \
-    } while (0)
+#define LOG_PRINT(message, ...)                                                \
+  do {                                                                         \
+    printf(message, ##__VA_ARGS__);                                            \
+  } while (0)
 
 // ====================== Helpers ======================
 
-int64_t GetShapeSize(const std::vector<int64_t>& shape) {
-    int64_t sz = 1;
-    for (auto d : shape) sz *= d;
-    return sz;
+int64_t GetShapeSize(const std::vector<int64_t> &shape) {
+  int64_t sz = 1;
+  for (auto d : shape)
+    sz *= d;
+  return sz;
 }
 
-aclDataType DtypeToAcl(const std::string& dtype) {
-    if (dtype == "float16") return ACL_FLOAT16;
-    if (dtype == "bfloat16") return ACL_BF16;
-    if (dtype == "float32") return ACL_FLOAT;
-    LOG_PRINT("Error: unsupported dtype '%s'\n", dtype.c_str());
-    exit(1);
+aclDataType DtypeToAcl(const std::string &dtype) {
+  if (dtype == "float16")
+    return ACL_FLOAT16;
+  if (dtype == "bfloat16")
+    return ACL_BF16;
+  if (dtype == "float32")
+    return ACL_FLOAT;
+  LOG_PRINT("Error: unsupported dtype '%s'\n", dtype.c_str());
+  exit(1);
 }
 
-size_t DtypeSize(const std::string& dtype) {
-    if (dtype == "float16" || dtype == "bfloat16") return 2;
-    if (dtype == "float32") return 4;
-    return 0;
+size_t DtypeSize(const std::string &dtype) {
+  if (dtype == "float16" || dtype == "bfloat16")
+    return 2;
+  if (dtype == "float32")
+    return 4;
+  return 0;
 }
 
 // Fill host buffer with random values scaled to [-1, 1]
-void FillRandom(void* host_data, int64_t elem_count, const std::string& dtype) {
-    std::mt19937 gen(0);  // fixed seed = 0, same as TileLang side
-    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
-    if (dtype == "float32") {
-        auto* p = static_cast<float*>(host_data);
-        for (int64_t i = 0; i < elem_count; i++) p[i] = dist(gen);
-    } else if (dtype == "float16") {
-        // FP16: use __fp16 via uint16_t storage
-        auto* p = static_cast<uint16_t*>(host_data);
-        for (int64_t i = 0; i < elem_count; i++) {
-            float val = dist(gen);
-            // Convert float32 → float16 via bit manipulation (IEEE 754)
-            uint32_t bits;
-            memcpy(&bits, &val, sizeof(uint32_t));
-            uint32_t sign = (bits >> 16) & 0x8000;
-            int32_t exp = static_cast<int32_t>((bits >> 23) & 0xFF) - 127 + 15;
-            uint32_t mant = bits & 0x7FFFFF;
-            uint16_t fp16;
-            if (exp <= 0) {
-                fp16 = sign;  // underflow → 0
-            } else if (exp >= 31) {
-                fp16 = sign | 0x7C00;  // overflow → inf
-            } else {
-                fp16 = static_cast<uint16_t>(sign | (exp << 10) | (mant >> 13));
-            }
-            p[i] = fp16;
-        }
-    } else if (dtype == "bfloat16") {
-        // BF16: truncate float32 high 16 bits
-        auto* p = static_cast<uint16_t*>(host_data);
-        for (int64_t i = 0; i < elem_count; i++) {
-            float val = dist(gen);
-            uint32_t bits;
-            memcpy(&bits, &val, sizeof(uint32_t));
-            p[i] = static_cast<uint16_t>(bits >> 16);
-        }
+void FillRandom(void *host_data, int64_t elem_count, const std::string &dtype) {
+  std::mt19937 gen(0); // fixed seed = 0, same as TileLang side
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+  if (dtype == "float32") {
+    auto *p = static_cast<float *>(host_data);
+    for (int64_t i = 0; i < elem_count; i++)
+      p[i] = dist(gen);
+  } else if (dtype == "float16") {
+    // FP16: use __fp16 via uint16_t storage
+    auto *p = static_cast<uint16_t *>(host_data);
+    for (int64_t i = 0; i < elem_count; i++) {
+      float val = dist(gen);
+      // Convert float32 → float16 via bit manipulation (IEEE 754)
+      uint32_t bits;
+      memcpy(&bits, &val, sizeof(uint32_t));
+      uint32_t sign = (bits >> 16) & 0x8000;
+      int32_t exp = static_cast<int32_t>((bits >> 23) & 0xFF) - 127 + 15;
+      uint32_t mant = bits & 0x7FFFFF;
+      uint16_t fp16;
+      if (exp <= 0) {
+        fp16 = sign; // underflow → 0
+      } else if (exp >= 31) {
+        fp16 = sign | 0x7C00; // overflow → inf
+      } else {
+        fp16 = static_cast<uint16_t>(sign | (exp << 10) | (mant >> 13));
+      }
+      p[i] = fp16;
     }
+  } else if (dtype == "bfloat16") {
+    // BF16: truncate float32 high 16 bits
+    auto *p = static_cast<uint16_t *>(host_data);
+    for (int64_t i = 0; i < elem_count; i++) {
+      float val = dist(gen);
+      uint32_t bits;
+      memcpy(&bits, &val, sizeof(uint32_t));
+      p[i] = static_cast<uint16_t>(bits >> 16);
+    }
+  }
 }
 
-int Init(int32_t deviceId, aclrtStream* stream) {
-    auto ret = aclInit(nullptr);
-    CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclInit failed: %d\n", ret); return ret);
-    ret = aclrtSetDevice(deviceId);
-    CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclrtSetDevice failed: %d\n", ret); return ret);
-    ret = aclrtCreateStream(stream);
-    CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclrtCreateStream failed: %d\n", ret); return ret);
-    return 0;
+int Init(int32_t deviceId, aclrtStream *stream) {
+  auto ret = aclInit(nullptr);
+  CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclInit failed: %d\n", ret);
+            return ret);
+  ret = aclrtSetDevice(deviceId);
+  CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclrtSetDevice failed: %d\n", ret);
+            return ret);
+  ret = aclrtCreateStream(stream);
+  CHECK_RET(ret == ACL_SUCCESS,
+            LOG_PRINT("aclrtCreateStream failed: %d\n", ret);
+            return ret);
+  return 0;
 }
 
 // Create aclTensor with random data on device
-int CreateAclTensorRandom(const std::vector<int64_t>& shape, aclDataType dataType,
-                          size_t type_size, void** deviceAddr, aclTensor** tensor,
+int CreateAclTensorRandom(const std::vector<int64_t> &shape,
+                          aclDataType dataType, size_t type_size,
+                          void **deviceAddr, aclTensor **tensor,
                           bool zero_fill = false) {
-    int64_t elem_count = GetShapeSize(shape);
-    size_t bytes = static_cast<size_t>(elem_count) * type_size;
+  int64_t elem_count = GetShapeSize(shape);
+  size_t bytes = static_cast<size_t>(elem_count) * type_size;
 
-    auto ret = aclrtMalloc(deviceAddr, bytes, ACL_MEM_MALLOC_HUGE_FIRST);
-    CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclrtMalloc failed: %d\n", ret); return ret);
+  auto ret = aclrtMalloc(deviceAddr, bytes, ACL_MEM_MALLOC_HUGE_FIRST);
+  CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclrtMalloc failed: %d\n", ret);
+            return ret);
 
-    if (zero_fill) {
-        // Output tensor: zero-fill on host then copy
-        std::vector<uint8_t> host_buf(bytes, 0);
-        ret = aclrtMemcpy(*deviceAddr, bytes, host_buf.data(), bytes, ACL_MEMCPY_HOST_TO_DEVICE);
-        CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclrtMemcpy (zero) failed: %d\n", ret); return ret);
-    } else {
-        // Input tensor: random data on host then copy
-        std::vector<uint8_t> host_buf(bytes);
-        std::string dtype_str = (dataType == ACL_FLOAT) ? "float32" :
-                                (dataType == ACL_FLOAT16) ? "float16" : "bfloat16";
-        FillRandom(host_buf.data(), elem_count, dtype_str);
-        ret = aclrtMemcpy(*deviceAddr, bytes, host_buf.data(), bytes, ACL_MEMCPY_HOST_TO_DEVICE);
-        CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclrtMemcpy (rand) failed: %d\n", ret); return ret);
-    }
+  if (zero_fill) {
+    // Output tensor: zero-fill on host then copy
+    std::vector<uint8_t> host_buf(bytes, 0);
+    ret = aclrtMemcpy(*deviceAddr, bytes, host_buf.data(), bytes,
+                      ACL_MEMCPY_HOST_TO_DEVICE);
+    CHECK_RET(ret == ACL_SUCCESS,
+              LOG_PRINT("aclrtMemcpy (zero) failed: %d\n", ret);
+              return ret);
+  } else {
+    // Input tensor: random data on host then copy
+    std::vector<uint8_t> host_buf(bytes);
+    std::string dtype_str = (dataType == ACL_FLOAT)     ? "float32"
+                            : (dataType == ACL_FLOAT16) ? "float16"
+                                                        : "bfloat16";
+    FillRandom(host_buf.data(), elem_count, dtype_str);
+    ret = aclrtMemcpy(*deviceAddr, bytes, host_buf.data(), bytes,
+                      ACL_MEMCPY_HOST_TO_DEVICE);
+    CHECK_RET(ret == ACL_SUCCESS,
+              LOG_PRINT("aclrtMemcpy (rand) failed: %d\n", ret);
+              return ret);
+  }
 
-    // Strides for contiguous ND tensor
-    std::vector<int64_t> strides(shape.size(), 1);
-    for (int64_t i = static_cast<int64_t>(shape.size()) - 2; i >= 0; i--) {
-        strides[i] = shape[i + 1] * strides[i + 1];
-    }
+  // Strides for contiguous ND tensor
+  std::vector<int64_t> strides(shape.size(), 1);
+  for (int64_t i = static_cast<int64_t>(shape.size()) - 2; i >= 0; i--) {
+    strides[i] = shape[i + 1] * strides[i + 1];
+  }
 
-    *tensor = aclCreateTensor(shape.data(), static_cast<int32_t>(shape.size()), dataType,
-                              strides.data(), 0, ACL_FORMAT_ND,
-                              shape.data(), static_cast<int32_t>(shape.size()), *deviceAddr);
-    return 0;
+  *tensor =
+      aclCreateTensor(shape.data(), static_cast<int32_t>(shape.size()),
+                      dataType, strides.data(), 0, ACL_FORMAT_ND, shape.data(),
+                      static_cast<int32_t>(shape.size()), *deviceAddr);
+  return 0;
 }
 
 // ====================== Arg parsing ======================
 
 struct Args {
-    std::vector<int64_t> shape;  // 4D: B S N D
-    int64_t mode = 0;            // 0=half, 2=interleave
-    std::string dtype = "float16";
-    int repeats = 6;
-    int32_t device_id = 0;
+  std::vector<int64_t> shape; // 4D: B S N D
+  int64_t mode = 0;           // 0=half, 2=interleave
+  std::string dtype = "float16";
+  int repeats = 6;
+  int32_t device_id = 0;
 };
 
 void PrintUsage() {
-    fprintf(stderr,
-        "Usage: perf_rope_ascendc --shape B S N D [--mode 0] [--dtype float16] [--repeats 6] [--device 0]\n"
-        "  --shape    4 ints (B S N D), e.g. 4 1 64 128\n"
-        "  --mode     0=half, 2=interleave (default: 0)\n"
-        "  --dtype    float16|bfloat16|float32 (default: float16)\n"
-        "  --repeats  kernel launches (default: 6, first is warm-up)\n"
-        "  --device   NPU device id (default: 0)\n");
+  fprintf(stderr,
+          "Usage: perf_rope_ascendc --shape B S N D [--mode 0] [--dtype "
+          "float16] [--repeats 6] [--device 0]\n"
+          "  --shape    4 ints (B S N D), e.g. 4 1 64 128\n"
+          "  --mode     0=half, 2=interleave (default: 0)\n"
+          "  --dtype    float16|bfloat16|float32 (default: float16)\n"
+          "  --repeats  kernel launches (default: 6, first is warm-up)\n"
+          "  --device   NPU device id (default: 0)\n");
 }
 
-Args ParseArgs(int argc, char* argv[]) {
-    Args a;
-    for (int i = 1; i < argc; i++) {
-        std::string arg = argv[i];
-        if (arg == "--shape" && i + 4 < argc) {
-            for (int j = 0; j < 4; j++) {
-                a.shape.push_back(std::atoll(argv[++i]));
-            }
-        } else if (arg == "--mode" && i + 1 < argc) {
-            a.mode = std::atoll(argv[++i]);
-        } else if (arg == "--dtype" && i + 1 < argc) {
-            a.dtype = argv[++i];
-        } else if (arg == "--repeats" && i + 1 < argc) {
-            a.repeats = std::atoi(argv[++i]);
-        } else if (arg == "--device" && i + 1 < argc) {
-            a.device_id = std::atoi(argv[++i]);
-        } else if (arg == "-h" || arg == "--help") {
-            PrintUsage();
-            exit(0);
-        } else {
-            LOG_PRINT("Unknown arg: %s\n", arg.c_str());
-            PrintUsage();
-            exit(1);
-        }
+Args ParseArgs(int argc, char *argv[]) {
+  Args a;
+  for (int i = 1; i < argc; i++) {
+    std::string arg = argv[i];
+    if (arg == "--shape" && i + 4 < argc) {
+      for (int j = 0; j < 4; j++) {
+        a.shape.push_back(std::atoll(argv[++i]));
+      }
+    } else if (arg == "--mode" && i + 1 < argc) {
+      a.mode = std::atoll(argv[++i]);
+    } else if (arg == "--dtype" && i + 1 < argc) {
+      a.dtype = argv[++i];
+    } else if (arg == "--repeats" && i + 1 < argc) {
+      a.repeats = std::atoi(argv[++i]);
+    } else if (arg == "--device" && i + 1 < argc) {
+      a.device_id = std::atoi(argv[++i]);
+    } else if (arg == "-h" || arg == "--help") {
+      PrintUsage();
+      exit(0);
+    } else {
+      LOG_PRINT("Unknown arg: %s\n", arg.c_str());
+      PrintUsage();
+      exit(1);
     }
-    if (a.shape.size() != 4) {
-        LOG_PRINT("Error: --shape requires exactly 4 ints (B S N D)\n");
-        PrintUsage();
-        exit(1);
-    }
-    return a;
+  }
+  if (a.shape.size() != 4) {
+    LOG_PRINT("Error: --shape requires exactly 4 ints (B S N D)\n");
+    PrintUsage();
+    exit(1);
+  }
+  return a;
 }
 
 // ====================== Main ======================
 
-int main(int argc, char* argv[]) {
-    Args args = ParseArgs(argc, argv);
+int main(int argc, char *argv[]) {
+  Args args = ParseArgs(argc, argv);
 
-    aclrtStream stream;
-    auto ret = Init(args.device_id, &stream);
-    CHECK_RET(ret == 0, LOG_PRINT("Init failed: %d\n", ret); return ret);
+  aclrtStream stream;
+  auto ret = Init(args.device_id, &stream);
+  CHECK_RET(ret == 0, LOG_PRINT("Init failed: %d\n", ret); return ret);
 
-    aclDataType dtype = DtypeToAcl(args.dtype);
-    size_t type_size = DtypeSize(args.dtype);
+  aclDataType dtype = DtypeToAcl(args.dtype);
+  size_t type_size = DtypeSize(args.dtype);
 
-    // x: [B, S, N, D]  (4D, ND layout)
-    // sin/cos: broadcast over N → [B, S, 1, D]
-    // out: same as x
-    std::vector<int64_t> x_shape = args.shape;            // B S N D
-    std::vector<int64_t> sc_shape = {args.shape[0], args.shape[1], 1, args.shape[3]};  // B S 1 D
+  // x: [B, S, N, D]  (4D, ND layout)
+  // sin/cos: broadcast over N → [B, S, 1, D]
+  // out: same as x
+  std::vector<int64_t> x_shape = args.shape; // B S N D
+  std::vector<int64_t> sc_shape = {args.shape[0], args.shape[1], 1,
+                                   args.shape[3]}; // B S 1 D
 
-    // --- Create tensors ---
-    void* x_dev = nullptr;
-    void* cos_dev = nullptr;
-    void* sin_dev = nullptr;
-    void* out_dev = nullptr;
-    aclTensor* x = nullptr;
-    aclTensor* cos = nullptr;
-    aclTensor* sin = nullptr;
-    aclTensor* out = nullptr;
+  // --- Create tensors ---
+  void *x_dev = nullptr;
+  void *cos_dev = nullptr;
+  void *sin_dev = nullptr;
+  void *out_dev = nullptr;
+  aclTensor *x = nullptr;
+  aclTensor *cos = nullptr;
+  aclTensor *sin = nullptr;
+  aclTensor *out = nullptr;
 
-    ret = CreateAclTensorRandom(x_shape, dtype, type_size, &x_dev, &x);
-    CHECK_RET(ret == 0, return ret);
-    ret = CreateAclTensorRandom(sc_shape, dtype, type_size, &cos_dev, &cos);
-    CHECK_RET(ret == 0, return ret);
-    ret = CreateAclTensorRandom(sc_shape, dtype, type_size, &sin_dev, &sin);
-    CHECK_RET(ret == 0, return ret);
-    ret = CreateAclTensorRandom(x_shape, dtype, type_size, &out_dev, &out, /*zero_fill=*/true);
-    CHECK_RET(ret == 0, return ret);
+  ret = CreateAclTensorRandom(x_shape, dtype, type_size, &x_dev, &x);
+  CHECK_RET(ret == 0, return ret);
+  ret = CreateAclTensorRandom(sc_shape, dtype, type_size, &cos_dev, &cos);
+  CHECK_RET(ret == 0, return ret);
+  ret = CreateAclTensorRandom(sc_shape, dtype, type_size, &sin_dev, &sin);
+  CHECK_RET(ret == 0, return ret);
+  ret = CreateAclTensorRandom(x_shape, dtype, type_size, &out_dev, &out,
+                              /*zero_fill=*/true);
+  CHECK_RET(ret == 0, return ret);
 
-    // --- Run kernel N times (no timing, msprof wraps) ---
-    for (int i = 0; i < args.repeats; i++) {
-        uint64_t workspace_size = 0;
-        aclOpExecutor* executor = nullptr;
+  // --- Run kernel N times (no timing, msprof wraps) ---
+  for (int i = 0; i < args.repeats; i++) {
+    uint64_t workspace_size = 0;
+    aclOpExecutor *executor = nullptr;
 
-        ret = aclnnRotaryPositionEmbeddingGetWorkspaceSize(x, cos, sin, args.mode, out,
-                                                            &workspace_size, &executor);
-        CHECK_RET(ret == ACL_SUCCESS,
-                  LOG_PRINT("GetWorkspaceSize failed: %d\n", ret); return ret);
+    ret = aclnnRotaryPositionEmbeddingGetWorkspaceSize(
+        x, cos, sin, args.mode, out, &workspace_size, &executor);
+    CHECK_RET(ret == ACL_SUCCESS,
+              LOG_PRINT("GetWorkspaceSize failed: %d\n", ret);
+              return ret);
 
-        void* workspace = nullptr;
-        if (workspace_size > 0) {
-            ret = aclrtMalloc(&workspace, workspace_size, ACL_MEM_MALLOC_HUGE_FIRST);
-            CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("workspace malloc failed: %d\n", ret); return ret);
-        }
-
-        ret = aclnnRotaryPositionEmbedding(workspace, workspace_size, executor, stream);
-        CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclnnRotaryPositionEmbedding failed: %d\n", ret); return ret);
-
-        ret = aclrtSynchronizeStream(stream);
-        CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("SyncStream failed: %d\n", ret); return ret);
-
-        if (workspace != nullptr) aclrtFree(workspace);
-        // executor freed internally by aclnn, do not manually free
+    void *workspace = nullptr;
+    if (workspace_size > 0) {
+      ret = aclrtMalloc(&workspace, workspace_size, ACL_MEM_MALLOC_HUGE_FIRST);
+      CHECK_RET(ret == ACL_SUCCESS,
+                LOG_PRINT("workspace malloc failed: %d\n", ret);
+                return ret);
     }
 
-    // --- Cleanup ---
-    aclDestroyTensor(x);
-    aclDestroyTensor(cos);
-    aclDestroyTensor(sin);
-    aclDestroyTensor(out);
-    aclrtFree(x_dev);
-    aclrtFree(cos_dev);
-    aclrtFree(sin_dev);
-    aclrtFree(out_dev);
-    aclrtDestroyStream(stream);
-    aclrtResetDevice(args.device_id);
-    aclFinalize();
+    ret = aclnnRotaryPositionEmbedding(workspace, workspace_size, executor,
+                                       stream);
+    CHECK_RET(ret == ACL_SUCCESS,
+              LOG_PRINT("aclnnRotaryPositionEmbedding failed: %d\n", ret);
+              return ret);
 
-    LOG_PRINT("Test Passed!\n");
-    return 0;
+    ret = aclrtSynchronizeStream(stream);
+    CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("SyncStream failed: %d\n", ret);
+              return ret);
+
+    if (workspace != nullptr)
+      aclrtFree(workspace);
+    // executor freed internally by aclnn, do not manually free
+  }
+
+  // --- Cleanup ---
+  aclDestroyTensor(x);
+  aclDestroyTensor(cos);
+  aclDestroyTensor(sin);
+  aclDestroyTensor(out);
+  aclrtFree(x_dev);
+  aclrtFree(cos_dev);
+  aclrtFree(sin_dev);
+  aclrtFree(out_dev);
+  aclrtDestroyStream(stream);
+  aclrtResetDevice(args.device_id);
+  aclFinalize();
+
+  LOG_PRINT("Test Passed!\n");
+  return 0;
 }

--- a/examples/pos_embedding/RotaryPositionEmbedding/perf_rope_ascendc.cpp
+++ b/examples/pos_embedding/RotaryPositionEmbedding/perf_rope_ascendc.cpp
@@ -1,0 +1,277 @@
+/**
+ * perf_rope_ascendc.cpp — RoPE AscendC baseline driver for msprof.
+ *
+ * Calls aclnnRotaryPositionEmbedding (CANN ops-transformer/posembedding/
+ * rotary_position_embedding) N times on a single shape. No timing —
+ * msprof wraps this process to collect device Task Duration.
+ *
+ * Usage:
+ *   ./perf_rope_ascendc --shape B S N D --mode 0 --dtype float16 --repeats 6
+ *
+ * mode: 0=half, 2=interleave  (see aclnn_rotary_position_embedding.h)
+ * dtype: float16, bfloat16, float32
+ */
+
+#include "acl/acl.h"
+#include "aclnnop/aclnn_rotary_position_embedding.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
+
+#define CHECK_RET(cond, return_expr) \
+    do {                             \
+        if (!(cond)) {               \
+            return_expr;             \
+        }                            \
+    } while (0)
+
+#define LOG_PRINT(message, ...)     \
+    do {                            \
+        printf(message, ##__VA_ARGS__); \
+    } while (0)
+
+// ====================== Helpers ======================
+
+int64_t GetShapeSize(const std::vector<int64_t>& shape) {
+    int64_t sz = 1;
+    for (auto d : shape) sz *= d;
+    return sz;
+}
+
+aclDataType DtypeToAcl(const std::string& dtype) {
+    if (dtype == "float16") return ACL_FLOAT16;
+    if (dtype == "bfloat16") return ACL_BF16;
+    if (dtype == "float32") return ACL_FLOAT;
+    LOG_PRINT("Error: unsupported dtype '%s'\n", dtype.c_str());
+    exit(1);
+}
+
+size_t DtypeSize(const std::string& dtype) {
+    if (dtype == "float16" || dtype == "bfloat16") return 2;
+    if (dtype == "float32") return 4;
+    return 0;
+}
+
+// Fill host buffer with random values scaled to [-1, 1]
+void FillRandom(void* host_data, int64_t elem_count, const std::string& dtype) {
+    std::mt19937 gen(0);  // fixed seed = 0, same as TileLang side
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    if (dtype == "float32") {
+        auto* p = static_cast<float*>(host_data);
+        for (int64_t i = 0; i < elem_count; i++) p[i] = dist(gen);
+    } else if (dtype == "float16") {
+        // FP16: use __fp16 via uint16_t storage
+        auto* p = static_cast<uint16_t*>(host_data);
+        for (int64_t i = 0; i < elem_count; i++) {
+            float val = dist(gen);
+            // Convert float32 → float16 via bit manipulation (IEEE 754)
+            uint32_t bits;
+            memcpy(&bits, &val, sizeof(uint32_t));
+            uint32_t sign = (bits >> 16) & 0x8000;
+            int32_t exp = static_cast<int32_t>((bits >> 23) & 0xFF) - 127 + 15;
+            uint32_t mant = bits & 0x7FFFFF;
+            uint16_t fp16;
+            if (exp <= 0) {
+                fp16 = sign;  // underflow → 0
+            } else if (exp >= 31) {
+                fp16 = sign | 0x7C00;  // overflow → inf
+            } else {
+                fp16 = static_cast<uint16_t>(sign | (exp << 10) | (mant >> 13));
+            }
+            p[i] = fp16;
+        }
+    } else if (dtype == "bfloat16") {
+        // BF16: truncate float32 high 16 bits
+        auto* p = static_cast<uint16_t*>(host_data);
+        for (int64_t i = 0; i < elem_count; i++) {
+            float val = dist(gen);
+            uint32_t bits;
+            memcpy(&bits, &val, sizeof(uint32_t));
+            p[i] = static_cast<uint16_t>(bits >> 16);
+        }
+    }
+}
+
+int Init(int32_t deviceId, aclrtStream* stream) {
+    auto ret = aclInit(nullptr);
+    CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclInit failed: %d\n", ret); return ret);
+    ret = aclrtSetDevice(deviceId);
+    CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclrtSetDevice failed: %d\n", ret); return ret);
+    ret = aclrtCreateStream(stream);
+    CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclrtCreateStream failed: %d\n", ret); return ret);
+    return 0;
+}
+
+// Create aclTensor with random data on device
+int CreateAclTensorRandom(const std::vector<int64_t>& shape, aclDataType dataType,
+                          size_t type_size, void** deviceAddr, aclTensor** tensor,
+                          bool zero_fill = false) {
+    int64_t elem_count = GetShapeSize(shape);
+    size_t bytes = static_cast<size_t>(elem_count) * type_size;
+
+    auto ret = aclrtMalloc(deviceAddr, bytes, ACL_MEM_MALLOC_HUGE_FIRST);
+    CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclrtMalloc failed: %d\n", ret); return ret);
+
+    if (zero_fill) {
+        // Output tensor: zero-fill on host then copy
+        std::vector<uint8_t> host_buf(bytes, 0);
+        ret = aclrtMemcpy(*deviceAddr, bytes, host_buf.data(), bytes, ACL_MEMCPY_HOST_TO_DEVICE);
+        CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclrtMemcpy (zero) failed: %d\n", ret); return ret);
+    } else {
+        // Input tensor: random data on host then copy
+        std::vector<uint8_t> host_buf(bytes);
+        std::string dtype_str = (dataType == ACL_FLOAT) ? "float32" :
+                                (dataType == ACL_FLOAT16) ? "float16" : "bfloat16";
+        FillRandom(host_buf.data(), elem_count, dtype_str);
+        ret = aclrtMemcpy(*deviceAddr, bytes, host_buf.data(), bytes, ACL_MEMCPY_HOST_TO_DEVICE);
+        CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclrtMemcpy (rand) failed: %d\n", ret); return ret);
+    }
+
+    // Strides for contiguous ND tensor
+    std::vector<int64_t> strides(shape.size(), 1);
+    for (int64_t i = static_cast<int64_t>(shape.size()) - 2; i >= 0; i--) {
+        strides[i] = shape[i + 1] * strides[i + 1];
+    }
+
+    *tensor = aclCreateTensor(shape.data(), static_cast<int32_t>(shape.size()), dataType,
+                              strides.data(), 0, ACL_FORMAT_ND,
+                              shape.data(), static_cast<int32_t>(shape.size()), *deviceAddr);
+    return 0;
+}
+
+// ====================== Arg parsing ======================
+
+struct Args {
+    std::vector<int64_t> shape;  // 4D: B S N D
+    int64_t mode = 0;            // 0=half, 2=interleave
+    std::string dtype = "float16";
+    int repeats = 6;
+    int32_t device_id = 0;
+};
+
+void PrintUsage() {
+    fprintf(stderr,
+        "Usage: perf_rope_ascendc --shape B S N D [--mode 0] [--dtype float16] [--repeats 6] [--device 0]\n"
+        "  --shape    4 ints (B S N D), e.g. 4 1 64 128\n"
+        "  --mode     0=half, 2=interleave (default: 0)\n"
+        "  --dtype    float16|bfloat16|float32 (default: float16)\n"
+        "  --repeats  kernel launches (default: 6, first is warm-up)\n"
+        "  --device   NPU device id (default: 0)\n");
+}
+
+Args ParseArgs(int argc, char* argv[]) {
+    Args a;
+    for (int i = 1; i < argc; i++) {
+        std::string arg = argv[i];
+        if (arg == "--shape" && i + 4 < argc) {
+            for (int j = 0; j < 4; j++) {
+                a.shape.push_back(std::atoll(argv[++i]));
+            }
+        } else if (arg == "--mode" && i + 1 < argc) {
+            a.mode = std::atoll(argv[++i]);
+        } else if (arg == "--dtype" && i + 1 < argc) {
+            a.dtype = argv[++i];
+        } else if (arg == "--repeats" && i + 1 < argc) {
+            a.repeats = std::atoi(argv[++i]);
+        } else if (arg == "--device" && i + 1 < argc) {
+            a.device_id = std::atoi(argv[++i]);
+        } else if (arg == "-h" || arg == "--help") {
+            PrintUsage();
+            exit(0);
+        } else {
+            LOG_PRINT("Unknown arg: %s\n", arg.c_str());
+            PrintUsage();
+            exit(1);
+        }
+    }
+    if (a.shape.size() != 4) {
+        LOG_PRINT("Error: --shape requires exactly 4 ints (B S N D)\n");
+        PrintUsage();
+        exit(1);
+    }
+    return a;
+}
+
+// ====================== Main ======================
+
+int main(int argc, char* argv[]) {
+    Args args = ParseArgs(argc, argv);
+
+    aclrtStream stream;
+    auto ret = Init(args.device_id, &stream);
+    CHECK_RET(ret == 0, LOG_PRINT("Init failed: %d\n", ret); return ret);
+
+    aclDataType dtype = DtypeToAcl(args.dtype);
+    size_t type_size = DtypeSize(args.dtype);
+
+    // x: [B, S, N, D]  (4D, ND layout)
+    // sin/cos: broadcast over N → [B, S, 1, D]
+    // out: same as x
+    std::vector<int64_t> x_shape = args.shape;            // B S N D
+    std::vector<int64_t> sc_shape = {args.shape[0], args.shape[1], 1, args.shape[3]};  // B S 1 D
+
+    // --- Create tensors ---
+    void* x_dev = nullptr;
+    void* cos_dev = nullptr;
+    void* sin_dev = nullptr;
+    void* out_dev = nullptr;
+    aclTensor* x = nullptr;
+    aclTensor* cos = nullptr;
+    aclTensor* sin = nullptr;
+    aclTensor* out = nullptr;
+
+    ret = CreateAclTensorRandom(x_shape, dtype, type_size, &x_dev, &x);
+    CHECK_RET(ret == 0, return ret);
+    ret = CreateAclTensorRandom(sc_shape, dtype, type_size, &cos_dev, &cos);
+    CHECK_RET(ret == 0, return ret);
+    ret = CreateAclTensorRandom(sc_shape, dtype, type_size, &sin_dev, &sin);
+    CHECK_RET(ret == 0, return ret);
+    ret = CreateAclTensorRandom(x_shape, dtype, type_size, &out_dev, &out, /*zero_fill=*/true);
+    CHECK_RET(ret == 0, return ret);
+
+    // --- Run kernel N times (no timing, msprof wraps) ---
+    for (int i = 0; i < args.repeats; i++) {
+        uint64_t workspace_size = 0;
+        aclOpExecutor* executor = nullptr;
+
+        ret = aclnnRotaryPositionEmbeddingGetWorkspaceSize(x, cos, sin, args.mode, out,
+                                                            &workspace_size, &executor);
+        CHECK_RET(ret == ACL_SUCCESS,
+                  LOG_PRINT("GetWorkspaceSize failed: %d\n", ret); return ret);
+
+        void* workspace = nullptr;
+        if (workspace_size > 0) {
+            ret = aclrtMalloc(&workspace, workspace_size, ACL_MEM_MALLOC_HUGE_FIRST);
+            CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("workspace malloc failed: %d\n", ret); return ret);
+        }
+
+        ret = aclnnRotaryPositionEmbedding(workspace, workspace_size, executor, stream);
+        CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclnnRotaryPositionEmbedding failed: %d\n", ret); return ret);
+
+        ret = aclrtSynchronizeStream(stream);
+        CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("SyncStream failed: %d\n", ret); return ret);
+
+        if (workspace != nullptr) aclrtFree(workspace);
+        // executor freed internally by aclnn, do not manually free
+    }
+
+    // --- Cleanup ---
+    aclDestroyTensor(x);
+    aclDestroyTensor(cos);
+    aclDestroyTensor(sin);
+    aclDestroyTensor(out);
+    aclrtFree(x_dev);
+    aclrtFree(cos_dev);
+    aclrtFree(sin_dev);
+    aclrtFree(out_dev);
+    aclrtDestroyStream(stream);
+    aclrtResetDevice(args.device_id);
+    aclFinalize();
+
+    LOG_PRINT("Test Passed!\n");
+    return 0;
+}

--- a/examples/pos_embedding/RotaryPositionEmbedding/perf_rope_ascendc.cpp
+++ b/examples/pos_embedding/RotaryPositionEmbedding/perf_rope_ascendc.cpp
@@ -1,15 +1,31 @@
 /**
- * perf_rope_ascendc.cpp — RoPE AscendC baseline driver for msprof.
+ * perf_rope_ascendc.cpp — RoPE AscendC baseline driver.
  *
  * Calls aclnnRotaryPositionEmbedding (CANN ops-transformer/posembedding/
- * rotary_position_embedding) N times on a single shape. No timing —
- * msprof wraps this process to collect device Task Duration.
+ * rotary_position_embedding) on a single shape.
  *
- * Usage:
+ * Two modes:
+ *   1. Perf mode (default): random-filled tensors, N repeats, no I/O.
+ *      Used with msprof for device Task Duration collection.
+ *   2. Golden mode (--load-prefix + --dump-output): load x/sin/cos from
+ *      binary files, run once, dump output to file. Used by the Python
+ *      test harness for accuracy comparison.
+ *
+ * Usage (perf):
  *   ./perf_rope_ascendc --shape B S N D --mode 0 --dtype float16 --repeats 6
  *
- * mode: 0=half, 2=interleave  (see aclnn_rotary_position_embedding.h)
+ * Usage (golden):
+ *   ./perf_rope_ascendc --shape B S N D --mode 0 --dtype float16 \
+ *     --load-prefix /tmp/rope --dump-output /tmp/rope_out.bin
+ *
+ * mode: 0=half, 1=interleave  (see aclnn_rotary_position_embedding.h;
+ *       NOTE: the header comment says 2=interleave but the actual enum
+ *       in op_host is 0=half, 1=interleave, 2=quarter, 3=interleave-half)
  * dtype: float16, bfloat16, float32
+ *
+ * File format: raw little-endian bytes (fp16/bf16 = 2 bytes/elem,
+ * fp32 = 4 bytes/elem). load-prefix reads {prefix}_x.bin, {prefix}_sin.bin,
+ * {prefix}_cos.bin. dump-output writes a single file.
  */
 
 #include "acl/acl.h"
@@ -18,6 +34,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <fstream>
 #include <random>
 #include <string>
 #include <vector>
@@ -60,6 +77,33 @@ size_t DtypeSize(const std::string &dtype) {
   if (dtype == "float32")
     return 4;
   return 0;
+}
+
+// Read a binary file into a host buffer. Returns false on failure.
+bool ReadFile(const std::string &path, void *buf, size_t bytes) {
+  std::ifstream f(path, std::ios::binary);
+  if (!f) {
+    LOG_PRINT("Error: cannot open '%s' for reading\n", path.c_str());
+    return false;
+  }
+  f.read(static_cast<char *>(buf), static_cast<std::streamsize>(bytes));
+  if (static_cast<size_t>(f.gcount()) != bytes) {
+    LOG_PRINT("Error: short read on '%s' (got %lld, expected %zu)\n",
+              path.c_str(), static_cast<long long>(f.gcount()), bytes);
+    return false;
+  }
+  return true;
+}
+
+// Write a host buffer to a binary file. Returns false on failure.
+bool WriteFile(const std::string &path, const void *buf, size_t bytes) {
+  std::ofstream f(path, std::ios::binary | std::ios::trunc);
+  if (!f) {
+    LOG_PRINT("Error: cannot open '%s' for writing\n", path.c_str());
+    return false;
+  }
+  f.write(static_cast<const char *>(buf), static_cast<std::streamsize>(bytes));
+  return f.good();
 }
 
 // Fill host buffer with random values scaled to [-1, 1]
@@ -117,11 +161,11 @@ int Init(int32_t deviceId, aclrtStream *stream) {
   return 0;
 }
 
-// Create aclTensor with random data on device
-int CreateAclTensorRandom(const std::vector<int64_t> &shape,
-                          aclDataType dataType, size_t type_size,
-                          void **deviceAddr, aclTensor **tensor,
-                          bool zero_fill = false) {
+// Create aclTensor on device.
+// fill_mode: "random" (FillRandom), "zero" (zero-fill), or file path (load).
+int CreateAclTensor(const std::vector<int64_t> &shape, aclDataType dataType,
+                    size_t type_size, void **deviceAddr, aclTensor **tensor,
+                    const std::string &fill_mode = "random") {
   int64_t elem_count = GetShapeSize(shape);
   size_t bytes = static_cast<size_t>(elem_count) * type_size;
 
@@ -129,27 +173,24 @@ int CreateAclTensorRandom(const std::vector<int64_t> &shape,
   CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclrtMalloc failed: %d\n", ret);
             return ret);
 
-  if (zero_fill) {
-    // Output tensor: zero-fill on host then copy
-    std::vector<uint8_t> host_buf(bytes, 0);
-    ret = aclrtMemcpy(*deviceAddr, bytes, host_buf.data(), bytes,
-                      ACL_MEMCPY_HOST_TO_DEVICE);
-    CHECK_RET(ret == ACL_SUCCESS,
-              LOG_PRINT("aclrtMemcpy (zero) failed: %d\n", ret);
-              return ret);
-  } else {
-    // Input tensor: random data on host then copy
-    std::vector<uint8_t> host_buf(bytes);
+  std::vector<uint8_t> host_buf(bytes);
+  if (fill_mode == "zero") {
+    std::memset(host_buf.data(), 0, bytes);
+  } else if (fill_mode == "random") {
     std::string dtype_str = (dataType == ACL_FLOAT)     ? "float32"
                             : (dataType == ACL_FLOAT16) ? "float16"
                                                         : "bfloat16";
     FillRandom(host_buf.data(), elem_count, dtype_str);
-    ret = aclrtMemcpy(*deviceAddr, bytes, host_buf.data(), bytes,
-                      ACL_MEMCPY_HOST_TO_DEVICE);
-    CHECK_RET(ret == ACL_SUCCESS,
-              LOG_PRINT("aclrtMemcpy (rand) failed: %d\n", ret);
-              return ret);
+  } else {
+    // fill_mode is a file path
+    if (!ReadFile(fill_mode, host_buf.data(), bytes)) {
+      return 1;
+    }
   }
+  ret = aclrtMemcpy(*deviceAddr, bytes, host_buf.data(), bytes,
+                    ACL_MEMCPY_HOST_TO_DEVICE);
+  CHECK_RET(ret == ACL_SUCCESS, LOG_PRINT("aclrtMemcpy failed: %d\n", ret);
+            return ret);
 
   // Strides for contiguous ND tensor
   std::vector<int64_t> strides(shape.size(), 1);
@@ -168,21 +209,28 @@ int CreateAclTensorRandom(const std::vector<int64_t> &shape,
 
 struct Args {
   std::vector<int64_t> shape; // 4D: B S N D
-  int64_t mode = 0;           // 0=half, 2=interleave
+  int64_t mode = 0;           // 0=half, 1=interleave
   std::string dtype = "float16";
   int repeats = 6;
   int32_t device_id = 0;
+  std::string load_prefix; // if set: load {prefix}_x/sin/cos.bin
+  std::string dump_output; // if set: dump output to this path
 };
 
 void PrintUsage() {
   fprintf(stderr,
           "Usage: perf_rope_ascendc --shape B S N D [--mode 0] [--dtype "
           "float16] [--repeats 6] [--device 0]\n"
-          "  --shape    4 ints (B S N D), e.g. 4 1 64 128\n"
-          "  --mode     0=half, 2=interleave (default: 0)\n"
-          "  --dtype    float16|bfloat16|float32 (default: float16)\n"
-          "  --repeats  kernel launches (default: 6, first is warm-up)\n"
-          "  --device   NPU device id (default: 0)\n");
+          "       perf_rope_ascendc --shape B S N D --load-prefix P "
+          "--dump-output F\n"
+          "  --shape        4 ints (B S N D), e.g. 4 1 64 128\n"
+          "  --mode         0=half, 1=interleave (default: 0)\n"
+          "  --dtype        float16|bfloat16|float32 (default: float16)\n"
+          "  --repeats      kernel launches (default: 6, first is warm-up)\n"
+          "  --device       NPU device id (default: 0)\n"
+          "  --load-prefix  load {prefix}_x.bin, {prefix}_sin.bin, "
+          "{prefix}_cos.bin\n"
+          "  --dump-output  run once and dump output to this file\n");
 }
 
 Args ParseArgs(int argc, char *argv[]) {
@@ -201,6 +249,10 @@ Args ParseArgs(int argc, char *argv[]) {
       a.repeats = std::atoi(argv[++i]);
     } else if (arg == "--device" && i + 1 < argc) {
       a.device_id = std::atoi(argv[++i]);
+    } else if (arg == "--load-prefix" && i + 1 < argc) {
+      a.load_prefix = argv[++i];
+    } else if (arg == "--dump-output" && i + 1 < argc) {
+      a.dump_output = argv[++i];
     } else if (arg == "-h" || arg == "--help") {
       PrintUsage();
       exit(0);
@@ -214,6 +266,10 @@ Args ParseArgs(int argc, char *argv[]) {
     LOG_PRINT("Error: --shape requires exactly 4 ints (B S N D)\n");
     PrintUsage();
     exit(1);
+  }
+  // Golden mode: force repeats=1 (only need one run for output)
+  if (!a.dump_output.empty()) {
+    a.repeats = 1;
   }
   return a;
 }
@@ -237,6 +293,12 @@ int main(int argc, char *argv[]) {
   std::vector<int64_t> sc_shape = {args.shape[0], args.shape[1], 1,
                                    args.shape[3]}; // B S 1 D
 
+  // --- Determine fill modes ---
+  bool golden = !args.load_prefix.empty();
+  std::string x_fill = golden ? (args.load_prefix + "_x.bin") : "random";
+  std::string sin_fill = golden ? (args.load_prefix + "_sin.bin") : "random";
+  std::string cos_fill = golden ? (args.load_prefix + "_cos.bin") : "random";
+
   // --- Create tensors ---
   void *x_dev = nullptr;
   void *cos_dev = nullptr;
@@ -247,14 +309,13 @@ int main(int argc, char *argv[]) {
   aclTensor *sin = nullptr;
   aclTensor *out = nullptr;
 
-  ret = CreateAclTensorRandom(x_shape, dtype, type_size, &x_dev, &x);
+  ret = CreateAclTensor(x_shape, dtype, type_size, &x_dev, &x, x_fill);
   CHECK_RET(ret == 0, return ret);
-  ret = CreateAclTensorRandom(sc_shape, dtype, type_size, &cos_dev, &cos);
+  ret = CreateAclTensor(sc_shape, dtype, type_size, &cos_dev, &cos, cos_fill);
   CHECK_RET(ret == 0, return ret);
-  ret = CreateAclTensorRandom(sc_shape, dtype, type_size, &sin_dev, &sin);
+  ret = CreateAclTensor(sc_shape, dtype, type_size, &sin_dev, &sin, sin_fill);
   CHECK_RET(ret == 0, return ret);
-  ret = CreateAclTensorRandom(x_shape, dtype, type_size, &out_dev, &out,
-                              /*zero_fill=*/true);
+  ret = CreateAclTensor(x_shape, dtype, type_size, &out_dev, &out, "zero");
   CHECK_RET(ret == 0, return ret);
 
   // --- Run kernel N times (no timing, msprof wraps) ---
@@ -289,6 +350,21 @@ int main(int argc, char *argv[]) {
     if (workspace != nullptr)
       aclrtFree(workspace);
     // executor freed internally by aclnn, do not manually free
+  }
+
+  // --- Dump output (golden mode) ---
+  if (!args.dump_output.empty()) {
+    int64_t out_elems = GetShapeSize(x_shape);
+    size_t out_bytes = static_cast<size_t>(out_elems) * type_size;
+    std::vector<uint8_t> host_buf(out_bytes);
+    ret = aclrtMemcpy(host_buf.data(), out_bytes, out_dev, out_bytes,
+                      ACL_MEMCPY_DEVICE_TO_HOST);
+    CHECK_RET(ret == ACL_SUCCESS,
+              LOG_PRINT("aclrtMemcpy (D2H) failed: %d\n", ret);
+              return ret);
+    if (!WriteFile(args.dump_output, host_buf.data(), out_bytes)) {
+      return 1;
+    }
   }
 
   // --- Cleanup ---

--- a/examples/pos_embedding/RotaryPositionEmbedding/rope_half_interleaved.py
+++ b/examples/pos_embedding/RotaryPositionEmbedding/rope_half_interleaved.py
@@ -363,8 +363,7 @@ def _make_input(shape, dtype_str, layout_kind):
     return x_cpu, sin_cpu, cos_cpu
 
 
-def run_case(shape, layout, dtype_str, layout_kind, level="l0",
-             inputs=None, tag="PRECISION", label=None):
+def run_case(shape, layout, dtype_str, layout_kind, level="l0", inputs=None, tag="PRECISION", label=None):
     """Run a single test case. Returns (passed, ratio, max_abs).
 
     inputs:  optional (x, sin, cos) CPU tuple; if None, generated via _make_input
@@ -459,26 +458,42 @@ def test_rope_l1():
 
 # ========== L2 Tests (negative: invalid inputs should be rejected) ==========
 L2_CASES = [
-    ("odd_rope_dim", lambda: (
-        torch.randn(4, 8, 128, dtype=torch.float16, device=device),
-        torch.randn(4, 1, 63, dtype=torch.float16, device=device),
-        torch.randn(4, 1, 63, dtype=torch.float16, device=device)),
-     ValueError),
-    ("bad_dim_1d", lambda: (
-        torch.randn(128, dtype=torch.float16, device=device),
-        torch.randn(1, 64, dtype=torch.float16, device=device),
-        torch.randn(1, 64, dtype=torch.float16, device=device)),
-     NotImplementedError),
-    ("bad_dim_5d", lambda: (
-        torch.randn(2, 4, 8, 16, 64, dtype=torch.float16, device=device),
-        torch.randn(2, 4, 1, 32, dtype=torch.float16, device=device),
-        torch.randn(2, 4, 1, 32, dtype=torch.float16, device=device)),
-     NotImplementedError),
-    ("rope_dim_too_large", lambda: (
-        torch.randn(4, 8, 64, dtype=torch.float16, device=device),
-        torch.randn(4, 1, 128, dtype=torch.float16, device=device),
-        torch.randn(4, 1, 128, dtype=torch.float16, device=device)),
-     (ValueError, IndexError, RuntimeError)),
+    (
+        "odd_rope_dim",
+        lambda: (
+            torch.randn(4, 8, 128, dtype=torch.float16, device=device),
+            torch.randn(4, 1, 63, dtype=torch.float16, device=device),
+            torch.randn(4, 1, 63, dtype=torch.float16, device=device),
+        ),
+        ValueError,
+    ),
+    (
+        "bad_dim_1d",
+        lambda: (
+            torch.randn(128, dtype=torch.float16, device=device),
+            torch.randn(1, 64, dtype=torch.float16, device=device),
+            torch.randn(1, 64, dtype=torch.float16, device=device),
+        ),
+        NotImplementedError,
+    ),
+    (
+        "bad_dim_5d",
+        lambda: (
+            torch.randn(2, 4, 8, 16, 64, dtype=torch.float16, device=device),
+            torch.randn(2, 4, 1, 32, dtype=torch.float16, device=device),
+            torch.randn(2, 4, 1, 32, dtype=torch.float16, device=device),
+        ),
+        NotImplementedError,
+    ),
+    (
+        "rope_dim_too_large",
+        lambda: (
+            torch.randn(4, 8, 64, dtype=torch.float16, device=device),
+            torch.randn(4, 1, 128, dtype=torch.float16, device=device),
+            torch.randn(4, 1, 128, dtype=torch.float16, device=device),
+        ),
+        (ValueError, IndexError, RuntimeError),
+    ),
 ]
 
 
@@ -490,36 +505,66 @@ def test_rope_l2():
 
 # ========== Boundary Tests (legal special/extreme values, non-blocking) ==========
 BOUNDARY_CASES = [
-    ("large_values", lambda: (
-        torch.randn(16, 64, 512, dtype=torch.float16) * 1000,
-        torch.randn(16, 1, 256, dtype=torch.float16),
-        torch.randn(16, 1, 256, dtype=torch.float16)),
-     "interleaved", "float16"),
-    ("zero_values", lambda: (
-        torch.zeros(16, 64, 512, dtype=torch.float16),
-        torch.randn(16, 1, 256, dtype=torch.float16),
-        torch.randn(16, 1, 256, dtype=torch.float16)),
-     "half", "float16"),
-    ("full_rope_large_batch", lambda: (
-        torch.randn(128, 64, 256, dtype=torch.float16),
-        torch.randn(128, 1, 256, dtype=torch.float16),
-        torch.randn(128, 1, 256, dtype=torch.float16)),
-     "interleaved", "float16"),
-    ("min_rope_dim", lambda: (
-        torch.randn(8, 16, 128, dtype=torch.bfloat16),
-        torch.randn(8, 1, 64, dtype=torch.bfloat16),
-        torch.randn(8, 1, 64, dtype=torch.bfloat16)),
-     "half", "bfloat16"),
-    ("single_row", lambda: (
-        torch.randn(1, 1, 128, dtype=torch.float16),
-        torch.randn(1, 1, 64, dtype=torch.float16),
-        torch.randn(1, 1, 64, dtype=torch.float16)),
-     "interleaved", "float16"),
-    ("bsnd_tail", lambda: (
-        torch.randn(3, 33, 8, 256, dtype=torch.float16),
-        torch.randn(1, 33, 1, 128, dtype=torch.float16),
-        torch.randn(1, 33, 1, 128, dtype=torch.float16)),
-     "half", "float16"),
+    (
+        "large_values",
+        lambda: (
+            torch.randn(16, 64, 512, dtype=torch.float16) * 1000,
+            torch.randn(16, 1, 256, dtype=torch.float16),
+            torch.randn(16, 1, 256, dtype=torch.float16),
+        ),
+        "interleaved",
+        "float16",
+    ),
+    (
+        "zero_values",
+        lambda: (
+            torch.zeros(16, 64, 512, dtype=torch.float16),
+            torch.randn(16, 1, 256, dtype=torch.float16),
+            torch.randn(16, 1, 256, dtype=torch.float16),
+        ),
+        "half",
+        "float16",
+    ),
+    (
+        "full_rope_large_batch",
+        lambda: (
+            torch.randn(128, 64, 256, dtype=torch.float16),
+            torch.randn(128, 1, 256, dtype=torch.float16),
+            torch.randn(128, 1, 256, dtype=torch.float16),
+        ),
+        "interleaved",
+        "float16",
+    ),
+    (
+        "min_rope_dim",
+        lambda: (
+            torch.randn(8, 16, 128, dtype=torch.bfloat16),
+            torch.randn(8, 1, 64, dtype=torch.bfloat16),
+            torch.randn(8, 1, 64, dtype=torch.bfloat16),
+        ),
+        "half",
+        "bfloat16",
+    ),
+    (
+        "single_row",
+        lambda: (
+            torch.randn(1, 1, 128, dtype=torch.float16),
+            torch.randn(1, 1, 64, dtype=torch.float16),
+            torch.randn(1, 1, 64, dtype=torch.float16),
+        ),
+        "interleaved",
+        "float16",
+    ),
+    (
+        "bsnd_tail",
+        lambda: (
+            torch.randn(3, 33, 8, 256, dtype=torch.float16),
+            torch.randn(1, 33, 1, 128, dtype=torch.float16),
+            torch.randn(1, 33, 1, 128, dtype=torch.float16),
+        ),
+        "half",
+        "float16",
+    ),
 ]
 
 
@@ -528,8 +573,7 @@ def test_rope_boundary():
     torch.manual_seed(123)
     for name, make_inputs, layout, dtype_str in BOUNDARY_CASES:
         try:
-            run_case(None, layout, dtype_str, None, level="boundary",
-                     inputs=make_inputs(), tag="BOUNDARY", label=name)
+            run_case(None, layout, dtype_str, None, level="boundary", inputs=make_inputs(), tag="BOUNDARY", label=name)
         except Exception as e:
             print(f"[BOUNDARY_WARN] boundary {name}: {type(e).__name__}: {e}")
 

--- a/examples/pos_embedding/RotaryPositionEmbedding/rope_half_interleaved.py
+++ b/examples/pos_embedding/RotaryPositionEmbedding/rope_half_interleaved.py
@@ -15,7 +15,10 @@ Unified formula:  out = x * cos + rotate(x) * (sin * sin_mask)
 """
 
 import argparse
+import os
+import subprocess
 import sys
+import tempfile
 
 import tilelang
 import tilelang.language as T
@@ -31,6 +34,15 @@ pass_configs = {
 
 NUM_CORES = 48
 device = torch.device("npu")
+
+# Module-level golden mode: "torch" (default) or "cann".
+# Set by main() via --golden; run_case reads this to pick the reference.
+_GOLDEN_MODE = "torch"
+
+# Path to the AscendC driver (relative to this file).
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_PERF_BIN = os.path.join(_SCRIPT_DIR, "build", "perf_rope_ascendc")
+_BUILD_SCRIPT = os.path.join(_SCRIPT_DIR, "build_perf_rope.sh")
 
 torch_dtype_map = {
     "float16": torch.float16,
@@ -311,6 +323,135 @@ def torch_rope_ref(x, sin, cos, layout="interleaved"):
     return out
 
 
+# ========== CANN Golden (aclnnRotaryPositionEmbedding via subprocess) ==========
+def _ensure_perf_bin():
+    """Build perf_rope_ascendc if missing. Returns path to the binary."""
+    if os.path.isfile(_PERF_BIN) and os.access(_PERF_BIN, os.X_OK):
+        return _PERF_BIN
+    if not os.path.isfile(_BUILD_SCRIPT):
+        raise FileNotFoundError(f"build script not found: {_BUILD_SCRIPT}")
+    print(f"[BUILD] perf_rope_ascendc not found, building via {_BUILD_SCRIPT} ...")
+    result = subprocess.run(["bash", _BUILD_SCRIPT], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"build_perf_rope.sh failed (exit {result.returncode}):\n{result.stderr}")
+    if not os.path.isfile(_PERF_BIN):
+        raise FileNotFoundError(f"build succeeded but binary not found: {_PERF_BIN}")
+    print("[BUILD] OK")
+    return _PERF_BIN
+
+
+def cann_rope_ref(x_cpu, sin_cpu, cos_cpu, layout, dtype_str):
+    """Reference via aclnnRotaryPositionEmbedding (subprocess to C++ driver).
+
+    CANN op is full-rope + non-in-place. We extract the rotating slice
+    (x[..., dim_start:]), run the CANN op on it, and place it back.
+
+    Args:
+        x_cpu, sin_cpu, cos_cpu: CPU tensors (same shapes as TileLang input)
+        layout: "half" or "interleaved"
+        dtype_str: "float16" or "bfloat16"
+
+    Returns:
+        out: CPU tensor, same shape as x_cpu, with RoPE applied to the slice.
+    """
+    perf_bin = _ensure_perf_bin()
+
+    rope_dim = sin_cpu.shape[-1]
+    hidden_size = x_cpu.shape[-1]
+    dim_start = hidden_size - rope_dim
+
+    # --- Extract the rotating slice and reshape to 4D [B, S, N, RD] ---
+    x_slice = x_cpu[..., dim_start:].contiguous()
+
+    if x_slice.dim() == 3:
+        # TND: [BS, N, RD] -> 4D [BS, 1, N, RD]
+        bs, n, rd = x_slice.shape
+        b, s = bs, 1
+        x_4d = x_slice.unsqueeze(1)  # [BS, 1, N, RD]
+        # sin [BS, 1, RD] -> [BS, 1, 1, RD]
+        sin_4d = sin_cpu.unsqueeze(1).contiguous()
+        cos_4d = cos_cpu.unsqueeze(1).contiguous()
+    elif x_slice.dim() == 4:
+        # BSND: [B, S, N, RD]
+        b_orig, s_orig, n, rd = x_slice.shape
+        # CANN op interleave (mode=1) doesn't support BSND sin/cos broadcast
+        # when B>1 and S>1. Reshape to equivalent TND so S=1.
+        b, s = b_orig * s_orig, 1
+        x_4d = x_slice.reshape(b, 1, n, rd)
+        # sin [1, S, 1, RD] -> expand to [B_orig, S, 1, RD] -> reshape [B*S, 1, 1, RD]
+        sin_4d = sin_cpu.expand(b_orig, s_orig, 1, rd).reshape(b, 1, 1, rd).contiguous()
+        cos_4d = cos_cpu.expand(b_orig, s_orig, 1, rd).reshape(b, 1, 1, rd).contiguous()
+    else:
+        raise NotImplementedError(f"x_slice.dim()={x_slice.dim()} not supported")
+
+    out_shape = x_slice.shape  # remember original slice shape for output reshape
+
+    # --- Dump inputs to temp files ---
+    tmp_dir = tempfile.mkdtemp(prefix="rope_golden_")
+    prefix = os.path.join(tmp_dir, "input")
+    x_path = f"{prefix}_x.bin"
+    sin_path = f"{prefix}_sin.bin"
+    cos_path = f"{prefix}_cos.bin"
+    out_path = os.path.join(tmp_dir, "output.bin")
+
+    try:
+        # bf16 not supported by numpy; view as uint16 (same bit layout).
+        # Works for fp16 too since we only need raw bytes.
+        with open(x_path, "wb") as f:
+            f.write(x_4d.view(torch.uint16).numpy().tobytes())
+        with open(sin_path, "wb") as f:
+            f.write(sin_4d.view(torch.uint16).numpy().tobytes())
+        with open(cos_path, "wb") as f:
+            f.write(cos_4d.view(torch.uint16).numpy().tobytes())
+
+        # --- Run CANN op ---
+        # mode: 0=half, 1=interleave (NOT 2; the header comment is wrong,
+        #       confirmed by op_host enum + ST golden)
+        mode = "0" if layout == "half" else "1"
+        cmd = [
+            perf_bin,
+            "--shape",
+            str(b),
+            str(s),
+            str(n),
+            str(rd),
+            "--mode",
+            mode,
+            "--dtype",
+            dtype_str,
+            "--load-prefix",
+            prefix,
+            "--dump-output",
+            out_path,
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(f"perf_rope_ascendc failed (exit {result.returncode}):\n{result.stderr}")
+
+        # --- Read output ---
+        # torch.frombuffer doesn't support bfloat16; read as uint16 via
+        # numpy then view to the target dtype (works for fp16 and bf16).
+        import numpy as np
+
+        with open(out_path, "rb") as f:
+            out_bytes = f.read()
+        torch_dtype = torch_dtype_map[dtype_str]
+        out_slice = torch.from_numpy(np.frombuffer(out_bytes, dtype=np.uint16).copy()).view(torch_dtype).reshape(b, s, n, rd)
+
+    finally:
+        import shutil
+
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    # --- Reshape output back to match original x_slice shape ---
+    out_slice = out_slice.reshape(out_shape)
+
+    # --- Place slice back into x ---
+    out = x_cpu.clone()
+    out[..., dim_start:] = out_slice
+    return out
+
+
 # ========== Precision Standard (mixed tolerance) ==========
 def get_precision(dtype):
     """Return (atol, rtol, max_abs_error_limit, required_matched_ratio)."""
@@ -375,7 +516,10 @@ def run_case(shape, layout, dtype_str, layout_kind, level="l0", inputs=None, tag
     else:
         x_cpu, sin_cpu, cos_cpu = inputs
 
-    out_ref = torch_rope_ref(x_cpu.clone(), sin_cpu, cos_cpu, layout)
+    if _GOLDEN_MODE == "cann":
+        out_ref = cann_rope_ref(x_cpu.clone(), sin_cpu, cos_cpu, layout, dtype_str)
+    else:
+        out_ref = torch_rope_ref(x_cpu.clone(), sin_cpu, cos_cpu, layout)
 
     x_npu = x_cpu.to(device)
     sin_npu = sin_cpu.to(device)
@@ -580,13 +724,18 @@ def test_rope_boundary():
 
 # ========== Main ==========
 def main():
+    global _GOLDEN_MODE
     parser = argparse.ArgumentParser(description="RoPE (Half + Interleaved) on Ascend NPU")
     parser.add_argument("--level", default="l0", choices=["l0", "l1", "l2", "boundary", "all"], help="Test level to run (default: l0)")
     parser.add_argument("--shape", type=int, nargs="+", help="Single-case shape: 4 ints (TND: BS H HS RD) or 5 ints (BSND: B S H HS RD)")
     parser.add_argument("--layout", default="interleaved", choices=["interleaved", "half"], help="RoPE layout (default: interleaved)")
     parser.add_argument("--dtype", default="float16", choices=["float16", "bfloat16"], help="Data type (default: float16)")
+    parser.add_argument(
+        "--golden", default="torch", choices=["torch", "cann"], help="Golden source: torch (CPU ref) or cann (aclnn op via subprocess)"
+    )
     args = parser.parse_args()
 
+    _GOLDEN_MODE = args.golden
     tilelang.disable_cache()
     torch.manual_seed(42)
 

--- a/examples/pos_embedding/RotaryPositionEmbedding/rope_half_interleaved.py
+++ b/examples/pos_embedding/RotaryPositionEmbedding/rope_half_interleaved.py
@@ -1,0 +1,601 @@
+"""RoPE (Half + Interleaved) unified implementation for Ascend NPU.
+
+Forward-only rotary position embedding with NPU-internal mask generation.
+Supports Half (GPT-NeoX/LLaMA) and Interleaved (GPT-J) layouts via a
+compile-time ``layout`` parameter that selects the code path inside
+``@T.prim_func``.
+
+Layouts:
+  - interleaved: rotate([x0, x1, x2, x3, ...]) = [x1, x0, x3, x2, ...]
+                 sin_mask = [-1, +1, -1, +1, ...]
+  - half:        rotate([x1, x2]) = [x2, x1]  (copy-swap)
+                 sin_mask = [-1, ..., -1, +1, ..., +1]
+
+Unified formula:  out = x * cos + rotate(x) * (sin * sin_mask)
+"""
+
+import argparse
+import sys
+
+import tilelang
+import tilelang.language as T
+import torch
+
+# ========== Pass Configs (Developer mode, auto-sync) ==========
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+}
+
+NUM_CORES = 48
+device = torch.device("npu")
+
+torch_dtype_map = {
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+}
+
+tilelang_dtype_map = {
+    torch.float16: "float16",
+    torch.bfloat16: "bfloat16",
+}
+
+
+# ========== Kernel ==========
+@tilelang.jit(pass_configs=pass_configs)
+def rope_kernel(M, block_M, num_blocks, total_chunks, sc_rows, hidden_size, rope_dim, head_num, layout, dtype="float16"):
+    """RoPE forward kernel (in-place on ``x``).
+
+    Parameters are Python-level (JIT compile-time constants). ``layout`` is a
+    Python string that selects the code path during ``@T.prim_func`` parsing.
+    """
+    VEC_NUM = 2
+    dim_start = hidden_size - rope_dim
+    row_per_vec = block_M // VEC_NUM
+    half = rope_dim // 2
+    ACC_DTYPE = "float32"
+    MASK_DTYPE = "uint32"
+    need_cast = dtype != "float32"
+
+    chunks_per_block = (total_chunks + num_blocks - 1) // num_blocks
+
+    x_elem_count = row_per_vec * rope_dim
+    sc_elem_count = rope_dim
+
+    @T.prim_func
+    def kernel(
+        x: T.Tensor([M, hidden_size], dtype),  # type: ignore
+        sin: T.Tensor([sc_rows, rope_dim], dtype),  # type: ignore
+        cos: T.Tensor([sc_rows, rope_dim], dtype),  # type: ignore
+    ):
+        with T.Kernel(num_blocks, is_npu=True) as (cid, vid):
+            # ===== Buffer allocation (all unconditional; MEMORY_PLANNING reclaims
+            #       unused mask buffers for the half layout) =====
+            x_half_ub = T.alloc_shared([row_per_vec, rope_dim], dtype)
+            x_ub = T.alloc_shared([row_per_vec, rope_dim], ACC_DTYPE)
+            sin_ub = T.alloc_shared([1, rope_dim], ACC_DTYPE)
+            sin_half_ub = T.alloc_shared([1, rope_dim], dtype)
+            cos_ub = T.alloc_shared([1, rope_dim], ACC_DTYPE)
+            cos_half_ub = T.alloc_shared([1, rope_dim], dtype)
+            sin_block_ub = T.alloc_shared([row_per_vec, rope_dim], ACC_DTYPE)
+            cos_block_ub = T.alloc_shared([row_per_vec, rope_dim], ACC_DTYPE)
+            x_rotate_ub = T.alloc_shared([row_per_vec, rope_dim], ACC_DTYPE)
+            out_ub = T.alloc_shared([row_per_vec, rope_dim], ACC_DTYPE)
+            # Mask buffers (used by interleaved gather; unused for half)
+            mask_ub = T.alloc_shared([row_per_vec, rope_dim], MASK_DTYPE)
+            idx_ub = T.alloc_shared([row_per_vec, rope_dim], "int32")
+            tmp_ub_i16 = T.alloc_shared([row_per_vec, rope_dim], "int16")
+            ones_mask_ub = T.alloc_shared([row_per_vec, rope_dim], "int16")
+            mask_ub_i16 = T.alloc_shared([row_per_vec, rope_dim], "int16")
+            mask_ub_f32 = T.alloc_shared([row_per_vec, rope_dim], "float32")
+            mask_ub_i32 = T.alloc_shared([row_per_vec, rope_dim], "int32")
+            # sin_mask (1D UB, needs scalar element access)
+            sin_mask_ub = T.alloc_ub(rope_dim, ACC_DTYPE)
+
+            # ===== NPU-internal gather-mask generation (Interleaved only) =====
+            if layout == "interleaved":
+                T.tile.createvecindex(idx_ub, 0)  # [0,1,2,...]
+                T.copy(idx_ub, tmp_ub_i16)
+                T.tile.fill(ones_mask_ub, 1)
+                T.tile.bitwise_xor(mask_ub_i16, tmp_ub_i16, ones_mask_ub)  # [1,0,3,2,...]
+                T.copy(mask_ub_i16, mask_ub_f32)
+                T.copy(mask_ub_f32, mask_ub_i32)
+                T.tile.mul(mask_ub_i32, mask_ub_i32, 4)  # byte offset (fp32=4B)
+                T.reinterpretcast(mask_ub, mask_ub_i32, "uint32_t")
+
+            # ===== NPU-internal sin_mask generation =====
+            T.tile.fill(sin_mask_ub, -1.0)
+            if layout == "interleaved":
+                for i in T.serial(0, half):
+                    sin_mask_ub[2 * i + 1] = 1.0  # [-1,+1,-1,+1,...]
+            else:  # half
+                for i in T.serial(0, half):
+                    sin_mask_ub[half + i] = 1.0  # [-1,...,-1,+1,...,+1]
+
+            # ===== Chunk loop =====
+            for chunk in T.serial(0, chunks_per_block):
+                chunk_idx = cid * chunks_per_block + chunk
+                if chunk_idx < total_chunks:
+                    row_x = chunk_idx * block_M + vid * row_per_vec
+                    row_sin_cos = (row_x // head_num) % sc_rows
+
+                    # --- Load x (fast path vs tail-guard path) ---
+                    if row_x + row_per_vec <= M:
+                        if dim_start == 0:
+                            T.copy(x[row_x : row_x + row_per_vec, :], x_half_ub)
+                        else:
+                            for i in T.serial(0, row_per_vec):
+                                T.copy(x[row_x + i, dim_start:], x_half_ub[i, :])
+                    else:
+                        for i in T.serial(0, row_per_vec):
+                            if row_x + i < M:
+                                if dim_start == 0:
+                                    T.copy(x[row_x + i, :], x_half_ub[i, :])
+                                else:
+                                    T.copy(x[row_x + i, dim_start:], x_half_ub[i, :])
+
+                    if need_cast:
+                        T.tile.cast(x_ub, x_half_ub, "CAST_NONE", x_elem_count)
+                    else:
+                        T.copy(x_half_ub, x_ub)
+
+                    # --- Load sin / cos ---
+                    T.copy(sin[row_sin_cos, :], sin_half_ub[0, :])
+                    if need_cast:
+                        T.tile.cast(sin_ub, sin_half_ub, "CAST_NONE", sc_elem_count)
+                    else:
+                        T.copy(sin_half_ub, sin_ub)
+                    T.copy(cos[row_sin_cos, :], cos_half_ub[0, :])
+                    if need_cast:
+                        T.tile.cast(cos_ub, cos_half_ub, "CAST_NONE", sc_elem_count)
+                    else:
+                        T.copy(cos_half_ub, cos_ub)
+
+                    # --- Apply sin_mask (in-place) ---
+                    T.tile.mul(sin_ub[0, :], sin_ub[0, :], sin_mask_ub)
+
+                    # --- Broadcast sin/cos to [row_per_vec, rope_dim] ---
+                    T.tile.broadcast(sin_block_ub, sin_ub)
+                    T.tile.broadcast(cos_block_ub, cos_ub)
+
+                    # --- Rotate x (layout branch) ---
+                    if layout == "interleaved":
+                        T.tile.gather(x_rotate_ub, x_ub, mask_ub, 0)
+                    else:  # half — copy-swap
+                        for i in T.serial(0, row_per_vec):
+                            T.copy(x_ub[i, half:], x_rotate_ub[i, :half])
+                            T.copy(x_ub[i, :half], x_rotate_ub[i, half:])
+
+                    # --- out = x * cos + x_rotate * sin_signed ---
+                    T.tile.mul(out_ub, x_ub, cos_block_ub)
+                    T.tile.mul(x_rotate_ub, x_rotate_ub, sin_block_ub)
+                    T.tile.add(out_ub, out_ub, x_rotate_ub)
+
+                    # --- Downcast and write back ---
+                    if need_cast:
+                        T.tile.cast(x_half_ub, out_ub, "CAST_RINT", x_elem_count)
+                    else:
+                        T.copy(out_ub, x_half_ub)
+
+                    if row_x + row_per_vec <= M:
+                        if dim_start == 0:
+                            T.copy(x_half_ub, x[row_x : row_x + row_per_vec, :])
+                        else:
+                            for i in T.serial(0, row_per_vec):
+                                T.copy(x_half_ub[i, :], x[row_x + i, dim_start:])
+                    else:
+                        for i in T.serial(0, row_per_vec):
+                            if row_x + i < M:
+                                if dim_start == 0:
+                                    T.copy(x_half_ub[i, :], x[row_x + i, :])
+                                else:
+                                    T.copy(x_half_ub[i, :], x[row_x + i, dim_start:])
+
+    return kernel
+
+
+# ========== Wrapper ==========
+def select_block_M(head_num, rope_dim, layout):
+    """Select block_M satisfying head_num alignment + UB budget.
+
+    Constraints:
+      - head_num % (block_M // 2) == 0  (sin/cos broadcast correctness)
+      - block_M * rope_dim * factor <= 192KB  (UB capacity)
+
+    Factor models total allocation (not peak-after-reuse).  Empirically,
+    AscendMemoryPlanning's LinearScanAllocator does not aggressively overlap
+    non-overlapping lifetimes (e.g. mask-generation temporaries remain
+    resident during chunk processing), so the effective constraint is close
+    to the sum of all alloc_shared/alloc_ub buffers.
+
+    Verified: block_M=64, rope_dim=256, interleaved (total ~356KB) crashes
+    at compile time; block_M=32 (total ~178KB) passes.  Half layout omits
+    7 mask buffers (~68KB), so factor=18.
+    """
+    UB_LIMIT = 196608  # 192KB
+    factor = 22 if layout == "interleaved" else 18
+    for bm in [64, 32, 16, 8, 4, 2]:
+        rpv = bm // 2
+        if head_num % rpv == 0 and bm * rope_dim * factor <= UB_LIMIT:
+            return bm
+    return 2
+
+
+def tilelang_rope(x, sin, cos, layout="interleaved"):
+    """Apply RoPE in-place to ``x``'s last ``rope_dim`` dimensions.
+
+    Args:
+        x:   [BS, N, D] (TND) or [B, S, N, D] (BSND)
+        sin: [BS, 1, RD] (TND) or [1, S, 1, RD] (BSND) — raw sin (no sign mask)
+        cos: same shape as sin — raw cos
+        layout: "interleaved" or "half"
+
+    Returns:
+        x (modified in-place, view-restored to original shape)
+
+    Host-side operations are metadata-only views (``.view()``); no
+    ``.clone()`` / ``.contiguous()`` / ``torch.cat`` / aclnn calls.
+    """
+    rope_dim = sin.shape[-1]
+    if rope_dim % 2 != 0:
+        raise ValueError(f"rope_dim must be even, got {rope_dim}")
+
+    org_shape = x.shape
+
+    if x.dim() == 3:
+        # TND: x=[BS, N, D], sin/cos=[BS, 1, RD]
+        bs, head_num, hidden_size = x.shape
+        x = x.view(-1, hidden_size)
+        sin = sin.view(-1, rope_dim)
+        cos = cos.view(-1, rope_dim)
+        sc_rows = bs
+    elif x.dim() == 4:
+        # BSND: x=[B, S, N, D], sin/cos=[1, S, 1, RD]
+        b, s, head_num, hidden_size = x.shape
+        x = x.view(-1, hidden_size)
+        sin = sin.view(-1, rope_dim)
+        cos = cos.view(-1, rope_dim)
+        sc_rows = s
+    else:
+        raise NotImplementedError(f"x.dim()={x.dim()} not supported, expected 3 (TND) or 4 (BSND)")
+
+    if rope_dim > hidden_size:
+        raise ValueError(f"rope_dim ({rope_dim}) must be <= hidden_size ({hidden_size})")
+
+    M = x.shape[0]
+    dtype_str = tilelang_dtype_map[x.dtype]
+
+    block_M = select_block_M(head_num, rope_dim, layout)
+
+    m_num_full = M // block_M
+    tail_rows = M % block_M
+    has_tail = 1 if tail_rows > 0 else 0
+    total_chunks = m_num_full + has_tail
+    num_blocks = min(total_chunks, NUM_CORES)
+
+    kernel = rope_kernel(M, block_M, num_blocks, total_chunks, sc_rows, hidden_size, rope_dim, head_num, layout, dtype=dtype_str)
+    kernel(x, sin, cos)
+
+    return x.view(org_shape)
+
+
+# ========== Reference (Golden) ==========
+def torch_rope_ref(x, sin, cos, layout="interleaved"):
+    """PyTorch reference for RoPE (Half + Interleaved).
+
+    CPU fp32 intermediate computation, then downcast to ``x.dtype``.
+    ``sin`` is raw (no sign mask); the sign is absorbed into ``x_rotated``.
+    """
+    rope_dim = sin.shape[-1]
+    dim_start = x.shape[-1] - rope_dim
+
+    x_part = x[..., dim_start:].to(torch.float32)
+    sin_f = sin.to(torch.float32)
+    cos_f = cos.to(torch.float32)
+
+    if layout == "interleaved":
+        # rotate([x0, x1, x2, x3, ...]) = [-x1, x0, -x3, x2, ...]
+        x_reshaped = x_part.reshape(*x_part.shape[:-1], -1, 2)
+        x_rotated = torch.stack([-x_reshaped[..., 1], x_reshaped[..., 0]], dim=-1).flatten(-2)
+    else:  # half
+        # rotate([x1, x2]) = [-x2, x1]
+        half = rope_dim // 2
+        x_rotated = torch.cat([-x_part[..., half:], x_part[..., :half]], dim=-1)
+
+    rope_out = (x_part * cos_f + x_rotated * sin_f).to(x.dtype)
+
+    out = x.clone()
+    out[..., dim_start:] = rope_out
+    return out
+
+
+# ========== Precision Standard (mixed tolerance) ==========
+def get_precision(dtype):
+    """Return (atol, rtol, max_abs_error_limit, required_matched_ratio)."""
+    fp_table = {
+        "float16": (2**-14, 2**-9, 1e-1, 0.99),  # atol 6.10e-5, rtol 1.95e-3
+        "bfloat16": (2**-10, 2**-6, 1e0, 0.99),  # atol 9.77e-4, rtol 1.56e-2
+        "float32": (2**-16, 2**-10, 1e-2, 0.99),
+    }
+    if dtype in {"int8", "int16", "int32", "int64", "uint8"}:
+        return (0.0, 0.0, 0.0, 1.0)
+    return fp_table.get(dtype, (2**-14, 2**-9, 1e-1, 0.99))
+
+
+def check_precision(actual, golden, dtype):
+    """Mixed-tolerance dual-gate check: returns (passed, matched_ratio, max_abs_error)."""
+    atol, rtol, max_abs_limit, required_ratio = get_precision(dtype)
+    a = actual.detach().cpu()
+    g = golden.detach().cpu()
+    if atol == 0.0 and rtol == 0.0:  # integer exact match
+        mism = (a != g).sum().item()
+        total = max(a.numel(), 1)
+        return mism == 0, 1.0 - mism / total, (0.0 if mism == 0 else float("inf"))
+    a = a.float()
+    g = g.float()
+    m = torch.isfinite(g)
+    if m.sum().item() == 0:
+        return True, 1.0, 0.0
+    abs_err = (a[m] - g[m]).abs()
+    ratio = (abs_err <= (atol + rtol * g[m].abs())).float().mean().item()
+    max_abs = abs_err.max().item()
+    return (ratio >= required_ratio and max_abs <= max_abs_limit), ratio, max_abs
+
+
+# ========== Test helpers ==========
+def _make_input(shape, dtype_str, layout_kind):
+    """Generate test input on CPU. Returns (x_cpu, sin_cpu, cos_cpu)."""
+    torch_dtype = torch_dtype_map[dtype_str]
+    if layout_kind == "tnd":
+        bs, h, hs, rd = shape
+        x_cpu = torch.randn(bs, h, hs, dtype=torch_dtype)
+        sin_cpu = torch.randn(bs, 1, rd, dtype=torch_dtype)
+        cos_cpu = torch.randn(bs, 1, rd, dtype=torch_dtype)
+    elif layout_kind == "bsnd":
+        b, s, h, hs, rd = shape
+        x_cpu = torch.randn(b, s, h, hs, dtype=torch_dtype)
+        sin_cpu = torch.randn(1, s, 1, rd, dtype=torch_dtype)
+        cos_cpu = torch.randn(1, s, 1, rd, dtype=torch_dtype)
+    else:
+        raise ValueError(f"Unknown layout_kind: {layout_kind}")
+    return x_cpu, sin_cpu, cos_cpu
+
+
+def run_case(shape, layout, dtype_str, layout_kind, level="l0",
+             inputs=None, tag="PRECISION", label=None):
+    """Run a single test case. Returns (passed, ratio, max_abs).
+
+    inputs:  optional (x, sin, cos) CPU tuple; if None, generated via _make_input
+    tag:     "PRECISION" (blocking) or "BOUNDARY" (non-blocking)
+    label:   optional print label (default: derived from shape/layout/kind)
+    """
+    if inputs is None:
+        x_cpu, sin_cpu, cos_cpu = _make_input(shape, dtype_str, layout_kind)
+    else:
+        x_cpu, sin_cpu, cos_cpu = inputs
+
+    out_ref = torch_rope_ref(x_cpu.clone(), sin_cpu, cos_cpu, layout)
+
+    x_npu = x_cpu.to(device)
+    sin_npu = sin_cpu.to(device)
+    cos_npu = cos_cpu.to(device)
+
+    tilelang_rope(x_npu, sin_npu, cos_npu, layout)
+
+    out_npu = x_npu.to("cpu")
+
+    passed, ratio, max_abs = check_precision(out_npu, out_ref, dtype_str)
+
+    status = "PASS" if passed else ("WARN" if tag == "BOUNDARY" else "FAIL")
+    desc = label if label else f"shape={shape} layout={layout} dtype={dtype_str} kind={layout_kind}"
+    print(f"[{tag}_{status}] {level} {desc} matched_ratio={ratio:.4f} max_abs={max_abs:.3e}")
+    return passed, ratio, max_abs
+
+
+def _run_cases(cases, level):
+    """Run a list of (shape, layout, dtype, kind) cases. Returns all-passed."""
+    ok = True
+    for shape, layout, dtype_str, kind in cases:
+        try:
+            passed, _, _ = run_case(shape, layout, dtype_str, kind, level=level)
+            ok &= passed
+        except Exception as e:
+            print(f"[PRECISION_FAIL] {level} shape={shape} layout={layout} dtype={dtype_str} kind={kind}: {e}")
+            ok = False
+    return ok
+
+
+def _run_negative(name, make_inputs, expected_exc, layout="interleaved"):
+    """Run a negative test: expect tilelang_rope to raise expected_exc."""
+    try:
+        x, sin, cos = make_inputs()
+        tilelang_rope(x, sin, cos, layout)
+        print(f"[BOUNDARY_WARN] l2 {name}: expected exception but none raised")
+    except expected_exc as e:
+        print(f"[BOUNDARY_PASS] l2 {name}: rejected ({type(e).__name__})")
+    except Exception as e:
+        print(f"[BOUNDARY_WARN] l2 {name}: unexpected {type(e).__name__}: {e}")
+
+
+# ========== L0 Tests (gate, regular shapes, block-aligned) ==========
+L0_CASES = [
+    ([16, 64, 512, 256], "interleaved", "float16", "tnd"),
+    ([16, 64, 512, 256], "half", "float16", "tnd"),
+    ([16, 64, 512, 256], "interleaved", "bfloat16", "tnd"),
+    ([16, 64, 512, 256], "half", "bfloat16", "tnd"),
+    ([4, 4, 64, 512, 256], "interleaved", "float16", "bsnd"),
+    ([4, 4, 64, 512, 256], "half", "float16", "bsnd"),
+]
+
+
+def test_rope_l0():
+    """L0 gate tests: 2 layout x 2 dtype x 2 layout_kind = 6 core cases."""
+    return _run_cases(L0_CASES, "l0")
+
+
+# ========== L1 Tests (functional, irregular / tail / varied params) ==========
+L1_CASES = [
+    ([16, 32, 512, 128], "half", "float16", "tnd"),
+    ([16, 8, 256, 64], "interleaved", "float16", "tnd"),
+    ([1, 1, 128, 64], "half", "float16", "tnd"),
+    ([16, 64, 256, 256], "interleaved", "bfloat16", "tnd"),
+    ([128, 64, 512, 256], "half", "float16", "tnd"),
+    ([4, 32, 8, 512, 256], "interleaved", "float16", "bsnd"),
+    ([5, 32, 512, 256], "interleaved", "float16", "tnd"),
+    ([33, 8, 256, 128], "half", "float16", "tnd"),
+    ([8, 1, 128, 64], "interleaved", "bfloat16", "tnd"),
+    ([2, 16, 32, 256, 256], "half", "bfloat16", "bsnd"),
+    ([2, 128, 64, 512, 256], "interleaved", "float16", "bsnd"),
+    ([3, 4, 128, 64], "half", "bfloat16", "tnd"),
+]
+
+
+def test_rope_l1():
+    """L1 functional tests: varied head_num, rope_dim, full/partial rope, tail rows."""
+    return _run_cases(L1_CASES, "l1")
+
+
+# ========== L2 Tests (negative: invalid inputs should be rejected) ==========
+L2_CASES = [
+    ("odd_rope_dim", lambda: (
+        torch.randn(4, 8, 128, dtype=torch.float16, device=device),
+        torch.randn(4, 1, 63, dtype=torch.float16, device=device),
+        torch.randn(4, 1, 63, dtype=torch.float16, device=device)),
+     ValueError),
+    ("bad_dim_1d", lambda: (
+        torch.randn(128, dtype=torch.float16, device=device),
+        torch.randn(1, 64, dtype=torch.float16, device=device),
+        torch.randn(1, 64, dtype=torch.float16, device=device)),
+     NotImplementedError),
+    ("bad_dim_5d", lambda: (
+        torch.randn(2, 4, 8, 16, 64, dtype=torch.float16, device=device),
+        torch.randn(2, 4, 1, 32, dtype=torch.float16, device=device),
+        torch.randn(2, 4, 1, 32, dtype=torch.float16, device=device)),
+     NotImplementedError),
+    ("rope_dim_too_large", lambda: (
+        torch.randn(4, 8, 64, dtype=torch.float16, device=device),
+        torch.randn(4, 1, 128, dtype=torch.float16, device=device),
+        torch.randn(4, 1, 128, dtype=torch.float16, device=device)),
+     (ValueError, IndexError, RuntimeError)),
+]
+
+
+def test_rope_l2():
+    """L2 negative tests: invalid inputs must raise exceptions (non-blocking)."""
+    for name, make_inputs, expected_exc in L2_CASES:
+        _run_negative(name, make_inputs, expected_exc)
+
+
+# ========== Boundary Tests (legal special/extreme values, non-blocking) ==========
+BOUNDARY_CASES = [
+    ("large_values", lambda: (
+        torch.randn(16, 64, 512, dtype=torch.float16) * 1000,
+        torch.randn(16, 1, 256, dtype=torch.float16),
+        torch.randn(16, 1, 256, dtype=torch.float16)),
+     "interleaved", "float16"),
+    ("zero_values", lambda: (
+        torch.zeros(16, 64, 512, dtype=torch.float16),
+        torch.randn(16, 1, 256, dtype=torch.float16),
+        torch.randn(16, 1, 256, dtype=torch.float16)),
+     "half", "float16"),
+    ("full_rope_large_batch", lambda: (
+        torch.randn(128, 64, 256, dtype=torch.float16),
+        torch.randn(128, 1, 256, dtype=torch.float16),
+        torch.randn(128, 1, 256, dtype=torch.float16)),
+     "interleaved", "float16"),
+    ("min_rope_dim", lambda: (
+        torch.randn(8, 16, 128, dtype=torch.bfloat16),
+        torch.randn(8, 1, 64, dtype=torch.bfloat16),
+        torch.randn(8, 1, 64, dtype=torch.bfloat16)),
+     "half", "bfloat16"),
+    ("single_row", lambda: (
+        torch.randn(1, 1, 128, dtype=torch.float16),
+        torch.randn(1, 1, 64, dtype=torch.float16),
+        torch.randn(1, 1, 64, dtype=torch.float16)),
+     "interleaved", "float16"),
+    ("bsnd_tail", lambda: (
+        torch.randn(3, 33, 8, 256, dtype=torch.float16),
+        torch.randn(1, 33, 1, 128, dtype=torch.float16),
+        torch.randn(1, 33, 1, 128, dtype=torch.float16)),
+     "half", "float16"),
+]
+
+
+def test_rope_boundary():
+    """Boundary tests: extreme values, full rope, minimal rope_dim, large batch."""
+    torch.manual_seed(123)
+    for name, make_inputs, layout, dtype_str in BOUNDARY_CASES:
+        try:
+            run_case(None, layout, dtype_str, None, level="boundary",
+                     inputs=make_inputs(), tag="BOUNDARY", label=name)
+        except Exception as e:
+            print(f"[BOUNDARY_WARN] boundary {name}: {type(e).__name__}: {e}")
+
+
+# ========== Main ==========
+def main():
+    parser = argparse.ArgumentParser(description="RoPE (Half + Interleaved) on Ascend NPU")
+    parser.add_argument("--level", default="l0", choices=["l0", "l1", "l2", "boundary", "all"], help="Test level to run (default: l0)")
+    parser.add_argument("--shape", type=int, nargs="+", help="Single-case shape: 4 ints (TND: BS H HS RD) or 5 ints (BSND: B S H HS RD)")
+    parser.add_argument("--layout", default="interleaved", choices=["interleaved", "half"], help="RoPE layout (default: interleaved)")
+    parser.add_argument("--dtype", default="float16", choices=["float16", "bfloat16"], help="Data type (default: float16)")
+    args = parser.parse_args()
+
+    tilelang.disable_cache()
+    torch.manual_seed(42)
+
+    # Single-case mode
+    if args.shape:
+        if len(args.shape) == 4:
+            kind = "tnd"
+        elif len(args.shape) == 5:
+            kind = "bsnd"
+        else:
+            print(f"Error: --shape needs 4 (TND) or 5 (BSND) values, got {len(args.shape)}")
+            sys.exit(1)
+        try:
+            passed, ratio, max_abs = run_case(args.shape, args.layout, args.dtype, kind, level="single")
+            if passed:
+                print("Test Passed!")
+                sys.exit(0)
+            sys.exit(1)
+        except Exception as e:
+            print(f"[PRECISION_FAIL] single shape={args.shape} layout={args.layout} dtype={args.dtype}: {e}")
+            sys.exit(1)
+
+    # Level mode
+    blocking_ok = True
+    if args.level in ("l0", "all"):
+        print("=" * 60)
+        print("L0 Gate Tests")
+        print("=" * 60)
+        blocking_ok &= test_rope_l0()
+    if args.level in ("l1", "all"):
+        print("=" * 60)
+        print("L1 Functional Tests")
+        print("=" * 60)
+        blocking_ok &= test_rope_l1()
+    if args.level in ("l2", "all"):
+        print("=" * 60)
+        print("L2 Negative Tests")
+        print("=" * 60)
+        test_rope_l2()
+    if args.level in ("boundary", "all"):
+        print("=" * 60)
+        print("Boundary Tests")
+        print("=" * 60)
+        test_rope_boundary()
+
+    print("=" * 60)
+    if blocking_ok:
+        print("Test Passed!")
+        sys.exit(0)
+    else:
+        print("Test FAILED (L0/L1 precision errors)")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* [Example] RoPE (half + interleaved) on Ascend NPU

- Add rope_half_interleaved.py: unified RoPE kernel supporting half (GPT-NeoX/LLaMA) and interleaved (GPT-J) layouts, fp16/bf16, TND/BSND, partial/full rope, in-place update
- NPU-internal mask generation (createvecindex + bitwise_xor) for interleaved gather; copy-swap path for half layout
- Developer mode with AscendMemoryPlanning for UB reuse

* [Test] L0/L1/L2/boundary tests with shared helpers

- Extract _run_cases / _run_negative to dedup L0/L1 loops and L2 try/except
- Extend run_case with optional inputs/tag/label so boundary cases reuse the same golden→H2D→kernel→D2H→check pipeline
- 28 cases total (L0=6, L1=12, L2=4, boundary=6), all passing

* [Perf] msprof benchmark vs aclnnRotaryPositionEmbedding

- perf_rope.py (TileLang side) + perf_rope_ascendc.cpp (CANN baseline)
- bench.sh orchestrates msprof on both sides, parses op_summary CSV, computes speedup (drop first launch, average rest)
- TileLang wins 12/13 scenarios, 1.19x–2.71x speedup

* [Docs] README and bench_mark

- README: op semantics, support matrix, file layout, quick start
- bench_mark: perf results table + key observations + precision standard