### PR TITLE
[Fix] Make bench_test honor example exit status

### DIFF
--- a/examples/bench_test.sh
+++ b/examples/bench_test.sh
@@ -484,13 +484,13 @@ for script in "${all_scripts[@]}"; do
         fi
 
         # 结果判定逻辑
-        # 判定条件：
-        # 1. 原有正则匹配 (KERNEL OUTPUT MATCH 或 TEST PASSED!)
-        # 2. OR (是自定义任务 且 退出码为 0)
+        # 1. 进程必须正常退出
+        # 2. 任务还必须匹配 KERNEL OUTPUT MATCH 或 TEST PASSED!
         last_line=$(echo "$output" | tail -n 1)
-        if [[ "$output" =~ [Kk][Ee][Rr][Nn][Ee][Ll][[:space:]][Oo][Uu][Tt][Pp][Uu][Tt][[:space:]][Mm][Aa][Tt][Cc][Hh] ]] || \
-           [[ "$output" =~ [Tt][Ee][Ss][Tt][[:space:]][Pp][Aa][Ss][Ss][Ee][Dd][!] ]] || \
-           [[ "$script" == CUSTOM_TASK::* && $exit_code -eq 0 ]]; then
+        if (( exit_code == 0 )) && {
+            [[ "$output" =~ [Kk][Ee][Rr][Nn][Ee][Ll][[:space:]][Oo][Uu][Tt][Pp][Uu][Tt][[:space:]][Mm][Aa][Tt][Cc][Hh] ]] ||
+            [[ "$output" =~ [Tt][Ee][Ss][Tt][[:space:]][Pp][Aa][Ss][Ss][Ee][Dd][!] ]]
+        }; then
             echo "[PASSED] $current_script_ref"
             touch "$temp_dir/pass_$total_scripts"
         else
@@ -513,6 +513,10 @@ wait # 等待所有任务完成
 passed_scripts=$(ls "$temp_dir" | grep "pass_" | wc -l)
 failed_scripts=$((total_scripts - passed_scripts))
 rm -rf "$temp_dir" # 清理计数文件
+bench_exit_code=0
+if (( failed_scripts > 0 )); then
+    bench_exit_code=1
+fi
 
 echo -e "\n====================================="
 echo "Execution Summary"
@@ -527,7 +531,10 @@ if [ "$SKIP_PYTEST" = true ]; then
     echo -e "\n====================================="
     echo "Skipping pytest (only examples/ .py/.md/.png files modified)"
     echo "====================================="
-    exit $operator_exit_code
+    if (( operator_exit_code != 0 )); then
+        exit "$operator_exit_code"
+    fi
+    exit "$bench_exit_code"
 fi
 
 echo -e "\n====================================="
@@ -661,7 +668,10 @@ echo "====================================="
 # 清理临时文件
 rm -f pytest_output.log
 
-if [ "$pytest_exit_code" -eq 0 ]; then
-    exit $operator_exit_code
+if (( pytest_exit_code != 0 )); then
+    exit "$pytest_exit_code"
 fi
-exit $pytest_exit_code
+if (( operator_exit_code != 0 )); then
+    exit "$operator_exit_code"
+fi
+exit "$bench_exit_code"

--- a/examples/sparse_flash_attention/bench_sfa/bench_sfa.py
+++ b/examples/sparse_flash_attention/bench_sfa/bench_sfa.py
@@ -78,7 +78,7 @@ def test_op(T, B, KV_S, Q_N, KV_N, D, D_rope, sparse_size, scale_value, sparse_b
             out = out.to(first_out.dtype)
             torch.testing.assert_close(out, first_out, rtol=1e-2, atol=1e-2, equal_nan=True)
     print(f"(last op) {tl_op.__name__} {out=}")
-    print("[PASSED]")
+    print(f"Case completed: T={T}, KV_S={KV_S}")
 
 
 from sparse_flash_attn_pa import init_test
@@ -151,3 +151,4 @@ test_op(
     act_kv_s=2560,
     tl_ops=tl_ops,
 )
+print("Kernel Output Match!")


### PR DESCRIPTION
## Summary

- require every benchmark task to exit successfully and emit an existing success marker before it can pass
- standardize the four custom sparse-attention tasks through their shared `bench_sfa.py` harness, which now emits one final `Kernel Output Match!` only after all cases complete
- return a nonzero status when any legacy example fails, while preserving operator and pytest failures

## Context

Issue #1423 showed that `bench_test.sh` could report an example as passed after it printed an early success marker and then failed with a nonzero status. PR #1496 has since fixed the Reduce workspace behavior that caused `rms_norm_grad` to fail, without requiring an `rms_norm.py` workaround. This PR addresses the remaining runner false positive and removes the custom-task result-classification exception.

Closes #1423.

## Scope

This retains the existing legacy success markers for ordinary examples. A normal example that exits 0 after printing an earlier per-case success marker can still be ambiguous; introducing a unique terminal result contract across the remaining examples is a separate migration.