### PR TITLE
[Feat] Add compiler-managed Ascend Vector mask state 🤖

### DIFF
--- a/.agents/skills/tilelang-pass-analyzer/references/pass-classification.md
+++ b/.agents/skills/tilelang-pass-analyzer/references/pass-classification.md
@@ -20,6 +20,8 @@
 | Pass | 功能简述 | 配置项 | 核心类 |
 |------|---------|--------|--------|
 | AscendSyncInsert | 自动插入同步指令，确保数据依赖正确 | `tl.ascend_auto_sync` | AscendSyncInsert |
+| AscendSyncInsertVS | 补充 V→V 和 Scalar↔其他 pipeline 同步 | `tl.ascend_auto_sync` | AscendSyncInsertVS |
+| AscendVectorMaskLegalize | 在 codegen 前修复并复用 Vector mask state | -（A2/A3 AscendC/auto 强制启用） | AscendVectorMaskLegalizer |
 | CrossCorePipeline | 跨核 (Cube-Vector) 流水线同步调度 | `tl.ascend_auto_cross_core_sync` | CrossCorePipeline |
 | CombineCV | 分离 Cube/Vector 操作，拆分为两块独立代码 | `tl.ascend_auto_cv_combine` | CVCombineEmitter |
 
@@ -27,6 +29,7 @@
 
 | Pass | 功能简述 | 配置项 | 核心类 |
 |------|---------|--------|--------|
+| AscendVectorInstructionSelection | 固化物理 Vector terminal 及 mask contract | -（A2/A3 AscendC/auto 强制启用） | AscendVectorInstructionSelector |
 | AscendLowerParallelToVector | Parallel 循环 lowering 为 Vector 指令 | - | AscendLowerParallelToVector |
 | AscendLowerOpaqueBlock | Opaque Block 结构 lowering | - | OpaqueBlockLower |
 
@@ -130,7 +133,9 @@ PassContext.current().config = {
 ```
 FrontendLegalize
   → AscendLowerParallelToVector (Parallel → Vector)
-  → Simplify (简化)
+  → AscendVectorInstructionSelection (A2/A3 AscendC/auto)
+  → ... Phase 2 中间 Pass 与同步插入
+  → AscendVectorMaskLegalize (最后一个结构化 TIR Pass)
   → MakePackedAPI
 ```
 
@@ -180,9 +185,9 @@ FrontendLegalize
 | 关键词 | 相关 Pass |
 |--------|----------|
 | 内存 / memory | AscendMemoryPlanning, AscendStorageRewrite, FlattenBuffer |
-| 同步 / sync | AscendSyncInsert, CrossCorePipeline |
+| 同步 / sync | AscendSyncInsert, AscendSyncInsertVS, AscendVectorMaskLegalize, CrossCorePipeline |
 | 流水线 / pipeline | CrossCorePipeline, InjectSoftwarePipeline |
-| 向量化 / vector | AscendLowerParallelToVector, VectorizeLoop, LoopVectorizeDynamic |
+| 向量化 / vector | AscendVectorInstructionSelection, AscendVectorMaskLegalize, AscendLowerParallelToVector, VectorizeLoop, LoopVectorizeDynamic |
 | Lowering | AscendLowerOpaqueBlock, LowerTileOp |
 | Layout | LayoutInference, InferAllocScope |
 | 简化 / simplify | Simplify |

--- a/.agents/skills/tilelang-pass-analyzer/references/pass-registry-ascend.md
+++ b/.agents/skills/tilelang-pass-analyzer/references/pass-registry-ascend.md
@@ -8,7 +8,10 @@
 
 | Pass 名称 | 注册名 | Python 函数 | C++ 文件 | 配置键 |
 |-----------|--------|-------------|---------|--------|
+| AscendVectorInstructionSelection | tl.transform.AscendVectorInstructionSelection | `AscendVectorInstructionSelection(target, platform)` | `ascend_vector_instruction_selection.cc` | -（A2/A3 AscendC/auto 强制启用） |
 | AscendSyncInsert | tl.transform.AscendSyncInsert | `AscendSyncInsert(target, platform)` | `ascend_sync_insert.cc` | `tl.ascend_auto_sync` |
+| AscendSyncInsertVS | tl.transform.AscendSyncInsertVS | `AscendSyncInsertVS(target, platform)` | `ascend_sync_insert_vs.cc` | `tl.ascend_auto_sync` |
+| AscendVectorMaskLegalize | tl.transform.AscendVectorMaskLegalize | `AscendVectorMaskLegalize(target, platform)` | `ascend_vector_mask_legalize.cc` | -（A2/A3 AscendC/auto 强制启用） |
 | AscendMemoryPlanning | tl.transform.AscendMemoryPlanning | `AscendMemoryPlanning()` | `ascend_memory_planning.cc` | `tl.ascend_memory_planning` |
 | CombineCV | tl.transform.CombineCV | `CombineCV()` | `ascend_combinecv.cc` | `tl.ascend_auto_cv_combine` |
 | CrossCorePipeline | tl.transform.CrossCorePipeline | `CrossCorePipeline()` | `cross_core_pipeline.cc` | `tl.ascend_auto_cross_core_sync` |
@@ -24,6 +27,25 @@
 ---
 
 ## Pass 详细信息
+
+### AscendVectorInstructionSelection
+
+**核心类：** `AscendVectorInstructionSelector`（继承 `IRMutatorWithAnalyzer`）
+
+**核心方法：**
+- `VisitStmt_(EvaluateNode)` - 识别 Vector 语义调用，并改写为带固定物理实现和
+  mask contract 的 selected terminal
+- `SelectSemanticTerminal()` - 根据语义操作和静态参数选择唯一 terminal
+- `ValidateSelectedPayloads()` - 检查 COUNTER/NORMAL mask payload 的作用域和合法性
+
+**功能简述：** 在 Phase 2 的第一步冻结 A2/A3 AscendC Vector 指令的物理实现，
+把后续 mask 分析所需的 requirement/ensure contract 编码到 selected terminal 身份和参数中。
+中间 Pass 只能保持这些 terminal，不能重新执行物理指令选择。
+
+**触发条件：** `target.model` 为 `ascendc` 或 `auto`，且 `platform` 为 `A2` 或 `A3`。
+这是编译器正确性流程，没有用户可关闭的 PassConfig 开关；A5、PTO 和非 AscendC 路径不启用。
+
+---
 
 ### AscendSyncInsert
 
@@ -44,6 +66,38 @@
 - `EventPair_<src>_<dst>` - 跨 pipeline 同步（共26种组合，见 operation_config.h:264-300）
 
 **功能简述：** 通过循环展开分析内存依赖，在 VisitStmt_(EvaluateNode) 中完成依赖检测、同步选择和插入，确保多 pipeline 异步执行的正确性。
+
+---
+
+### AscendSyncInsertVS
+
+**核心类：** `AscendSyncInsertVS`（继承 `IRMutatorWithAnalyzer`）
+
+**功能简述：** 作为 `AscendSyncInsert` 的补充，处理 V→V 和 Scalar↔其他 pipeline 的
+同步关系。compiler-managed mask 流程必须在此 Pass 完成后再运行最终 `Simplify` 和
+`AscendVectorMaskLegalize`，使 Legalizer 能看到完整的同步边界。
+
+---
+
+### AscendVectorMaskLegalize
+
+**核心类：** `AscendVectorMaskLegalizer`（继承 `IRMutatorWithAnalyzer`）
+
+**核心方法：**
+- `RewriteConsumer()` - 在 selected terminal 前补齐最小必要的 mode/payload setter
+- `MergeFacts()` - 合并 `if` 分支和控制流路径上的已知 mask facts
+- `ApplyContract()` - 根据 terminal 的 ensure contract 更新抽象 mask 状态
+- `CompletePayload()` - 为部分 payload requirement 构造完整、确定的 payload pair
+
+**功能简述：** 在所有结构化 TIR 改写和同步插入完成后，对每个 AIV 区域执行
+前向 mask-state 数据流分析；只在当前 facts 不满足 selected terminal requirement 时插入
+compiler mask setter，并在 barrier、不透明调用和控制流汇合处保守失效状态。
+
+**顺序约束：** 必须紧跟 Phase 2 最后的 `tir.transform.Simplify()`，并且是进入
+AscendC codegen 前最后一个结构化 TIR Pass。managed 路径的 `device_codegen()` 不得再运行
+额外的 `Simplify()`。
+
+**触发条件：** 与 `AscendVectorInstructionSelection` 相同，无用户可关闭的 PassConfig 开关。
 
 ---
 
@@ -183,7 +237,10 @@ tilelang_root → 创建两个 Emitter(is_aiv=true/false)
 
 ```
 src/transform/
+├── ascend_vector_instruction_selection.cc (~650 行)
+├── ascend_vector_mask_legalize.cc   (~550 行)
 ├── ascend_sync_insert.cc          (1559 行)
+├── ascend_sync_insert_vs.cc       (~920 行)
 ├── ascend_memory_planning.cc      (884 行)
 ├── ascend_combinecv.cc            (~700 行)
 ├── cross_core_pipeline.cc         (~1200 行)

--- a/.agents/skills/tilelang-pass-workflow-analyzer/references/new-pass-placement-guide.md
+++ b/.agents/skills/tilelang-pass-workflow-analyzer/references/new-pass-placement-guide.md
@@ -2,6 +2,9 @@
 
 本文档提供添加新 Pass 到 TileLang-Ascend Pipeline 的完整指南，帮助确定 Pass 应该在哪个位置添加。
 
+> **定位规则：** Pipeline 含 target-dependent 分支，步骤号会随 A2/A3 managed 流程变化。
+> 新 Pass 必须使用相邻 Pass 名称作为定位锚点，不要依赖全局步骤号。
+
 ---
 
 ## 定位原则
@@ -27,12 +30,12 @@
 
 | 输入数据 | 上游 Pass | 约束 |
 |---------|-----------|------|
-| **buffer scope** | `AscendInferBufferScope` (Phase 1, 步骤 1) | 必须在此 Pass 后执行 |
-| **buffer_shapess** | `CollectBufferShapes` (Phase 1, 步骤 8) | 必须在此 Pass 后执行 |
-| **address_map** | `AscendMemoryPlanning` (Phase 2, 步骤 20) | 必须在此 Pass 后执行 |
-| **size_map** | `AscendMemoryPlanning` (Phase 2, 步骤 20) | 必须在此 Pass 后执行 |
-| **pipeline layout** | `PipelinePlanning` (Phase 2, 步骤 4) | 必须在此 Pass 后执行 |
-| **cross-core annotations** | `CrossCorePipeline` (Phase 2, 步骤 2) | 必须在此 Pass 后执行 |
+| **buffer scope** | `AscendInferBufferScope` (Phase 1) | 必须在此 Pass 后执行 |
+| **buffer_shapess** | `CollectBufferShapes` (Phase 1) | 必须在此 Pass 后执行 |
+| **address_map** | `AscendMemoryPlanning` (Phase 2) | 必须在此 Pass 后执行 |
+| **size_map** | `AscendMemoryPlanning` (Phase 2) | 必须在此 Pass 后执行 |
+| **pipeline layout** | `PipelinePlanning` (Phase 2) | 必须在此 Pass 后执行 |
+| **cross-core annotations** | `CrossCorePipeline` (Phase 2) | 必须在此 Pass 后执行 |
 
 ### 3. 输出供给原则
 
@@ -55,6 +58,18 @@
 | **Ascend 特定** | Phase 2 | 针对 Ascend NPU 的硬件特性优化 |
 | **GPU/CPU 兼容** | Phase 1 | 如果 Pass 需要支持多种平台，放在 Phase 1 |
 
+### 5. Compiler-managed Vector mask 边界
+
+对于 A2/A3 AscendC/auto，Phase 2 以 `AscendVectorInstructionSelection` 开始，并以
+final `Simplify` → `AscendVectorMaskLegalize` 结束：
+
+- 修改 semantic Vector op 或参与物理指令选择的 Pass，必须放在 Selection 之前，或把逻辑
+  合并到 Selection 中。
+- Selection 之后的 Pass 必须保持 selected terminal identity、operands 和顶层
+  `Evaluate(Call(...))` 终端形式。
+- 会新增 barrier、不透明调用或控制流的 Pass 必须放在 Legalizer 之前。
+- Legalizer 之后不得再添加结构化 TIR rewrite；其输出直接进入 mechanical AscendC emitter。
+
 ---
 
 ## 典型定位场景
@@ -70,14 +85,14 @@
 | **输出**：合法化报告 | 供调试使用 | 不影响后续 Pass |
 | **语义**：平台无关 | Phase 1 | 不依赖 Ascend 特性 |
 
-**具体位置**：Phase 1，在 `tir.transform.Simplify`（步骤 12）后，或替换为新的合法化 Pass。
+**具体位置**：Phase 1，在末尾的 `tir.transform.Simplify` 后，或替换该合法化位置。
 
 **示例**：
 ```python
 # tilelang/engine/phase.py
 def LowerAndLegalize(mod, target):
-    # ... 现有 Pass (步骤 1-11)
-    mod = tir.transform.Simplify()(mod)  # 步骤 12
+    # ... 现有 Phase 1 Pass
+    mod = tir.transform.Simplify()(mod)  # Phase 1 末尾
     # 新增 Pass
     mod = MyIRLegalizationPass()(mod)
     return mod
@@ -93,18 +108,20 @@ def LowerAndLegalize(mod, target):
 | **语义**：平台无关（如通用操作）或 Ascend 特定（如硬件原语） | Phase 1 或 Phase 2 | 根据操作的语义范围决定 |
 
 **具体位置**：
-- 如果是**通用 Tile 操作**：Phase 1，在 `LowerTileOp`（步骤 9）后，`LegalizeVectorizedLoop`（步骤 10）前。
-- 如果是**Ascend 特定 Tile 操作**：可以考虑在 Phase 2，`AscendLowerOpaqueBlock`（步骤 6）后。
+- 如果是**通用 Tile 操作**：Phase 1，在 `LowerTileOp` 后、
+  `LegalizeVectorizedLoop` 前。
+- 如果是**Ascend 特定 Tile 操作**：可以考虑在 Phase 2，
+  `AscendLowerOpaqueBlock` 后。
 
 **示例**：
 ```python
 # tilelang/engine/phase.py
 def LowerAndLegalize(mod, target):
-    # ... 现有 Pass (步骤 1-8)
-    mod = LowerTileOp()(mod)  # 步骤 9
+    # ... 现有 Phase 1 Pass
+    mod = LowerTileOp()(mod)
     # 新增 Pass
     mod = MyNewTileOpLoweringPass()(mod)
-    mod = LegalizeVectorizedLoop()(mod)  # 步骤 10
+    mod = LegalizeVectorizedLoop()(mod)
     # ...
 ```
 
@@ -117,7 +134,7 @@ def LowerAndLegalize(mod, target):
 | **输出**：优化后的内存分配 | 供 `AscendMemoryPlanning` 使用 | 影响 memory planning |
 | **语义**：Ascend 特定 | Phase 2 | 针对 Ascend 内存层级优化 |
 
-**具体位置**：Phase 2，在 `AscendStorageRewrite`（步骤 13）后，`AscendMemoryPlanning`（步骤 20）前。
+**具体位置**：Phase 2，在 `AscendStorageRewrite` 后、`AscendMemoryPlanning` 前。
 
 **注意**：
 - 如果新 Pass 影响 buffer 的数量或大小，需要在 `AscendMemoryPlanning` 前执行。
@@ -127,16 +144,16 @@ def LowerAndLegalize(mod, target):
 ```python
 # tilelang/engine/phase.py
 def OptimizeForTarget(mod, target, platform):
-    # ... 现有 Pass (步骤 1-13)
-    mod = AscendStorageRewrite(is_npu)(mod)  # 步骤 13
+    # ... 现有 Phase 2 Pass
+    mod = AscendStorageRewrite(is_npu)(mod)
     # 新增 Pass（影响 buffer 数量/大小）
     mod = MyMemoryOptimizationPass()(mod)
-    mod = tir.transform.UnrollLoop()(mod)  # 步骤 14
-    # ... (步骤 15-19)
-    mod = AscendMemoryPlanning()(mod)  # 步骤 20
+    mod = tir.transform.UnrollLoop()(mod)
+    # ... 中间 Phase 2 Pass
+    mod = AscendMemoryPlanning()(mod)
     # 新增 Pass（不影响 buffer 数量/大小）
     mod = MyAddressReorderPass()(mod)
-    mod = AscendSyncInsert(target, platform)(mod)  # 步骤 21
+    mod = AscendSyncInsert(target, platform)(mod)
     return mod
 ```
 
@@ -149,17 +166,19 @@ def OptimizeForTarget(mod, target, platform):
 | **输出**：同步建议或替代同步策略 | 供 `AscendSyncInsert` 使用或替代 | 影响同步插入 |
 | **语义**：Ascend 特定 | Phase 2 | 针对 Ascend 多核同步优化 |
 
-**具体位置**：Phase 2，在 `AscendMemoryPlanning`（步骤 20）后，`AscendSyncInsert`（步骤 21）前，或替代 `AscendSyncInsert`。
+**具体位置**：Phase 2，在 `AscendMemoryPlanning` 后、`AscendSyncInsert` 前，
+或替代 `AscendSyncInsert`。managed 路径的最终 `Simplify` 和
+`AscendVectorMaskLegalize` 仍必须位于完整同步流程之后。
 
 **示例**：
 ```python
 # tilelang/engine/phase.py
 def OptimizeForTarget(mod, target, platform):
-    # ... 现有 Pass (步骤 1-20)
-    mod = AscendMemoryPlanning()(mod)  # 步骤 20
+    # ... 现有 Phase 2 Pass
+    mod = AscendMemoryPlanning()(mod)
     # 新增 Pass
     mod = MySyncOptimizationPass()(mod)
-    mod = AscendSyncInsert(target, platform)(mod)  # 步骤 21
+    mod = AscendSyncInsert(target, platform)(mod)
     return mod
 ```
 
@@ -173,18 +192,19 @@ def OptimizeForTarget(mod, target, platform):
 | **语义**：Ascend 特定 | Phase 2 | 针对 Ascend 多核流水线 |
 
 **具体位置**：
-- 如果是**调整流水线阶段**：Phase 2，在 `PipelinePlanning`（步骤 4）后，`InjectSoftwarePipeline`（步骤 5）前。
-- 如果是**优化核间协作**：Phase 2，在 `CombineCV`（步骤 3）后，`PipelinePlanning`（步骤 4）前。
+- 如果是**调整流水线阶段**：Phase 2，在 `PipelinePlanning` 后、
+  `InjectSoftwarePipeline` 前。
+- 如果是**优化核间协作**：Phase 2，在 `CombineCV` 后、`PipelinePlanning` 前。
 
 **示例**：
 ```python
 # tilelang/engine/phase.py
 def OptimizeForTarget(mod, target, platform):
-    # ... 现有 Pass (步骤 1-3)
-    mod = CombineCV()(mod)  # 步骤 3
+    # ... 现有 Phase 2 Pass
+    mod = CombineCV()(mod)
     # 新增 Pass
     mod = MyCrossCoreOptimizationPass()(mod)
-    mod = PipelinePlanning()(mod)  # 步骤 4
+    mod = PipelinePlanning()(mod)
     # ...
 ```
 
@@ -206,11 +226,11 @@ def OptimizeForTarget(mod, target, platform):
 ```python
 # tilelang/engine/phase.py
 def LowerAndLegalize(mod, target):
-    # ... 现有 Pass (步骤 1-7)
-    mod = LayoutInference()(mod)  # 步骤 7
+    # ... 现有 Phase 1 Pass
+    mod = LayoutInference()(mod)
     # 新增 Pass
     mod = MyBufferInfoCollectorPass()(mod)
-    mod = CollectBufferShapes()(mod)  # 步骤 8
+    mod = CollectBufferShapes()(mod)
     # ...
 ```
 
@@ -291,9 +311,9 @@ def LowerAndLegalize(mod, target):
 
 **Step 2: 分析依赖**
 - 输入数据：`buffer_shapess`（buffer 形状信息）
-- 输入数据来源：`CollectBufferShapes` (Phase 1, 步骤 8)
+- 输入数据来源：`CollectBufferShapes` (Phase 1)
 - 输出数据：优化后的 buffer 定义
-- 输出数据使用：`AscendMemoryPlanning` (Phase 2, 步骤 20) 会使用 buffer 信息
+- 输出数据使用：`AscendMemoryPlanning` (Phase 2) 会使用 buffer 信息
 
 **Step 3: 确定阶段**
 - 功能是硬件优化 → Phase 2
@@ -304,10 +324,10 @@ def LowerAndLegalize(mod, target):
 
 **Step 4: 确定位置**
 - 输入依赖：必须在 `CollectBufferShapes` 后 → Phase 1 已完成
-- 输出供给：必须在 `AscendMemoryPlanning` 前 → Phase 2 步骤 20 前
-- 功能相邻：内存优化 Pass → 在 `AscendStorageRewrite`（步骤 13）附近
+- 输出供给：必须在 `AscendMemoryPlanning` 前
+- 功能相邻：内存优化 Pass → 在 `AscendStorageRewrite` 附近
 
-**推荐位置**：Phase 2，在 `AscendStorageRewrite`（步骤 13）后，`AscendMemoryPlanning`（步骤 20）前。
+**推荐位置**：Phase 2，在 `AscendStorageRewrite` 后、`AscendMemoryPlanning` 前。
 
 **Step 5: 验证**
 - 依赖数据可用：`buffer_shapess` 来自 Phase 1，已满足 ✓
@@ -319,13 +339,13 @@ def LowerAndLegalize(mod, target):
 ```python
 # tilelang/engine/phase.py
 def OptimizeForTarget(mod, target, platform):
-    # ... (步骤 1-13)
-    mod = AscendStorageRewrite(is_npu)(mod)  # 步骤 13
+    # ... 现有 Phase 2 Pass
+    mod = AscendStorageRewrite(is_npu)(mod)
     # 新增 Pass
     mod = BufferSizeOptimizationPass()(mod)
-    mod = tir.transform.UnrollLoop()(mod)  # 步骤 14
-    # ... (步骤 15-19)
-    mod = AscendMemoryPlanning()(mod)  # 步骤 20
+    mod = tir.transform.UnrollLoop()(mod)
+    # ... 中间 Phase 2 Pass
+    mod = AscendMemoryPlanning()(mod)
     # ...
 ```
 
@@ -341,9 +361,9 @@ def OptimizeForTarget(mod, target, platform):
 
 **Step 2: 分析依赖**
 - 输入数据：buffer scope（知道哪个 buffer 是 L0C）
-- 输入数据来源：`AscendInferBufferScope` (Phase 1, 步骤 1)
+- 输入数据来源：`AscendInferBufferScope` (Phase 1)
 - 输出数据：优化后的 L0C layout
-- 输出数据使用：`CrossCorePipeline` (Phase 2, 步骤 2) 会考虑 L0C layout
+- 输出数据使用：`CrossCorePipeline` (Phase 2) 会考虑 L0C layout
 
 **Step 3: 确定阶段**
 - 功能是硬件优化 → Phase 2
@@ -359,9 +379,9 @@ def OptimizeForTarget(mod, target, platform):
 
 **考虑两种方案**：
 1. **方案 A**：在 `CrossCorePipeline` 前（影响流水线规划）
-   - 位置：Phase 2，步骤 2 前（替换或修改步骤 1）
+   - 位置：Phase 2，在 `CrossCorePipeline` 前
 2. **方案 B**：在 `CrossCorePipeline` 后（不影响流水线规划）
-   - 位置：Phase 2，步骤 2 后，`CombineCV` 前
+   - 位置：Phase 2，在 `CrossCorePipeline` 后、`CombineCV` 前
 
 **推荐方案**：方案 A（影响流水线规划更合理）
 
@@ -375,11 +395,11 @@ def OptimizeForTarget(mod, target, platform):
 ```python
 # tilelang/engine/phase.py
 def OptimizeForTarget(mod, target, platform):
-    # ... (步骤 1)
-    mod = tir.transform.PlanAndUpdateBufferAllocationLocation()(mod)  # 步骤 1
+    # ... 现有 Phase 2 Pass
+    mod = tir.transform.PlanAndUpdateBufferAllocationLocation()(mod)
     # 新增 Pass
     mod = L0CLayoutOptimizationPass()(mod)
-    mod = CrossCorePipeline()(mod)  # 步骤 2
+    mod = CrossCorePipeline()(mod)
     # ...
 ```
 
@@ -411,7 +431,7 @@ def OptimizeForTarget(mod, target, platform):
 - 输出供给：不影响后续 Pass，位置灵活
 - 功能相邻：合法化 Pass → 在 Phase 1 末尾
 
-**推荐位置**：Phase 1，在 `tir.transform.Simplify`（步骤 12）后，Phase 1 末尾。
+**推荐位置**：Phase 1，在末尾的 `tir.transform.Simplify` 后。
 
 **Step 5: 验证**
 - 依赖数据可用：Phase 1 IR 已完成 ✓
@@ -423,8 +443,8 @@ def OptimizeForTarget(mod, target, platform):
 ```python
 # tilelang/engine/phase.py
 def LowerAndLegalize(mod, target):
-    # ... (步骤 1-11)
-    mod = tir.transform.Simplify()(mod)  # 步骤 12
+    # ... 现有 Phase 1 Pass
+    mod = tir.transform.Simplify()(mod)  # Phase 1 末尾
     # 新增 Pass
     mod = IRCorrectnessValidationPass()(mod)
     return mod

--- a/.agents/skills/tilelang-pass-workflow-analyzer/references/pass-dependency-graph.md
+++ b/.agents/skills/tilelang-pass-workflow-analyzer/references/pass-dependency-graph.md
@@ -29,6 +29,9 @@ CollectBufferShapes → buffer_shapess (Map<Var, Array<PrimExpr>>)
     ↓
 [Phase 2: OptimizeForTarget]
     ↓
+AscendVectorInstructionSelection
+    → selected terminal identity + mask contract operands（仅 A2/A3 AscendC/auto）
+    ↓
 CrossCorePipeline (使用 buffer scope)
     ↓
 CombineCV (使用 buffer scope)
@@ -37,7 +40,13 @@ AscendMemoryPlanning (使用 buffer_shapess) → address_map, size_map
     ↓
 AscendSyncInsert (使用 address_map, size_map)
     ↓
-Final IR
+AscendSyncInsertVS
+    ↓
+tir.transform.Simplify（managed 路径最后一次结构化简化）
+    ↓
+AscendVectorMaskLegalize（使用 selected terminal contract 和完整同步边界）
+    ↓
+AscendC codegen-ready IR
 ```
 
 ---
@@ -54,6 +63,7 @@ Final IR
 | **Size Map** | `size_map` | Map<Var, PrimExpr> | `AscendMemoryPlanning` | `AscendSyncInsert` | 记录每个 buffer 的大小 |
 | **Pipeline Layout** | pipeline layout annotations | Map | `PipelinePlanning` | `InjectSoftwarePipeline` | 记录流水线的 layout 信息 |
 | **Cross-Core Pipeline** | cross-core annotations | Map | `CrossCorePipeline` | `CombineCV` | 记录 Cube-Vector 核间流水线信息 |
+| **Selected Vector Terminal** | 无独立 attr；物化为 Op identity + operands | TIR Call | `AscendVectorInstructionSelection` | 中间 Pass 保持；`AscendVectorMaskLegalize` 与 AscendC codegen 消费 | 固定物理实现并携带 mask requirement/ensure contract |
 
 ### 辅助数据流
 
@@ -62,6 +72,7 @@ Final IR
 | **Target Attr** | `tir.transform.BindTarget` | 多个 Pass | 记录编译目标（Ascend NPU） |
 | **Buffer Allocation Plan** | `tir.transform.PlanAndUpdateBufferAllocationLocation` | `Flatten2DBuffer`, `FlattenBuffer` | 确定 buffer 分配位置 |
 | **Vectorized IR** | `AscendLowerParallelToVector` | `LegalizeVectorizedLoop` | 提供 Vector 指令 IR |
+| **同步边界** | `AscendSyncInsert`, `AscendSyncInsertVS` | `AscendVectorMaskLegalize` | 使 Legalizer 在 barrier/不透明边界后保守失效 mask facts |
 
 ---
 
@@ -72,8 +83,12 @@ Final IR
 ```
 DSL IR
   ↓
+InjectTmpBuffer
+  ↓ (output: IR with Vector tmp buffers)
 AscendInferBufferScope
   ↓ (output: buffer scope annotations)
+AscendVidReduction
+  ↓ (output: normalized vid IR)
 BufferShapeCollector
   ↓ (output: buffer shapes (初步))
 tir.transform.BindTarget
@@ -90,6 +105,10 @@ CollectBufferShapes
   ↓ (output: buffer_shapess) ← **关键输出**
 LowerTileOp
   ↓ (output: lowered tile ops)
+AscendTailMaskPropagation
+  ↓ (output: tail-aware Vector IR; 配置关闭时为 no-op)
+AscendWorkspaceReduction
+  ↓ (output: workspace-reduced IR)
 LegalizeVectorizedLoop
   ↓
 LegalizeSafeMemoryAccess
@@ -103,11 +122,15 @@ Phase 1 Final IR
 
 | Pass | 输入依赖 | 输出供给 | 重要性 |
 |------|---------|---------|--------|
+| `InjectTmpBuffer` | DSL IR | IR with Vector tmp buffers | 为底层 Vector helper 注入临时空间 |
 | `AscendInferBufferScope` | DSL IR | buffer scope annotations | **基础 Pass**：为 Phase 2 多个 Pass 提供依赖 |
+| `AscendVidReduction` | buffer scope | normalized vid IR | 规约 1:2 Vector core 映射下的 UB shape、index 和相关操作参数 |
 | `BufferShapeCollector` | buffer scope | buffer shapes (初步) | 辅助 Pass：收集初步形状信息 |
 | `AscendLowerParallelToVector` | simplified IR | vectorized IR | **核心 Lowering Pass**：将 Parallel → Vector |
 | `CollectBufferShapes` | layout annotations | **`buffer_shapess`** | **关键 Pass**：Phase 2 的 `AscendMemoryPlanning` 依赖此输出 |
 | `LowerTileOp` | buffer shapes | lowered tile ops | **核心 Lowering Pass**：将 Tile DSL → 底层 IR |
+| `AscendTailMaskPropagation` | lowered tile ops | tail-aware Vector IR | 传播 UB tail valid region；配置关闭时为 no-op |
+| `AscendWorkspaceReduction` | tail-aware IR | workspace-reduced IR | 消除 virtual CV copy 的手工 workspace |
 
 ---
 
@@ -118,6 +141,8 @@ Phase 1 Final IR
 ```
 Phase 1 Final IR (含 buffer_shapess)
   ↓
+AscendVectorInstructionSelection
+  ↓ (仅 A2/A3 AscendC/auto；output: selected terminals + mask contracts)
 tir.transform.PlanAndUpdateBufferAllocationLocation
   ↓ (output: buffer allocation plan)
 CrossCorePipeline
@@ -160,7 +185,13 @@ AscendMemoryPlanning
   ↓ (output: **address_map**, **size_map**, 使用 buffer_shapess)
 AscendSyncInsert
   ↓ (使用 address_map, size_map)
-Phase 2 Final IR
+AscendSyncInsertVS
+  ↓ (补充 V→V、Scalar↔其他 pipeline 的同步)
+tir.transform.Simplify
+  ↓ (仅 managed 路径；最后一次 structured simplify)
+AscendVectorMaskLegalize
+  ↓ (仅 managed 路径；插入最小必要 compiler mask setter)
+AscendC codegen-ready IR
 ```
 
 ### Phase 2 依赖说明
@@ -172,7 +203,10 @@ Phase 2 Final IR
 | `InjectSoftwarePipeline` | pipeline layout | software pipeline | **性能优化 Pass**：依赖 layout 信息 |
 | `AscendStorageRewrite` | vectorized loops | optimized storage | **内存优化 Pass**：为 memory planning 提供优化的 IR |
 | `AscendMemoryPlanning` | **`buffer_shapess`** (来自 Phase 1) | **`address_map`**, **`size_map`** | **关键 Pass**：跨阶段依赖，使用 Phase 1 输出 |
-| `AscendSyncInsert` | **`address_map`**, **`size_map`** | final IR with syncs | **最后一环**：依赖 memory planning 的输出 |
+| `AscendSyncInsert` | **`address_map`**, **`size_map`** | IR with general syncs | 依赖 memory planning 的输出 |
+| `AscendSyncInsertVS` | 通用同步后的 IR | IR with VS syncs | 补充 V→V 和 Scalar↔其他 pipeline 同步 |
+| `AscendVectorInstructionSelection` | semantic Vector IR | selected terminals + mask contracts | managed 路径第一步，必须先于所有 Phase 2 重写 |
+| `AscendVectorMaskLegalize` | selected terminals + 完整同步边界 | codegen-ready IR | managed 路径最后一个结构化 TIR Pass |
 
 ---
 
@@ -206,14 +240,14 @@ CombineCV ← buffer scope (使用)
 ### 依赖链 1: Buffer Scope 相关
 
 ```
-AscendInferBufferScope (Phase 1, 步骤 1)
+AscendInferBufferScope (Phase 1)
   ↓ (output: buffer scope annotations)
   
 [跨阶段传递]
   
-CrossCorePipeline (Phase 2, 步骤 2)
+CrossCorePipeline (Phase 2)
   ↓ (使用 buffer scope, output: cross-core annotations)
-CombineCV (Phase 2, 步骤 3)
+CombineCV (Phase 2)
   ↓ (使用 buffer scope, output: separated CV ops)
 ```
 
@@ -225,14 +259,14 @@ CombineCV (Phase 2, 步骤 3)
 ### 依赖链 2: Buffer Shapes 相关
 
 ```
-CollectBufferShapes (Phase 1, 步骤 8)
+CollectBufferShapes (Phase 1)
   ↓ (output: buffer_shapess)
   
 [跨阶段传递]
   
-AscendMemoryPlanning (Phase 2, 步骤 20)
+AscendMemoryPlanning (Phase 2)
   ↓ (使用 buffer_shapess, output: address_map, size_map)
-AscendSyncInsert (Phase 2, 步骤 21)
+AscendSyncInsert (Phase 2)
   ↓ (使用 address_map, size_map)
 ```
 
@@ -244,14 +278,14 @@ AscendSyncInsert (Phase 2, 步骤 21)
 ### 依赖链 3: Lowering 相关
 
 ```
-AscendLowerParallelToVector (Phase 1, 步骤 6)
+AscendLowerParallelToVector (Phase 1)
   ↓ (output: vectorized IR)
-LegalizeVectorizedLoop (Phase 1, 步骤 10)
+LegalizeVectorizedLoop (Phase 1)
   ↓ (使用 vectorized IR, output: legalized loops)
 
-LowerTileOp (Phase 1, 步骤 9)
+LowerTileOp (Phase 1)
   ↓ (output: lowered tile ops)
-LegalizeSafeMemoryAccess (Phase 1, 步骤 11)
+LegalizeSafeMemoryAccess (Phase 1)
   ↓ (使用 lowered tile ops, output: safe memory IR)
 ```
 
@@ -264,13 +298,13 @@ LegalizeSafeMemoryAccess (Phase 1, 步骤 11)
 ### 依赖链 4: 流水线相关
 
 ```
-CrossCorePipeline (Phase 2, 步骤 2)
+CrossCorePipeline (Phase 2)
   ↓ (output: cross-core annotations)
-CombineCV (Phase 2, 步骤 3)
+CombineCV (Phase 2)
   ↓ (使用 cross-core annotations, output: separated CV ops)
-PipelinePlanning (Phase 2, 步骤 4)
+PipelinePlanning (Phase 2)
   ↓ (output: pipeline layout)
-InjectSoftwarePipeline (Phase 2, 步骤 5)
+InjectSoftwarePipeline (Phase 2)
   ↓ (使用 pipeline layout, output: software pipeline)
 ```
 
@@ -279,6 +313,34 @@ InjectSoftwarePipeline (Phase 2, 步骤 5)
 - `CombineCV` 分离 Cube/Vector 操作，依赖跨核流水线信息
 - `PipelinePlanning` 推断流水线的 layout
 - `InjectSoftwarePipeline` 注入软件流水线，依赖 layout 信息
+
+### 依赖链 5: Compiler-managed Vector mask
+
+```
+AscendVectorInstructionSelection
+  ↓ (selected terminal identity + contract operands 物化在 TIR Call 中)
+Phase 2 中间重写
+  ↓ (必须保持 selected identity、operands 和顶层 Evaluate terminal)
+AscendSyncInsert
+  ↓
+AscendSyncInsertVS
+  ↓
+tir.transform.Simplify
+  ↓ (最后一次 structured simplify)
+AscendVectorMaskLegalize
+  ↓ (局部 must-facts 数据流；插入显式 mode/payload setter)
+AscendC mechanical emitter
+```
+
+**依赖说明**：
+- Selection 必须位于 Phase 2 第一项，避免 allocation、pipeline 或 control-flow 重写后
+  再做物理指令选择。
+- selected terminal contract 不通过 `PrimFunc` attr 旁路传递，而是物化在 Op identity 和
+  operands 中，因此中间 Pass 必须保持它们。
+- Legalizer 必须位于 `AscendSyncInsertVS` 和最后一次 `Simplify` 之后，才能看到所有会使
+  mask facts 失效的同步和控制流边界。
+- managed 路径的 `device_codegen()` 跳过旧的额外 `Simplify`，Legalizer 输出直接交给
+  AscendC emitter。
 
 ---
 
@@ -330,14 +392,17 @@ DSL IR
   └─ buffer_shapess → AscendMemoryPlanning
   ↓
 [Phase 2]
+  ├─ AscendVectorInstructionSelection → selected terminals + contracts ★
   ├─ CrossCorePipeline ← buffer scope
   ├─ CombineCV ← buffer scope
   ├─ InjectSoftwarePipeline ← pipeline layout
   ├─ AscendStorageRewrite → optimized storage
   ├─ AscendMemoryPlanning ← buffer_shapess → address_map, size_map ★
-  └─ AscendSyncInsert ← address_map, size_map
+  ├─ AscendSyncInsert ← address_map, size_map
+  ├─ AscendSyncInsertVS → complete sync boundaries
+  └─ AscendVectorMaskLegalize ← selected contracts + sync boundaries ★
   ↓
-Final IR
+AscendC codegen-ready IR
 ```
 
 ### 关键数据流路径
@@ -355,6 +420,13 @@ CollectBufferShapes → buffer_shapess
 AscendMemoryPlanning ← buffer_shapess → address_map, size_map
   ↓ [Phase 2 内部]
 AscendSyncInsert ← address_map, size_map
+
+[A2/A3 AscendC/auto managed mask]
+AscendVectorInstructionSelection → selected terminal + mask contract
+  ↓ [中间 Pass 保持 identity/operands]
+AscendSyncInsert → AscendSyncInsertVS → final Simplify
+  ↓
+AscendVectorMaskLegalize → explicit compiler mask setters
 ```
 
 ---
@@ -370,10 +442,18 @@ AscendSyncInsert ← address_map, size_map
 2. **Phase 2 内部顺序严格**
    - `AscendMemoryPlanning` 必须在 `AscendSyncInsert` 前执行
    - `CrossCorePipeline` 必须在 `CombineCV` 前执行
+   - managed 路径必须以 `AscendVectorInstructionSelection` 开始
+   - managed 路径必须以 final `Simplify` → `AscendVectorMaskLegalize` 结束，之后不得再有
+     结构化 TIR rewrite
 
 3. **跨阶段依赖不可打破**
    - 不能在 Phase 1 之前添加需要 Phase 2 输入的 Pass
    - 不能在 Phase 2 之后添加需要 Phase 1 输出的 Pass
+
+4. **Selected terminal contract 不可丢失**
+   - 中间 Pass 不得把 selected terminal 还原为 semantic op
+   - 不得改写或丢弃承载 mask contract 的 operands
+   - 新增 barrier 或不透明调用必须位于 Legalizer 之前，使 facts 能正确失效
 
 ### 添加新 Pass 的约束
 

--- a/.agents/skills/tilelang-pass-workflow-analyzer/references/pass-pipeline-overview.md
+++ b/.agents/skills/tilelang-pass-workflow-analyzer/references/pass-pipeline-overview.md
@@ -12,12 +12,12 @@ Python DSL (@tilelang.jit)
 [Phase 1: LowerAndLegalize] ← 前端标准化、Lowering
     - 目标：将高级 DSL 转换为标准化 TIR
     - 特点：语义保持、平台无关优化
-    - Pass 数量：12 个
+    - Pass 数量：16 个
     ↓
 [Phase 2: OptimizeForTarget] ← 后端优化、平台特化
     - 目标：针对 Ascend 硬件特性的优化
     - 特点：硬件相关、性能导向
-    - Pass 数量：21 个
+    - Pass 数量：A2/A3 AscendC/auto 25 个；其他 OptimizeForTarget 路径 22 个
     ↓
 CANN 工具链 → NPU 执行
 ```
@@ -63,18 +63,22 @@ CANN 工具链 → NPU 执行
 
 | 步骤 | Pass | 功能 | 输入依赖 | 输出供给 | 关键逻辑 |
 |------|------|------|---------|---------|---------|
-| 1 | `AscendInferBufferScope()` | 推断 buffer scope (L1/UB/L0A/L0B/L0C) | DSL IR | buffer scope annotations | 分析 buffer 访问模式，推断内存层级 |
-| 2 | `BufferShapeCollector()` | 收集 buffer 形状信息 | buffer scope | buffer shapes (初步) | 为后续 Pass 提供形状信息 |
-| 3 | `tir.transform.BindTarget(target)` | 绑定 Target 信息 | IR | target attr | 记录编译目标（Ascend NPU） |
-| 4 | `HostProcesser()` | Host 端数据处理 | IR | processed host data | 处理 CPU 端数据准备 |
-| 5 | `tir.transform.Simplify()` | 简化 IR 表达式 | IR | simplified IR | 算术简化、常量折叠 |
-| 6 | `AscendLowerParallelToVector()` | Parallel 循环 → Vector 指令 | simplified IR | vectorized IR | **核心 Pass**：将高级 Parallel 原语 lowering 到 Vector 指令 |
-| 7 | `LayoutInference()` | 推断 fragment/shared memory layout | vectorized IR | layout annotations | 分析数据布局，推断最优 layout |
-| 8 | `CollectBufferShapes()` | 再次收集 buffer 形状 | layout annotations | `buffer_shapess` | **关键输出**：为 Phase 2 提供 buffer 形状 |
-| 9 | `LowerTileOp()` | Tile 操作 → 底层 IR | buffer shapes | lowered tile ops | **核心 Pass**：将 `T.copy`、`T.matmul` 等 lowering 到具体硬件操作 |
-| 10 | `LegalizeVectorizedLoop()` | 合法化向量化循环 | lowered tile ops | legalized loops | 确保向量化循环符合硬件约束 |
-| 11 | `LegalizeSafeMemoryAccess()` | 安全内存访问检查 | legalized loops | safe memory IR | 检查内存访问是否越界、是否符合硬件规范 |
-| 12 | `tir.transform.Simplify()` | 再次简化 | safe memory IR | final Phase 1 IR | 清理冗余 IR，为 Phase 2 准备 |
+| 1 | `InjectTmpBuffer(target)` | 为 Vector API 分配临时 buffer | DSL IR | IR with tmp buffers | 注入底层 Vector helper 所需临时空间 |
+| 2 | `AscendInferBufferScope()` | 推断 buffer scope (L1/UB/L0A/L0B/L0C) | DSL IR | buffer scope annotations | 分析 buffer 访问模式，推断内存层级 |
+| 3 | `AscendVidReduction()` | 规约 Vector core id 使用 | buffer scope | normalized vid IR | 规范化 Ascend Vector core 映射 |
+| 4 | `BufferShapeCollector()` | 收集 buffer 形状信息 | buffer scope | buffer shapes (初步) | 为后续 Pass 提供形状信息 |
+| 5 | `tir.transform.BindTarget(target)` | 绑定 Target 信息 | IR | target attr | 记录编译目标（Ascend NPU） |
+| 6 | `HostProcesser()` | Host 端数据处理 | IR | processed host data | 处理 CPU 端数据准备 |
+| 7 | `tir.transform.Simplify()` | 简化 IR 表达式 | IR | simplified IR | 算术简化、常量折叠 |
+| 8 | `AscendLowerParallelToVector()` | Parallel 循环 → Vector 指令 | simplified IR | vectorized IR | **核心 Pass**：将高级 Parallel 原语 lowering 到 Vector 指令 |
+| 9 | `LayoutInference()` | 推断 fragment/shared memory layout | vectorized IR | layout annotations | 分析数据布局，推断最优 layout |
+| 10 | `CollectBufferShapes()` | 再次收集 buffer 形状 | layout annotations | `buffer_shapess` | **关键输出**：为 Phase 2 提供 buffer 形状 |
+| 11 | `LowerTileOp()` | Tile 操作 → 底层 IR | buffer shapes | lowered tile ops | **核心 Pass**：将 `T.copy`、`T.matmul` 等 lowering 到具体硬件操作 |
+| 12 | `AscendTailMaskPropagation(rewrite_reduce)` | 传播 UB tail valid region | lowered tile ops | tail-aware Vector IR | 配置关闭时为 no-op；启用时改写 allow-list 操作 |
+| 13 | `AscendWorkspaceReduction()` | 消除 virtual CV copy 的手工 workspace | tail-aware IR | workspace-reduced IR | 为后续自动 workspace 处理准备 IR |
+| 14 | `LegalizeVectorizedLoop()` | 合法化向量化循环 | lowered tile ops | legalized loops | 确保向量化循环符合硬件约束 |
+| 15 | `LegalizeSafeMemoryAccess()` | 安全内存访问检查 | legalized loops | safe memory IR | 检查内存访问是否越界、是否符合硬件规范 |
+| 16 | `tir.transform.Simplify()` | 再次简化 | safe memory IR | final Phase 1 IR | 清理冗余 IR，为 Phase 2 准备 |
 
 ### Phase 1 关键 Pass 说明
 
@@ -122,33 +126,64 @@ CANN 工具链 → NPU 执行
 
 针对 Ascend 硬件特性进行性能优化，生成高效的机器码。
 
+### A2/A3 AscendC/auto 的强制扩展
+
+当 `target.model` 为 `ascendc` 或 `auto`，且 `platform` 为 `A2` 或 `A3` 时，
+`OptimizeForTarget` 强制启用 compiler-managed Vector mask 流程：
+
+1. `AscendVectorInstructionSelection` 在所有其他 Phase 2 Pass 之前冻结物理 Vector terminal，
+   并附带显式 mask contract。
+2. 中间 Pass 可以重排或插入同步，但必须保持 selected terminal 身份和 contract 参数。
+3. `AscendSyncInsert` 与 `AscendSyncInsertVS` 完成同步插入后，运行最后一次 `Simplify`。
+4. `AscendVectorMaskLegalize` 作为最后一个结构化 TIR Pass 修复 mask state；之后直接进入
+   AscendC codegen。
+
+该流程属于正确性约束，没有用户可关闭的 PassConfig 开关。A5、PTO 和非 AscendC 路径
+保持原有流程。
+
 ### Pass 列表（按执行顺序）
 
 | 步骤 | Pass | 功能 | 输入依赖 | 输出供给 | 关键逻辑 |
 |------|------|------|---------|---------|---------|
-| 1 | `tir.transform.PlanAndUpdateBufferAllocationLocation()` | Buffer 分配位置规划 | Phase 1 IR | buffer allocation plan | 确定每个 buffer 在代码中的分配位置 |
-| 2 | `CrossCorePipeline()` | 跨核流水线规划 | buffer scope, allocation plan | cross-core pipeline | **核心 Pass**：规划 Cube-Vector 核间流水线 |
-| 3 | `CombineCV()` | 分离 Cube/Vector 操作 | cross-core pipeline | separated CV ops | 将操作分离为 Cube 和 Vector 两部分 |
-| 4 | `PipelinePlanning()` | 流水线 layout 推断 | separated CV ops | pipeline layout | 推断流水线中每个阶段的 layout |
-| 5 | `InjectSoftwarePipeline()` | 软件流水线注入 | pipeline layout | software pipeline | 注入软件流水线，提升吞吐量 |
-| 6 | `AscendLowerOpaqueBlock()` | Block IR → 可执行 IR | software pipeline | executable IR | 将 Block IR lowering 到可执行形式 |
-| 7 | `tir.transform.NarrowDataType(32)` | 数据类型缩窄 | executable IR | narrowed data types | 缩窄数据类型以减少内存占用 |
-| 8 | `ConfigIndexBitwidth()` | 索引位宽配置 | narrowed data types | configured indices | 配置索引变量的位宽 |
-| 9 | `Flatten2DBuffer()` | Buffer 扁平化到 2D | configured indices | 2D buffers | 将多维 buffer 扁平化为 2D |
-| 10 | `FlattenBuffer()` | Buffer 扁平化到 1D | 2D buffers | 1D buffers | 将 2D buffer 扁平化为 1D |
-| 11 | `tir.transform.Simplify()` | 简化 | 1D buffers | simplified IR | 清理扁平化后的冗余 IR |
-| 12 | `VectorizeLoop()` | 循环向量化（可配置） | simplified IR | vectorized loops | 将循环转换为向量指令 |
-| 13 | `AscendStorageRewrite(is_npu)` | 存储重写优化 | vectorized loops | optimized storage | **核心 Pass**：优化内存访问模式，共享存储 |
-| 14 | `tir.transform.UnrollLoop()` | 循环展开 | optimized storage | unrolled loops | 展开小循环以提升性能 |
-| 15 | `tir.transform.RenormalizeSplitPattern()` | 重规范化分割模式 | unrolled loops | renormalized patterns | 规范化循环分割模式 |
-| 16 | `tir.transform.Simplify()` | 简化 | renormalized patterns | simplified IR | 清理展开后的冗余 IR |
-| 17 | `tir.transform.RemoveNoOp()` | 移除空操作 | simplified IR | no-op removed | 删除无实际作用的 IR |
-| 18 | `tir.transform.RewriteUnsafeSelect()` | 重写不安全 select | no-op removed | safe select | 重写可能导致硬件异常的 select |
-| 19 | `tir.transform.HoistIfThenElse()` | 提升 if-then-else | safe select | hoisted conditionals | 提升 if-then-else 以减少分支开销 |
-| 20 | `AscendMemoryPlanning()` | 内存规划 | `buffer_shapess` | `address_map`, `size_map` | **关键 Pass**：规划 buffer 地址，输出地址映射 |
-| 21 | `AscendSyncInsert()` | 同步插入 | `address_map`, `size_map` | final IR with syncs | **最后一环**：插入同步指令 |
+| 1* | `AscendVectorInstructionSelection(target, platform)` | 冻结物理 Vector terminal 与 mask contract | Phase 1 semantic Vector IR | selected terminals | **仅 A2/A3 AscendC/auto**；必须在其他 Phase 2 Pass 之前 |
+| 2 | `tir.transform.PlanAndUpdateBufferAllocationLocation()` | Buffer 分配位置规划 | Phase 1 IR | buffer allocation plan | 确定每个 buffer 在代码中的分配位置 |
+| 3 | `CrossCorePipeline()` | 跨核流水线规划 | buffer scope, allocation plan | cross-core pipeline | **核心 Pass**：规划 Cube-Vector 核间流水线 |
+| 4 | `CombineCV()` | 分离 Cube/Vector 操作 | cross-core pipeline | separated CV ops | 将操作分离为 Cube 和 Vector 两部分 |
+| 5 | `PipelinePlanning()` | 流水线 layout 推断 | separated CV ops | pipeline layout | 推断流水线中每个阶段的 layout |
+| 6 | `InjectSoftwarePipeline()` | 软件流水线注入 | pipeline layout | software pipeline | 注入软件流水线，提升吞吐量 |
+| 7 | `AscendLowerOpaqueBlock()` | Block IR → 可执行 IR | software pipeline | executable IR | 将 Block IR lowering 到可执行形式 |
+| 8 | `tir.transform.NarrowDataType(32)` | 数据类型缩窄 | executable IR | narrowed data types | 缩窄数据类型以减少内存占用 |
+| 9 | `ConfigIndexBitwidth()` | 索引位宽配置 | narrowed data types | configured indices | 配置索引变量的位宽 |
+| 10 | `Flatten2DBuffer()` | Buffer 扁平化到 2D | configured indices | 2D buffers | 将多维 buffer 扁平化为 2D |
+| 11 | `FlattenBuffer()` | Buffer 扁平化到 1D | 2D buffers | 1D buffers | 将 2D buffer 扁平化为 1D |
+| 12 | `tir.transform.Simplify()` | 简化 | 1D buffers | simplified IR | 清理扁平化后的冗余 IR |
+| 13 | `VectorizeLoop()` | 循环向量化（可配置） | simplified IR | vectorized loops | 将循环转换为向量指令 |
+| 14 | `AscendStorageRewrite(is_npu)` | 存储重写优化 | vectorized loops | optimized storage | **核心 Pass**：优化内存访问模式，共享存储 |
+| 15 | `tir.transform.UnrollLoop()` | 循环展开 | optimized storage | unrolled loops | 展开小循环以提升性能 |
+| 16 | `tir.transform.RenormalizeSplitPattern()` | 重规范化分割模式 | unrolled loops | renormalized patterns | 规范化循环分割模式 |
+| 17 | `tir.transform.Simplify()` | 简化 | renormalized patterns | simplified IR | 清理展开后的冗余 IR |
+| 18 | `tir.transform.RemoveNoOp()` | 移除空操作 | simplified IR | no-op removed | 删除无实际作用的 IR |
+| 19 | `tir.transform.RewriteUnsafeSelect()` | 重写不安全 select | no-op removed | safe select | 重写可能导致硬件异常的 select |
+| 20 | `tir.transform.HoistIfThenElse()` | 提升 if-then-else | safe select | hoisted conditionals | 提升 if-then-else 以减少分支开销 |
+| 21 | `AscendMemoryPlanning()` | 内存规划 | `buffer_shapess` | `address_map`, `size_map` | **关键 Pass**：规划 buffer 地址，输出地址映射 |
+| 22 | `AscendSyncInsert()` | 通用同步插入 | `address_map`, `size_map` | IR with general syncs | 插入 pipeline 同步指令 |
+| 23 | `AscendSyncInsertVS()` | Vector-Scalar 同步插入 | 通用同步后的 IR | IR with VS syncs | 完成后续 mask 分析必须看到的同步边界 |
+| 24* | `tir.transform.Simplify()` | 最后一次结构化简化 | 完整同步后的 IR | canonical managed IR | **仅 A2/A3 AscendC/auto**；之后不得再运行 TIR rewrite |
+| 25* | `AscendVectorMaskLegalize(target, platform)` | 修复并复用 Vector mask state | selected terminals, sync boundaries | codegen-ready IR | **仅 A2/A3 AscendC/auto**；最后一个结构化 TIR Pass |
+
+带 `*` 的步骤只在 A2/A3 AscendC/auto compiler-managed mask 路径执行。其他路径从步骤 2
+开始，并在步骤 23 后结束。
 
 ### Phase 2 关键 Pass 说明
+
+#### `AscendVectorInstructionSelection`
+
+- **功能**：把语义 Vector 调用改写为唯一的 selected terminal，并显式携带 mask contract
+- **核心逻辑**：
+  1. 根据 semantic op、dtype、shape 和静态参数选择固定物理实现
+  2. 校验 selected terminal 的 mask payload 和词法作用域
+  3. 拒绝 A2/A3 managed grammar 不支持或未分类的调用
+- **重要性**：把“选择物理指令”和“发射目标代码”分离，确保后续数据流分析面对稳定终端
 
 #### `CrossCorePipeline`
 
@@ -202,7 +237,17 @@ CANN 工具链 → NPU 执行
   1. 使用 `address_map` 和 `size_map`（来自 `AscendMemoryPlanning`）
   2. 分析操作的依赖关系
   3. 在必要位置插入同步（`T.barrier_all`、`T.set_flag`、`T.wait_flag`）
-- **重要性**：Pipeline 的最后一环，确保执行正确性
+- **重要性**：确保 pipeline 执行正确性；managed mask 路径还会继续运行
+  `AscendSyncInsertVS`、最终 `Simplify` 和 `AscendVectorMaskLegalize`
+
+#### `AscendVectorMaskLegalize`
+
+- **功能**：在 codegen 前修复并复用 AIV 的 Vector mask hardware state
+- **核心逻辑**：
+  1. 跟踪 NORMAL/COUNTER mode 以及 low/high payload facts
+  2. 在 selected terminal 前仅插入缺失的 compiler setter
+  3. 在分支、循环、barrier 和不透明调用处合并或失效 facts
+- **重要性**：必须看到所有上游同步和控制流变化，因此是 managed 路径最后一个 TIR Pass
 
 ---
 
@@ -236,14 +281,24 @@ def AscendSyncInsert(target: Target, platform: str):
 ### Pipeline 调用
 
 ```python
-# 文件: tilelang/engine/phase.py:79-105
+# 文件: tilelang/engine/phase.py
 def OptimizeForTarget(mod, target, platform):
     """Optimize the TIR for the target platform."""
-    # ... (调用所有 Phase 2 Pass)
+    managed_vector_mask = use_compiler_managed_vector_mask(target, platform)
+    if managed_vector_mask:
+        mod = AscendVectorInstructionSelection(target, platform)(mod)
+    # ... (调用中间 Phase 2 Pass)
     mod = AscendMemoryPlanning()(mod)
     mod = AscendSyncInsert(target, platform)(mod)
+    mod = AscendSyncInsertVS(target, platform)(mod)
+    if managed_vector_mask:
+        mod = tir.transform.Simplify()(mod)
+        mod = AscendVectorMaskLegalize(target, platform)(mod)
     return mod
 ```
+
+`tilelang/engine/lower.py::device_codegen()` 只在非 managed 路径补做 `Simplify()`；
+managed 路径直接把 Legalizer 输出交给 AscendC codegen，保持 Legalizer 的最终性。
 
 ---
 
@@ -285,6 +340,12 @@ if (!ascend_auto_sync) {
   return f;  // 配置为 false 时跳过该 Pass
 }
 ```
+
+### Compiler-managed Vector mask 门控
+
+`AscendVectorInstructionSelection` 和 `AscendVectorMaskLegalize` 不读取 PassConfig。
+它们由 `use_compiler_managed_vector_mask(target, platform)` 统一门控，并在 A2/A3 AscendC/auto
+路径强制成对运行，避免用户关闭其中一半而破坏 codegen contract。
 
 ---
 

--- a/docs/ascend/compiler_managed_vector_mask_inventory.md
+++ b/docs/ascend/compiler_managed_vector_mask_inventory.md
@@ -1,0 +1,99 @@
+# A2/A3 AscendC compiler-managed Vector-mask inventory
+
+This inventory closes the compatibility domain used by the mandatory A2/A3
+AscendC mask pipeline. The machine-readable source of truth is
+`src/op/ascend_vector_mask_ops.inc`; this document records the evidence and the
+selection/contract/emission grouping used to construct it.
+
+## Evidence baseline
+
+- Repository baseline: live parent `272c0ab3928df30f84d7ac644456856366ff60c4`
+  (the plan's historical audit commit `38e6b38f` is an ancestor).
+- Toolkit: CANN 9.1.0-beta.1, `dav_c220` (`__NPU_ARCH__ == 2201`).
+- Public interfaces: `kernel_operator_vec_*_intf.h` and their matching
+  `kernel_operator_vec_*_intf_impl.h` files.
+- Product implementations: `impl/basic_api/dav_c220/kernel_operator_vec_*.h`.
+- TileLang emission: `src/target/codegen_ascend.cc` and
+  `src/tl_templates/ascend/common.h`.
+- Validation: generated AscendC source, Bisheng compilation, and the existing
+  A2/A3 device tests under `testing/python/language/`.
+
+`Raw` means the selected emitter reaches a Level-0 instruction with internal
+mask setting disabled. `Composite` retains a Level-2/helper implementation and
+models its observed pre/post state. `Neutral` does not read or modify the
+Vector mask. `Self-contained` establishes the listed post-state without a
+precondition.
+
+## Selection, contract, and emission groups
+
+| Semantic operations | Selected behavior | Contract | Emission |
+|---|---|---|---|
+| `add`, `sub`, `mul`, `div`, `max`, `min`, `bitwise_and`, `bitwise_or` | raw counter | require/ensure COUNTER + exact count | Level-0 binary, `isSetMask=false` |
+| `adds`, `subs`, `muls`, `divs`, `maxs`, `mins`, `leaky_relu`, `axpy`, `bitwise_lshift`, `bitwise_rshift` | raw counter | require/ensure COUNTER + exact count | Level-0 scalar, `isSetMask=false` |
+| `exp`, `ln`, `abs`, `reciprocal`, `sqrt`, `rsqrt`, `relu`, `bitwise_not` | raw counter | require/ensure COUNTER + exact count | Level-0 unary, `isSetMask=false` |
+| `mul_add_dst`, `fill` | raw counter | require/ensure COUNTER + exact count | Level-0 binary/duplicate, `isSetMask=false` |
+| `cast`, simple `round` | raw counter | require/ensure COUNTER + exact count | Level-0 cast, `isSetMask=false`; repeat strides preserve Level-2 dtype-width rules |
+| `clamp_max`, `clamp_min`, `clamp` | raw counter | require/ensure COUNTER + exact count | one or two Level-0 scalar calls, `isSetMask=false` |
+| no-scratch `broadcast` | raw counter | require/ensure COUNTER + exact destination count | TileLang helper with `isSetMask=false` |
+| `sub_experiment`, `abs_experiment`, `mins_experiment` | raw counter | require/ensure COUNTER + exact count | corresponding Level-0 operation, `isSetMask=false` |
+| narrow `reduce`, fp16 clear `reduce_sum` | raw normal | require/ensure NORMAL + exact materialized bit mask | WholeReduce/narrow helper, `isSetMask=false` |
+| `block_reduce_max/min/sum`, `wholereducemax/min/sum` | raw normal | require/ensure NORMAL + exact materialized bit mask | Level-0 reduce, `isSetMask=false` |
+| `fill_experiment` | raw normal | require/ensure NORMAL + `(mask0, 0)` | scalar-mask Duplicate, `isSetMask=false` |
+| row-expand mul/sub/div experiments, `exp_experiment` | raw normal full | require/ensure NORMAL/FULL | existing explicit-mask helpers (already raw) |
+| same-dtype UB-to-UB copy, `sort32`, `transpose`, `gatherb`, `merge_sort`, DCCI experiment, BRCB experiment | neutral | all fields preserve | existing mechanical emitter |
+| `compare`, `compare_scalar` | neutral | all fields preserve | CANN Level-2 compare loop |
+| `createvecindex`, `gather` | unknown | all fields become unknown | existing composite emitter |
+| `arith_progression`, `init_sort_buf` | composite normal full | require NORMAL/FULL; mode remains NORMAL, payload becomes unknown | existing composite emitter |
+| `sin`, `cos`, advanced `reduce`, `pow`, `bitwise_xor`, scratch `broadcast`, `sort`, `topk`, custom `gather_mask`, advanced `round`, ReduceSum/Sum experiments, tail unary/binary/scalar/reduce | composite normal full | require NORMAL/FULL; post-state unknown | existing composite emitter |
+| dtype-converting UB-to-UB copy, `silu`, `sigmoid` | self-contained normal full | no requirement; ensure NORMAL/FULL | existing Level-2/helper emitter |
+| fixed-pattern `gather_mask` | self-contained normal zero | no requirement; ensure NORMAL/zero payload | existing fixed-pattern emitter |
+| bilinear interpolation, gather-mask experiment | self-contained normal dynamic | no requirement; ensure materialized NORMAL payload | existing emitter; selected operands carry the payload |
+| `select` (tensor or scalar) | self-contained normal full | no requirement; ensure NORMAL/FULL | CANN Level-2 Select |
+
+### Product-specific corrections found during validation
+
+- `Compare`/`CompareScalar` on `dav_c220` use `CompareCompute` loops and do not
+  touch the Vector mask. Treating them as raw counter consumers produced an
+  invalid repeat schedule; they are neutral.
+- `Select` exposes an `isSetMask` template parameter publicly, but the c220
+  `VselImpl` reached by the interface does not propagate it and performs its own
+  cmpmask/mask setup and restore. It is self-contained, not a raw consumer.
+- Cross-dtype raw Cast must reproduce the Level-2 repeat-stride adjustment
+  (`4/8` or `8/4` 32-byte blocks); default `8/8` silently skips half the data.
+- The `Fill_experiment` helper's one-word mask array is not a valid two-word
+  NORMAL mask operand. Selected emission uses the scalar overload with the
+  compiler-established state instead.
+
+## Non-semantic registrations
+
+| Name | Classification |
+|---|---|
+| `tl.ascend_duplicate` | stale config-only name; no registered semantic op |
+| `tl.arith_progression` | stale config-only spelling; public op is `tl.ascend_arith_progression` |
+| `tl.ascend_copy_vc_experiment` | PTO-only config entry; not an AscendC semantic terminal |
+| `tl.ascend_row_expand_mul` | unsupported on AscendC; Selection emits a user-facing diagnostic |
+
+`T._src_code` is the only intentional mask black box. It is a full facts
+barrier. New semantic Vector operations must add an explicit selected identity,
+contract, base projection, emitter, and tests; no prefix-based fallback exists
+on managed A2/A3.
+
+## Audited non-terminal effect table
+
+The Selection input grammar classifies non-terminal calls by exact identity or
+an explicit predicate. A miss is a compile error rather than an implicit
+neutral operation.
+
+| Call identity/predicate | Effect | Evidence boundary |
+|---|---|---|
+| `tl.ascend_src_code` | barrier | arbitrary injected source may read or write mask state |
+| TIR calls whose registered `TCallEffectKind` is expression annotation, pure, read-state, special-call-argument, or embedded-info | neutral | expression construction/addressing only; opaque, update-state, and control calls are rejected |
+| exact `call_extern` helpers `copy_*` except `copy_ub_to_ub`, A5-only `copy_ub_to_ub_Nz`, and A5-only `copy_pipe_to_ub_V`; plus `atomic_add_*`, `mma`, `gemm_v0`, `gemm_v1` | neutral | execute on A2/A3 DMA/Cube paths and do not issue Vector-mask instructions; ordinary UB-to-UB copy is selected separately |
+| `tl.ascend_copy`, `tl.ascend_atomic_add`, `tl.region`, `tl.ascend_set_deq_scale`, `tl.ascend_reinterpretcast` | neutral | audited data movement, annotation, and scalar/Cube configuration calls |
+| flag, cross-flag, pipe barrier, free-pipe, global-sync, and compiler auto-sync identities | neutral | synchronization only; they neither read nor write Vector mask registers |
+| GEMM/MMA, printf/dump, swizzle, SHMEM, and CV/VC-copy identities listed in `ClassifyNonTerminalMaskEffect` | neutral | audited infrastructure calls outside the Vector ALU mask interface |
+
+Mask payload expressions use a deliberately smaller grammar: integer
+arithmetic over lexical variables, with no `BufferLoad` or general call. The
+only call node admitted there is TVM's internal `tir.large_uint_imm` encoding
+of a `uint64` literal; it is not an executable helper.

--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -1513,5 +1513,21 @@ TIR_DEFINE_TL_BUILTIN(ascend_tail_reduce)
     .set_num_inputs(-1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ascend_set_mask_mode)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ascend_set_mask_payload)
+    .set_num_inputs(2)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+#define TL_ASCEND_SELECTED_VECTOR_OP(Name, Arity, Base, ContractKind)          \
+  TIR_DEFINE_TL_BUILTIN(Name).set_num_inputs(Arity).set_attr<TCallEffectKind>( \
+      "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+#include "ascend_vector_mask_ops.inc"
+#undef TL_ASCEND_SELECTED_VECTOR_OP
 } // namespace tl
 } // namespace tvm

--- a/src/op/ascend.h
+++ b/src/op/ascend.h
@@ -295,6 +295,13 @@ TVM_DLL const Op &ascend_tail_reduce();
 TVM_DLL const Op &ascend_copy_cv_experiment();
 
 TVM_DLL const Op &ascend_copy_vc_experiment();
+
+// Internal compiler-managed Vector mask operations. These identities are
+// emitted only by AscendVectorInstructionSelection/MaskLegalize and are not
+// part of the public TileLang language API.
+TVM_DLL const Op &ascend_set_mask_mode();
+
+TVM_DLL const Op &ascend_set_mask_payload();
 } // namespace tl
 } // namespace tvm
 

--- a/src/op/ascend_vector_mask_ops.inc
+++ b/src/op/ascend_vector_mask_ops.inc
@@ -1,0 +1,178 @@
+/*
+ * Internal compiler-managed Vector terminal identities.
+ *
+ * Consumers define TL_ASCEND_SELECTED_VECTOR_OP(name, arity, base,
+ * contract_kind) before including this file. Keep this list in the explicit
+ * selection priority order for terminals that share a semantic base op.
+ */
+
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_copy_ub_to_ub_neutral, -1,
+                             builtin::call_extern, kNeutral)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_copy_ub_to_ub_self_contained_normal_full,
+                             -1, builtin::call_extern, kSelfContainedNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_silu_self_contained_normal_full, 3,
+                             ascend_silu, kSelfContainedNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_mul_add_dst_raw_counter, 4,
+                             ascend_mul_add_dst, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_add_raw_counter, 4, ascend_add, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_adds_raw_counter, -1, ascend_adds,
+                             kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_mul_raw_counter, 4, ascend_mul, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_muls_raw_counter, -1, ascend_muls,
+                             kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_sub_raw_counter, 4, ascend_sub, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_subs_raw_counter, -1, ascend_subs,
+                             kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_div_raw_counter, 4, ascend_div, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_divs_raw_counter, -1, ascend_divs,
+                             kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_max_raw_counter, 4, ascend_max, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_maxs_raw_counter, -1, ascend_maxs,
+                             kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_min_raw_counter, 4, ascend_min, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_mins_raw_counter, -1, ascend_mins,
+                             kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_bitwise_and_raw_counter, 4,
+                             ascend_bitwise_and, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_bitwise_or_raw_counter, 4,
+                             ascend_bitwise_or, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_compare_neutral, 5, ascend_compare,
+                             kNeutral)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_compare_scalar_neutral, -1,
+                             ascend_compare_scalar, kNeutral)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_exp_raw_counter, 3, ascend_exp, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_ln_raw_counter, 3, ascend_ln, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_abs_raw_counter, 3, ascend_abs, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_reciprocal_raw_counter, 3,
+                             ascend_reciprocal, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_sqrt_raw_counter, 3, ascend_sqrt,
+                             kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_rsqrt_raw_counter, 3, ascend_rsqrt,
+                             kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_relu_raw_counter, 3, ascend_relu,
+                             kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_bitwise_not_raw_counter, 3,
+                             ascend_bitwise_not, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_select_self_contained_normal_full, -1,
+                             ascend_select, kSelfContainedNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_leaky_relu_raw_counter, 5,
+                             ascend_leaky_relu, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_axpy_raw_counter, 5, ascend_axpy,
+                             kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_bitwise_lshift_raw_counter, 4,
+                             ascend_bitwise_lshift, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_bitwise_rshift_raw_counter, 4,
+                             ascend_bitwise_rshift, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_sort32_neutral, 4, ascend_sort32, kNeutral)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_createvecindex_composite, 3,
+                             ascend_createvecindex, kUnknownAll)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_arith_progression_composite, 5,
+                             ascend_arith_progression,
+                             kCompositeNormalFullToNormalUnknownPayload)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_sin_composite, 4, ascend_sin,
+                             kCompositeNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_cos_composite, 4, ascend_cos,
+                             kCompositeNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_transpose_neutral, 2, ascend_transpose,
+                             kNeutral)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_gather_composite, -1, ascend_gather,
+                             kUnknownAll)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_reduce_narrow_raw_normal, -1, ascend_reduce,
+                             kRawNormalDynamicPayload)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_reduce_half_sum_raw_normal, -1,
+                             ascend_reduce, kRawNormalDynamicPayload)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_reduce_advanced_composite, -1,
+                             ascend_reduce, kCompositeNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_block_reduce_max_raw_normal, -1,
+                             ascend_block_reduce_max, kRawNormalDynamicPayload)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_block_reduce_min_raw_normal, -1,
+                             ascend_block_reduce_min, kRawNormalDynamicPayload)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_block_reduce_sum_raw_normal, -1,
+                             ascend_block_reduce_sum, kRawNormalDynamicPayload)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_gatherb_neutral, 7, ascend_gatherb,
+                             kNeutral)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_cast_raw_counter, 4, ascend_cast,
+                             kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_pow_composite, 4, ascend_pow,
+                             kCompositeNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_bitwise_xor_composite, 4,
+                             ascend_bitwise_xor, kCompositeNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_broadcast_advanced_composite, -1,
+                             ascend_broadcast, kCompositeNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_broadcast_raw_counter, -1, ascend_broadcast,
+                             kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_fill_raw_counter, 4, ascend_fill,
+                             kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_sort_composite, 6, ascend_sort,
+                             kCompositeNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_merge_sort_neutral, 6, ascend_merge_sort,
+                             kNeutral)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_topk_composite, 7, ascend_topk,
+                             kCompositeNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_gather_mask_fixed_self_contained_normal, -1,
+                             ascend_gather_mask, kSelfContainedNormalZero)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_gather_mask_custom_composite, -1,
+                             ascend_gather_mask, kCompositeNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_init_sort_buf_composite, 4,
+                             ascend_init_sort_buf,
+                             kCompositeNormalFullToNormalUnknownPayload)
+TL_ASCEND_SELECTED_VECTOR_OP(
+    ascend_bilinear_interpolation_self_contained_normal, -1,
+    ascend_bilinear_interpolation, kSelfContainedNormalDynamicPayload)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_wholereducemax_raw_normal, -1,
+                             ascend_wholereducemax, kRawNormalDynamicPayload)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_wholereducemin_raw_normal, -1,
+                             ascend_wholereducemin, kRawNormalDynamicPayload)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_wholereducesum_raw_normal, -1,
+                             ascend_wholereducesum, kRawNormalDynamicPayload)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_sigmoid_self_contained_normal_full, 4,
+                             ascend_sigmoid, kSelfContainedNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_clamp_max_raw_counter, 6, ascend_clamp_max,
+                             kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_clamp_min_raw_counter, 6, ascend_clamp_min,
+                             kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_clamp_raw_counter, 6, ascend_clamp,
+                             kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_round_cast_raw_counter, -1, ascend_round,
+                             kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_round_advanced_composite, 4, ascend_round,
+                             kCompositeNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_sub_experiment_raw_counter, 4,
+                             ascend_sub_experiment, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_abs_experiment_raw_counter, 3,
+                             ascend_abs_experiment, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_mins_experiment_raw_counter, 4,
+                             ascend_mins_experiment, kRawCounter)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_reducesum_experiment_composite, 4,
+                             ascend_reducesum_experiment, kCompositeNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_reducesum_mask_experiment_composite, 6,
+                             ascend_reducesum_mask_experiment,
+                             kCompositeNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(
+    ascend_gather_mask_experiment_self_contained_normal, -1,
+    ascend_gather_mask_experiment, kSelfContainedNormalDynamicPayload)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_fill_experiment_raw_normal, -1,
+                             ascend_fill_experiment, kRawNormalDynamicPayload)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_sum_experiment_composite, 6,
+                             ascend_sum_experiment, kCompositeNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_datacachecleanandinvalid_experiment_neutral,
+                             2, ascend_datacachecleanandinvalid_experiment,
+                             kNeutral)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_brcb_experiment_neutral, 6,
+                             ascend_brcb_experiment, kNeutral)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_row_expand_mul_experiment_raw_normal, -1,
+                             ascend_row_expand_mul_experiment, kRawNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_row_expand_sub_experiment_raw_normal, -1,
+                             ascend_row_expand_sub_experiment, kRawNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_row_expand_div_experiment_raw_normal, -1,
+                             ascend_row_expand_div_experiment, kRawNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_exp_experiment_raw_normal, -1,
+                             ascend_exp_experiment, kRawNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_tail_unary_dynamic_composite, -1,
+                             ascend_tail_unary, kCompositeNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_tail_binary_dynamic_composite, -1,
+                             ascend_tail_binary, kCompositeNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_tail_scalar_dynamic_composite, -1,
+                             ascend_tail_scalar, kCompositeNormalFull)
+TL_ASCEND_SELECTED_VECTOR_OP(ascend_tail_reduce_dynamic_composite, -1,
+                             ascend_tail_reduce, kCompositeNormalFull)

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -24,6 +24,7 @@
 
 #include "../op/ascend.h"
 #include "../op/builtin.h"
+#include "../transform/common/ascend_vector_mask_contract.h"
 #include "../transform/common/attr.h"
 
 #include "arith/pattern_match.h"
@@ -507,7 +508,24 @@ void CodeGenTileLangAscend::VisitStmt_(const BufferStoreNode *op) {
 }
 
 void CodeGenTileLangAscend::VisitExpr_(const CallNode *op, std::ostream &os) {
-  if (op->op.same_as(builtin::call_extern())) {
+  Call call = GetRef<Call>(op);
+  if (tl::IsVectorMaskSetter(call)) {
+    MaskSetterCodegen(op);
+  } else if (tl::IsSelectedVectorTerminal(call)) {
+    ICHECK(platform_ == "A2" || platform_ == "A3")
+        << "Compiler-selected Vector terminal reached unsupported platform "
+        << platform_ << ": " << call;
+    SelectedVectorTerminalCodegen(op);
+  } else if ((platform_ == "A2" || platform_ == "A3") &&
+             op->op.as<OpNode>() != nullptr &&
+             !op->op.same_as(builtin::call_extern()) &&
+             !tl::SelectedVectorTerminalSpecsForBase(
+                  GetRef<Op>(op->op.as<OpNode>()))
+                  .empty()) {
+    ICHECK(false) << "Semantic Vector call bypassed "
+                     "AscendVectorInstructionSelection on managed "
+                  << platform_ << ": " << call;
+  } else if (op->op.same_as(builtin::call_extern())) {
     std::string op_name = Downcast<StringImm>(op->args[0])->value;
     if (op_name.find("tl::ascend::copy") != std::string::npos ||
         op_name.find("tl::ascend::atomic_add_ub_to_gm") != std::string::npos ||
@@ -3000,6 +3018,509 @@ void CodeGenTileLangAscend::BrcbExperimentCodegen(const CallNode *op) {
   std::string op_name =
       "tl::ascend::" + Downcast<StringImm>(op->args[0])->value;
   PrintOpCall(op, op_name, {1, 3}, {3, 6});
+}
+
+void CodeGenTileLangAscend::SelectedVectorTerminalCodegen(const CallNode *op) {
+  Call selected = GetRef<Call>(op);
+  const tl::SelectedVectorTerminalSpec *spec =
+      tl::SelectedVectorTerminalSpecOf(selected);
+  ICHECK(spec != nullptr);
+  const std::string selected_name = spec->selected->name;
+
+  size_t strip = 0;
+  if (spec->contract_kind ==
+          tl::SelectedMaskContractKind::kRawNormalDynamicPayload ||
+      spec->contract_kind ==
+          tl::SelectedMaskContractKind::kSelfContainedNormalDynamicPayload) {
+    strip = 2;
+  }
+  ICHECK_GE(op->args.size(), strip);
+  Array<PrimExpr> base_args;
+  for (size_t i = 0; i + strip < op->args.size(); ++i) {
+    base_args.push_back(op->args[i]);
+  }
+  Call base_call(op->dtype, spec->base, base_args, op->span);
+  const CallNode *base = base_call.get();
+
+  if (selected_name.find("copy_ub_to_ub_") != std::string::npos) {
+    CopyCodegen(base);
+    return;
+  }
+
+  const Op &base_op = spec->base;
+  if (base_op.same_as(tl::ascend_add())) {
+    ManagedBinaryCodegen(base, "AscendC::Add");
+  } else if (base_op.same_as(tl::ascend_sub()) ||
+             base_op.same_as(tl::ascend_sub_experiment())) {
+    ManagedBinaryCodegen(base, "AscendC::Sub",
+                         base_op.same_as(tl::ascend_sub()) ? 0 : 1);
+  } else if (base_op.same_as(tl::ascend_mul())) {
+    ManagedBinaryCodegen(base, "AscendC::Mul");
+  } else if (base_op.same_as(tl::ascend_div())) {
+    ManagedBinaryCodegen(base, "AscendC::Div");
+  } else if (base_op.same_as(tl::ascend_max())) {
+    ManagedBinaryCodegen(base, "AscendC::Max");
+  } else if (base_op.same_as(tl::ascend_min())) {
+    ManagedBinaryCodegen(base, "AscendC::Min");
+  } else if (base_op.same_as(tl::ascend_bitwise_and())) {
+    ManagedBinaryCodegen(base, "AscendC::And");
+  } else if (base_op.same_as(tl::ascend_bitwise_or())) {
+    ManagedBinaryCodegen(base, "AscendC::Or");
+  } else if (base_op.same_as(tl::ascend_adds())) {
+    ManagedScalarCodegen(base, "AscendC::Adds");
+  } else if (base_op.same_as(tl::ascend_subs())) {
+    ManagedScalarCodegen(base, "AscendC::Adds", true);
+  } else if (base_op.same_as(tl::ascend_muls())) {
+    ManagedScalarCodegen(base, "AscendC::Muls");
+  } else if (base_op.same_as(tl::ascend_divs())) {
+    ManagedScalarCodegen(base, "AscendC::Muls", false, true);
+  } else if (base_op.same_as(tl::ascend_maxs())) {
+    ManagedScalarCodegen(base, "AscendC::Maxs");
+  } else if (base_op.same_as(tl::ascend_mins())) {
+    ManagedScalarCodegen(base, "AscendC::Mins");
+  } else if (base_op.same_as(tl::ascend_leaky_relu())) {
+    ManagedScalarCodegen(base, "AscendC::LeakyRelu");
+  } else if (base_op.same_as(tl::ascend_axpy())) {
+    ManagedScalarCodegen(base, "AscendC::Axpy");
+  } else if (base_op.same_as(tl::ascend_bitwise_lshift())) {
+    ManagedScalarCodegen(base, "AscendC::ShiftLeft");
+  } else if (base_op.same_as(tl::ascend_bitwise_rshift())) {
+    ManagedScalarCodegen(base, "AscendC::ShiftRight");
+  } else if (base_op.same_as(tl::ascend_exp())) {
+    ManagedUnaryCodegen(base, "AscendC::Exp");
+  } else if (base_op.same_as(tl::ascend_ln())) {
+    ManagedUnaryCodegen(base, "AscendC::Ln");
+  } else if (base_op.same_as(tl::ascend_abs()) ||
+             base_op.same_as(tl::ascend_abs_experiment())) {
+    ManagedUnaryCodegen(base, "AscendC::Abs",
+                        base_op.same_as(tl::ascend_abs()) ? 0 : 1);
+  } else if (base_op.same_as(tl::ascend_reciprocal())) {
+    ManagedUnaryCodegen(base, "AscendC::Reciprocal");
+  } else if (base_op.same_as(tl::ascend_sqrt())) {
+    ManagedUnaryCodegen(base, "AscendC::Sqrt");
+  } else if (base_op.same_as(tl::ascend_rsqrt())) {
+    ManagedUnaryCodegen(base, "AscendC::Rsqrt");
+  } else if (base_op.same_as(tl::ascend_relu())) {
+    ManagedUnaryCodegen(base, "AscendC::Relu");
+  } else if (base_op.same_as(tl::ascend_bitwise_not())) {
+    ManagedUnaryCodegen(base, "AscendC::Not");
+  } else if (base_op.same_as(tl::ascend_compare())) {
+    CompareCodegen(base, "AscendC::Compare");
+  } else if (base_op.same_as(tl::ascend_compare_scalar())) {
+    CompareScalarCodegen(base, "AscendC::CompareScalar");
+  } else if (base_op.same_as(tl::ascend_select())) {
+    SelectCodegen(base, "AscendC::Select");
+  } else if (base_op.same_as(tl::ascend_cast())) {
+    ManagedCastCodegen(base);
+  } else if (base_op.same_as(tl::ascend_round()) &&
+             selected_name.find("round_cast") != std::string::npos) {
+    ManagedCastCodegen(base, true);
+  } else if (base_op.same_as(tl::ascend_mul_add_dst())) {
+    DataType dst_dtype = GetAccessPtrDtype(base->args[0].as<CallNode>());
+    DataType src_dtype = GetAccessPtrDtype(base->args[1].as<CallNode>());
+    this->PrintIndent();
+    this->stream << "AscendC::MulAddDst<" << getType(dst_dtype) << ", "
+                 << getType(src_dtype) << ", false>("
+                 << PrintBufferOffset(base->args[0].as<CallNode>()) << ", "
+                 << PrintBufferOffset(base->args[1].as<CallNode>()) << ", "
+                 << PrintBufferOffset(base->args[2].as<CallNode>())
+                 << ", AscendC::MASK_PLACEHOLDER, 1, "
+                    "AscendC::BinaryRepeatParams());\n";
+  } else if (base_op.same_as(tl::ascend_fill())) {
+    DataType dtype = GetAccessPtrDtype(base->args[1].as<CallNode>());
+    this->PrintIndent();
+    this->stream << "AscendC::Duplicate<" << getType(dtype) << ", false>("
+                 << PrintBufferOffset(base->args[1].as<CallNode>()) << ", "
+                 << PrintExpr(base->args[2])
+                 << ", AscendC::MASK_PLACEHOLDER, 1, 1, 8);\n";
+  } else if (base_op.same_as(tl::ascend_mins_experiment())) {
+    ManagedScalarCodegen(base, "AscendC::Mins");
+  } else if (base_op.same_as(tl::ascend_clamp_max()) ||
+             base_op.same_as(tl::ascend_clamp_min()) ||
+             base_op.same_as(tl::ascend_clamp())) {
+    int scalar_index = base->args[3].as<CallNode>() ? 4 : 3;
+    DataType dtype = GetAccessPtrDtype(base->args[1].as<CallNode>());
+    std::string type = getType(dtype);
+    std::string dst = PrintBufferOffset(base->args[1].as<CallNode>());
+    std::string src = PrintBufferOffset(base->args[2].as<CallNode>());
+    auto emit_scalar = [&](const std::string &api, const std::string &source,
+                           int index) {
+      this->PrintIndent();
+      this->stream << api << "<" << type << ", false>(" << dst << ", " << source
+                   << ", " << PrintExpr(base->args[index])
+                   << ", AscendC::MASK_PLACEHOLDER, 1, "
+                      "AscendC::UnaryRepeatParams());\n";
+    };
+    if (base_op.same_as(tl::ascend_clamp_max())) {
+      emit_scalar("AscendC::Mins", src, scalar_index);
+    } else if (base_op.same_as(tl::ascend_clamp_min())) {
+      emit_scalar("AscendC::Maxs", src, scalar_index);
+    } else {
+      emit_scalar("AscendC::Maxs", src, scalar_index);
+      emit_scalar("AscendC::Mins", dst, scalar_index + 1);
+    }
+  } else if (base_op.same_as(tl::ascend_broadcast()) &&
+             selected_name.find("raw_counter") != std::string::npos) {
+    Array<PrimExpr> args = base->args;
+    std::string tag = Downcast<StringImm>(args[0])->value;
+    ICHECK(!tag.empty() && tag.back() == '>');
+    tag.insert(tag.size() - 1, ", false");
+    args.Set(0, StringImm(tag));
+    Call raw(base->dtype, base->op, args, base->span);
+    BroadcastOpCodegen(raw.get());
+  } else if (base_op.same_as(tl::ascend_reduce()) ||
+             base_op.same_as(tl::ascend_block_reduce_max()) ||
+             base_op.same_as(tl::ascend_block_reduce_min()) ||
+             base_op.same_as(tl::ascend_block_reduce_sum()) ||
+             base_op.same_as(tl::ascend_wholereducemax()) ||
+             base_op.same_as(tl::ascend_wholereducemin()) ||
+             base_op.same_as(tl::ascend_wholereducesum())) {
+    if (selected_name.find("raw_normal") != std::string::npos) {
+      ManagedNormalReduceCodegen(op, selected_name);
+    } else {
+      ReduceOpCodegen(base);
+    }
+  } else if (base_op.same_as(tl::ascend_fill_experiment())) {
+    DataType dtype = GetAccessPtrDtype(base->args[1].as<CallNode>());
+    this->PrintIndent();
+    this->stream << "AscendC::Duplicate<" << getType(dtype) << ", false>("
+                 << PrintBufferOffset(base->args[1].as<CallNode>()) << ", "
+                 << PrintExpr(base->args[2]) << ", " << PrintExpr(base->args[3])
+                 << ", " << PrintExpr(base->args[4]) << ", "
+                 << PrintExpr(base->args[5]) << ", " << PrintExpr(base->args[6])
+                 << ");\n";
+  } else if (base_op.same_as(tl::ascend_silu())) {
+    SigmoidCodegen(base, "AscendC::Silu");
+  } else if (base_op.same_as(tl::ascend_sigmoid())) {
+    SigmoidCodegen(base, "AscendC::Sigmoid");
+  } else if (base_op.same_as(tl::ascend_sort32())) {
+    Sort32Codegen(base, "AscendC::Sort32");
+  } else if (base_op.same_as(tl::ascend_createvecindex())) {
+    CreateVecIndexCodegen(base, "AscendC::CreateVecIndex");
+  } else if (base_op.same_as(tl::ascend_arith_progression())) {
+    ArithProgressionCodegen(base);
+  } else if (base_op.same_as(tl::ascend_sin())) {
+    TrigOpCodegen(base, "AscendC::Sin");
+  } else if (base_op.same_as(tl::ascend_cos())) {
+    TrigOpCodegen(base, "AscendC::Cos");
+  } else if (base_op.same_as(tl::ascend_transpose())) {
+    TransposeCodegen(base, "AscendC::Transpose");
+  } else if (base_op.same_as(tl::ascend_gather())) {
+    GatherCodegen(base, "AscendC::Gather");
+  } else if (base_op.same_as(tl::ascend_gatherb())) {
+    GatherbCodegen(base);
+  } else if (base_op.same_as(tl::ascend_pow())) {
+    PowerOpCodegen(base, "AscendC::Power");
+  } else if (base_op.same_as(tl::ascend_bitwise_xor())) {
+    PrintOpCall(base, "AscendC::Xor", {0, base->args.size()}, {0, 0});
+  } else if (base_op.same_as(tl::ascend_broadcast())) {
+    BroadcastOpCodegen(base);
+  } else if (base_op.same_as(tl::ascend_sort())) {
+    SortCodegen(base);
+  } else if (base_op.same_as(tl::ascend_merge_sort())) {
+    MergeSortCodegen(base);
+  } else if (base_op.same_as(tl::ascend_topk())) {
+    TopKCodegen(base);
+  } else if (base_op.same_as(tl::ascend_gather_mask())) {
+    GatherMaskCodegen(base);
+  } else if (base_op.same_as(tl::ascend_init_sort_buf())) {
+    InitSortBufCodegen(base);
+  } else if (base_op.same_as(tl::ascend_bilinear_interpolation())) {
+    BilinearInterpolationCodegen(base);
+  } else if (base_op.same_as(tl::ascend_round())) {
+    RoundCodegen(base, "AscendC::Round");
+  } else if (base_op.same_as(tl::ascend_reducesum_experiment())) {
+    CreateReduceSumExperimentCodegen(base, "AscendC::ReduceSum");
+  } else if (base_op.same_as(tl::ascend_reducesum_mask_experiment())) {
+    CreateReduceSumExperimentCodegen(base, "AscendC::ReduceSum");
+  } else if (base_op.same_as(tl::ascend_gather_mask_experiment())) {
+    GatherMaskExperimentCodegen(base);
+  } else if (base_op.same_as(tl::ascend_sum_experiment())) {
+    SumExperimentCodegen(base);
+  } else if (base_op.same_as(
+                 tl::ascend_datacachecleanandinvalid_experiment())) {
+    CreateDatacacheExperimentCodegen(base);
+  } else if (base_op.same_as(tl::ascend_brcb_experiment())) {
+    BrcbExperimentCodegen(base);
+  } else if (base_op.same_as(tl::ascend_row_expand_mul_experiment())) {
+    RowExpandMulExperimentCodegen(base);
+  } else if (base_op.same_as(tl::ascend_row_expand_sub_experiment())) {
+    RowExpandSubExperimentCodegen(base);
+  } else if (base_op.same_as(tl::ascend_row_expand_div_experiment())) {
+    RowExpandDivExperimentCodegen(base);
+  } else if (base_op.same_as(tl::ascend_exp_experiment())) {
+    ExpExperimentCodegen(base);
+  } else if (base_op.same_as(tl::ascend_tail_unary())) {
+    TailUnaryOpCodegen(base);
+  } else if (base_op.same_as(tl::ascend_tail_binary())) {
+    TailBinaryOpCodegen(base);
+  } else if (base_op.same_as(tl::ascend_tail_scalar())) {
+    TailScalarOpCodegen(base);
+  } else if (base_op.same_as(tl::ascend_tail_reduce())) {
+    TailReduceOpCodegen(base);
+  } else {
+    ICHECK(false) << "Selected Vector terminal has no mechanical emitter: "
+                  << selected;
+  }
+}
+
+void CodeGenTileLangAscend::MaskSetterCodegen(const CallNode *op) {
+  this->PrintIndent();
+  if (op->op.same_as(tl::ascend_set_mask_mode())) {
+    ICHECK_EQ(op->args.size(), 1U);
+    const auto *mode = op->args[0].as<IntImmNode>();
+    ICHECK(mode && (mode->value == 0 || mode->value == 1));
+    this->stream << (mode->value == 0 ? "AscendC::SetMaskNorm();\n"
+                                      : "AscendC::SetMaskCount();\n");
+    return;
+  }
+  ICHECK(op->op.same_as(tl::ascend_set_mask_payload()));
+  ICHECK_EQ(op->args.size(), 2U);
+  auto print_payload = [&](const PrimExpr &value) {
+    const auto *imm = value.as<IntImmNode>();
+    if (imm != nullptr && imm->dtype.is_uint() && imm->dtype.bits() == 64 &&
+        imm->value < 0) {
+      std::ostringstream stream;
+      stream << "0x" << std::hex << static_cast<uint64_t>(imm->value) << "ULL";
+      return stream.str();
+    }
+    const auto *call = value.as<CallNode>();
+    if (call != nullptr && call->op.same_as(tir::builtin::large_uint_imm())) {
+      ICHECK_EQ(call->args.size(), 2U);
+      uint64_t low =
+          static_cast<uint64_t>(Downcast<IntImm>(call->args[0])->value);
+      uint64_t high =
+          static_cast<uint64_t>(Downcast<IntImm>(call->args[1])->value);
+      std::ostringstream stream;
+      stream << "0x" << std::hex << ((high << 32U) | low) << "ULL";
+      return stream.str();
+    }
+    return PrintExpr(value);
+  };
+  // The managed IR schema is (lo, hi), while AscendC's public API is
+  // SetVectorMask(high, low).
+  this->stream << "AscendC::SetVectorMask<uint8_t>("
+               << print_payload(op->args[1]) << ", "
+               << print_payload(op->args[0]) << ");\n";
+}
+
+void CodeGenTileLangAscend::ManagedBinaryCodegen(const CallNode *op,
+                                                 const std::string &op_name,
+                                                 int first_buffer) {
+  ICHECK_GE(op->args.size(), static_cast<size_t>(first_buffer + 4));
+  DataType dtype = GetAccessPtrDtype(op->args[first_buffer].as<CallNode>());
+  this->PrintIndent();
+  this->stream << op_name << "<" << getType(dtype) << ", false>(";
+  for (int i = 0; i < 3; ++i) {
+    if (i != 0) {
+      this->stream << ", ";
+    }
+    this->stream << PrintBufferOffset(
+        op->args[first_buffer + i].as<CallNode>());
+  }
+  this->stream << ", AscendC::MASK_PLACEHOLDER, 1, "
+                  "AscendC::BinaryRepeatParams());\n";
+}
+
+void CodeGenTileLangAscend::ManagedUnaryCodegen(const CallNode *op,
+                                                const std::string &op_name,
+                                                int first_buffer) {
+  ICHECK_GE(op->args.size(), static_cast<size_t>(first_buffer + 3));
+  DataType dtype = GetAccessPtrDtype(op->args[first_buffer].as<CallNode>());
+  this->PrintIndent();
+  this->stream << op_name << "<" << getType(dtype) << ", false>("
+               << PrintBufferOffset(op->args[first_buffer].as<CallNode>())
+               << ", "
+               << PrintBufferOffset(op->args[first_buffer + 1].as<CallNode>())
+               << ", AscendC::MASK_PLACEHOLDER, 1, "
+                  "AscendC::UnaryRepeatParams());\n";
+}
+
+void CodeGenTileLangAscend::ManagedScalarCodegen(const CallNode *op,
+                                                 const std::string &op_name,
+                                                 bool negate, bool reciprocal) {
+  ICHECK_GE(op->args.size(), 4U);
+  DataType dtype = GetAccessPtrDtype(op->args[0].as<CallNode>());
+  std::string type = getType(dtype);
+  std::string dst = PrintBufferOffset(op->args[0].as<CallNode>());
+  std::string src = PrintBufferOffset(op->args[1].as<CallNode>());
+
+  this->PrintIndent();
+  this->stream << "{\n";
+  std::string scalar;
+  if (op->args[2].as<CallNode>()) {
+    std::string tensor = PrintBufferOffset(op->args[2].as<CallNode>(), false);
+    std::string index = PrintExpr(op->args[op->args.size() - 2]);
+    this->PrintIndent();
+    this->stream << "AscendC::PipeBarrier<PIPE_ALL>();\n";
+    this->PrintIndent();
+    scalar = tensor + "_managed_scalar";
+    this->stream << "auto " << scalar << " = ";
+    if (reciprocal) {
+      this->stream << (dtype.is_float16() ? "half(1.0f / (float)"
+                                          : "1.0f / (float)")
+                   << tensor << ".GetValue(" << index << ")"
+                   << (dtype.is_float16() ? ")" : "") << ";\n";
+    } else if (negate) {
+      this->stream << (dtype.is_float16() ? "half(-(float)" : "-(float)")
+                   << tensor << ".GetValue(" << index << ")"
+                   << (dtype.is_float16() ? ")" : "") << ";\n";
+    } else {
+      this->stream << tensor << ".GetValue(" << index << ");\n";
+    }
+  } else {
+    scalar = PrintExpr(op->args[op->args.size() - 2]);
+    if (reciprocal) {
+      scalar = dtype.is_float16() ? "half(1.0f / " + scalar + ")"
+                                  : "1.0f / " + scalar;
+    } else if (negate) {
+      scalar = type + "(-" + scalar + ")";
+    } else if (op->args[op->args.size() - 2].dtype() != dtype) {
+      scalar = type + "(" + scalar + ")";
+    }
+  }
+
+  this->PrintIndent();
+  if (op_name == "AscendC::Axpy") {
+    this->stream << op_name << "<" << type << ", " << type << ", false>(";
+  } else {
+    this->stream << op_name << "<" << type << ", false>(";
+  }
+  this->stream << dst << ", " << src << ", " << scalar
+               << ", AscendC::MASK_PLACEHOLDER, 1, "
+                  "AscendC::UnaryRepeatParams());\n";
+  this->PrintIndent();
+  this->stream << "}\n";
+}
+
+void CodeGenTileLangAscend::ManagedCastCodegen(const CallNode *op,
+                                               bool round_cast) {
+  DataType dst_dtype = GetAccessPtrDtype(op->args[0].as<CallNode>());
+  DataType src_dtype = GetAccessPtrDtype(op->args[1].as<CallNode>());
+  ICHECK_NE(dst_dtype.bits(), 4)
+      << "Compiler-managed Cast does not yet support an int4 destination";
+  ICHECK_NE(src_dtype.bits(), 4)
+      << "Compiler-managed Cast does not yet support an int4 source";
+  int dst_repeat_stride = 8;
+  int src_repeat_stride = 8;
+  if (dst_dtype.bytes() > src_dtype.bytes()) {
+    src_repeat_stride = 4;
+  } else if (dst_dtype.bytes() < src_dtype.bytes()) {
+    dst_repeat_stride = 4;
+  }
+  std::string round_mode =
+      round_cast ? "CAST_RINT"
+                 : std::string(Downcast<StringImm>(op->args[2])->value);
+  this->PrintIndent();
+  this->stream << "AscendC::Cast<" << getType(dst_dtype) << ", "
+               << getType(src_dtype) << ", false>("
+               << PrintBufferOffset(op->args[0].as<CallNode>()) << ", "
+               << PrintBufferOffset(op->args[1].as<CallNode>())
+               << ", AscendC::RoundMode::" << round_mode
+               << ", AscendC::MASK_PLACEHOLDER, 1, "
+                  "AscendC::UnaryRepeatParams(1, 1, "
+               << dst_repeat_stride << ", " << src_repeat_stride << "));\n";
+}
+
+void CodeGenTileLangAscend::ManagedNormalReduceCodegen(
+    const CallNode *op, const std::string &selected_name) {
+  ICHECK_GE(op->args.size(), 4U);
+  Array<PrimExpr> args;
+  for (size_t i = 0; i + 2 < op->args.size(); ++i) {
+    args.push_back(op->args[i]);
+  }
+  Call base_call(op->dtype, tl::BaseOperationOf(GetRef<Call>(op)), args,
+                 op->span);
+  const CallNode *base = base_call.get();
+
+  if (selected_name.find("block_reduce") != std::string::npos) {
+    std::string api = selected_name.find("_max_") != std::string::npos
+                          ? "AscendC::BlockReduceMax"
+                      : selected_name.find("_min_") != std::string::npos
+                          ? "AscendC::BlockReduceMin"
+                          : "AscendC::BlockReduceSum";
+    DataType dtype = GetAccessPtrDtype(base->args[1].as<CallNode>());
+    this->PrintIndent();
+    this->stream << api << "<" << getType(dtype) << ", false>("
+                 << PrintBufferOffset(base->args[0].as<CallNode>()) << ", "
+                 << PrintBufferOffset(base->args[1].as<CallNode>());
+    for (size_t i = 2; i < base->args.size(); ++i) {
+      if (const auto *order = base->args[i].as<StringImmNode>()) {
+        this->stream << ", AscendC::ReduceOrder::" << order->value;
+      } else {
+        this->stream << ", " << PrintExpr(base->args[i]);
+      }
+    }
+    this->stream << ");\n";
+    return;
+  }
+
+  if (selected_name.find("wholereduce") != std::string::npos) {
+    std::string api = selected_name.find("max") != std::string::npos
+                          ? "AscendC::WholeReduceMax"
+                      : selected_name.find("min") != std::string::npos
+                          ? "AscendC::WholeReduceMin"
+                          : "AscendC::WholeReduceSum";
+    DataType dtype = GetAccessPtrDtype(base->args[1].as<CallNode>());
+    this->PrintIndent();
+    this->stream << api << "<" << getType(dtype) << ", false>("
+                 << PrintBufferOffset(base->args[0].as<CallNode>()) << ", "
+                 << PrintBufferOffset(base->args[1].as<CallNode>());
+    for (size_t i = 2; i < base->args.size(); ++i) {
+      if (const auto *order = base->args[i].as<StringImmNode>()) {
+        this->stream << ", AscendC::ReduceOrder::" << order->value;
+      } else {
+        this->stream << ", " << PrintExpr(base->args[i]);
+      }
+    }
+    this->stream << ");\n";
+    return;
+  }
+
+  // Narrow and fp16-sum reductions retain the existing compile-time operand
+  // derivation, but call a helper whose explicit false template argument is
+  // now the frozen physical terminal.
+  std::string tag = Downcast<StringImm>(base->args[0])->value;
+  size_t lt = tag.find('<');
+  size_t comma = tag.find(',', lt);
+  std::string dtype = tag.substr(lt + 1, comma - lt - 1);
+  std::string dst = PrintBufferOffset(base->args[1].as<CallNode>());
+  std::string src = PrintBufferOffset(base->args[2].as<CallNode>());
+  std::vector<std::string> params;
+  std::stringstream parser(tag.substr(lt + 1, tag.rfind('>') - lt - 1));
+  std::string item;
+  while (std::getline(parser, item, ',')) {
+    item.erase(0, item.find_first_not_of(" \t"));
+    item.erase(item.find_last_not_of(" \t") + 1);
+    params.push_back(item);
+  }
+  ICHECK_EQ(params.size(), 4U);
+  int64_t m = std::stoll(params[1]);
+  int64_t n = std::stoll(params[2]);
+  int64_t dim = std::stoll(params[3]);
+  int64_t mask = dim == -1 ? n : (dim == 0 ? m : m * n);
+  int64_t repeat = dim == -1 ? m : (dim == 0 ? n : 1);
+
+  this->PrintIndent();
+  if (selected_name.find("half_sum") != std::string::npos) {
+    int64_t stride = dim == -1 ? (n + 15) / 16 : (m + 15) / 16;
+    this->stream << "tl::ascend::reduce_sum_half<" << dtype << ", false>("
+                 << dst << ", " << src << ", " << mask << ", " << repeat << ", "
+                 << stride << ");\n";
+    return;
+  }
+  ICHECK(base->args.back().as<IntImmNode>());
+  int64_t physical_row = Downcast<IntImm>(base->args.back())->value;
+  DataType src_dtype = GetAccessPtrDtype(base->args[2].as<CallNode>());
+  ICHECK_EQ((physical_row * src_dtype.bytes()) % 32, 0);
+  int64_t stride = physical_row * src_dtype.bytes() / 32;
+  std::string helper =
+      tag.find("reduce_sum") != std::string::npos   ? "reduce_sum_narrow"
+      : tag.find("reduce_min") != std::string::npos ? "reduce_min_narrow"
+                                                    : "reduce_max_narrow";
+  this->stream << "tl::ascend::" << helper << "<" << dtype << ", false>(" << dst
+               << ", " << src << ", " << mask << ", " << repeat << ", "
+               << stride << ");\n";
 }
 
 } // namespace codegen

--- a/src/target/codegen_ascend.h
+++ b/src/target/codegen_ascend.h
@@ -227,6 +227,24 @@ private:
 
   void BrcbExperimentCodegen(const CallNode *op);
 
+  void MaskSetterCodegen(const CallNode *op);
+
+  void SelectedVectorTerminalCodegen(const CallNode *op);
+
+  void ManagedBinaryCodegen(const CallNode *op, const std::string &op_name,
+                            int first_buffer = 0);
+
+  void ManagedUnaryCodegen(const CallNode *op, const std::string &op_name,
+                           int first_buffer = 0);
+
+  void ManagedScalarCodegen(const CallNode *op, const std::string &op_name,
+                            bool negate = false, bool reciprocal = false);
+
+  void ManagedCastCodegen(const CallNode *op, bool round_cast = false);
+
+  void ManagedNormalReduceCodegen(const CallNode *op,
+                                  const std::string &selected_name);
+
 private:
   // Whether scope such as "__shared__" or "__constant__"  is part of type.
   bool IsScopePartOfType() const final { return false; }

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -452,13 +452,13 @@ CATLASS_DEVICE void cast(LocalTensor<dst> const &ubOut,
 //   AscendC::Duplicate(ubOut, value, Len);
 // }
 
-template <typename T>
+template <typename T, bool isSetMask = true>
 CATLASS_DEVICE void
 reduce_sum_half(LocalTensor<T> const &dstTensor,
                 LocalTensor<T> const &srcTensor, const int32_t mask,
                 const int32_t repeatTime, const int32_t srcRepStride) {
-  AscendC::WholeReduceSum<T>(dstTensor, srcTensor, mask, repeatTime, 1, 1,
-                             srcRepStride);
+  AscendC::WholeReduceSum<T, isSetMask>(dstTensor, srcTensor, mask, repeatTime,
+                                        1, 1, srcRepStride);
 }
 
 // Row-reduce a narrow column range of a wider tile.
@@ -471,33 +471,33 @@ reduce_sum_half(LocalTensor<T> const &dstTensor,
 // stride, so one repeat per row with srcRepStride set to the PHYSICAL row width
 // reduces the intended region. One repeat covers at most 256 bytes, which is
 // what bounds the usable width.
-template <typename T>
+template <typename T, bool isSetMask = true>
 CATLASS_DEVICE void
 reduce_max_narrow(LocalTensor<T> const &dstTensor,
                   LocalTensor<T> const &srcTensor, const int32_t mask,
                   const int32_t repeatTime, const int32_t srcRepStride) {
-  AscendC::WholeReduceMax<T>(dstTensor, srcTensor, mask, repeatTime, 1, 1,
-                             srcRepStride,
-                             AscendC::ReduceOrder::ORDER_ONLY_VALUE);
+  AscendC::WholeReduceMax<T, isSetMask>(dstTensor, srcTensor, mask, repeatTime,
+                                        1, 1, srcRepStride,
+                                        AscendC::ReduceOrder::ORDER_ONLY_VALUE);
 }
 
-template <typename T>
+template <typename T, bool isSetMask = true>
 CATLASS_DEVICE void
 reduce_min_narrow(LocalTensor<T> const &dstTensor,
                   LocalTensor<T> const &srcTensor, const int32_t mask,
                   const int32_t repeatTime, const int32_t srcRepStride) {
-  AscendC::WholeReduceMin<T>(dstTensor, srcTensor, mask, repeatTime, 1, 1,
-                             srcRepStride,
-                             AscendC::ReduceOrder::ORDER_ONLY_VALUE);
+  AscendC::WholeReduceMin<T, isSetMask>(dstTensor, srcTensor, mask, repeatTime,
+                                        1, 1, srcRepStride,
+                                        AscendC::ReduceOrder::ORDER_ONLY_VALUE);
 }
 
-template <typename T>
+template <typename T, bool isSetMask = true>
 CATLASS_DEVICE void
 reduce_sum_narrow(LocalTensor<T> const &dstTensor,
                   LocalTensor<T> const &srcTensor, const int32_t mask,
                   const int32_t repeatTime, const int32_t srcRepStride) {
-  AscendC::WholeReduceSum<T>(dstTensor, srcTensor, mask, repeatTime, 1, 1,
-                             srcRepStride);
+  AscendC::WholeReduceSum<T, isSetMask>(dstTensor, srcTensor, mask, repeatTime,
+                                        1, 1, srcRepStride);
 }
 
 template <typename T, uint32_t M, uint32_t N, int32_t dim>
@@ -1426,7 +1426,8 @@ Broadcast(const LocalTensor<T> &dst, const LocalTensor<T> &src,
                                                   sharedTmpBuffer);
 }
 
-template <typename T, int32_t dim, int32_t axis, bool isReuseSource = false>
+template <typename T, int32_t dim, int32_t axis, bool isReuseSource = false,
+          bool isSetMask = true>
 CATLASS_DEVICE void
 Broadcast(const LocalTensor<T> &dst, const LocalTensor<T> &src,
           const uint32_t dstShape[dim], const uint32_t srcShape[dim]) {
@@ -1437,14 +1438,25 @@ Broadcast(const LocalTensor<T> &dst, const LocalTensor<T> &src,
     srcSize *= srcShape[i];
   }
   if (srcSize == dstSize) {
-    AscendC::Muls(dst, src, static_cast<T>(1), dstSize);
+    if constexpr (isSetMask) {
+      AscendC::Muls(dst, src, static_cast<T>(1), dstSize);
+    } else {
+      AscendC::Muls<T, false>(dst, src, static_cast<T>(1),
+                              AscendC::MASK_PLACEHOLDER, 1,
+                              AscendC::UnaryRepeatParams());
+    }
     return;
   }
   ASCENDC_ASSERT((srcSize == 1), {
     KERNEL_LOG(KERNEL_ERROR,
                "Workspace-free Broadcast only supports equal or scalar shapes");
   });
-  AscendC::Duplicate(dst, src.GetValue(0), dstSize);
+  if constexpr (isSetMask) {
+    AscendC::Duplicate(dst, src.GetValue(0), dstSize);
+  } else {
+    AscendC::Duplicate<T, false>(dst, src.GetValue(0),
+                                 AscendC::MASK_PLACEHOLDER, 1, 1, 8);
+  }
 }
 
 template <typename T>

--- a/src/transform/ascend_sync_insert.cc
+++ b/src/transform/ascend_sync_insert.cc
@@ -1256,9 +1256,7 @@ private:
             op_name = op_ptr->name;
 
             std::string normalized_name = op_name;
-
-            auto config_it = operation_config_.find(normalized_name);
-            if (config_it != operation_config_.end()) {
+            if (HasOperationConfig(call)) {
               const OperationConfig config = ResolveOperationConfig(call);
 
               std::unordered_map<std::string, BufferAccess> buffer_access_map;

--- a/src/transform/ascend_sync_insert_vs.cc
+++ b/src/transform/ascend_sync_insert_vs.cc
@@ -450,13 +450,10 @@ private:
       }
     } else {
       auto *op_ptr = call->op.as<OpNode>();
-      if (op_ptr) {
+      if (op_ptr && HasOperationConfig(call)) {
         std::string op_name = op_ptr->name;
-        auto config_it = operation_config_.find(op_name);
-        if (config_it != operation_config_.end()) {
-          CollectBufferAccesses(ResolveOperationConfig(call), op_name,
-                                call->args, 0, accesses);
-        }
+        CollectBufferAccesses(ResolveOperationConfig(call), op_name, call->args,
+                              0, accesses);
       }
     }
 

--- a/src/transform/ascend_vector_instruction_selection.cc
+++ b/src/transform/ascend_vector_instruction_selection.cc
@@ -1,0 +1,648 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+
+/*!
+ * \file ascend_vector_instruction_selection.cc
+ * \brief Select physical Ascend Vector terminals before Phase-2 scheduling.
+ */
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "arith/ir_mutator_with_analyzer.h"
+
+#include <tvm/runtime/registry.h>
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/builtin.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+
+#include "../op/ascend.h"
+#include "common/ascend_vector_mask_contract.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+using namespace tir::transform;
+
+namespace {
+
+DataType AccessPtrDtype(const PrimExpr &expr) {
+  const auto *access_ptr = expr.as<CallNode>();
+  ICHECK(access_ptr && access_ptr->op.same_as(builtin::tvm_access_ptr()) &&
+         !access_ptr->args.empty())
+      << "Expected tvm_access_ptr, got " << expr;
+  const PrimExpr &type_arg = access_ptr->args[0];
+  if (const auto *call = type_arg.as<CallNode>()) {
+    return call->dtype;
+  }
+  if (const auto *str = type_arg.as<StringImmNode>()) {
+    return DataType(runtime::String2DLDataType(str->value));
+  }
+  LOG(FATAL) << "Unexpected access_ptr dtype operand " << type_arg;
+  throw;
+}
+
+std::string Trim(std::string value) {
+  auto first = std::find_if_not(value.begin(), value.end(), [](char c) {
+    return std::isspace(static_cast<unsigned char>(c));
+  });
+  auto last = std::find_if_not(value.rbegin(), value.rend(), [](char c) {
+                return std::isspace(static_cast<unsigned char>(c));
+              }).base();
+  return first < last ? std::string(first, last) : std::string();
+}
+
+std::vector<std::string> ParseTemplateArguments(const std::string &tag) {
+  size_t begin = tag.find('<');
+  size_t end = tag.rfind('>');
+  ICHECK(begin != std::string::npos && end != std::string::npos && begin < end)
+      << "Expected a templated Ascend operation tag, got " << tag;
+  std::vector<std::string> result;
+  std::stringstream stream(tag.substr(begin + 1, end - begin - 1));
+  std::string item;
+  while (std::getline(stream, item, ',')) {
+    result.push_back(Trim(item));
+  }
+  return result;
+}
+
+std::pair<PrimExpr, PrimExpr> NormalMaskBits(const PrimExpr &length,
+                                             DataType dtype) {
+  const auto *imm = length.as<IntImmNode>();
+  ICHECK(imm) << "NORMAL mask length must be compile-time constant, got "
+              << length;
+  int64_t len = imm->value;
+  ICHECK_GE(len, 0);
+  ICHECK_LE(len, 128);
+  int64_t type_len = 0;
+  if (dtype.is_int() && dtype.bits() == 4) {
+    type_len = 64;
+  } else {
+    ICHECK_GT(dtype.bytes(), 0);
+    type_len = 32 / dtype.bytes();
+  }
+
+  constexpr uint64_t kFull = std::numeric_limits<uint64_t>::max();
+  uint64_t lo = 0;
+  uint64_t hi = 0;
+  if (len == 64) {
+    lo = kFull;
+  } else if (len == type_len || len >= 128) {
+    lo = kFull;
+    hi = kFull;
+  } else if (len > 64) {
+    lo = kFull;
+    hi = (uint64_t{1} << static_cast<uint32_t>(len - 64)) - 1;
+  } else if (len > 0) {
+    lo = (uint64_t{1} << static_cast<uint32_t>(len)) - 1;
+  }
+  return {make_const(DataType::UInt(64), lo),
+          make_const(DataType::UInt(64), hi)};
+}
+
+Call WithSelectedOp(const CallNode *call, const std::string &selected_name,
+                    Array<PrimExpr> args) {
+  return Call(call->dtype, Op::Get(selected_name), std::move(args), call->span);
+}
+
+Call WithSelectedOp(const CallNode *call, const std::string &selected_name) {
+  return WithSelectedOp(call, selected_name, call->args);
+}
+
+bool IsCopyUbToUb(const CallNode *call) {
+  if (!call->op.same_as(builtin::call_extern()) || call->args.empty()) {
+    return false;
+  }
+  const auto *name = call->args[0].as<StringImmNode>();
+  if (name == nullptr) {
+    return false;
+  }
+  std::string value = name->value;
+  return value.find("copy_ub_to_ub<") != std::string::npos;
+}
+
+bool CopyUbToUbIsTypeNeutral(const CallNode *call) {
+  std::string name = Downcast<StringImm>(call->args[0])->value;
+  std::vector<std::string> params = ParseTemplateArguments(name);
+  ICHECK_GE(params.size(), 2U) << "Malformed copy_ub_to_ub tag " << name;
+  return params[0] == params[1];
+}
+
+bool IsIntegerLiteral(const PrimExpr &value) {
+  if (value.as<IntImmNode>() != nullptr) {
+    return true;
+  }
+  const auto *call = value.as<CallNode>();
+  if (call == nullptr || !call->op.same_as(tir::builtin::large_uint_imm())) {
+    return false;
+  }
+  return std::all_of(
+      call->args.begin(), call->args.end(),
+      [](const PrimExpr &part) { return part.as<IntImmNode>() != nullptr; });
+}
+
+arith::ConstIntBound InferLetValueBound(const PrimExpr &value,
+                                        arith::Analyzer *analyzer) {
+  ICHECK(analyzer != nullptr);
+  PrimExpr true_value;
+  PrimExpr false_value;
+  if (const auto *select = value.as<SelectNode>()) {
+    true_value = select->true_value;
+    false_value = select->false_value;
+  } else if (const auto *call = value.as<CallNode>();
+             call != nullptr &&
+             call->op.same_as(tir::builtin::if_then_else()) &&
+             call->args.size() == 3U) {
+    true_value = call->args[1];
+    false_value = call->args[2];
+  } else {
+    return analyzer->const_int_bound(value);
+  }
+  arith::ConstIntBound true_bound = InferLetValueBound(true_value, analyzer);
+  arith::ConstIntBound false_bound = InferLetValueBound(false_value, analyzer);
+  return arith::ConstIntBound(
+      std::min(true_bound->min_value, false_bound->min_value),
+      std::max(true_bound->max_value, false_bound->max_value));
+}
+
+class ResourceScopeDetector final : public StmtVisitor {
+public:
+  void VisitStmt_(const AttrStmtNode *op) final {
+    if (op->attr_key == "resource_scope") {
+      found = true;
+    }
+    StmtVisitor::VisitStmt_(op);
+  }
+
+  bool found{false};
+};
+
+} // namespace
+
+class AscendVectorInstructionSelector final
+    : public arith::IRMutatorWithAnalyzer {
+public:
+  static PrimFunc Substitute(PrimFunc func, PassContext ctx, Target target,
+                             std::string platform) {
+    if (!UseCompilerManagedVectorMask(target, platform)) {
+      return func;
+    }
+    ResourceScopeDetector detector;
+    detector(func->body);
+    arith::Analyzer analyzer;
+    PrimExpr shape_constraint = const_true();
+    for (const auto &[_, buffer] : func->buffer_map) {
+      for (const PrimExpr &dimension : buffer->shape) {
+        if (dimension.dtype().is_int() || dimension.dtype().is_uint()) {
+          shape_constraint =
+              And(shape_constraint, dimension >= make_zero(dimension.dtype()));
+        }
+      }
+    }
+    AscendVectorInstructionSelector selector(&analyzer, std::move(target),
+                                             std::move(platform), func->params,
+                                             detector.found);
+    PrimFuncNode *copy = func.CopyOnWrite();
+    With<arith::ConstraintContext> constraint(&analyzer, shape_constraint);
+    copy->body = selector(func->body);
+    return func;
+  }
+
+  AscendVectorInstructionSelector(arith::Analyzer *analyzer, Target target,
+                                  std::string platform,
+                                  const Array<Var> &parameters,
+                                  bool has_resource_scopes)
+      : arith::IRMutatorWithAnalyzer(analyzer), target_(std::move(target)),
+        platform_(std::move(platform)),
+        has_resource_scopes_(has_resource_scopes) {
+    for (const Var &parameter : parameters) {
+      lexical_scope_.insert(parameter.get());
+    }
+  }
+
+private:
+  Stmt VisitStmt_(const EvaluateNode *op) final {
+    if (const auto *call = op->value.as<CallNode>()) {
+      if (IsCopyUbToUb(call)) {
+        ValidateVectorRegion(call);
+        ValidateNeutralOperands(call);
+        const char *selected =
+            CopyUbToUbIsTypeNeutral(call)
+                ? "tl.ascend_copy_ub_to_ub_neutral"
+                : "tl.ascend_copy_ub_to_ub_self_contained_normal_full";
+        Call selected_call = WithSelectedOp(call, selected);
+        ValidateSelectedPayloads(call, selected_call);
+        return Evaluate(selected_call);
+      }
+      if (const auto *op_node = call->op.as<OpNode>()) {
+        Op semantic_op = GetRef<Op>(op_node);
+        if (!semantic_op.same_as(builtin::call_extern()) &&
+            !SelectedVectorTerminalSpecsForBase(semantic_op).empty()) {
+          ValidateVectorRegion(call);
+          ValidateNeutralOperands(call);
+          Call selected_call = SelectSemanticTerminal(call);
+          ValidateSelectedPayloads(call, selected_call);
+          return Evaluate(selected_call);
+        }
+      }
+      if (call->op.same_as(ascend_set_mask_mode()) ||
+          call->op.same_as(ascend_set_mask_payload()) ||
+          IsSelectedVectorTerminal(GetRef<Call>(call))) {
+        ReportUnsupported(call, "internal mask operation appeared before "
+                                "instruction selection");
+      }
+      if (call->op.same_as(ascend_row_expand_mul())) {
+        ReportUnsupported(call,
+                          "tl.ascend_row_expand_mul has no AscendC emission; "
+                          "use the public experiment primitive only on a "
+                          "supported backend");
+      }
+      NonTerminalMaskEffect effect =
+          ClassifyNonTerminalMaskEffect(GetRef<Call>(call));
+      if (effect == NonTerminalMaskEffect::kBarrier) {
+        ValidateVectorRegion(call);
+        return GetRef<Stmt>(op);
+      }
+      if (effect == NonTerminalMaskEffect::kUnclassified) {
+        ReportUnsupported(
+            call, "call is absent from the audited non-terminal effect table");
+      }
+    }
+    PrimExpr value = VisitExpr(op->value);
+    return Evaluate(value);
+  }
+
+  PrimExpr VisitExpr_(const CallNode *op) final {
+    Call call = GetRef<Call>(op);
+    if (const auto *op_node = op->op.as<OpNode>()) {
+      Op semantic_op = GetRef<Op>(op_node);
+      if (!semantic_op.same_as(builtin::call_extern()) &&
+          !SelectedVectorTerminalSpecsForBase(semantic_op).empty()) {
+        ReportUnsupported(
+            op, "mask-effect Vector call must be the direct value of an "
+                "Evaluate statement");
+      }
+    }
+    if (ClassifyNonTerminalMaskEffect(call) !=
+        NonTerminalMaskEffect::kNeutral) {
+      ReportUnsupported(
+          op, "nested call is not an audited mask-neutral expression call");
+    }
+    return arith::IRMutatorWithAnalyzer::VisitExpr_(op);
+  }
+
+  void ValidateNeutralOperands(const CallNode *call) {
+    for (const PrimExpr &argument : call->args) {
+      VisitExpr(argument);
+    }
+  }
+
+  Stmt VisitStmt_(const WhileNode *op) final {
+    LOG(FATAL) << "AscendVectorInstructionSelection does not support While in "
+                  "the managed A2/A3 Vector-mask grammar: "
+               << GetRef<Stmt>(op);
+    throw;
+  }
+
+  Stmt VisitStmt_(const ForNode *op) final {
+    lexical_scope_.insert(op->loop_var.get());
+    Stmt result = arith::IRMutatorWithAnalyzer::VisitStmt_(op);
+    lexical_scope_.erase(op->loop_var.get());
+    return result;
+  }
+
+  Stmt VisitStmt_(const LetStmtNode *op) final {
+    PrimExpr value = VisitExpr(op->value);
+    PrimExpr body_constraint = const_true();
+    if (SideEffect(value) <= CallEffectKind::kPure) {
+      analyzer_->Bind(op->var, value);
+    } else if (value.dtype().is_int() || value.dtype().is_uint()) {
+      arith::ConstIntBound bound = InferLetValueBound(value, analyzer_);
+      if (bound->min_value != arith::ConstIntBound::kNegInf) {
+        body_constraint =
+            And(body_constraint,
+                op->var >= make_const(op->var.dtype(), bound->min_value));
+      }
+      if (bound->max_value != arith::ConstIntBound::kPosInf) {
+        body_constraint =
+            And(body_constraint,
+                op->var <= make_const(op->var.dtype(), bound->max_value));
+      }
+    }
+
+    lexical_scope_.insert(op->var.get());
+    Stmt body;
+    {
+      With<arith::ConstraintContext> context(analyzer_, body_constraint);
+      body = VisitStmt(op->body);
+    }
+    lexical_scope_.erase(op->var.get());
+    if (value.same_as(op->value) && body.same_as(op->body)) {
+      return GetRef<Stmt>(op);
+    }
+    return LetStmt(op->var, value, body, op->span);
+  }
+
+  Stmt VisitStmt_(const AttrStmtNode *op) final {
+    if (op->attr_key != "resource_scope") {
+      return arith::IRMutatorWithAnalyzer::VisitStmt_(op);
+    }
+    const auto *scope_imm = op->value.as<IntImmNode>();
+    if (scope_imm == nullptr ||
+        (scope_imm->value != 0 && scope_imm->value != 1)) {
+      LOG(FATAL) << "Unsupported A2/A3 compiler-managed Vector-mask input: "
+                    "resource_scope must be 0 (AIC) or 1 (AIV), got "
+                 << op->value;
+    }
+    int scope = static_cast<int>(scope_imm->value);
+    if (active_resource_scope_ != -1 && active_resource_scope_ != scope) {
+      LOG(FATAL) << "Unsupported A2/A3 compiler-managed Vector-mask input: "
+                    "overlapping AIC/AIV resource scopes";
+    }
+    int saved_scope = active_resource_scope_;
+    active_resource_scope_ = scope;
+    Stmt body = VisitStmt(op->body);
+    active_resource_scope_ = saved_scope;
+    return AttrStmt(op->node, op->attr_key, op->value, body, op->span);
+  }
+
+  Stmt VisitStmt_(const BlockNode *op) final {
+    if (op->init.defined()) {
+      LOG(FATAL) << "AscendVectorInstructionSelection does not support a "
+                    "Block init in the managed A2/A3 Vector-mask grammar: "
+                 << GetRef<Stmt>(op);
+    }
+    for (const IterVar &iter_var : op->iter_vars) {
+      lexical_scope_.insert(iter_var->var.get());
+    }
+    Stmt result = arith::IRMutatorWithAnalyzer::VisitStmt_(op);
+    for (const IterVar &iter_var : op->iter_vars) {
+      lexical_scope_.erase(iter_var->var.get());
+    }
+    return result;
+  }
+
+  void ValidateSelectedPayloads(const CallNode *semantic,
+                                const Call &selected) const {
+    const auto *spec = SelectedVectorTerminalSpecOf(selected);
+    ICHECK(spec != nullptr);
+    std::vector<PrimExpr> payloads;
+    bool counter = false;
+    bool normal = false;
+    switch (spec->contract_kind) {
+    case SelectedMaskContractKind::kRawCounter:
+      ICHECK(!selected->args.empty());
+      payloads.push_back(selected->args.back());
+      counter = true;
+      break;
+    case SelectedMaskContractKind::kRawNormalDynamicPayload:
+    case SelectedMaskContractKind::kSelfContainedNormalDynamicPayload:
+      ICHECK_GE(selected->args.size(), 2U);
+      payloads.push_back(selected->args[selected->args.size() - 2]);
+      payloads.push_back(selected->args.back());
+      normal = true;
+      break;
+    default:
+      return;
+    }
+
+    for (const PrimExpr &payload : payloads) {
+      PrimExpr simplified = analyzer_->Simplify(payload);
+      if (!IsPureBufferFreeMaskPayload(simplified, lexical_scope_)) {
+        ReportUnsupported(semantic,
+                          "mask payload is not pure, buffer-free, and lexical");
+      }
+      bool non_negative =
+          simplified.dtype().is_uint() ||
+          simplified.as<SizeVarNode>() != nullptr ||
+          analyzer_->CanProve(simplified >= make_zero(simplified.dtype()));
+      if (!(simplified.dtype().is_int() || simplified.dtype().is_uint()) ||
+          simplified.dtype().bits() > 64 || !non_negative) {
+        ReportUnsupported(semantic,
+                          "mask payload must be provably non-negative and "
+                          "representable as uint64");
+      }
+      if (normal && !IsIntegerLiteral(simplified)) {
+        ReportUnsupported(
+            semantic,
+            "NORMAL mask payload must simplify to a compile-time constant");
+      }
+      if (counter) {
+        PrimExpr normalized = NormalizeMaskPayload(simplified, analyzer_);
+        PrimExpr limit = make_const(DataType::UInt(64),
+                                    std::numeric_limits<uint32_t>::max());
+        bool fits_counter = analyzer_->CanProve(normalized <= limit) ||
+                            simplified.dtype().bits() <= 32;
+        if (!fits_counter) {
+          ReportUnsupported(semantic,
+                            "COUNTER mask payload must fit in uint32");
+        }
+      }
+    }
+  }
+
+  void ValidateVectorRegion(const CallNode *call) const {
+    if (has_resource_scopes_ && active_resource_scope_ != 1) {
+      ReportUnsupported(
+          call, "mask-effect call must be inside exactly one resource_scope=1 "
+                "Vector execution region");
+    }
+  }
+
+  Call SelectSemanticTerminal(const CallNode *call) {
+    const Op base = Downcast<Op>(call->op);
+    const auto &candidates = SelectedVectorTerminalSpecsForBase(base);
+    ICHECK(!candidates.empty());
+
+    if (base.same_as(ascend_reduce())) {
+      return SelectReduce(call);
+    }
+    if (base.same_as(ascend_broadcast())) {
+      return SelectBroadcast(call);
+    }
+    if (base.same_as(ascend_gather_mask())) {
+      ICHECK_GE(call->args.size(), 4U);
+      const bool custom = call->args[3].as<CallNode>() != nullptr;
+      return WithSelectedOp(
+          call, custom ? "tl.ascend_gather_mask_custom_composite"
+                       : "tl.ascend_gather_mask_fixed_self_contained_normal");
+    }
+    if (base.same_as(ascend_round())) {
+      const bool has_tmp =
+          call->args.size() >= 4 && call->args[2].as<CallNode>() != nullptr;
+      return WithSelectedOp(call, has_tmp ? "tl.ascend_round_advanced_composite"
+                                          : "tl.ascend_round_cast_raw_counter");
+    }
+
+    const SelectedVectorTerminalSpec &candidate = candidates.front();
+    Array<PrimExpr> args = call->args;
+    if (candidate.contract_kind ==
+        SelectedMaskContractKind::kRawNormalDynamicPayload) {
+      AppendNormalPayload(call, base, &args);
+    } else if (candidate.contract_kind ==
+               SelectedMaskContractKind::kSelfContainedNormalDynamicPayload) {
+      AppendSelfContainedPayload(call, base, &args);
+    }
+    return WithSelectedOp(call, candidate.selected->name, std::move(args));
+  }
+
+  Call SelectBroadcast(const CallNode *call) {
+    const bool has_tmp =
+        call->args.size() >= 4 && call->args[3].as<CallNode>() != nullptr;
+    if (has_tmp) {
+      return WithSelectedOp(call, "tl.ascend_broadcast_advanced_composite");
+    }
+    ICHECK_GE(call->args.size(), 4U);
+    const auto *dim_imm = call->args[3].as<IntImmNode>();
+    ICHECK(dim_imm && dim_imm->value > 0)
+        << "Broadcast rank must be a positive constant";
+    int64_t dim = dim_imm->value;
+    ICHECK_GE(call->args.size(), static_cast<size_t>(4 + 2 * dim));
+    PrimExpr count = 1;
+    for (int64_t i = 0; i < dim; ++i) {
+      count *= call->args[4 + i];
+    }
+    Array<PrimExpr> args = call->args;
+    args.push_back(NormalizeMaskPayload(count, analyzer_));
+    return WithSelectedOp(call, "tl.ascend_broadcast_raw_counter",
+                          std::move(args));
+  }
+
+  Call SelectReduce(const CallNode *call) {
+    ICHECK_GE(call->args.size(), 4U);
+    std::string tag = Downcast<StringImm>(call->args[0])->value;
+    std::vector<std::string> params = ParseTemplateArguments(tag);
+    ICHECK_EQ(params.size(), 4U) << "Malformed reduce tag " << tag;
+
+    bool has_physical_row = call->args.size() > 4 &&
+                            !call->args.back().dtype().is_bool() &&
+                            call->args.back().as<IntImmNode>() != nullptr;
+    bool clear = true;
+    for (auto it = call->args.rbegin(); it != call->args.rend(); ++it) {
+      if ((*it).dtype().is_bool()) {
+        clear = !is_zero(*it);
+        break;
+      }
+    }
+    bool half_sum = tag.find("reduce_sum<half") != std::string::npos && clear;
+    if (!has_physical_row && !half_sum) {
+      return WithSelectedOp(call, "tl.ascend_reduce_advanced_composite");
+    }
+
+    int64_t m = std::stoll(params[1]);
+    int64_t n = std::stoll(params[2]);
+    int64_t dim = std::stoll(params[3]);
+    int64_t mask = dim == -1 ? n : (dim == 0 ? m : m * n);
+    auto bits = NormalMaskBits(IntImm(DataType::Int(32), mask),
+                               AccessPtrDtype(call->args[2]));
+    Array<PrimExpr> args = call->args;
+    args.push_back(bits.first);
+    args.push_back(bits.second);
+    return WithSelectedOp(call,
+                          has_physical_row
+                              ? "tl.ascend_reduce_narrow_raw_normal"
+                              : "tl.ascend_reduce_half_sum_raw_normal",
+                          std::move(args));
+  }
+
+  PrimExpr RequireConstantNormalLength(const CallNode *call,
+                                       PrimExpr length) const {
+    PrimExpr simplified = analyzer_->Simplify(std::move(length));
+    const auto *imm = simplified.as<IntImmNode>();
+    if (imm == nullptr || imm->value < 0 || imm->value > 128) {
+      ReportUnsupported(
+          call, "NORMAL mask length must simplify to a constant in [0, 128]");
+    }
+    return simplified;
+  }
+
+  void AppendNormalPayload(const CallNode *call, const Op &base,
+                           Array<PrimExpr> *args) {
+    size_t mask_index = 0;
+    size_t dtype_index = 1;
+    if (base.same_as(ascend_block_reduce_max()) ||
+        base.same_as(ascend_block_reduce_min()) ||
+        base.same_as(ascend_block_reduce_sum())) {
+      mask_index = 3;
+    } else if (base.same_as(ascend_wholereducemax()) ||
+               base.same_as(ascend_wholereducemin()) ||
+               base.same_as(ascend_wholereducesum())) {
+      mask_index = 2;
+    } else if (base.same_as(ascend_fill_experiment())) {
+      ICHECK_GE(call->args.size(), 4U);
+      args->push_back(NormalizeMaskPayload(call->args[3], analyzer_));
+      args->push_back(make_zero(DataType::UInt(64)));
+      return;
+    } else {
+      ReportUnsupported(call, "cataloged NORMAL terminal is missing a payload "
+                              "materializer");
+    }
+    PrimExpr mask_length =
+        RequireConstantNormalLength(call, call->args[mask_index]);
+    auto bits =
+        NormalMaskBits(mask_length, AccessPtrDtype(call->args[dtype_index]));
+    args->push_back(bits.first);
+    args->push_back(bits.second);
+  }
+
+  void AppendSelfContainedPayload(const CallNode *call, const Op &base,
+                                  Array<PrimExpr> *args) {
+    if (base.same_as(ascend_bilinear_interpolation())) {
+      PrimExpr mask_length = RequireConstantNormalLength(call, call->args[4]);
+      auto bits = NormalMaskBits(mask_length, AccessPtrDtype(call->args[1]));
+      args->push_back(bits.first);
+      args->push_back(bits.second);
+      return;
+    }
+    if (base.same_as(ascend_gather_mask_experiment())) {
+      args->push_back(NormalizeMaskPayload(call->args[5], analyzer_));
+      args->push_back(make_zero(DataType::UInt(64)));
+      return;
+    }
+    ReportUnsupported(call, "cataloged self-contained NORMAL terminal is "
+                            "missing a payload materializer");
+  }
+
+  [[noreturn]] void ReportUnsupported(const CallNode *call,
+                                      const std::string &reason) const {
+    const auto *op_node = call->op.as<OpNode>();
+    std::string op_name =
+        op_node ? std::string(op_node->name) : std::string("<non-Op>");
+    LOG(FATAL) << "Unsupported A2/A3 compiler-managed Vector-mask input: op="
+               << op_name << ", target=" << target_
+               << ", platform=" << platform_ << ", reason=" << reason
+               << ", call=" << GetRef<Call>(call);
+    throw;
+  }
+
+  Target target_;
+  std::string platform_;
+  std::unordered_set<const VarNode *> lexical_scope_;
+  bool has_resource_scopes_{false};
+  int active_resource_scope_{-1};
+};
+
+tvm::transform::Pass AscendVectorInstructionSelection(Target target,
+                                                      std::string platform) {
+  auto pass_func = [=](PrimFunc func, IRModule module, PassContext ctx) {
+    return AscendVectorInstructionSelector::Substitute(std::move(func), ctx,
+                                                       target, platform);
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.AscendVectorInstructionSelection",
+                            {});
+}
+
+TVM_REGISTER_GLOBAL("tl.transform.AscendVectorInstructionSelection")
+    .set_body_typed(AscendVectorInstructionSelection);
+
+} // namespace tl
+} // namespace tvm

--- a/src/transform/ascend_vector_mask_contract.cc
+++ b/src/transform/ascend_vector_mask_contract.cc
@@ -1,0 +1,474 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+
+/*!
+ * \file ascend_vector_mask_contract.cc
+ * \brief Canonical semantics for compiler-managed Ascend Vector mask state.
+ */
+
+#include "common/ascend_vector_mask_contract.h"
+
+#include <limits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include <tvm/runtime/logging.h>
+#include <tvm/tir/builtin.h>
+#include <tvm/tir/op_attr_types.h>
+#include <tvm/tir/stmt_functor.h>
+
+#include "../op/ascend.h"
+
+namespace tvm {
+namespace tl {
+
+namespace {
+
+PrimExpr ModeExpr(AscendMaskMode mode) {
+  return IntImm(DataType::Int(32), static_cast<int32_t>(mode));
+}
+
+PrimExpr FullPayload() {
+  return make_const(DataType::UInt(64), std::numeric_limits<uint64_t>::max());
+}
+
+const std::vector<SelectedVectorTerminalSpec> &AllSelectedTerminalSpecs() {
+  static const std::vector<SelectedVectorTerminalSpec> specs = {
+#define TL_ASCEND_SELECTED_VECTOR_OP(Name, Arity, Base, ContractKind)          \
+  {Op::Get("tl." #Name), Base(), SelectedMaskContractKind::ContractKind},
+#include "../op/ascend_vector_mask_ops.inc"
+#undef TL_ASCEND_SELECTED_VECTOR_OP
+  };
+  return specs;
+}
+
+const std::unordered_map<std::string, size_t> &SelectedTerminalIndex() {
+  static const std::unordered_map<std::string, size_t> index = [] {
+    std::unordered_map<std::string, size_t> result;
+    const auto &specs = AllSelectedTerminalSpecs();
+    for (size_t i = 0; i < specs.size(); ++i) {
+      bool inserted = result.emplace(specs[i].selected->name, i).second;
+      ICHECK(inserted) << "Duplicate selected Vector terminal "
+                       << specs[i].selected;
+    }
+    return result;
+  }();
+  return index;
+}
+
+class PureBufferFreePayloadChecker final : public ExprVisitor {
+public:
+  explicit PureBufferFreePayloadChecker(
+      const std::unordered_set<const VarNode *> &lexical_scope)
+      : lexical_scope_(lexical_scope) {}
+
+  bool Check(const PrimExpr &value) {
+    VisitExpr(value);
+    return valid_;
+  }
+
+private:
+  void VisitExpr_(const VarNode *op) final {
+    if (!lexical_scope_.count(op) && !local_scope_.count(op)) {
+      valid_ = false;
+    }
+  }
+
+  void VisitExpr_(const LetNode *op) final {
+    VisitExpr(op->value);
+    local_scope_.insert(op->var.get());
+    VisitExpr(op->body);
+    local_scope_.erase(op->var.get());
+  }
+
+  void VisitExpr_(const BufferLoadNode *op) final { valid_ = false; }
+
+  void VisitExpr_(const CallNode *op) final {
+    if (op->op.same_as(tir::builtin::large_uint_imm())) {
+      ExprVisitor::VisitExpr_(op);
+      return;
+    }
+    // Payloads are deliberately restricted to the arithmetic expression
+    // grammar plus TVM's internal encoding for a uint64 literal. Even another
+    // pure Call would make later effect classification and lexical projection
+    // ambiguous.
+    valid_ = false;
+  }
+
+  const std::unordered_set<const VarNode *> &lexical_scope_;
+  std::unordered_set<const VarNode *> local_scope_;
+  bool valid_{true};
+};
+
+} // namespace
+
+MaskFieldContract::MaskFieldContract(MaskRequirementKind requirement_kind,
+                                     MaskEnsureKind ensure_kind,
+                                     PrimExpr required, PrimExpr ensured)
+    : requirement_kind_(requirement_kind), ensure_kind_(ensure_kind),
+      required_(std::move(required)), ensured_(std::move(ensured)) {
+  ICHECK(!(ensure_kind_ == MaskEnsureKind::kPreserve &&
+           requirement_kind_ == MaskRequirementKind::kExact))
+      << "Exact/Preserve is not a canonical mask contract form";
+  ICHECK_EQ(requirement_kind_ == MaskRequirementKind::kExact,
+            required_.defined());
+  ICHECK_EQ(ensure_kind_ == MaskEnsureKind::kExact, ensured_.defined());
+}
+
+MaskFieldContract MaskFieldContract::AnyPreserve() {
+  return MaskFieldContract(MaskRequirementKind::kAny, MaskEnsureKind::kPreserve,
+                           PrimExpr(), PrimExpr());
+}
+
+MaskFieldContract MaskFieldContract::AnyExact(PrimExpr ensured) {
+  return MaskFieldContract(MaskRequirementKind::kAny, MaskEnsureKind::kExact,
+                           PrimExpr(), std::move(ensured));
+}
+
+MaskFieldContract MaskFieldContract::AnyUnknown() {
+  return MaskFieldContract(MaskRequirementKind::kAny, MaskEnsureKind::kUnknown,
+                           PrimExpr(), PrimExpr());
+}
+
+MaskFieldContract MaskFieldContract::ExactExact(PrimExpr required,
+                                                PrimExpr ensured) {
+  return MaskFieldContract(MaskRequirementKind::kExact, MaskEnsureKind::kExact,
+                           std::move(required), std::move(ensured));
+}
+
+MaskFieldContract MaskFieldContract::ExactUnknown(PrimExpr required) {
+  return MaskFieldContract(MaskRequirementKind::kExact,
+                           MaskEnsureKind::kUnknown, std::move(required),
+                           PrimExpr());
+}
+
+bool UseCompilerManagedVectorMask(const Target &target,
+                                  const std::string &platform) {
+  if (!target.defined() || (platform != "A2" && platform != "A3")) {
+    return false;
+  }
+  auto model_attr = target->attrs.Get("model");
+  if (!model_attr.defined()) {
+    return false;
+  }
+  std::string model = Downcast<String>(model_attr).operator std::string();
+  return model == "ascendc" || model == "auto";
+}
+
+PrimExpr NormalizeMaskPayload(PrimExpr value, arith::Analyzer *analyzer) {
+  ICHECK(value.defined());
+  ICHECK(analyzer != nullptr);
+  return analyzer->Simplify(cast(DataType::UInt(64), std::move(value)));
+}
+
+bool MaskPayloadEqual(const PrimExpr &lhs, const PrimExpr &rhs,
+                      arith::Analyzer *analyzer) {
+  ICHECK(lhs.defined() && rhs.defined());
+  ICHECK(analyzer != nullptr);
+  return analyzer->CanProveEqual(analyzer->Simplify(lhs),
+                                 analyzer->Simplify(rhs));
+}
+
+bool IsPureBufferFreeMaskPayload(
+    const PrimExpr &value,
+    const std::unordered_set<const VarNode *> &lexical_scope) {
+  if (!value.defined()) {
+    return false;
+  }
+  return PureBufferFreePayloadChecker(lexical_scope).Check(value);
+}
+
+const AscendVectorMaskTargetProfile &
+AscendVectorMaskTargetProfile::Get(const std::string &platform) {
+  static const AscendVectorMaskTargetProfile a2("A2");
+  static const AscendVectorMaskTargetProfile a3("A3");
+  ICHECK(platform == "A2" || platform == "A3")
+      << "Compiler-managed Vector mask is only defined for A2/A3, got "
+      << platform;
+  return platform == "A2" ? a2 : a3;
+}
+
+bool AscendVectorMaskTargetProfile::LegalPayloadPair(
+    uint8_t possible_modes, const PrimExpr &lo, const PrimExpr &hi,
+    arith::Analyzer *analyzer) const {
+  ICHECK_NE(possible_modes, 0U);
+  ICHECK(lo.defined() && hi.defined());
+  ICHECK(analyzer != nullptr);
+
+  if (possible_modes & kPossibleCounter) {
+    PrimExpr normalized_lo = NormalizeMaskPayload(lo, analyzer);
+    PrimExpr normalized_hi = NormalizeMaskPayload(hi, analyzer);
+    PrimExpr limit =
+        make_const(DataType::UInt(64), std::numeric_limits<uint32_t>::max());
+    PrimExpr zero = make_zero(DataType::UInt(64));
+    bool legal_lo = analyzer->CanProve(normalized_lo <= limit);
+    if (!legal_lo) {
+      // Selection proves signed symbolic lengths non-negative before building
+      // selected IR.  Preserve that white-box symbolic form through the
+      // uint64 normalization used by contracts and setters.
+      if (const auto *cast_node = normalized_lo.as<CastNode>()) {
+        DataType source_dtype = cast_node->value.dtype();
+        legal_lo = (source_dtype.is_int() || source_dtype.is_uint()) &&
+                   source_dtype.bits() <= 32;
+      }
+    }
+    return legal_lo && analyzer->CanProveEqual(normalized_hi, zero);
+  }
+  return true;
+}
+
+PayloadPair AscendVectorMaskTargetProfile::CanonicalComplete(
+    uint8_t possible_modes, const std::optional<PrimExpr> &fixed_lo,
+    const std::optional<PrimExpr> &fixed_hi, arith::Analyzer *analyzer) const {
+  ICHECK_NE(possible_modes, 0U);
+  ICHECK(analyzer != nullptr);
+  PrimExpr zero = make_zero(DataType::UInt(64));
+  PayloadPair result{
+      fixed_lo.has_value() ? NormalizeMaskPayload(*fixed_lo, analyzer) : zero,
+      fixed_hi.has_value() ? NormalizeMaskPayload(*fixed_hi, analyzer) : zero};
+  ICHECK(LegalPayloadPair(possible_modes, result.lo, result.hi, analyzer))
+      << "Mask payload requirements have no legal canonical completion for "
+      << platform_ << ": lo=" << result.lo << ", hi=" << result.hi;
+  return result;
+}
+
+bool IsSelectedVectorTerminal(const Call &call) {
+  if (!call.defined()) {
+    return false;
+  }
+  const auto *op_node = call->op.as<OpNode>();
+  if (op_node == nullptr) {
+    return false;
+  }
+  return SelectedTerminalIndex().count(op_node->name) != 0;
+}
+
+bool IsVectorMaskSetter(const Call &call) {
+  if (!call.defined()) {
+    return false;
+  }
+  return call->op.same_as(ascend_set_mask_mode()) ||
+         call->op.same_as(ascend_set_mask_payload());
+}
+
+const SelectedVectorTerminalSpec *
+SelectedVectorTerminalSpecOf(const Call &call) {
+  if (!call.defined()) {
+    return nullptr;
+  }
+  const auto *op_node = call->op.as<OpNode>();
+  if (op_node == nullptr) {
+    return nullptr;
+  }
+  auto it = SelectedTerminalIndex().find(op_node->name);
+  if (it == SelectedTerminalIndex().end()) {
+    return nullptr;
+  }
+  return &AllSelectedTerminalSpecs()[it->second];
+}
+
+const std::vector<SelectedVectorTerminalSpec> &
+SelectedVectorTerminalSpecsForBase(const Op &base) {
+  static const std::unordered_map<std::string,
+                                  std::vector<SelectedVectorTerminalSpec>>
+      by_base = [] {
+        std::unordered_map<std::string, std::vector<SelectedVectorTerminalSpec>>
+            result;
+        for (const auto &spec : AllSelectedTerminalSpecs()) {
+          result[spec.base->name].push_back(spec);
+        }
+        return result;
+      }();
+  static const std::vector<SelectedVectorTerminalSpec> empty;
+  auto it = by_base.find(base->name);
+  return it == by_base.end() ? empty : it->second;
+}
+
+const Op &BaseOperationOf(const Call &selected) {
+  const auto *spec = SelectedVectorTerminalSpecOf(selected);
+  ICHECK(spec != nullptr)
+      << "BaseOperationOf expects a selected Vector terminal, got " << selected;
+  return spec->base;
+}
+
+MaskContract MaskContractOf(const Call &selected, arith::Analyzer *analyzer) {
+  const auto *spec = SelectedVectorTerminalSpecOf(selected);
+  ICHECK(spec != nullptr)
+      << "MaskContractOf expects a selected Vector terminal, got " << selected;
+  ICHECK(analyzer != nullptr);
+
+  PrimExpr normal = ModeExpr(AscendMaskMode::kNormal);
+  PrimExpr counter = ModeExpr(AscendMaskMode::kCounter);
+  PrimExpr full = FullPayload();
+  PrimExpr zero = make_zero(DataType::UInt(64));
+  auto neutral = [] {
+    return MaskContract{MaskFieldContract::AnyPreserve(),
+                        MaskFieldContract::AnyPreserve(),
+                        MaskFieldContract::AnyPreserve()};
+  };
+  auto unknown_all = [] {
+    return MaskContract{MaskFieldContract::AnyUnknown(),
+                        MaskFieldContract::AnyUnknown(),
+                        MaskFieldContract::AnyUnknown()};
+  };
+  auto normal_full_composite = [&] {
+    return MaskContract{MaskFieldContract::ExactUnknown(normal),
+                        MaskFieldContract::ExactUnknown(full),
+                        MaskFieldContract::ExactUnknown(full)};
+  };
+
+  switch (spec->contract_kind) {
+  case SelectedMaskContractKind::kRawCounter: {
+    ICHECK(!selected->args.empty());
+    PrimExpr count = NormalizeMaskPayload(selected->args.back(), analyzer);
+    return MaskContract{MaskFieldContract::ExactExact(counter, counter),
+                        MaskFieldContract::ExactExact(count, count),
+                        MaskFieldContract::AnyPreserve()};
+  }
+  case SelectedMaskContractKind::kRawNormalDynamicPayload: {
+    ICHECK_GE(selected->args.size(), 2U);
+    PrimExpr lo = NormalizeMaskPayload(
+        selected->args[selected->args.size() - 2], analyzer);
+    PrimExpr hi = NormalizeMaskPayload(selected->args.back(), analyzer);
+    return MaskContract{MaskFieldContract::ExactExact(normal, normal),
+                        MaskFieldContract::ExactExact(lo, lo),
+                        MaskFieldContract::ExactExact(hi, hi)};
+  }
+  case SelectedMaskContractKind::kRawNormalFull:
+    return MaskContract{MaskFieldContract::ExactExact(normal, normal),
+                        MaskFieldContract::ExactExact(full, full),
+                        MaskFieldContract::ExactExact(full, full)};
+  case SelectedMaskContractKind::kNeutral:
+    return neutral();
+  case SelectedMaskContractKind::kUnknownAll:
+    return unknown_all();
+  case SelectedMaskContractKind::kCompositeNormalFull:
+    return normal_full_composite();
+  case SelectedMaskContractKind::kCompositeNormalFullToNormalUnknownPayload:
+    return MaskContract{MaskFieldContract::ExactExact(normal, normal),
+                        MaskFieldContract::ExactUnknown(full),
+                        MaskFieldContract::ExactUnknown(full)};
+  case SelectedMaskContractKind::kSelfContainedNormalFull:
+    return MaskContract{MaskFieldContract::AnyExact(normal),
+                        MaskFieldContract::AnyExact(full),
+                        MaskFieldContract::AnyExact(full)};
+  case SelectedMaskContractKind::kSelfContainedNormalZero:
+    return MaskContract{MaskFieldContract::AnyExact(normal),
+                        MaskFieldContract::AnyExact(zero),
+                        MaskFieldContract::AnyExact(zero)};
+  case SelectedMaskContractKind::kSelfContainedNormalDynamicPayload: {
+    ICHECK_GE(selected->args.size(), 2U);
+    PrimExpr lo = NormalizeMaskPayload(
+        selected->args[selected->args.size() - 2], analyzer);
+    PrimExpr hi = NormalizeMaskPayload(selected->args.back(), analyzer);
+    return MaskContract{MaskFieldContract::AnyExact(normal),
+                        MaskFieldContract::AnyExact(lo),
+                        MaskFieldContract::AnyExact(hi)};
+  }
+  }
+  LOG(FATAL) << "Unknown selected Vector mask contract kind for "
+             << selected->op;
+  throw;
+}
+
+NonTerminalMaskEffect ClassifyNonTerminalMaskEffect(const Call &call) {
+  if (call->op.same_as(ascend_src_code())) {
+    return NonTerminalMaskEffect::kBarrier;
+  }
+  if (IsVectorMaskSetter(call) || IsSelectedVectorTerminal(call)) {
+    return NonTerminalMaskEffect::kUnclassified;
+  }
+  const auto *op_node = call->op.as<OpNode>();
+  if (op_node == nullptr) {
+    return NonTerminalMaskEffect::kUnclassified;
+  }
+  Op op = GetRef<Op>(op_node);
+  if (!op.same_as(tir::builtin::call_extern()) &&
+      !SelectedVectorTerminalSpecsForBase(op).empty()) {
+    return NonTerminalMaskEffect::kUnclassified;
+  }
+
+  const std::string op_name = op_node->name;
+  if (op_name.rfind("tir.", 0) == 0 &&
+      !op.same_as(tir::builtin::call_extern())) {
+    static const auto call_effect =
+        Op::GetAttrMap<tir::TCallEffectKind>("TCallEffectKind");
+    if (!call_effect.count(op)) {
+      return NonTerminalMaskEffect::kUnclassified;
+    }
+    auto effect = static_cast<tir::CallEffectKind>(call_effect[op]->value);
+    if (effect == tir::CallEffectKind::kExprAnnotation ||
+        effect == tir::CallEffectKind::kPure ||
+        effect == tir::CallEffectKind::kReadState ||
+        effect == tir::CallEffectKind::kSpecialCallArg ||
+        effect == tir::CallEffectKind::kEmbedInfo) {
+      return NonTerminalMaskEffect::kNeutral;
+    }
+    return NonTerminalMaskEffect::kUnclassified;
+  }
+  if (op.same_as(tir::builtin::call_extern())) {
+    if (call->args.empty()) {
+      return NonTerminalMaskEffect::kUnclassified;
+    }
+    const auto *name_imm = call->args[0].as<StringImmNode>();
+    if (name_imm == nullptr) {
+      return NonTerminalMaskEffect::kUnclassified;
+    }
+    std::string name = name_imm->value;
+    size_t namespace_pos = name.find("tl::ascend::");
+    if (namespace_pos != std::string::npos) {
+      name = name.substr(namespace_pos + 12);
+    }
+    size_t template_pos = name.find('<');
+    if (template_pos != std::string::npos) {
+      name = name.substr(0, template_pos);
+    }
+    if ((name.rfind("copy_", 0) == 0 && name != "copy_ub_to_ub" &&
+         name != "copy_ub_to_ub_Nz" && name != "copy_pipe_to_ub_V") ||
+        name.rfind("atomic_add_", 0) == 0 || name == "mma" ||
+        name == "gemm_v0" || name == "gemm_v1") {
+      return NonTerminalMaskEffect::kNeutral;
+    }
+    return NonTerminalMaskEffect::kUnclassified;
+  }
+
+  static const std::unordered_set<std::string> neutral_ops = {
+      "tl.ascend_atomic_add",
+      "tl.ascend_copy",
+      "tl.region",
+      "tl.ascend_set_deq_scale",
+      "tl.ascend_reinterpretcast",
+      "tl.ascend_wait_cross_flag",
+      "tl.ascend_set_cross_flag",
+      "tl.ascend_set_flag",
+      "tl.ascend_wait_flag",
+      "tl.ascend_pipe_barrier",
+      "tl.ascend_free_pipe",
+      "tl.ascend_sync_all",
+      "tl.ascend_gemm_v0",
+      "tl.ascend_gemm_v1",
+      "tl.ascend_printf",
+      "tl.ascend_dump_tensor",
+      "tl.ascend_auto_barrier",
+      "tl.ascend_auto_set_flag",
+      "tl.ascend_auto_wait_flag",
+      "tl.ascend_auto_set_cross_flag",
+      "tl.ascend_auto_wait_cross_flag",
+      "tl.ascend_use_swizzle",
+      "tl.ascend_mma",
+      "tl.ascend_shmem_put_nbi",
+      "tl.ascend_shmem_get_nbi",
+      "tl.ascend_shmem_ub_put_nbi",
+      "tl.ascend_shmem_ub_get_nbi",
+      "tl.ascend_copy_cv_experiment",
+      "tl.ascend_copy_vc_experiment",
+  };
+  if (neutral_ops.count(op_name)) {
+    return NonTerminalMaskEffect::kNeutral;
+  }
+  return NonTerminalMaskEffect::kUnclassified;
+}
+
+} // namespace tl
+} // namespace tvm

--- a/src/transform/ascend_vector_mask_legalize.cc
+++ b/src/transform/ascend_vector_mask_legalize.cc
@@ -1,0 +1,543 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+
+/*!
+ * \file ascend_vector_mask_legalize.cc
+ * \brief Repair Ascend Vector mask state immediately before target codegen.
+ */
+
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "arith/ir_mutator_with_analyzer.h"
+
+#include <tvm/arith/analyzer.h>
+#include <tvm/runtime/registry.h>
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/builtin.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+
+#include "../op/ascend.h"
+#include "common/ascend_vector_mask_contract.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+using namespace tir::transform;
+
+namespace {
+
+struct Transparency {
+  bool mode{true};
+  bool lo{true};
+  bool hi{true};
+};
+
+class ResourceScopeDetector final : public StmtVisitor {
+public:
+  void VisitStmt_(const AttrStmtNode *op) final {
+    if (op->attr_key == "resource_scope") {
+      found = true;
+    }
+    StmtVisitor::VisitStmt_(op);
+  }
+
+  bool found{false};
+};
+
+class LoopTransparencySummarizer final : public StmtExprVisitor {
+public:
+  explicit LoopTransparencySummarizer(arith::Analyzer *analyzer)
+      : analyzer_(analyzer) {}
+
+  void VisitExpr_(const CallNode *op) final {
+    Call call = GetRef<Call>(op);
+    if (IsSelectedVectorTerminal(call)) {
+      MaskContract contract = MaskContractOf(call, analyzer_);
+      transparency.mode &=
+          contract.mode.requirement_kind() == MaskRequirementKind::kAny &&
+          contract.mode.ensure_kind() == MaskEnsureKind::kPreserve;
+      const bool no_payload_requirement =
+          contract.lo.requirement_kind() == MaskRequirementKind::kAny &&
+          contract.hi.requirement_kind() == MaskRequirementKind::kAny;
+      transparency.lo &= no_payload_requirement &&
+                         contract.lo.ensure_kind() == MaskEnsureKind::kPreserve;
+      transparency.hi &= no_payload_requirement &&
+                         contract.hi.ensure_kind() == MaskEnsureKind::kPreserve;
+      return;
+    }
+    NonTerminalMaskEffect effect = ClassifyNonTerminalMaskEffect(call);
+    ICHECK(effect != NonTerminalMaskEffect::kUnclassified)
+        << "Unclassified call reached AscendVectorMaskLegalize: " << call;
+    if (effect == NonTerminalMaskEffect::kBarrier) {
+      transparency = {false, false, false};
+      return;
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+  Transparency transparency;
+
+private:
+  arith::Analyzer *analyzer_;
+};
+
+AscendMaskMode ParseMode(const PrimExpr &value) {
+  const auto *imm = value.as<IntImmNode>();
+  ICHECK(imm && (imm->value == 0 || imm->value == 1))
+      << "Mask mode must be NORMAL(0) or COUNTER(1), got " << value;
+  return imm->value == 0 ? AscendMaskMode::kNormal : AscendMaskMode::kCounter;
+}
+
+bool UsesBoundVar(const PrimExpr &expr, const Var &var) {
+  if (!expr.defined()) {
+    return false;
+  }
+  return UsesVar(
+      expr, [&](const VarNode *candidate) { return candidate == var.get(); });
+}
+
+} // namespace
+
+class AscendVectorMaskLegalizer final : public arith::IRMutatorWithAnalyzer {
+public:
+  static PrimFunc Substitute(PrimFunc func, PassContext ctx, Target target,
+                             std::string platform) {
+    if (!UseCompilerManagedVectorMask(target, platform)) {
+      return func;
+    }
+
+    ResourceScopeDetector detector;
+    detector(func->body);
+
+    arith::Analyzer analyzer;
+    PrimExpr shape_constraint = const_true();
+    for (const auto &[_, buffer] : func->buffer_map) {
+      for (const PrimExpr &dimension : buffer->shape) {
+        if (dimension.dtype().is_int() || dimension.dtype().is_uint()) {
+          shape_constraint =
+              And(shape_constraint, dimension >= make_zero(dimension.dtype()));
+        }
+      }
+    }
+    AscendVectorMaskLegalizer legalizer(&analyzer, std::move(target),
+                                        std::move(platform), detector.found,
+                                        func->params);
+    PrimFuncNode *copy = func.CopyOnWrite();
+    With<arith::ConstraintContext> constraint(&analyzer, shape_constraint);
+    if (detector.found) {
+      copy->body = legalizer(func->body);
+    } else {
+      legalizer.in_vector_region_ = true;
+      legalizer.facts_ = MaskFacts::Unknown();
+      copy->body = legalizer(func->body);
+      legalizer.in_vector_region_ = false;
+    }
+    return func;
+  }
+
+  AscendVectorMaskLegalizer(arith::Analyzer *analyzer, Target target,
+                            std::string platform, bool has_resource_scopes,
+                            const Array<Var> &parameters)
+      : arith::IRMutatorWithAnalyzer(analyzer), target_(std::move(target)),
+        platform_(std::move(platform)),
+        profile_(AscendVectorMaskTargetProfile::Get(platform_)),
+        has_resource_scopes_(has_resource_scopes) {
+    for (const Var &parameter : parameters) {
+      lexical_scope_.insert(parameter.get());
+    }
+  }
+
+private:
+  Stmt VisitStmt_(const SeqStmtNode *op) final {
+    Array<Stmt> sequence;
+    for (const Stmt &stmt : op->seq) {
+      Stmt rewritten = VisitStmt(stmt);
+      if (const auto *nested = rewritten.as<SeqStmtNode>()) {
+        for (const Stmt &item : nested->seq) {
+          sequence.push_back(item);
+        }
+      } else {
+        sequence.push_back(rewritten);
+      }
+    }
+    if (sequence.empty()) {
+      return Evaluate(0);
+    }
+    if (sequence.size() == 1) {
+      return sequence[0];
+    }
+    return SeqStmt(sequence);
+  }
+
+  Stmt VisitStmt_(const EvaluateNode *op) final {
+    const auto *call_node = op->value.as<CallNode>();
+    if (!call_node) {
+      return GetRef<Stmt>(op);
+    }
+    Call call = GetRef<Call>(call_node);
+    if (IsSelectedVectorTerminal(call)) {
+      ICHECK(in_vector_region_)
+          << "Selected Vector terminal escaped its resource_scope=1 region: "
+          << call;
+      return RewriteConsumer(call);
+    }
+    ICHECK(!IsVectorMaskSetter(call))
+        << "Mask Legalizer input already contains a compiler mask setter: "
+        << call;
+    NonTerminalMaskEffect effect = ClassifyNonTerminalMaskEffect(call);
+    ICHECK(effect != NonTerminalMaskEffect::kUnclassified)
+        << "Unclassified call reached AscendVectorMaskLegalize: " << call;
+    if (effect == NonTerminalMaskEffect::kBarrier) {
+      ICHECK(in_vector_region_ || !has_resource_scopes_)
+          << "T._src_code mask barrier is outside resource_scope=1";
+      facts_ = MaskFacts::Unknown();
+    }
+    return GetRef<Stmt>(op);
+  }
+
+  Stmt VisitStmt_(const IfThenElseNode *op) final {
+    PrimExpr condition = VisitExpr(op->condition);
+    MaskFacts incoming = facts_;
+
+    Stmt then_case;
+    {
+      With<arith::ConstraintContext> context(analyzer_, condition);
+      facts_ = incoming;
+      then_case = VisitStmt(op->then_case);
+    }
+    MaskFacts then_out = facts_;
+
+    Optional<Stmt> else_case;
+    MaskFacts else_out = incoming;
+    if (op->else_case.defined()) {
+      With<arith::ConstraintContext> context(
+          analyzer_, analyzer_->rewrite_simplify(Not(condition)));
+      facts_ = incoming;
+      else_case = VisitStmt(op->else_case.value());
+      else_out = facts_;
+    }
+    facts_ = MergeFacts(then_out, else_out);
+
+    if (is_one(condition)) {
+      facts_ = then_out;
+      return then_case;
+    }
+    if (is_zero(condition)) {
+      facts_ = else_out;
+      return else_case.value_or(Evaluate(0));
+    }
+    return IfThenElse(condition, then_case, else_case, op->span);
+  }
+
+  Stmt VisitStmt_(const ForNode *op) final {
+    LoopTransparencySummarizer summarizer(analyzer_);
+    summarizer(op->body);
+    MaskFacts incoming = facts_;
+    MaskFacts body_in = incoming;
+    if (!summarizer.transparency.mode) {
+      body_in.mode.reset();
+    }
+    if (!summarizer.transparency.lo) {
+      body_in.lo.reset();
+    }
+    if (!summarizer.transparency.hi) {
+      body_in.hi.reset();
+    }
+
+    facts_ = body_in;
+    lexical_scope_.insert(op->loop_var.get());
+    Stmt rewritten = arith::IRMutatorWithAnalyzer::VisitStmt_(op);
+    lexical_scope_.erase(op->loop_var.get());
+
+    facts_ = incoming;
+    if (!summarizer.transparency.mode) {
+      facts_.mode.reset();
+    }
+    if (!summarizer.transparency.lo) {
+      facts_.lo.reset();
+    }
+    if (!summarizer.transparency.hi) {
+      facts_.hi.reset();
+    }
+    DropBoundVar(op->loop_var, &facts_);
+    return rewritten;
+  }
+
+  Stmt VisitStmt_(const LetStmtNode *op) final {
+    lexical_scope_.insert(op->var.get());
+    Stmt rewritten = arith::IRMutatorWithAnalyzer::VisitStmt_(op);
+    lexical_scope_.erase(op->var.get());
+    ProjectLet(op->var, op->value,
+               IsPureBufferFreeMaskPayload(op->value, lexical_scope_), &facts_);
+    return rewritten;
+  }
+
+  Stmt VisitStmt_(const AttrStmtNode *op) final {
+    if (op->attr_key != "resource_scope") {
+      return arith::IRMutatorWithAnalyzer::VisitStmt_(op);
+    }
+    const auto *scope_imm = op->value.as<IntImmNode>();
+    ICHECK(scope_imm && (scope_imm->value == 0 || scope_imm->value == 1))
+        << "resource_scope must be 0 (AIC) or 1 (AIV), got " << op->value;
+    int scope = static_cast<int>(scope_imm->value);
+    ICHECK(active_resource_scope_ == -1 || active_resource_scope_ == scope)
+        << "Overlapping AIC/AIV resource scopes are unsupported";
+
+    int saved_scope = active_resource_scope_;
+    bool saved_in_region = in_vector_region_;
+    MaskFacts saved_facts = facts_;
+    active_resource_scope_ = scope;
+    if (saved_scope == -1 && scope == 1) {
+      in_vector_region_ = true;
+      facts_ = MaskFacts::Unknown();
+    }
+    Stmt body = VisitStmt(op->body);
+    if (saved_scope == -1 && scope == 1) {
+      facts_ = saved_facts;
+      in_vector_region_ = saved_in_region;
+    }
+    active_resource_scope_ = saved_scope;
+    return AttrStmt(op->node, op->attr_key, op->value, body, op->span);
+  }
+
+  Stmt VisitStmt_(const BlockNode *op) final {
+    for (const IterVar &iter : op->iter_vars) {
+      lexical_scope_.insert(iter->var.get());
+    }
+    Stmt rewritten = arith::IRMutatorWithAnalyzer::VisitStmt_(op);
+    for (const IterVar &iter : op->iter_vars) {
+      lexical_scope_.erase(iter->var.get());
+      DropBoundVar(iter->var, &facts_);
+    }
+    return rewritten;
+  }
+
+  PrimExpr VisitExpr_(const CallNode *op) final {
+    Call call = GetRef<Call>(op);
+    ICHECK(ClassifyNonTerminalMaskEffect(call) ==
+           NonTerminalMaskEffect::kNeutral)
+        << "Non-neutral or unclassified call is nested in an expression "
+           "after Selection: "
+        << call;
+    return arith::IRMutatorWithAnalyzer::VisitExpr_(op);
+  }
+
+  Stmt VisitStmt_(const WhileNode *op) final {
+    ICHECK(false) << "While reached AscendVectorMaskLegalize after Selection";
+    throw;
+  }
+
+  Stmt RewriteConsumer(const Call &call) {
+    MaskContract contract = MaskContractOf(call, analyzer_);
+    ValidateConsumerPayloads(call);
+    std::vector<Stmt> sequence;
+
+    if (contract.mode.requirement_kind() == MaskRequirementKind::kExact &&
+        !ModeSatisfied(contract.mode.required())) {
+      PrimExpr required = contract.mode.required();
+      sequence.push_back(Evaluate(
+          Call(DataType::Handle(), ascend_set_mask_mode(), {required})));
+      facts_.mode = ParseMode(required);
+    }
+
+    bool repair_lo =
+        contract.lo.requirement_kind() == MaskRequirementKind::kExact &&
+        !PayloadSatisfied(facts_.lo, contract.lo.required());
+    bool repair_hi =
+        contract.hi.requirement_kind() == MaskRequirementKind::kExact &&
+        !PayloadSatisfied(facts_.hi, contract.hi.required());
+    if (repair_lo || repair_hi) {
+      PayloadPair pair = CompletePayload(contract);
+      sequence.push_back(Evaluate(Call(
+          DataType::Handle(), ascend_set_mask_payload(), {pair.lo, pair.hi})));
+      facts_.lo = pair.lo;
+      facts_.hi = pair.hi;
+    }
+
+    sequence.push_back(Evaluate(call));
+    ApplyContract(contract, &facts_);
+    if (sequence.size() == 1) {
+      return sequence[0];
+    }
+    return SeqStmt(sequence);
+  }
+
+  bool ModeSatisfied(const PrimExpr &required) const {
+    return facts_.mode.has_value() &&
+           facts_.mode.value() == ParseMode(required);
+  }
+
+  void ValidateConsumerPayloads(const Call &call) const {
+    const auto *spec = SelectedVectorTerminalSpecOf(call);
+    ICHECK(spec != nullptr);
+    std::vector<PrimExpr> payloads;
+    if (spec->contract_kind == SelectedMaskContractKind::kRawCounter) {
+      ICHECK(!call->args.empty());
+      payloads.push_back(call->args.back());
+    } else if (spec->contract_kind ==
+                   SelectedMaskContractKind::kRawNormalDynamicPayload ||
+               spec->contract_kind == SelectedMaskContractKind::
+                                          kSelfContainedNormalDynamicPayload) {
+      ICHECK_GE(call->args.size(), 2U);
+      payloads.push_back(call->args[call->args.size() - 2]);
+      payloads.push_back(call->args.back());
+    }
+    for (const PrimExpr &payload : payloads) {
+      ICHECK(IsPureBufferFreeMaskPayload(payload, lexical_scope_))
+          << "Selected Vector terminal has a non-pure, buffer-backed, or "
+             "out-of-scope mask payload: "
+          << call;
+    }
+  }
+
+  bool PayloadSatisfied(const std::optional<PrimExpr> &known,
+                        const PrimExpr &required) const {
+    return known.has_value() && MaskPayloadEqual(*known, required, analyzer_);
+  }
+
+  PayloadPair CompletePayload(const MaskContract &contract) {
+    uint8_t possible_modes = kPossibleNormal | kPossibleCounter;
+    if (contract.mode.requirement_kind() == MaskRequirementKind::kExact) {
+      possible_modes =
+          ParseMode(contract.mode.required()) == AscendMaskMode::kNormal
+              ? kPossibleNormal
+              : kPossibleCounter;
+    } else if (facts_.mode.has_value()) {
+      possible_modes = facts_.mode.value() == AscendMaskMode::kNormal
+                           ? kPossibleNormal
+                           : kPossibleCounter;
+    }
+
+    std::optional<PrimExpr> fixed_lo;
+    std::optional<PrimExpr> fixed_hi;
+    if (contract.lo.requirement_kind() == MaskRequirementKind::kExact) {
+      fixed_lo = NormalizeMaskPayload(contract.lo.required(), analyzer_);
+    }
+    if (contract.hi.requirement_kind() == MaskRequirementKind::kExact) {
+      fixed_hi = NormalizeMaskPayload(contract.hi.required(), analyzer_);
+    }
+
+    std::optional<PrimExpr> candidate_lo =
+        fixed_lo.has_value() ? fixed_lo : facts_.lo;
+    std::optional<PrimExpr> candidate_hi =
+        fixed_hi.has_value() ? fixed_hi : facts_.hi;
+    if (candidate_lo.has_value() && candidate_hi.has_value() &&
+        profile_.LegalPayloadPair(possible_modes, *candidate_lo, *candidate_hi,
+                                  analyzer_)) {
+      return {NormalizeMaskPayload(*candidate_lo, analyzer_),
+              NormalizeMaskPayload(*candidate_hi, analyzer_)};
+    }
+    return profile_.CanonicalComplete(possible_modes, fixed_lo, fixed_hi,
+                                      analyzer_);
+  }
+
+  void ApplyContract(const MaskContract &contract, MaskFacts *facts) {
+    ApplyModeEnsure(contract.mode, facts);
+    ApplyPayloadEnsure(contract.lo, &facts->lo);
+    ApplyPayloadEnsure(contract.hi, &facts->hi);
+  }
+
+  void ApplyModeEnsure(const MaskFieldContract &field, MaskFacts *facts) {
+    switch (field.ensure_kind()) {
+    case MaskEnsureKind::kPreserve:
+      return;
+    case MaskEnsureKind::kExact:
+      facts->mode = ParseMode(field.ensured());
+      return;
+    case MaskEnsureKind::kUnknown:
+      facts->mode.reset();
+      return;
+    }
+  }
+
+  void ApplyPayloadEnsure(const MaskFieldContract &field,
+                          std::optional<PrimExpr> *fact) {
+    switch (field.ensure_kind()) {
+    case MaskEnsureKind::kPreserve:
+      return;
+    case MaskEnsureKind::kExact:
+      *fact = NormalizeMaskPayload(field.ensured(), analyzer_);
+      return;
+    case MaskEnsureKind::kUnknown:
+      fact->reset();
+      return;
+    }
+  }
+
+  MaskFacts MergeFacts(const MaskFacts &lhs, const MaskFacts &rhs) {
+    MaskFacts result;
+    if (lhs.mode.has_value() && rhs.mode.has_value() && lhs.mode == rhs.mode) {
+      result.mode = lhs.mode;
+    }
+    if (lhs.lo.has_value() && rhs.lo.has_value() &&
+        MaskPayloadEqual(*lhs.lo, *rhs.lo, analyzer_)) {
+      result.lo = lhs.lo;
+    }
+    if (lhs.hi.has_value() && rhs.hi.has_value() &&
+        MaskPayloadEqual(*lhs.hi, *rhs.hi, analyzer_)) {
+      result.hi = lhs.hi;
+    }
+    return result;
+  }
+
+  void ProjectLet(const Var &var, const PrimExpr &value, bool legal_value,
+                  MaskFacts *facts) {
+    auto project = [&](std::optional<PrimExpr> *fact) {
+      if (!fact->has_value() || !UsesBoundVar(**fact, var)) {
+        return;
+      }
+      if (!legal_value) {
+        fact->reset();
+        return;
+      }
+      PrimExpr substituted =
+          tir::Substitute(**fact, {{var, analyzer_->Simplify(value)}});
+      if (UsesBoundVar(substituted, var)) {
+        fact->reset();
+      } else {
+        *fact = NormalizeMaskPayload(substituted, analyzer_);
+      }
+    };
+    project(&facts->lo);
+    project(&facts->hi);
+  }
+
+  void DropBoundVar(const Var &var, MaskFacts *facts) {
+    if (facts->lo.has_value() && UsesBoundVar(*facts->lo, var)) {
+      facts->lo.reset();
+    }
+    if (facts->hi.has_value() && UsesBoundVar(*facts->hi, var)) {
+      facts->hi.reset();
+    }
+  }
+
+  Target target_;
+  std::string platform_;
+  const AscendVectorMaskTargetProfile &profile_;
+  bool has_resource_scopes_{false};
+  bool in_vector_region_{false};
+  int active_resource_scope_{-1};
+  MaskFacts facts_;
+  std::unordered_set<const VarNode *> lexical_scope_;
+};
+
+tvm::transform::Pass AscendVectorMaskLegalize(Target target,
+                                              std::string platform) {
+  auto pass_func = [=](PrimFunc func, IRModule module, PassContext ctx) {
+    return AscendVectorMaskLegalizer::Substitute(std::move(func), ctx, target,
+                                                 platform);
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.AscendVectorMaskLegalize", {});
+}
+
+TVM_REGISTER_GLOBAL("tl.transform.AscendVectorMaskLegalize")
+    .set_body_typed(AscendVectorMaskLegalize);
+
+} // namespace tl
+} // namespace tvm

--- a/src/transform/common/ascend_vector_mask_contract.h
+++ b/src/transform/common/ascend_vector_mask_contract.h
@@ -1,0 +1,154 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+
+/*!
+ * \file ascend_vector_mask_contract.h
+ * \brief Canonical contracts for compiler-managed Ascend Vector mask state.
+ */
+
+#ifndef TVM_TL_TRANSFORM_COMMON_ASCEND_VECTOR_MASK_CONTRACT_H_
+#define TVM_TL_TRANSFORM_COMMON_ASCEND_VECTOR_MASK_CONTRACT_H_
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <tvm/arith/analyzer.h>
+#include <tvm/target/target.h>
+#include <tvm/tir/expr.h>
+#include <tvm/tir/op.h>
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+
+enum class AscendMaskMode : int32_t { kNormal = 0, kCounter = 1 };
+
+enum class MaskRequirementKind : uint8_t { kAny, kExact };
+enum class MaskEnsureKind : uint8_t { kPreserve, kExact, kUnknown };
+
+/*!
+ * \brief One canonical field of a mask contract.
+ *
+ * Only the five factory-produced forms are representable:
+ * Any/Preserve, Any/Exact, Any/Unknown, Exact/Exact, Exact/Unknown.
+ */
+class MaskFieldContract {
+public:
+  static MaskFieldContract AnyPreserve();
+  static MaskFieldContract AnyExact(PrimExpr ensured);
+  static MaskFieldContract AnyUnknown();
+  static MaskFieldContract ExactExact(PrimExpr required, PrimExpr ensured);
+  static MaskFieldContract ExactUnknown(PrimExpr required);
+
+  MaskRequirementKind requirement_kind() const { return requirement_kind_; }
+  MaskEnsureKind ensure_kind() const { return ensure_kind_; }
+  const PrimExpr &required() const { return required_; }
+  const PrimExpr &ensured() const { return ensured_; }
+
+private:
+  MaskFieldContract(MaskRequirementKind requirement_kind,
+                    MaskEnsureKind ensure_kind, PrimExpr required,
+                    PrimExpr ensured);
+
+  MaskRequirementKind requirement_kind_;
+  MaskEnsureKind ensure_kind_;
+  PrimExpr required_;
+  PrimExpr ensured_;
+};
+
+struct MaskContract {
+  MaskFieldContract mode;
+  MaskFieldContract lo;
+  MaskFieldContract hi;
+};
+
+struct MaskFacts {
+  std::optional<AscendMaskMode> mode;
+  std::optional<PrimExpr> lo;
+  std::optional<PrimExpr> hi;
+
+  static MaskFacts Unknown() { return {}; }
+};
+
+struct PayloadPair {
+  PrimExpr lo;
+  PrimExpr hi;
+};
+
+enum class NonTerminalMaskEffect : uint8_t {
+  kNeutral,
+  kBarrier,
+  kUnclassified
+};
+
+enum class SelectedMaskContractKind : uint8_t {
+  kRawCounter,
+  kRawNormalDynamicPayload,
+  kRawNormalFull,
+  kNeutral,
+  kUnknownAll,
+  kCompositeNormalFull,
+  kCompositeNormalFullToNormalUnknownPayload,
+  kSelfContainedNormalFull,
+  kSelfContainedNormalZero,
+  kSelfContainedNormalDynamicPayload,
+};
+
+struct SelectedVectorTerminalSpec {
+  Op selected;
+  Op base;
+  SelectedMaskContractKind contract_kind;
+};
+
+constexpr uint8_t kPossibleNormal = 1U << 0;
+constexpr uint8_t kPossibleCounter = 1U << 1;
+
+bool UseCompilerManagedVectorMask(const Target &target,
+                                  const std::string &platform);
+
+PrimExpr NormalizeMaskPayload(PrimExpr value, arith::Analyzer *analyzer);
+
+bool MaskPayloadEqual(const PrimExpr &lhs, const PrimExpr &rhs,
+                      arith::Analyzer *analyzer);
+
+bool IsPureBufferFreeMaskPayload(
+    const PrimExpr &value,
+    const std::unordered_set<const VarNode *> &lexical_scope);
+
+class AscendVectorMaskTargetProfile {
+public:
+  static const AscendVectorMaskTargetProfile &Get(const std::string &platform);
+
+  bool LegalPayloadPair(uint8_t possible_modes, const PrimExpr &lo,
+                        const PrimExpr &hi, arith::Analyzer *analyzer) const;
+
+  PayloadPair CanonicalComplete(uint8_t possible_modes,
+                                const std::optional<PrimExpr> &fixed_lo,
+                                const std::optional<PrimExpr> &fixed_hi,
+                                arith::Analyzer *analyzer) const;
+
+private:
+  explicit AscendVectorMaskTargetProfile(std::string platform)
+      : platform_(std::move(platform)) {}
+
+  std::string platform_;
+};
+
+bool IsSelectedVectorTerminal(const Call &call);
+bool IsVectorMaskSetter(const Call &call);
+const SelectedVectorTerminalSpec *
+SelectedVectorTerminalSpecOf(const Call &call);
+const std::vector<SelectedVectorTerminalSpec> &
+SelectedVectorTerminalSpecsForBase(const Op &base);
+const Op &BaseOperationOf(const Call &selected);
+MaskContract MaskContractOf(const Call &selected, arith::Analyzer *analyzer);
+NonTerminalMaskEffect ClassifyNonTerminalMaskEffect(const Call &call);
+
+} // namespace tl
+} // namespace tvm
+
+#endif // TVM_TL_TRANSFORM_COMMON_ASCEND_VECTOR_MASK_CONTRACT_H_

--- a/src/transform/common/operation_config.h
+++ b/src/transform/common/operation_config.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "../../op/ascend.h"
+#include "ascend_vector_mask_contract.h"
 
 namespace tvm {
 namespace tl {
@@ -390,14 +391,49 @@ GetWorkspaceOpConfigs() {
 }
 
 inline OperationConfig ResolveOperationConfig(const tvm::tir::CallNode *call) {
-  const auto *op_node = call->op.as<tvm::OpNode>();
-  ICHECK(op_node);
-  const auto config_it = GetOperationConfig().find(op_node->name);
+  tvm::tir::Call call_ref = GetRef<tvm::tir::Call>(call);
+  const tvm::Op *config_op = nullptr;
+  tvm::Op base;
+  if (const auto *spec = SelectedVectorTerminalSpecOf(call_ref)) {
+    base = spec->base;
+    config_op = &base;
+  } else if (const auto *op_node = call->op.as<tvm::OpNode>()) {
+    base = GetRef<tvm::Op>(op_node);
+    config_op = &base;
+  }
+  ICHECK(config_op != nullptr);
+
+  std::string config_name;
+  size_t access_offset = 0;
+  if (config_op->same_as(tvm::tir::builtin::call_extern())) {
+    ICHECK(!call->args.empty() && call->args[0].as<tvm::tir::StringImmNode>())
+        << "Selected call_extern terminal is missing its function name";
+    config_name =
+        std::string(call->args[0].as<tvm::tir::StringImmNode>()->value);
+    size_t template_pos = config_name.find('<');
+    if (template_pos != std::string::npos) {
+      config_name = config_name.substr(0, template_pos);
+    }
+    size_t namespace_pos = config_name.find("tl::ascend::");
+    if (namespace_pos != std::string::npos) {
+      config_name = config_name.substr(namespace_pos + 12);
+    }
+    access_offset = 1;
+  } else {
+    config_name = (*config_op)->name;
+  }
+
+  const auto config_it = GetOperationConfig().find(config_name);
   ICHECK(config_it != GetOperationConfig().end())
-      << "Missing operation configuration for " << op_node->name;
+      << "Missing operation configuration for " << config_name;
 
   OperationConfig config = config_it->second;
-  if (!GetWorkspaceOpConfigs().count(op_node)) {
+  if (!GetWorkspaceOpConfigs().count(config_op->get())) {
+    if (access_offset != 0) {
+      for (auto &access : config.buffer_accesses) {
+        access.first += access_offset;
+      }
+    }
     return config;
   }
 
@@ -411,10 +447,10 @@ inline OperationConfig ResolveOperationConfig(const tvm::tir::CallNode *call) {
       continue;
     }
     ICHECK_GE(arg->args.size(), 5U)
-        << "Malformed tvm_access_ptr in " << op_node->name;
+        << "Malformed tvm_access_ptr in " << config_name;
     const auto *mask = arg->args[4].as<tvm::IntImmNode>();
     ICHECK(mask && mask->value > 0 && (mask->value & ~3) == 0)
-        << "Invalid access mask in " << op_node->name;
+        << "Invalid access mask in " << config_name;
     if (mask->value & 1) {
       config.buffer_accesses.emplace_back(i, "read");
     }
@@ -423,6 +459,33 @@ inline OperationConfig ResolveOperationConfig(const tvm::tir::CallNode *call) {
     }
   }
   return config;
+}
+
+inline bool HasOperationConfig(const tvm::tir::CallNode *call) {
+  tvm::tir::Call call_ref = GetRef<tvm::tir::Call>(call);
+  if (const auto *spec = SelectedVectorTerminalSpecOf(call_ref)) {
+    if (spec->base.same_as(tvm::tir::builtin::call_extern())) {
+      if (call->args.empty() || !call->args[0].as<tvm::tir::StringImmNode>()) {
+        return false;
+      }
+      std::string name =
+          std::string(call->args[0].as<tvm::tir::StringImmNode>()->value);
+      size_t template_pos = name.find('<');
+      if (template_pos != std::string::npos) {
+        name = name.substr(0, template_pos);
+      }
+      size_t namespace_pos = name.find("tl::ascend::");
+      if (namespace_pos != std::string::npos) {
+        name = name.substr(namespace_pos + 12);
+      }
+      return GetOperationConfig().count(name) != 0;
+    }
+    return GetOperationConfig().count(spec->base->name) != 0;
+  }
+  if (const auto *op_node = call->op.as<tvm::OpNode>()) {
+    return GetOperationConfig().count(op_node->name) != 0;
+  }
+  return false;
 }
 
 } // namespace tl

--- a/src/transform/cross_core_pipeline.cc
+++ b/src/transform/cross_core_pipeline.cc
@@ -21,6 +21,7 @@
 
 #include "../op/ascend.h"
 #include "../op/builtin.h"
+#include "./common/ascend_vector_mask_contract.h"
 #include "./common/collector.h"
 
 namespace tvm {
@@ -1466,8 +1467,15 @@ private:
           Array<PrimExpr> new_args =
               AdjustCallArgs(origin_map_, call->args, call);
           if (new_args.size() > 0) {
-            if (call->op.same_as(tl::ascend_muls()) ||
-                call->op.same_as(tl::ascend_adds())) {
+            Op semantic_op;
+            if (IsSelectedVectorTerminal(GetRef<Call>(call))) {
+              semantic_op = BaseOperationOf(GetRef<Call>(call));
+            } else if (const auto *op_node = call->op.as<OpNode>()) {
+              semantic_op = GetRef<Op>(op_node);
+            }
+            if (semantic_op.defined() &&
+                (semantic_op.same_as(tl::ascend_muls()) ||
+                 semantic_op.same_as(tl::ascend_adds()))) {
               if (const CallNode *scalar_call = new_args[2].as<CallNode>()) {
                 if (const VarNode *var = scalar_call->args[1].as<VarNode>()) {
                   std::string buffer_name = var->name_hint;

--- a/src/transform/pipeline_planning.cc
+++ b/src/transform/pipeline_planning.cc
@@ -129,15 +129,7 @@ private:
   }
 
   bool is_func_in_operation_config(const CallNode *op) {
-    bool result = false;
-    if (auto *op_ptr = op->op.as<OpNode>()) {
-      std::string op_name = op_ptr->name;
-      auto config_it = GetOperationConfig().find(op_name);
-      if (config_it != GetOperationConfig().end()) {
-        result = true;
-      }
-    }
-    return result;
+    return HasOperationConfig(op);
   }
 
   void VisitExpr_(const CallNode *op) final {

--- a/testing/python/language/benchmark_ascend_vector_mask.py
+++ b/testing/python/language/benchmark_ascend_vector_mask.py
@@ -1,0 +1,126 @@
+"""Synchronization-free performance gate for compiler-managed Vector masks.
+
+Run this file under ``msprof op`` in a clean checkout.  The timed kernels use
+only UB-local Vector operations: TileLang auto-sync and BiSheng CCE auto-sync
+are both disabled, and there are no source-level barriers or events.  Run the
+same file from the old and new checkout roots so that the DSL workload and
+profiler settings stay identical while the imported compiler changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+
+import tilelang
+import tilelang.language as T
+
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+ITERATIONS = 4096
+NUM_AIVS = 48
+COUNTER_CONSUMERS = 8
+MODE_SWITCH_CONSUMERS = 4
+
+
+@T.prim_func
+def counter_chain(
+    a: T.Tensor((NUM_AIVS, 128), "float16"),
+    b: T.Tensor((NUM_AIVS, 128), "float16"),
+    c: T.Tensor((NUM_AIVS, 128), "float16"),
+):
+    """Eight consecutive equal-count consumers with no DMA or synchronization."""
+    with T.Kernel(NUM_AIVS, threads=1, is_npu=True) as cid:  # noqa: F841
+        a_ub = T.alloc_ub((128,), "float16")
+        b_ub = T.alloc_ub((128,), "float16")
+        c_ub = T.alloc_ub((128,), "float16")
+        T.tile.fill(a_ub, 1.0)
+        T.tile.fill(b_ub, 0.0)
+        T.tile.fill(c_ub, 0.0)
+        for _ in T.serial(ITERATIONS):
+            T.tile.add(c_ub, a_ub, b_ub)
+            T.tile.add(a_ub, c_ub, b_ub)
+            T.tile.add(c_ub, a_ub, b_ub)
+            T.tile.add(a_ub, c_ub, b_ub)
+            T.tile.add(c_ub, a_ub, b_ub)
+            T.tile.add(a_ub, c_ub, b_ub)
+            T.tile.add(c_ub, a_ub, b_ub)
+            T.tile.add(a_ub, c_ub, b_ub)
+
+
+@T.prim_func
+def mode_switch(
+    a: T.Tensor((NUM_AIVS, 128), "float16"),
+    b: T.Tensor((NUM_AIVS, 128), "float16"),
+    c: T.Tensor((NUM_AIVS, 128), "float16"),
+):
+    """Alternate raw NORMAL reductions and raw COUNTER arithmetic without sync."""
+    with T.Kernel(NUM_AIVS, threads=1, is_npu=True) as cid:  # noqa: F841
+        a_ub = T.alloc_ub((128,), "float16")
+        b_ub = T.alloc_ub((128,), "float16")
+        c_ub = T.alloc_ub((128,), "float16")
+        reduced_ub = T.alloc_ub((8,), "float16")
+        T.tile.fill(a_ub, 1.0)
+        T.tile.fill(b_ub, 0.0)
+        T.tile.fill(c_ub, 0.0)
+        T.tile.fill(reduced_ub, 0.0)
+        for _ in T.serial(ITERATIONS):
+            T.tile.block_reduce_max(reduced_ub, a_ub, 1, 128, 1, 1, 8)
+            T.tile.add(c_ub, a_ub, b_ub)
+            T.tile.block_reduce_max(reduced_ub, c_ub, 1, 128, 1, 1, 8)
+            T.tile.add(a_ub, c_ub, b_ub)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--case", choices=["counter_chain", "mode_switch"], required=True)
+    parser.add_argument("--launches", type=int, default=100)
+    args = parser.parse_args()
+
+    # Every benchmark process must lower its current checkout afresh.
+    tilelang.disable_cache()
+
+    program = counter_chain if args.case == "counter_chain" else mode_switch
+    consumers = COUNTER_CONSUMERS if args.case == "counter_chain" else MODE_SWITCH_CONSUMERS
+    kernel = tilelang.compile(
+        program,
+        out_idx=[2],
+        pass_configs=PASS_CONFIGS,
+        compile_flags=["--cce-auto-sync=off"],
+        target="ascendc",
+        platform="A3",
+    )
+    source = kernel.get_kernel_source()
+
+    a = torch.empty((NUM_AIVS, 128), dtype=torch.float16, device="npu")
+    b = torch.empty((NUM_AIVS, 128), dtype=torch.float16, device="npu")
+    torch.npu.synchronize()
+    for _ in range(args.launches):
+        kernel(a, b)
+    torch.npu.synchronize()
+
+    result = {
+        "case": args.case,
+        "tilelang_root": str(Path(tilelang.__file__).resolve().parent.parent),
+        "launches": args.launches,
+        "iterations": ITERATIONS,
+        "aiv_count": NUM_AIVS,
+        "consumers_per_iteration": consumers,
+        "count_form_add_count_in_source": source.count("AscendC::Add("),
+        "raw_add_count_in_source": source.count("AscendC::Add<"),
+        "set_mode_count_in_source": source.count("AscendC::SetMaskCount();") + source.count("AscendC::SetMaskNorm();"),
+        "set_payload_count_in_source": source.count("AscendC::SetVectorMask"),
+    }
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/python/language/test_tilelang_ascend_vector_mask.py
+++ b/testing/python/language/test_tilelang_ascend_vector_mask.py
@@ -1,0 +1,696 @@
+"""Compiler-managed A2/A3 Ascend Vector-mask tests."""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+import tilelang
+import tilelang.language as T
+from tilelang import tvm
+from tvm import IRModule, tir
+from tvm.ir import Op
+from tvm.target import Target
+
+
+ASCENDC = Target({"kind": "llvm", "model": "ascendc"})
+PTO = Target({"kind": "llvm", "model": "pto"})
+
+
+def _calls(node) -> list[tir.Call]:
+    result = []
+
+    def visit(current):
+        if isinstance(current, tir.Call):
+            result.append(current)
+
+    tir.stmt_functor.post_order_visit(node, visit)
+    return result
+
+
+def _op_name(call: tir.Call) -> str | None:
+    return call.op.name if isinstance(call.op, Op) else None
+
+
+def _pass(func, transform, target=ASCENDC, platform="A2"):
+    return transform(target, platform)(IRModule({"main": func}))["main"]
+
+
+@T.prim_func
+def _two_adds(
+    a: T.Tensor((128,), "float32"),
+    b: T.Tensor((128,), "float32"),
+    c: T.Tensor((128,), "float32"),
+):
+    with T.Kernel(1, threads=1, is_npu=True) as _cid:
+        a_ub = T.alloc_ub((128,), "float32")
+        b_ub = T.alloc_ub((128,), "float32")
+        c_ub = T.alloc_ub((128,), "float32")
+        T.copy(a, a_ub)
+        T.copy(b, b_ub)
+        T.tile.add(c_ub, a_ub, b_ub)
+        T.tile.add(a_ub, c_ub, b_ub)
+        T.copy(c_ub, c)
+
+
+@T.prim_func
+def _full_normal_reduce(
+    source: T.Tensor((128,), "float16"),
+    result: T.Tensor((8,), "float16"),
+):
+    with T.Kernel(1, threads=1, is_npu=True) as _cid:
+        source_ub = T.alloc_ub((128,), "float16")
+        result_ub = T.alloc_ub((8,), "float16")
+        T.copy(source, source_ub)
+        T.tile.block_reduce_max(result_ub, source_ub, 1, 128, 1, 1, 8)
+        T.copy(result_ub, result)
+
+
+def test_selection_uses_fixed_selected_identity_and_preserves_operands():
+    selected = _pass(
+        _two_adds,
+        tilelang.transform.AscendVectorInstructionSelection,
+    )
+    selected_calls = [call for call in _calls(selected.body) if _op_name(call) == "tl.ascend_add_raw_counter"]
+    assert len(selected_calls) == 2
+    assert all(len(call.args) == 4 for call in selected_calls)
+    assert all(tvm.ir.structural_equal(call.args[-1], tir.IntImm("int32", 128)) for call in selected_calls)
+    assert not any(_op_name(call) == "tl.ascend_add" for call in _calls(selected.body))
+
+
+def test_selection_is_strictly_gated_to_a2_a3_ascendc():
+    for target, platform in [(ASCENDC, "A5"), (PTO, "A2")]:
+        result = _pass(
+            _two_adds,
+            tilelang.transform.AscendVectorInstructionSelection,
+            target,
+            platform,
+        )
+        names = {_op_name(call) for call in _calls(result.body)}
+        assert "tl.ascend_add" in names
+        assert "tl.ascend_add_raw_counter" not in names
+
+
+def test_selection_accepts_symbolic_counter_from_dynamic_buffer_shape():
+    length = tir.Var("length", "int32")
+    buffer = tir.decl_buffer((length,), "float32", name="buffer")
+    semantic = tir.Call(
+        "handle",
+        Op.get("tl.ascend_add"),
+        [tir.IntImm("int32", 0)] * 3 + [length],
+    )
+    func = tir.PrimFunc(
+        [length, buffer.data],
+        tir.Evaluate(semantic),
+        buffer_map={buffer.data: buffer},
+    ).with_attr("global_symbol", "main")
+    selected = _pass(func, tilelang.transform.AscendVectorInstructionSelection)
+    call = next(call for call in _calls(selected.body) if _op_name(call) == "tl.ascend_add_raw_counter")
+    assert tvm.ir.structural_equal(call.args[-1], length)
+
+
+def test_selection_keeps_buffer_derived_let_counter_as_white_box_var():
+    source = tir.decl_buffer((1,), "int32", name="source")
+    length = tir.Var("length", "int32")
+    value = tir.if_then_else(
+        tir.BufferLoad(source, [0]) > 0,
+        tir.IntImm("int32", 32),
+        tir.IntImm("int32", 64),
+    )
+    semantic = tir.Call(
+        "handle",
+        Op.get("tl.ascend_add"),
+        [tir.IntImm("int32", 0)] * 3 + [length],
+    )
+    func = tir.PrimFunc(
+        [source.data],
+        tir.LetStmt(length, value, tir.Evaluate(semantic)),
+        buffer_map={source.data: source},
+    ).with_attr("global_symbol", "main")
+
+    selected = _pass(func, tilelang.transform.AscendVectorInstructionSelection)
+    call = next(call for call in _calls(selected.body) if _op_name(call) == "tl.ascend_add_raw_counter")
+    assert tvm.ir.structural_equal(call.args[-1], length)
+
+
+def test_selection_rejects_symbolic_normal_payload():
+    length = tir.Var("length", "uint32")
+    semantic = tir.Call(
+        "handle",
+        Op.get("tl.ascend_fill_experiment"),
+        [tir.IntImm("int32", 0)] * 3 + [length],
+    )
+    func = tir.PrimFunc([length], tir.Evaluate(semantic)).with_attr("global_symbol", "main")
+    with pytest.raises(tvm.TVMError, match="NORMAL mask payload"):
+        _pass(func, tilelang.transform.AscendVectorInstructionSelection)
+
+
+def test_selection_accepts_large_uint_encoding_of_full_normal_mask():
+    src = tir.decl_buffer((128,), "float16", name="src")
+    dst = tir.decl_buffer((8,), "float16", name="dst")
+    semantic = tir.Call(
+        "handle",
+        Op.get("tl.ascend_block_reduce_max"),
+        [
+            dst.access_ptr("w"),
+            src.access_ptr("r"),
+            tir.IntImm("int32", 1),
+            tir.IntImm("int32", 128),
+            tir.IntImm("int32", 1),
+            tir.IntImm("int32", 1),
+            tir.IntImm("int32", 8),
+        ],
+    )
+    func = tir.PrimFunc(
+        [src.data, dst.data],
+        tir.Evaluate(semantic),
+        buffer_map={src.data: src, dst.data: dst},
+    ).with_attr("global_symbol", "main")
+
+    selected = _pass(func, tilelang.transform.AscendVectorInstructionSelection)
+    call = next(call for call in _calls(selected.body) if _op_name(call) == "tl.ascend_block_reduce_max_raw_normal")
+    assert _op_name(call.args[-2]) == "tir.large_uint_imm"
+    assert _op_name(call.args[-1]) == "tir.large_uint_imm"
+    legalized = _pass(selected, tilelang.transform.AscendVectorMaskLegalize)
+    _assert_consumer_contracts(legalized.body)
+
+
+def test_selection_classifies_gather_mask_by_pattern_not_optional_tmp():
+    src = tir.decl_buffer((128,), "float16", name="src")
+    dst = tir.decl_buffer((128,), "float16", name="dst")
+    pattern = tir.decl_buffer((8,), "uint32", name="pattern")
+    tmp = tir.decl_buffer((256,), "uint8", name="tmp")
+    common = [
+        tir.StringImm("GatherMask<half>"),
+        dst.access_ptr("w"),
+        src.access_ptr("r"),
+    ]
+    fixed = tir.Evaluate(
+        tir.Call(
+            "handle",
+            Op.get("tl.ascend_gather_mask"),
+            [*common, tir.StringImm("P0101"), tmp.access_ptr("w")],
+        )
+    )
+    custom = tir.Evaluate(
+        tir.Call(
+            "handle",
+            Op.get("tl.ascend_gather_mask"),
+            [*common, pattern.access_ptr("r"), tmp.access_ptr("w")],
+        )
+    )
+    func = tir.PrimFunc(
+        [src.data, dst.data, pattern.data, tmp.data],
+        tir.SeqStmt([fixed, custom]),
+        buffer_map={
+            src.data: src,
+            dst.data: dst,
+            pattern.data: pattern,
+            tmp.data: tmp,
+        },
+    ).with_attr("global_symbol", "main")
+
+    selected = _pass(func, tilelang.transform.AscendVectorInstructionSelection)
+    names = _managed_names(selected.body)
+    assert names.count("tl.ascend_gather_mask_fixed_self_contained_normal") == 1
+    assert names.count("tl.ascend_gather_mask_custom_composite") == 1
+
+
+def test_selection_rejects_unclassified_extern_and_nested_semantic_call():
+    unknown = tir.Evaluate(tir.call_extern("handle", "unreviewed_helper"))
+    unknown_func = tir.PrimFunc([], unknown).with_attr("global_symbol", "main")
+    with pytest.raises(tvm.TVMError, match="effect table"):
+        _pass(unknown_func, tilelang.transform.AscendVectorInstructionSelection)
+
+    semantic = tir.Call(
+        "handle",
+        Op.get("tl.ascend_add"),
+        [tir.IntImm("int32", 0)] * 4,
+    )
+    nested = tir.Evaluate(tir.Call("handle", Op.get("tir.tvm_tuple"), [semantic]))
+    nested_func = tir.PrimFunc([], nested).with_attr("global_symbol", "main")
+    with pytest.raises(tvm.TVMError, match="direct value of an Evaluate"):
+        _pass(nested_func, tilelang.transform.AscendVectorInstructionSelection)
+
+
+def test_selection_requires_mask_effects_to_stay_in_aiv_resource_scope():
+    resource = tir.Var("resource", "int32")
+    semantic = tir.Evaluate(
+        tir.Call(
+            "handle",
+            Op.get("tl.ascend_add"),
+            [tir.IntImm("int32", 0)] * 4,
+        )
+    )
+
+    aic_only = tir.PrimFunc(
+        [],
+        tir.AttrStmt(resource, "resource_scope", 0, semantic),
+    ).with_attr("global_symbol", "main")
+    with pytest.raises(tvm.TVMError, match="resource_scope=1"):
+        _pass(aic_only, tilelang.transform.AscendVectorInstructionSelection)
+
+    outside = tir.PrimFunc(
+        [],
+        tir.SeqStmt(
+            [
+                tir.AttrStmt(resource, "resource_scope", 1, tir.Evaluate(0)),
+                semantic,
+            ]
+        ),
+    ).with_attr("global_symbol", "main")
+    with pytest.raises(tvm.TVMError, match="resource_scope=1"):
+        _pass(outside, tilelang.transform.AscendVectorInstructionSelection)
+
+
+def test_selection_rejects_overlapping_aic_aiv_resource_scopes():
+    resource = tir.Var("resource", "int32")
+    nested = tir.AttrStmt(
+        resource,
+        "resource_scope",
+        1,
+        tir.AttrStmt(resource, "resource_scope", 0, tir.Evaluate(0)),
+    )
+    func = tir.PrimFunc([], nested).with_attr("global_symbol", "main")
+    with pytest.raises(tvm.TVMError, match="overlapping AIC/AIV"):
+        _pass(func, tilelang.transform.AscendVectorInstructionSelection)
+
+
+def test_legalizer_reuses_counter_mode_and_payload_in_straight_line():
+    selected = _pass(
+        _two_adds,
+        tilelang.transform.AscendVectorInstructionSelection,
+    )
+    legalized = _pass(selected, tilelang.transform.AscendVectorMaskLegalize)
+    names = [_op_name(call) for call in _calls(legalized.body)]
+    assert names.count("tl.ascend_set_mask_mode") == 1
+    assert names.count("tl.ascend_set_mask_payload") == 1
+    assert names.count("tl.ascend_add_raw_counter") == 2
+
+
+def _selected_counter(length: tir.PrimExpr) -> tir.Stmt:
+    args = [tir.IntImm("int32", 0)] * 3 + [length]
+    return tir.Evaluate(tir.Call("handle", Op.get("tl.ascend_add_raw_counter"), args))
+
+
+def _selected_normal(lo: int, hi: int) -> tir.Stmt:
+    args = [tir.IntImm("int32", 0)] * 4
+    args.extend([tir.IntImm("uint64", lo), tir.IntImm("uint64", hi)])
+    return tir.Evaluate(tir.Call("handle", Op.get("tl.ascend_block_reduce_max_raw_normal"), args))
+
+
+def _legalize_stmt(stmt: tir.Stmt) -> tir.Stmt:
+    func = tir.PrimFunc([], stmt).with_attr("global_symbol", "main")
+    return _pass(func, tilelang.transform.AscendVectorMaskLegalize).body
+
+
+def _managed_names(stmt: tir.Stmt) -> list[str | None]:
+    return [_op_name(call) for call in _calls(stmt)]
+
+
+def _same_fact(lhs, rhs) -> bool:
+    if lhs is None or rhs is None:
+        return lhs is rhs
+    return tvm.ir.structural_equal(lhs, rhs)
+
+
+def _merge_facts(lhs, rhs):
+    return tuple(left if _same_fact(left, right) else None for left, right in zip(lhs, rhs))
+
+
+def _assert_consumer_contracts(stmt: tir.Stmt, incoming=(None, None, None)):
+    """Independently validate required mask facts in legalized test IR."""
+    if isinstance(stmt, tir.SeqStmt):
+        facts = incoming
+        for child in stmt.seq:
+            facts = _assert_consumer_contracts(child, facts)
+        return facts
+    if isinstance(stmt, tir.IfThenElse):
+        then_out = _assert_consumer_contracts(stmt.then_case, incoming)
+        else_out = incoming
+        if stmt.else_case is not None:
+            else_out = _assert_consumer_contracts(stmt.else_case, incoming)
+        return _merge_facts(then_out, else_out)
+    if isinstance(stmt, tir.For):
+        effect_names = {
+            "tl.ascend_add_raw_counter",
+            "tl.ascend_block_reduce_max_raw_normal",
+            "tl.ascend_src_code",
+        }
+        has_effect = any(_op_name(call) in effect_names for call in _calls(stmt.body))
+        if not has_effect:
+            _assert_consumer_contracts(stmt.body, incoming)
+            return incoming
+        _assert_consumer_contracts(stmt.body)
+        return (None, None, None)
+    if not isinstance(stmt, tir.Evaluate) or not isinstance(stmt.value, tir.Call):
+        return incoming
+
+    call = stmt.value
+    name = _op_name(call)
+    if name == "tl.ascend_set_mask_mode":
+        mode = "counter" if call.args[0].value == 1 else "normal"
+        return (mode, incoming[1], incoming[2])
+    if name == "tl.ascend_set_mask_payload":
+        return (incoming[0], call.args[0], call.args[1])
+    if name == "tl.ascend_add_raw_counter":
+        lo = tvm.arith.Analyzer().simplify(tir.Cast("uint64", call.args[-1]))
+        required = ("counter", lo, tir.IntImm("uint64", 0))
+    elif name == "tl.ascend_block_reduce_max_raw_normal":
+        required = ("normal", call.args[-2], call.args[-1])
+    else:
+        return incoming
+    assert all(_same_fact(actual, expected) for actual, expected in zip(incoming, required))
+    return required
+
+
+def test_mode_switch_keeps_payload_facts_and_repairs_only_required_fields():
+    body = tir.SeqStmt(
+        [
+            _selected_counter(tir.IntImm("int32", 64)),
+            _selected_normal(64, 0),
+            _selected_counter(tir.IntImm("int32", 64)),
+        ]
+    )
+    names = _managed_names(_legalize_stmt(body))
+    assert names.count("tl.ascend_set_mask_mode") == 3
+    assert names.count("tl.ascend_set_mask_payload") == 1
+
+
+def test_equal_if_branches_preserve_must_facts_but_missing_else_does_not():
+    cond = tir.Var("cond", "bool")
+    warm = _selected_counter(tir.IntImm("int32", 64))
+    equal_if = tir.IfThenElse(
+        cond,
+        _selected_counter(tir.IntImm("int32", 64)),
+        _selected_counter(tir.IntImm("int32", 64)),
+    )
+    equal_body = tir.SeqStmt([warm, equal_if, _selected_counter(tir.IntImm("int32", 64))])
+    equal_names = _managed_names(_legalize_stmt(equal_body))
+    assert equal_names.count("tl.ascend_set_mask_payload") == 1
+
+    missing_if = tir.IfThenElse(cond, _selected_counter(tir.IntImm("int32", 32)), None)
+    missing_body = tir.SeqStmt([warm, missing_if, _selected_counter(tir.IntImm("int32", 64))])
+    missing_names = _managed_names(_legalize_stmt(missing_body))
+    assert missing_names.count("tl.ascend_set_mask_payload") == 3
+
+
+def test_src_code_is_a_mask_fact_barrier():
+    src_code = tir.Evaluate(tir.Call("handle", Op.get("tl.ascend_src_code"), [tir.StringImm("// opaque")]))
+    body = tir.SeqStmt(
+        [
+            _selected_counter(tir.IntImm("int32", 64)),
+            src_code,
+            _selected_counter(tir.IntImm("int32", 64)),
+        ]
+    )
+    names = _managed_names(_legalize_stmt(body))
+    assert names.count("tl.ascend_set_mask_mode") == 2
+    assert names.count("tl.ascend_set_mask_payload") == 2
+
+
+def test_symbolic_counter_payload_stays_in_selected_ir_and_setter():
+    length = tir.SizeVar("length", "int32")
+    func = tir.PrimFunc([length], _selected_counter(length)).with_attr("global_symbol", "main")
+    legalized = _pass(func, tilelang.transform.AscendVectorMaskLegalize)
+    calls = _calls(legalized.body)
+    selected = next(call for call in calls if _op_name(call) == "tl.ascend_add_raw_counter")
+    setter = next(call for call in calls if _op_name(call) == "tl.ascend_set_mask_payload")
+    assert tvm.ir.structural_equal(selected.args[-1], length)
+    assert tvm.ir.structural_equal(setter.args[0], tir.Cast("uint64", length))
+
+
+def test_legalizer_rejects_buffer_backed_payload():
+    buffer = tir.decl_buffer((1,), "int32", name="buffer")
+    payload = tir.BufferLoad(buffer, [0])
+    func = tir.PrimFunc(
+        [buffer.data],
+        _selected_counter(payload),
+        buffer_map={buffer.data: buffer},
+    ).with_attr("global_symbol", "main")
+    with pytest.raises(tvm.TVMError, match="buffer-backed"):
+        _pass(func, tilelang.transform.AscendVectorMaskLegalize)
+
+
+def test_let_projection_substitutes_only_pure_parent_scope_values():
+    let_var = tir.Var("let_var", "int32")
+    pure = tir.SeqStmt(
+        [
+            tir.LetStmt(
+                let_var,
+                tir.IntImm("int32", 64),
+                _selected_counter(let_var),
+            ),
+            _selected_counter(tir.IntImm("int32", 64)),
+        ]
+    )
+    pure_names = _managed_names(_legalize_stmt(pure))
+    assert pure_names.count("tl.ascend_set_mask_payload") == 1
+
+    buffer = tir.decl_buffer((1,), "int32", name="buffer")
+    impure = tir.SeqStmt(
+        [
+            tir.LetStmt(
+                let_var,
+                tir.BufferLoad(buffer, [0]),
+                _selected_counter(let_var),
+            ),
+            _selected_counter(tir.IntImm("int32", 64)),
+        ]
+    )
+    func = tir.PrimFunc([buffer.data], impure, buffer_map={buffer.data: buffer}).with_attr("global_symbol", "main")
+    names = _managed_names(_pass(func, tilelang.transform.AscendVectorMaskLegalize).body)
+    assert names.count("tl.ascend_set_mask_payload") == 2
+
+
+def test_loop_projection_drops_variant_facts_but_neutral_loop_preserves_them():
+    loop_var = tir.Var("i", "int32")
+    variant_loop = tir.For(
+        loop_var,
+        0,
+        4,
+        tir.ForKind.SERIAL,
+        _selected_counter(loop_var + 1),
+    )
+    variant_body = tir.SeqStmt([variant_loop, _selected_counter(tir.IntImm("int32", 4))])
+    variant_names = _managed_names(_legalize_stmt(variant_body))
+    assert variant_names.count("tl.ascend_set_mask_mode") == 2
+    assert variant_names.count("tl.ascend_set_mask_payload") == 2
+
+    neutral_loop = tir.For(loop_var, 0, 4, tir.ForKind.SERIAL, tir.Evaluate(0))
+    neutral_body = tir.SeqStmt(
+        [
+            _selected_counter(tir.IntImm("int32", 4)),
+            neutral_loop,
+            _selected_counter(tir.IntImm("int32", 4)),
+        ]
+    )
+    neutral_names = _managed_names(_legalize_stmt(neutral_body))
+    assert neutral_names.count("tl.ascend_set_mask_mode") == 1
+    assert neutral_names.count("tl.ascend_set_mask_payload") == 1
+
+
+def test_aiv_resource_scope_has_independent_entry_facts():
+    resource = tir.Var("resource", "int32")
+    first = tir.AttrStmt(
+        resource,
+        "resource_scope",
+        1,
+        _selected_counter(tir.IntImm("int32", 64)),
+    )
+    second = tir.AttrStmt(
+        resource,
+        "resource_scope",
+        1,
+        _selected_counter(tir.IntImm("int32", 64)),
+    )
+    names = _managed_names(_legalize_stmt(tir.SeqStmt([first, second])))
+    assert names.count("tl.ascend_set_mask_mode") == 2
+    assert names.count("tl.ascend_set_mask_payload") == 2
+
+
+def test_legalizer_rejects_preexisting_internal_setter():
+    setter = tir.Evaluate(
+        tir.Call(
+            "handle",
+            Op.get("tl.ascend_set_mask_mode"),
+            [tir.IntImm("int32", 1)],
+        )
+    )
+    with pytest.raises(tvm.TVMError, match="already contains"):
+        _legalize_stmt(setter)
+
+
+@pytest.mark.parametrize("seed", range(20))
+def test_random_straight_line_setter_count_matches_reference(seed):
+    rng = random.Random(seed)
+    lengths = [rng.choice([16, 32, 64, 128]) for _ in range(25)]
+    body = tir.SeqStmt([_selected_counter(tir.IntImm("int32", length)) for length in lengths])
+    legalized = _legalize_stmt(body)
+    names = _managed_names(legalized)
+    reference_payload_repairs = 1 + sum(a != b for a, b in zip(lengths, lengths[1:]))
+    assert names.count("tl.ascend_set_mask_mode") == 1
+    assert names.count("tl.ascend_set_mask_payload") == reference_payload_repairs
+    _assert_consumer_contracts(legalized)
+
+    before = [call for call in _calls(body) if _op_name(call) == "tl.ascend_add_raw_counter"]
+    after = [call for call in _calls(legalized) if _op_name(call) == "tl.ascend_add_raw_counter"]
+    assert len(before) == len(after)
+    assert all(tvm.ir.structural_equal(lhs, rhs) for lhs, rhs in zip(before, after))
+
+
+def _random_control_spec(rng: random.Random, depth: int, ordinal: list[int]):
+    if depth == 0:
+        if rng.randrange(4) == 0:
+            return ("neutral",)
+        return ("counter", rng.choice([16, 32, 64, 128]))
+    kind = rng.choice(["counter", "seq", "if", "for"])
+    if kind == "counter":
+        return ("counter", rng.choice([16, 32, 64, 128]))
+    ordinal[0] += 1
+    current = ordinal[0]
+    if kind == "seq":
+        return (
+            "seq",
+            [_random_control_spec(rng, depth - 1, ordinal) for _ in range(rng.randint(1, 3))],
+        )
+    if kind == "if":
+        else_spec = None
+        if rng.randrange(3) != 0:
+            else_spec = _random_control_spec(rng, depth - 1, ordinal)
+        return (
+            "if",
+            current,
+            _random_control_spec(rng, depth - 1, ordinal),
+            else_spec,
+        )
+    return ("for", current, _random_control_spec(rng, depth - 1, ordinal))
+
+
+def _control_spec_to_stmt(spec):
+    kind = spec[0]
+    if kind == "neutral":
+        return tir.Evaluate(0)
+    if kind == "counter":
+        return _selected_counter(tir.IntImm("int32", spec[1]))
+    if kind == "seq":
+        statements = [_control_spec_to_stmt(item) for item in spec[1]]
+        return statements[0] if len(statements) == 1 else tir.SeqStmt(statements)
+    if kind == "if":
+        else_case = None if spec[3] is None else _control_spec_to_stmt(spec[3])
+        return tir.IfThenElse(
+            tir.Var(f"condition_{spec[1]}", "bool"),
+            _control_spec_to_stmt(spec[2]),
+            else_case,
+        )
+    loop_var = tir.Var(f"loop_{spec[1]}", "int32")
+    return tir.For(
+        loop_var,
+        0,
+        3,
+        tir.ForKind.SERIAL,
+        _control_spec_to_stmt(spec[2]),
+    )
+
+
+def _reference_control(spec, incoming):
+    kind = spec[0]
+    if kind == "neutral":
+        return (0, 0), incoming, False
+    if kind == "counter":
+        length = spec[1]
+        mode_repairs = int(incoming[0] != "counter")
+        payload_repairs = int(incoming[1] != length)
+        return (mode_repairs, payload_repairs), ("counter", length, 0), True
+    if kind == "seq":
+        counts = [0, 0]
+        facts = incoming
+        has_effect = False
+        for item in spec[1]:
+            item_counts, facts, item_effect = _reference_control(item, facts)
+            counts[0] += item_counts[0]
+            counts[1] += item_counts[1]
+            has_effect |= item_effect
+        return tuple(counts), facts, has_effect
+    if kind == "if":
+        then_counts, then_out, then_effect = _reference_control(spec[2], incoming)
+        if spec[3] is None:
+            else_counts, else_out, else_effect = (0, 0), incoming, False
+        else:
+            else_counts, else_out, else_effect = _reference_control(spec[3], incoming)
+        merged = tuple(lhs if lhs == rhs else None for lhs, rhs in zip(then_out, else_out))
+        return (
+            (then_counts[0] + else_counts[0], then_counts[1] + else_counts[1]),
+            merged,
+            then_effect or else_effect,
+        )
+    _, _, body = spec
+    _, _, has_effect = _reference_control(body, incoming)
+    if not has_effect:
+        return (0, 0), incoming, False
+    body_counts, _, _ = _reference_control(body, (None, None, None))
+    return body_counts, (None, None, None), True
+
+
+@pytest.mark.parametrize("seed", range(20))
+def test_random_structured_setter_counts_match_reference(seed):
+    spec = _random_control_spec(random.Random(seed), 3, [0])
+    expected, _, _ = _reference_control(spec, (None, None, None))
+    selected = _control_spec_to_stmt(spec)
+    legalized = _legalize_stmt(selected)
+    names = _managed_names(legalized)
+    assert names.count("tl.ascend_set_mask_mode") == expected[0]
+    assert names.count("tl.ascend_set_mask_payload") == expected[1]
+    _assert_consumer_contracts(legalized)
+
+    before = [call for call in _calls(selected) if _op_name(call) == "tl.ascend_add_raw_counter"]
+    after = [call for call in _calls(legalized) if _op_name(call) == "tl.ascend_add_raw_counter"]
+    assert len(before) == len(after)
+    assert all(tvm.ir.structural_equal(lhs, rhs) for lhs, rhs in zip(before, after))
+
+
+def test_full_pipeline_source_has_one_repair_for_two_equal_consumers():
+    kernel = tilelang.compile(_two_adds, target="ascendc", platform="A2", out_idx=[2])
+    source = kernel.get_kernel_source()
+    assert source.count("AscendC::SetMaskCount();") == 1
+    assert source.count("AscendC::SetVectorMask<uint8_t>((uint64_t)0, (uint64_t)128);") == 1
+    assert source.count("AscendC::Add<float, false>") == 2
+    assert "AscendC::Add(c_ub, a_ub, b_ub, 128)" not in source
+
+
+def test_full_normal_payload_codegen_uses_unsigned_64_bit_literals():
+    kernel = tilelang.compile(_full_normal_reduce, target="ascendc", platform="A2", out_idx=[1])
+    source = kernel.get_kernel_source()
+    assert source.count("AscendC::SetVectorMask<uint8_t>(0xffffffffffffffffULL, 0xffffffffffffffffULL);") == 1
+
+
+def test_selected_identity_survives_phase2_and_legalizer_is_last_tir_pass(monkeypatch):
+    snapshots = {}
+    production_legalizer = tilelang.transform.AscendVectorMaskLegalize
+
+    @tvm.transform.module_pass(opt_level=0)
+    def capture_before(mod, _ctx):
+        snapshots["before"] = mod
+        return mod
+
+    @tvm.transform.module_pass(opt_level=0)
+    def capture_after(mod, _ctx):
+        snapshots["after"] = mod
+        return mod
+
+    def captured_legalizer(target, platform):
+        return tvm.transform.Sequential([capture_before, production_legalizer(target, platform), capture_after])
+
+    monkeypatch.setattr(tilelang.transform, "AscendVectorMaskLegalize", captured_legalizer)
+    artifact = tilelang.lower(_two_adds, target="ascendc", platform="A2")
+
+    before_func = snapshots["before"].functions_items()[0][1]
+    after_func = snapshots["after"].functions_items()[0][1]
+
+    before_calls = [call for call in _calls(before_func.body) if _op_name(call) == "tl.ascend_add_raw_counter"]
+    after_calls = [call for call in _calls(after_func.body) if _op_name(call) == "tl.ascend_add_raw_counter"]
+    assert len(before_calls) == len(after_calls) == 2
+    assert all(tvm.ir.structural_equal(lhs, rhs) for lhs, rhs in zip(before_calls, after_calls))
+    assert all(call.args[-1].value == 128 for call in before_calls)
+    assert tvm.ir.structural_equal(artifact.device_mod, snapshots["after"])

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -19,6 +19,7 @@ from tilelang.utils.target import determine_target  # noqa: F401
 from tilelang.engine.phase import (
     LowerAndLegalize,
     OptimizeForTarget,
+    use_compiler_managed_vector_mask,
 )
 
 
@@ -157,7 +158,8 @@ def host_codegen(host_mod: tvm.IRModule, target_host: Target) -> tvm.IRModule:
 
 
 def device_codegen(device_mod: tvm.IRModule, target: Target, platform: str) -> tvm.IRModule:
-    device_mod = tir.transform.Simplify()(device_mod)
+    if not use_compiler_managed_vector_mask(target, platform):
+        device_mod = tir.transform.Simplify()(device_mod)
 
     if target.model == "ascendc" or target.model == "auto":
         device_mod = tvm._ffi.get_global_func("target.build.tilelang_ascend")(device_mod, target, platform)

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -46,6 +46,11 @@ def allow_vectorize(pass_ctx: PassContext | None = None) -> bool:
     return not disable_vectorize
 
 
+def use_compiler_managed_vector_mask(target: Target, platform: str) -> bool:
+    """Return whether the mandatory A2/A3 AscendC mask pipeline applies."""
+    return target.model in {"ascendc", "auto"} and platform in {"A2", "A3"}
+
+
 def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
     # allocate the tmp buffer for vector api
     mod = tilelang.transform.InjectTmpBuffer(target)(mod)
@@ -97,6 +102,9 @@ def OptimizeForTarget(mod: IRModule, target: Target, platform: str) -> IRModule:
     from tilelang.utils.target import check_npu_availability
 
     pass_ctx = tilelang.transform.get_pass_context()
+    managed_vector_mask = use_compiler_managed_vector_mask(target, platform)
+    if managed_vector_mask:
+        mod = tilelang.transform.AscendVectorInstructionSelection(target, platform)(mod)
     mod = tir.transform.PlanAndUpdateBufferAllocationLocation()(mod)
     mod = tilelang.transform.CrossCorePipeline()(mod)
     mod = tilelang.transform.CombineCV()(mod)
@@ -120,5 +128,10 @@ def OptimizeForTarget(mod: IRModule, target: Target, platform: str) -> IRModule:
     mod = tilelang.transform.AscendMemoryPlanning()(mod)
     mod = tilelang.transform.AscendSyncInsert(target, platform)(mod)
     mod = tilelang.transform.AscendSyncInsertVS(target, platform)(mod)
+    if managed_vector_mask:
+        # This is the final structured simplification.  No TIR rewrite may run
+        # between legalization and the mechanical AscendC emitter.
+        mod = tir.transform.Simplify()(mod)
+        mod = tilelang.transform.AscendVectorMaskLegalize(target, platform)(mod)
     # print(mod)
     return mod

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -392,6 +392,16 @@ def AscendSyncInsertVS(target: Target, platform: str):
     return _ffi_api.AscendSyncInsertVS(target, platform)  # type: ignore
 
 
+def AscendVectorInstructionSelection(target: Target, platform: str):
+    """Select compiler-managed Ascend Vector terminals on A2/A3 AscendC."""
+    return _ffi_api.AscendVectorInstructionSelection(target, platform)  # type: ignore
+
+
+def AscendVectorMaskLegalize(target: Target, platform: str):
+    """Repair compiler-managed Ascend Vector mask state before codegen."""
+    return _ffi_api.AscendVectorMaskLegalize(target, platform)  # type: ignore
+
+
 def CombineCV():
     """CombineCV
 


### PR DESCRIPTION
## Background

在 AscendC / CCE Vector API 中，mask 用来描述一次 Vector 调用中哪些元素有效。它既可以
由元素数量表示，也可以由 NORMAL bit mask 表示；配置完成后，相邻的 Vector 调用可以继续
使用当前 mask。

AscendC 因此提供了两类调用方式：count overload 为单次调用自行配置并恢复 mask，
`isSetMask=false` 的调用则复用调用前已经建立的配置。前者适合独立调用，但当 kernel 连续执行
许多等长的短 Vector 操作时，即使它们需要完全相同的 mask，每个调用仍会重复管理同一状态。

## Summary

Closes #1411.

本 PR 为 A2/A3 AscendC 增加编译器托管的 Vector mask 复用。用户继续使用现有的
`T.tile.*` API；compiler 会跨相邻 Vector 操作跟踪 mask 配置，复用仍然兼容的状态，
并只在需要时重新配置。

例如，连续的等长操作不再各自重复管理同一状态：

```python
T.tile.add(c0_ub, a_ub, b_ub)
T.tile.add(c1_ub, a_ub, b_ub)
T.tile.add(c2_ub, a_ub, b_ub)
```

这项优化默认生效，不新增用户 API、kernel 级开关或手动 mask 接口。

## Scope

| 路径 | 行为 |
| --- | --- |
| AscendC / `auto`，A2/A3 | 启用 compiler-managed mask pipeline |
| AscendC，A5 | 保持原有 lowering |
| PTO | 保持原有 lowering |
| Developer / Hybrid / Expert | `T.tile.*` 用户接口均不变 |
| 自动同步策略 | 保持不变 |

## Performance

性能测试采用 issue #1411 的短 Vector Add workload，并关闭所有 TileLang 自动同步和 CCE
自动同步：

```python
tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False
tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC_VS: False
compile_flags=["--cce-auto-sync=off", "-O3"]
```

测试在 Atlas A3 上启动两个 AIV。每个 AIV 将两个 64 KiB fp32 buffer 搬入 UB，再通过一个
位于 `T.serial(256)` 中的 `T.tile.add` 调用点处理 256 个互不重叠的 fp32[64] chunk，最后写回
输出。每次 Add 的 `repeatTime=1`；不同 chunk 之间不存在 RAW、WAR 或 WAW。热循环中没有
barrier 或 event，只在 GM/UB copy 边界保留两次相同的 `T.barrier_all()`。

父提交在循环中生成一个 self-contained count-form Add 调用点；本 PR 生成显式 mask repair 和
`isSetMask=false` Add，不再在每次 Add 后恢复默认状态。首版 legalizer 仍在循环体内保守 repair，
尚未把循环不变量 setter 提到循环外，因此这里测量的是当前实现的实际收益，而不是未来
loop-hoist 后的上限。

每个 checkout 都在独立 Python 进程中执行 `tilelang.disable_cache()`，先 warmup 20 次，再由
Level0 `torch_npu.profiler` 记录 100 个完整 kernel 样本。两边各运行 5 个独立进程，并取
process median 的中位数：

| 实现 | 5 个 process median | Median of medians | 相对父提交 |
| --- | --- | ---: | ---: |
| 父提交 `272c0ab3` | 3.43 / 3.42 / 3.42 / 3.43 / 3.42 us | 3.42 us | 1.000 |
| 本 PR | 2.74 / 2.72 / 2.74 / 2.74 / 2.74 us | 2.74 us | 0.801 |

完整 kernel latency 降低 **19.9%**，约为 **1.248x**。每个进程另执行 20 次逐元素精确检查，
父提交与本 PR 均为 100/100 通过。`msprof op BasicInfo` 单独确认实际启动参数为
`Block Dim=1`、`Mix Block Dim=2`；它不参与上述延迟统计。

这是针对 issue 的双 AIV microbenchmark，用于验证大量短 Vector API 调用时的收益，不作为
48-AIV 满核运算的通用性能结论。

复现入口：`testing/python/language/benchmark_ascend_vector_mask.py --case counter_chain`。

<details>
<summary><strong>Why this change spans 26 files (+4,077/-164)</strong> — one <code>T.tile.*</code> chain through the compiler</summary>

如果只在 codegen 中把某个调用换成可复用 mask 的形式，codegen 无法可靠回答两个问题：
当前状态是否仍满足要求，以及中间的控制流和编译 pass 是否已经使该事实失效。相反，如果
过早插入 setter，后续变换又可能移动或重组操作，使原先的判断失效。

本 PR 因此把“选择操作形式”和“修复状态”放在 Phase 2 的两端：

```text
T.tile.* semantic call
  -> AscendVectorInstructionSelection
       choose one selected terminal and its mask contract
  -> existing scheduling / memory / synchronization passes
       query the original semantic operation through base projection
  -> AscendVectorMaskLegalize
       track must-facts and insert only the missing setters
  -> AscendC codegen
       emit the selected terminal mechanically
```

### 1. One catalog defines the compatibility domain

`src/op/ascend_vector_mask_ops.inc` 是 A2/A3 AscendC Vector 操作的单一清单。每个受支持的
语义操作都对应一个 selected terminal、mask contract 和 base operation。Contract 区分：

- 需要并保持精确 COUNTER 或 NORMAL 状态的操作；
- 不读写 mask 状态的操作；
- 自行建立已知状态的操作；
- 状态结果需要保守视为 unknown 的复合操作。

新操作必须显式加入 catalog；managed 路径没有按名称前缀猜测行为的 fallback。完整分组与
审计依据记录在 `docs/ascend/compiler_managed_vector_mask_inventory.md`。

### 2. Selection runs before Phase 2 rewrites

`AscendVectorInstructionSelection` 在 `OptimizeForTarget` 入口选择最终 terminal，并把动态
COUNTER payload 或已物化的 NORMAL payload 一起保存在 selected call 中。这样后续 pass 不会
再次选择 overload，也不会在 codegen 才发现调用缺少可证明的 contract。

Selection 同时关闭输入 grammar：未分类的 extern、unsupported Vector op、越出 AIV resource
scope 的状态依赖，以及不合法 payload 都会得到诊断。`T._src_code` 仍可使用，但会使已有
mask facts 失效。

### 3. Existing passes keep seeing semantic metadata

Selection 之后仍有 PipelinePlanning、CrossCorePipeline、SyncInsert 等 pass。它们需要的是原始
操作的 buffer、pipe 和同步属性，而不是 selected terminal 的内部名称。

`BaseOperationOf(selected_call)` 将 selected terminal 投影回语义操作，因此这些 pass 继续使用
原有 metadata；同时 selected identity 和 contract operands 在整个 Phase 2 中保持不变。

### 4. Legalizer is the final TIR mutation

`AscendVectorMaskLegalize` 对 mode、low payload 和 high payload 做前向 must-fact 分析：直线代码
复用相同事实，`If` 只保留两支共同事实，`For`、`Let` 和 resource scope 只向外传播仍然有效的
表达式。状态边界会清空事实；下一个 consumer 再按 contract 补齐缺失字段。

Legalizer 位于 SyncInsert 之后，并且是 managed 路径最后一个 TIR mutation。最终 codegen 只发射
selected terminal 和 legalizer 已经插入的 setter，不再执行 selection、repair 或 fallback。

### Diff composition

| 组成 | 文件数 | Diff |
| --- | ---: | ---: |
| Production implementation | 18 | `+2,700/-46` |
| Tests and benchmark | 2 | `+937/-0` |
| Documentation and `.agents` references | 6 | `+440/-118` |
| **Total** | **26** | **`+4,077/-164`** |

</details>

## Validation

| 验证层次 | 结果 |
| --- | --- |
| 增量构建与重组 commit 后重建 | `bash install_ascend.sh --enable-incremental` 与 `cmake --build build -j8` 均成功 |
| 新增 contract / Selection / Legalizer / pipeline / codegen 测试 | `63 passed` |
| Dynamic fill、A5/PTO SyncInsertVS、tail/workspace、elementwise、CV copy 回归 | `512 passed, 1 xfailed, 3 skipped` |
| Benchmark changed-file Ruff lint / format | 通过 |

`test_ub_to_l1_special_shapes[pto]` 的 16x16 特殊形状在本 PR 与父提交 `272c0ab3`
上均会产生 NaN/Inf，因此记录为既有 PTO 基线问题，不归因于本改动。

## Suggested review order

1. `docs/ascend/compiler_managed_vector_mask_inventory.md` 与
   `src/op/ascend_vector_mask_ops.inc`：确认兼容域和 contract 分组。
2. `ascend_vector_mask_contract.cc` 与 `ascend_vector_instruction_selection.cc`：确认 selected
   terminal、payload 和严格诊断。
3. `ascend_vector_mask_legalize.cc`：确认直线与控制流的 must-fact 合并和最小 repair。
4. `phase.py`、metadata bridges 与 `codegen_ascend.cc`：确认 pass 边界和机械 emission。
5. `test_tilelang_ascend_vector_mask.py` 与 benchmark：确认结构、随机属性、源码和性能覆盖。
