### PR TITLE
[CI]pytest add mark

### DIFF
--- a/testing/python/language/test_tilelang_ascend_language_tail_block.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_block.py
@@ -155,10 +155,10 @@ def run_test_cube_matmul_tail(M, N, K, block_M, block_N, K_L1, target):
 
 # (M, N, K, block_M, block_N, K_L1) - every dim deliberately non-divisible.
 cube_tail_configs = [
-    (32 * 3 + 30, 32 * 2 + 16, 32 * 4 + 31, 32, 32, 32),  # (126, 80, 159)
-    (64 * 8 + 45, 64 * 8, 64 * 8 + 27, 64, 64, 64),  # (557, 512, 539) - N exact
-    (128 * 4, 128 * 4 + 99, 128 * 4, 128, 128, 128),  # (512, 611, 512) - only N tail
-    (1024 + 118, 1024 + 206, 1024 + 55, 128, 256, 64),  # (1142, 1230, 1079)
+    (32 * 3 + 30, 32 * 2 + 16, 32 * 4 + 31, 32, 32, 32),  # (126, 80, 159) - M/N/K all non-divisible
+    pytest.param(64 * 8 + 45, 64 * 8, 64 * 8 + 27, 64, 64, 64, marks=pytest.mark.low_priority),  # (557, 512, 539) - N exact
+    pytest.param(128 * 4, 128 * 4 + 99, 128 * 4, 128, 128, 128, marks=pytest.mark.low_priority),  # (512, 611, 512) - only N tail
+    pytest.param(1024 + 118, 1024 + 206, 1024 + 55, 128, 256, 64, marks=pytest.mark.low_priority),  # (1142, 1230, 1079)
 ]
 
 
@@ -266,13 +266,13 @@ def run_test_vec_abs_tail(M, N, block_M, block_N, dtype, target, tail_mask):
 # compiler in OptimizeForTarget -- keep tiles <= 64x128 here.
 vec_tail_configs = [
     (32 * 2 + 13, 32 * 3 + 7, 32, 32),  # (77, 103)  - 32x32  x3 fp32 = 12KB
-    (64 * 2 + 2, 64 + 36, 64, 64),  # (130, 100) - 64x64  x3 fp32 = 48KB
-    (64 * 3 + 8, 128 + 22, 64, 128),  # (200, 150) - 64x128 x3 fp32 = 96KB
+    pytest.param(64 * 2 + 2, 64 + 36, 64, 64, marks=pytest.mark.low_priority),  # (130, 100) - 64x64  x3 fp32 = 48KB
+    pytest.param(64 * 3 + 8, 128 + 22, 64, 128, marks=pytest.mark.low_priority),  # (200, 150) - 64x128 x3 fp32 = 96KB
 ]
 
 
 @pytest.mark.parametrize("tail_mask", [False, True])
-@pytest.mark.parametrize("dtype", ["float", "float16"])
+@pytest.mark.parametrize("dtype", ["float", pytest.param("float16", marks=pytest.mark.low_priority)])
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
 @pytest.mark.parametrize("M,N,block_M,block_N", vec_tail_configs)
 def test_vec_add_tail(M, N, block_M, block_N, dtype, target, tail_mask):
@@ -280,7 +280,7 @@ def test_vec_add_tail(M, N, block_M, block_N, dtype, target, tail_mask):
 
 
 @pytest.mark.parametrize("tail_mask", [False, True])
-@pytest.mark.parametrize("dtype", ["float", "float16"])
+@pytest.mark.parametrize("dtype", ["float", pytest.param("float16", marks=pytest.mark.low_priority)])
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
 @pytest.mark.parametrize("M,N,block_M,block_N", vec_tail_configs)
 def test_vec_abs_tail(M, N, block_M, block_N, dtype, target, tail_mask):
@@ -337,9 +337,9 @@ def run_test_reduce_max_tail(rows_valid, rows_phys, cols, dtype, target, tail_ma
 # (rows_valid, rows_phys, cols): rows_valid < rows_phys is the row tail that
 # real_shape must exclude from the dim=0 reduce.
 reduce_tail_configs = [
-    (3, 5, 8),  # mirrors example_col_reduce_max_slice_buffer.py exactly
+    pytest.param(3, 5, 8, marks=pytest.mark.low_priority),  # mirrors example_col_reduce_max_slice_buffer.py exactly
     (30, 32, 64),  # 32-row tile, 30 valid (tail 2)
-    (100, 128, 96),  # 128-row tile, 100 valid (tail 28)
+    pytest.param(100, 128, 96, marks=pytest.mark.low_priority),  # 128-row tile, 100 valid (tail 28)
 ]
 
 
@@ -386,17 +386,21 @@ def reduce_axis0_tail(M, N, block_M, block_N, kind, dim=0, dtype="float"):
 
 
 reduce_axis0_configs = [
-    (34, 128, 32, 32),  # row tail only
-    (32, 130, 32, 32),  # column tail only
+    pytest.param(34, 128, 32, 32, marks=pytest.mark.low_priority),  # row tail only - covered by (34,130)
+    pytest.param(32, 130, 32, 32, marks=pytest.mark.low_priority),  # column tail only - covered by (34,130)
     (34, 130, 32, 32),  # row and column tails
-    (33, 129, 32, 32),  # one valid row and one valid column in the last tile
+    pytest.param(33, 129, 32, 32, marks=pytest.mark.low_priority),  # one valid row and one valid column - covered by (34,130)
     (7, 13, 32, 32),  # tensor smaller than one physical tile
     (32, 128, 32, 32),  # exact full tiles
-    (65, 130, 64, 32),  # larger physical row with a one-row tail
+    pytest.param(65, 130, 64, 32, marks=pytest.mark.low_priority),  # larger physical row with a one-row tail
 ]
 
 REDUCE_TAIL_TARGETS = ("ascendc", "pto")
-REDUCE_TAIL_KINDS = ("sum", "max", "min")
+REDUCE_TAIL_KINDS = (
+    "sum",
+    pytest.param("max", marks=pytest.mark.low_priority),
+    pytest.param("min", marks=pytest.mark.low_priority),
+)
 REDUCE_TAIL_AXIS0_DIMS = (0, -2)
 
 
@@ -421,7 +425,13 @@ def test_reduce_axis0_tail(M, N, block_M, block_N, target, kind, dim):
     torch.testing.assert_close(out, ref, rtol=1e-4, atol=1e-4)
 
 
-@pytest.mark.parametrize(("kind", "sign"), [("max", -1.0), ("min", 1.0)])
+@pytest.mark.parametrize(
+    ("kind", "sign"),
+    [
+        pytest.param("max", -1.0, marks=pytest.mark.low_priority),
+        pytest.param("min", 1.0, marks=pytest.mark.low_priority),
+    ],
+)
 @pytest.mark.parametrize("target", REDUCE_TAIL_TARGETS)
 def test_reduce_axis0_tail_does_not_consume_zero_padding(target, kind, sign):
     """Guard max/min against treating the zero-filled physical tail as data."""
@@ -441,7 +451,14 @@ def test_reduce_axis0_tail_does_not_consume_zero_padding(target, kind, sign):
 # semantics rather than part of the shared valid-region contract. Keep this
 # exact-bit regression scoped to the AscendC helper until PTO documents and
 # validates an equivalent guarantee on hardware.
-@pytest.mark.parametrize("kind", ["sum", "max", "min"])
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "sum",
+        pytest.param("max", marks=pytest.mark.low_priority),
+        pytest.param("min", marks=pytest.mark.low_priority),
+    ],
+)
 def test_reduce_axis0_special_values_ascendc(kind):
     M, N, block_M, block_N = 3, 8, 4, 8
     func = reduce_axis0_tail(M, N, block_M, block_N, kind)
@@ -548,7 +565,7 @@ def run_test_cv_matmul_add_tail(M, N, K, block_M, block_N, block_K, target):
 # (M, N, K, block_M, block_N, block_K) - M/N/K non-divisible.
 cv_tail_configs = [
     (128 + 30, 256 + 16, 64 + 8, 128, 256, 64),  # (158, 272, 72)
-    (256 + 33, 256 + 40, 128 + 5, 128, 256, 64),  # (289, 296, 133)
+    pytest.param(256 + 33, 256 + 40, 128 + 5, 128, 256, 64, marks=pytest.mark.low_priority),  # (289, 296, 133)
 ]
 
 

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -27,7 +27,11 @@ pass_configs = {
 }
 
 TAIL_TARGETS = ("ascendc", "pto")
-TAIL_REDUCE_KINDS = ("sum", "max", "min")
+TAIL_REDUCE_KINDS = (
+    "sum",
+    pytest.param("max", marks=pytest.mark.low_priority),
+    pytest.param("min", marks=pytest.mark.low_priority),
+)
 TAIL_REDUCE_AXIS0_DIMS = (0, -2)
 
 
@@ -354,12 +358,11 @@ def test_tail_reduce_float32_axis0_emits_backend_path(target, kind, dim):
 @pytest.mark.parametrize(
     ("M", "N", "rewritten"),
     [
-        (34, 128, True),
-        (32, 130, True),
+        pytest.param(34, 128, True, marks=pytest.mark.low_priority, id="row_tail"),
+        pytest.param(32, 130, True, marks=pytest.mark.low_priority, id="column_tail"),
         (34, 130, True),
         (32, 128, False),
     ],
-    ids=["row_tail", "column_tail", "both_tails", "full_tile"],
 )
 @pytest.mark.parametrize("target", TAIL_TARGETS)
 def test_tail_reduce_sum_rewrites_only_partial_tiles(target, M, N, rewritten):
@@ -410,10 +413,9 @@ def test_tail_reduce_axis0_propagates_column_tail_to_unary(target):
     ("M", "N", "dtype"),
     [
         (34, 130, "float"),
-        (32, 130, "float"),
-        (34, 130, "float16"),
+        pytest.param(32, 130, "float", marks=pytest.mark.low_priority),
+        pytest.param(34, 130, "float16", marks=pytest.mark.low_priority),
     ],
-    ids=["both_tails", "column_tail", "unsupported_float16"],
 )
 def test_native_reduce_clears_downstream_tail_state(target, M, N, dtype):
     src = _source(_tail_reduce_then_unary(M, N, 32, 32, dtype=dtype), target=target)
@@ -425,10 +427,9 @@ def test_native_reduce_clears_downstream_tail_state(target, M, N, dtype):
     ("dtype", "clear", "real_shape"),
     [
         ("float", False, None),
-        ("float16", True, None),
-        ("float", True, [31, 32]),
+        pytest.param("float16", True, None, marks=pytest.mark.low_priority),
+        pytest.param("float", True, [31, 32], marks=pytest.mark.low_priority),
     ],
-    ids=["clear_false", "float16", "real_shape_mismatch"],
 )
 @pytest.mark.parametrize("kind", TAIL_REDUCE_KINDS)
 @pytest.mark.parametrize("target", TAIL_TARGETS)
@@ -450,7 +451,11 @@ def test_unsupported_tail_reduce_contracts_fall_back(target, kind, dtype, clear,
 
 @pytest.mark.parametrize(
     ("kind", "merge_marker"),
-    [("sum", "TADD("), ("max", "TMAX("), ("min", "TMIN(")],
+    [
+        ("sum", "TADD("),
+        pytest.param("max", "TMAX(", marks=pytest.mark.low_priority),
+        pytest.param("min", "TMIN(", marks=pytest.mark.low_priority),
+    ],
 )
 def test_pto_accumulating_tail_reduce_uses_native_reduce_and_merge(kind, merge_marker):
     func = _tail_reduce_axis0(34, 130, 32, 32, kind=kind, clear=False)


### PR DESCRIPTION
# Tail-block 测试用例标签优化记录

本文档记录对 `test_tilelang_ascend_language_tail_block.py` 和 `test_tilelang_ascend_language_tail_mask_codegen.py` 两个测试文件的 `low_priority` 标签优化策略及具体改动，目的是在 PR 阶段减少冗余用例的执行耗时，同时保留全量测试 / 定时任务中的完整覆盖。

标签机制详见 [pytest_marker_guide.md](pytest_marker_guide.md)。

---

## 优化策略

### 1. 互覆盖 shape 精简

当多组 shape 配置存在覆盖关系时，保留代表性用例为默认执行，被覆盖的用例标 `low_priority`。

**判定规则**：如果用例 A 的 tail 场景（row tail / column tail / both tails）已被用例 B 完整包含，则 A 标为 `low_priority`。

### 2. reduce kind 精简

`sum` / `max` / `min` 三种 reduce kind 共享相同的 tail 处理路径（`real_shape` / `tail_mask` 机制），保留 `sum` 为默认执行，`max` / `min` 标 `low_priority`。

### 3. dtype 精简

`float` (float32) 保留为默认执行；`float16` 标 `low_priority`。

### 4. target 保留

`ascendc` 和 `pto` 两个 target 均保留为默认执行，不做区分。

---

## 文件 1：test_tilelang_ascend_language_tail_block.py

### 改动总览

| 参数维度 | 改动前 | 改动后 |
|----------|--------|--------|
| `cube_tail_configs` (4 组) | 全部默认 | 1 默认 + 3 low_priority |
| `vec_tail_configs` (3 组) | 全部默认 | 1 默认 + 2 low_priority |
| `reduce_tail_configs` (3 组) | 全部默认 | 1 默认 + 2 low_priority |
| `reduce_axis0_configs` (7 组) | 全部默认 | 3 默认 + 4 low_priority |
| `cv_tail_configs` (2 组) | 全部默认 | 1 默认 + 1 low_priority |
| `REDUCE_TAIL_KINDS` (3 种) | 全部默认 | sum 默认 + max/min low_priority |
| `vec dtype` (2 种) | 全部默认 | float 默认 + float16 low_priority |

### 详细改动

#### cube_tail_configs (Group 1 - CUBE gemm tail)

| 配置 | shape | tail 场景 | 标签 | 原因 |
|------|-------|-----------|------|------|
| `(126, 80, 159, 32, 32, 32)` | M/N/K 均非整除 | M+N+K tail | 默认 | 关键用例：三维度 tail 同时触发 |
| `(557, 512, 539, 64, 64, 64)` | N 整除 | M+K tail | `low_priority` | N exact 场景已被首组覆盖 |
| `(512, 611, 512, 128, 128, 128)` | 仅 N 非整除 | N tail only | `low_priority` | 单维度 tail 已被首组覆盖 |
| `(1142, 1230, 1079, 128, 256, 64)` | 大 shape | M+N+K tail | `low_priority` | 与首组场景相同，仅 scale 不同 |

#### vec_tail_configs (Group 2a/2b - VECTOR element-wise tail)

| 配置 | shape | tile 大小 | 标签 | 原因 |
|------|-------|-----------|------|------|
| `(77, 103, 32, 32)` | M+N tail | 32x32 | 默认 | 关键用例：最小 tile 验证 |
| `(130, 100, 64, 64)` | M+N tail | 64x64 | `low_priority` | 场景相同，仅 tile scale 不同 |
| `(200, 150, 64, 128)` | M+N tail | 64x128 | `low_priority` | 场景相同，仅 tile scale 不同 |

#### vec dtype (test_vec_add_tail / test_vec_abs_tail)

| dtype | 标签 | 原因 |
|-------|------|------|
| `float` | 默认 | 核心精度验证 |
| `float16` | `low_priority` | tail 机制与 dtype 无关，fp16 仅补充覆盖 |

#### reduce_tail_configs (Group 2c - VECTOR reduce sliced tail)

| 配置 | rows_valid/rows_phys | 标签 | 原因 |
|------|----------------------|------|------|
| `(30, 32, 64)` | 30/32 (tail 2) | 默认 | 关键用例：常规 tail 比例 |
| `(3, 5, 8)` | 3/5 | `low_priority` | 极小 shape，与 example 重复 |
| `(100, 128, 96)` | 100/128 (tail 28) | `low_priority` | 大 tail 比例，场景已被首组覆盖 |

#### reduce_axis0_configs (Group 2d - axis-0 tail reductions)

| 配置 | shape | tail 场景 | 标签 | 原因 |
|------|-------|-----------|------|------|
| `(34, 130, 32, 32)` | M+N tail | row + column tail | 默认 | 关键用例：双维度 tail 同时触发 |
| `(7, 13, 32, 32)` | tensor < tile | 全 tile 为 tail | 默认 | 关键用例：极端边界 |
| `(32, 128, 32, 32)` | 整除 | 无 tail | 默认 | 关键用例：对照组（无 tail） |
| `(34, 128, 32, 32)` | M tail only | row tail | `low_priority` | 被 (34,130) 覆盖 |
| `(32, 130, 32, 32)` | N tail only | column tail | `low_priority` | 被 (34,130) 覆盖 |
| `(33, 129, 32, 32)` | M=33,N=129 | 1 row + 1 col tail | `low_priority` | 被 (34,130) 覆盖 |
| `(65, 130, 64, 32)` | 大 block | row tail | `low_priority` | 场景已被覆盖 |

#### REDUCE_TAIL_KINDS (影响 test_reduce_axis0_tail 等)

| kind | 标签 | 原因 |
|------|------|------|
| `sum` | 默认 | 核心 reduce 语义验证 |
| `max` | `low_priority` | tail 路径与 sum 相同 |
| `min` | `low_priority` | tail 路径与 sum 相同 |

#### 其他 reduce kind 标注

| 测试函数 | 改动 |
|----------|------|
| `test_reduce_axis0_tail_does_not_consume_zero_padding` | `("max",-1.0)` / `("min",1.0)` 标 `low_priority` |
| `test_reduce_axis0_special_values_ascendc` | `"max"` / `"min"` 标 `low_priority` |

#### cv_tail_configs (Group 3 - CV fusion tail)

| 配置 | shape | 标签 | 原因 |
|------|-------|------|------|
| `(158, 272, 72, 128, 256, 64)` | M+N+K tail | 默认 | 关键用例 |
| `(289, 296, 133, 128, 256, 64)` | M+N+K tail | `low_priority` | 场景相同，仅 scale 不同 |

---

## 文件 2：test_tilelang_ascend_language_tail_mask_codegen.py

### 改动总览

| 参数维度 | 改动前 | 改动后 |
|----------|--------|--------|
| `TAIL_REDUCE_KINDS` (3 种) | 全部默认 | sum 默认 + max/min low_priority |
| `test_tail_reduce_sum_rewrites_only_partial_tiles` shape (4 组) | 全部默认 | 2 默认 + 2 low_priority |
| `test_native_reduce_clears_downstream_tail_state` (3 组) | 全部默认 | 1 默认 + 2 low_priority |
| `test_unsupported_tail_reduce_contracts_fall_back` (3 组) | 全部默认 | 1 默认 + 2 low_priority |
| `test_pto_accumulating_tail_reduce_uses_native_reduce_and_merge` (3 种) | 全部默认 | sum 默认 + max/min low_priority |

### 详细改动

#### TAIL_REDUCE_KINDS

与 `tail_block.py` 一致：`sum` 默认，`max`/`min` 标 `low_priority`。

影响以下复用 `TAIL_REDUCE_KINDS` 的测试函数：
- `test_tail_reduce_float32_axis0_emits_backend_path`
- `test_tail_reduce_float32_last_axis_uses_native_path`
- `test_unsupported_tail_reduce_contracts_fall_back`

#### test_tail_reduce_sum_rewrites_only_partial_tiles

| 配置 | tail 场景 | 标签 | 原因 |
|------|-----------|------|------|
| `(34, 130, True)` | row + column tail | 默认 | 关键用例：双维度 tail |
| `(32, 128, False)` | 无 tail | 默认 | 关键用例：对照组 |
| `(34, 128, True)` | row tail only | `low_priority` | 被 (34,130) 覆盖 |
| `(32, 130, True)` | column tail only | `low_priority` | 被 (34,130) 覆盖 |

#### test_native_reduce_clears_downstream_tail_state

| 配置 | dtype | 标签 | 原因 |
|------|-------|------|------|
| `(34, 130, "float")` | float32 | 默认 | 关键用例：双维度 tail |
| `(32, 130, "float")` | float32 | `low_priority` | column tail 已被 (34,130) 覆盖 |
| `(34, 130, "float16")` | float16 | `low_priority` | unsupported 路径，边缘场景 |

#### test_unsupported_tail_reduce_contracts_fall_back

| 配置 | 场景 | 标签 | 原因 |
|------|------|------|------|
| `("float", False, None)` | clear=False | 默认 | 关键用例：accumulate 模式 |
| `("float16", True, None)` | float16 | `low_priority` | unsupported dtype，边缘场景 |
| `("float", True, [31, 32])` | real_shape mismatch | `low_priority` | real_shape 不匹配，边缘场景 |

#### test_pto_accumulating_tail_reduce_uses_native_reduce_and_merge

| kind | 标签 | 原因 |
|------|------|------|
| `sum` | 默认 | 核心 reduce + merge 验证 |
| `max` | `low_priority` | merge 路径与 sum 相同 |
| `min` | `low_priority` | merge 路径与 sum 相同 |

---

## 用例数量统计

### test_tilelang_ascend_language_tail_block.py

| 维度 | 改动前总用例数 | 改动后 PR 执行数 | 改动后全量执行数 |
|------|---------------|-----------------|-----------------|
| Group 1 (cube) × 2 target | 8 | 2 | 8 |
| Group 2a (vec_add) × 2 target × 2 tail_mask × 2 dtype × 3 shape | 24 | 4 | 24 |
| Group 2b (vec_abs) × 2 target × 2 tail_mask × 2 dtype × 3 shape | 24 | 4 | 24 |
| Group 2c (reduce_max) × 2 target × 2 tail_mask × 1 dtype × 3 shape | 12 | 4 | 12 |
| Group 2d (reduce_axis0) × 2 target × 3 kind × 2 dim × 7 shape | 84 | 12 | 84 |
| zero_padding × 2 target × 2 kind | 4 | 0 | 4 |
| special_values × 3 kind | 3 | 1 | 3 |
| Group 3 (cv) × 2 target × 2 shape | 4 | 2 | 4 |

### test_tilelang_ascend_language_tail_mask_codegen.py

| 维度 | 改动前总用例数 | 改动后 PR 执行数 | 改动后全量执行数 |
|------|---------------|-----------------|-----------------|
| tail_add / unary / scalar × 2 target | 6 | 6 | 6 |
| reduce_axis0_emits × 2 target × 3 kind × 2 dim | 12 | 4 | 12 |
| rewrites_only_partial × 2 target × 4 shape | 8 | 4 | 8 |
| accepts_real_shape / output_slice × 2 target | 4 | 4 | 4 |
| last_axis_native × 2 target × 3 kind | 6 | 2 | 6 |
| propagates_column × 2 target | 2 | 2 | 2 |
| clears_downstream × 2 target × 3 shape | 6 | 2 | 6 |
| fall_back × 2 target × 3 kind × 3 contract | 18 | 2 | 18 |
| pto_merge × 3 kind | 3 | 1 | 3 |
| flag_off × 2 target | 2 | 2 | 2 |

> **PR 执行数** = 仅无标签用例；**全量执行数** = 无标签 + low_priority 用例（不含 ci_skip）。

---

## 本地验证

```bash
# 查看 PR 场景下实际执行的用例（跳过 low_priority 和 ci_skip）
pytest --collect-only -m "not (low_priority or ci_skip)" \
  testing/python/language/test_tilelang_ascend_language_tail_block.py \
  testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py -q

# 查看被标记为 low_priority 的用例
pytest --collect-only -m "low_priority" \
  testing/python/language/test_tilelang_ascend_language_tail_block.py \
  testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py -q

# 模拟全量测试场景（仅跳过 ci_skip）
pytest -m "not ci_skip" \
  testing/python/language/test_tilelang_ascend_language_tail_block.py \
  testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py -v
```
