### PR TITLE
Fix: Remove redundant rank check in `T.tile.atomic_add` BufferRegion branch

### DIFF
--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -295,8 +295,6 @@ def _atomic_add_to_tile_region(data, access_type: str, extents: list[PrimExpr]):
     if isinstance(data, BufferRegion):
         mins = [x.min for x in data.region]
         region_extents = [x.extent for x in data.region]
-        if len(region_extents) < len(extents):
-            raise ValueError(f"{_ATOMIC_ADD_V1_ERR} Region rank is smaller than inferred extent rank.")
         return _tile_region(
             T.BufferLoad(data.buffer, mins),
             access_type,


### PR DESCRIPTION

## 问题背景

Issue #1566 报告：当 `T.tile.atomic_add` 的 dst 和 src 是不同 rank 的 buffer 时，Python 前端报错：

```
T.tile.atomic_add V1 only supports local tensor -> GM atomic add.
Region rank is smaller than inferred extent rank.
```

复现代码：

```python
ws_dv: T.Tensor([2, 256, 2, 128], "float")  # 4D GM buffer
l0c  = T.alloc_L0C([2, 128, 128], "float")   # 3D L0C buffer

T.tile.atomic_add(
    ws_dv[0, 0:128, 0, 0:128],  # dst: 4D, dim1/dim3 切片
    l0c[0, :, :],                # src: 3D, 完整 2D slice
)
```

## 原因分析

`atomic_add` 的执行流程：

1. `_atomic_add_extent` — 分别提取 dst（4D `[1,128,1,128]`）和 src（3D `[1,128,128]`）的 extent
2. `_merge_atomic_add_extents` — 合并两侧 extent，将低 rank 一侧填充到高 rank，得到 merged extent `[1,128,128,128]`
3. `_atomic_add_to_tile_region` — 把 dst/src 转成 `tl.region` IR 节点，传入 merged extent

问题出在第 3 步的 `BufferRegion` 分支（`ascend_tile.py:285-286`）：

```python
if isinstance(data, BufferRegion):
    mins = [x.min for x in data.region]
    region_extents = [x.extent for x in data.region]
    if len(region_extents) < len(extents):           # ← 冗余检查
        raise ValueError(...)                         # ← 误报
    return _tile_region(..., *region_extents)         # ← 用的是 region_extents，不是 extents
```

**`extents` 参数在该分支中仅用于检查，返回值用的是 `region_extents`（buffer 自身的维度）。** 当 src 是 3D `BufferRegion`、merged extent 被 `_merge_atomic_add_extents` 填充到 4D 时，`len(region_extents)=3 < len(extents)=4` 触发误报。

三个分支行为不一致也印证了这是 bug：

| 分支 | 是否检查 rank | 跨 rank 行为 |
|------|:---:|------|
| `Buffer` | 否 | 允许 |
| `BufferRegion` | 是（检查未使用的参数） | **拒绝** |
| `BufferLoad` | 调整 extents 适配 | 允许 |

## C++ codegen 已支持该模式

C++ codegen（`src/op/ascend.cc`）独立处理每个 buffer 的维度，不要求 src/dst rank 相同：

- `find_active_dim_indices`（line 724）：找到 extent≠1 的维度，正确识别 dim1 和 dim3
- `compute_strideN`（line 677）：折叠 extent=1 的维度，计算行间 stride = 256
- rank 校验（line 756-761）：只检查每个 region 与**自身 buffer** 的 rank 匹配，不要求 src/dst rank 相同

## 修复方式

移除 `BufferRegion` 分支中检查未使用参数的 2 行冗余代码：

```diff
     if isinstance(data, BufferRegion):
         mins = [x.min for x in data.region]
         region_extents = [x.extent for x in data.region]
-        if len(region_extents) < len(extents):
-            raise ValueError(f"{_ATOMIC_ADD_V1_ERR} Region rank is smaller than inferred extent rank.")
         return _tile_region(
             T.BufferLoad(data.buffer, mins),
             access_type,
             *region_extents,
         )
```

移除后三个分支行为一致，`BufferRegion` 分支直接使用自身携带的 `region_extents`。

## 测试结论

- issue 复现脚本：**编译成功，不再报错** ✅
- `test_tilelang_ascend_language_tile_atomic_add.py`（8 个用例，1D/2D/L0C-GEMM × ascendc/pto）：**全部通过** ✅
- `test_tilelang_ascend_language_copy_runtime_extent.py` 中 2 个 atomic_add 用例失败：**修改前就存在**，是 TVM parser 对动态变量的 slice 处理 bug，与本次修复无关
