### PR TITLE
Enhance the tilelang-perf-optimization skills with performance bottleneck analysis and a layered priority framework

### DIFF
--- a/.agents/skills/tilelang-perf-optimization/SKILL.md
+++ b/.agents/skills/tilelang-perf-optimization/SKILL.md
@@ -63,6 +63,35 @@ print(func.get_kernel_source())
 | `IS_ASCEND_AIV` 出现 | Vector 型 | RoPE、Softmax、Add |
 | 两者均出现 | 混合型 | FlashAttention、SparseFlashAttention |
 
+### Step 2.5: Roofline 瓶颈分析（Vector 核强制，Cube 核建议）
+
+算子类型的判断只回答了"算什么核"，但"优化方向选 GM 流量还是计算吞吐"需要通过 Arithmetic Intensity 判定。跳过这一步容易在 Memory-Bound 算子上做指令融合、或在 Compute-Bound 算子上做 Pass 融合——方向性浪费。
+
+**计算步骤**：
+
+1. **GM 流量统计**：统计 kernel 所有 pass 的 GM 读取/写入总字节数。多 pass 架构要算每遍读取的所有 tensor（含 weight、参数 tile）。
+2. **有效 FLOPs 统计**：统计每次 kernel 执行的浮点操作数（包括 add、mul、cmp 等，cast 可近似算 0.5 FLOP）。
+3. **Arithmetic Intensity**：`AI = FLOPs / GM_Bytes`（单位 FLOP/Byte）。
+4. **对照硬件平衡点**：
+
+   | 核类型 | 平衡点 (FLOP/Byte) | 说明 |
+   |--------|-------------------|------|
+   | AIV (Vector) | 10-20 | Vector pipe 单位带宽吞吐 |
+   | AIC (Cube) | 30-50 | Matrix pipe 单位带宽吞吐 |
+   | Mix | 取主路径 | 按实际耗时主导核判定 |
+
+5. **判定结论**：
+
+   | 判定 | 条件 | 主要优化方向 |
+   |------|------|-------------|
+   | 强 Memory-Bound | AI < 平衡点 / 2 | **减少 GM 流量**：Pass 融合（归约/输出）、block_N 扩展、数据复用 |
+   | 弱 Memory-Bound | 平衡点/2 ≤ AI ≤ 平衡点 | GM 流量和计算吞吐并行 |
+   | Compute-Bound | AI > 平衡点 × 2 | **提升计算吞吐**：指令融合、分块计算、Double Buffer 重叠 |
+
+6. **理论最小时间**：`T_min = GM_Bytes / HBM_Bandwidth`（910B ≈ 1.6 TB/s）。实测时间 / T_min 即为当前效率指标。
+
+**输出位置**：写入 `optimization_log.md` 的 Roofline 分析段落，包含 FLOPs、GM 字节、AI 值、判定结论、理论最小时间、理论最大加速比。Memory-Bound 算子的优化方向全部围绕"减少 GM 流量"展开，后续 Part A 只列出此类优化的适用项；Compute-Bound 算子反过来。
+
 ### Step 3: 识别优化点（强制，禁止与 Step 4 合并）
 
 先读取 `optimization-guide.md` 的目录和各章节标题 + `performance-antipatterns.md` 的各条目标题，根据算子类型（Step 2 判定）和算子实现特征初步筛选出可能适用的优化点清单。再针对每个候选优化点，读取其"适用场景"、"约束"、"使用条件"等描述，确认是否真正适用。如果是 cube 核额外参考 `best-practices/cube_optimization_path.md`，如果是 vector 核额外参考 `vector-practices/` 目录下的文档。
@@ -91,15 +120,37 @@ plan: direct-reuse / repair-kernel-first / new-kernel-first
 
 > **重点**：每节都需读取其"适用场景"和"约束"描述确认是否适用。仅当章节标题明确标注了特定算子类型专属（如"Cube 核"）且当前算子不属于该类型时，才可初步排除；其余所有章节必须读约束确认，不得仅凭标题或算子类型跳过。
 
-**Part B `[ORDER-PLAN]`**：分析依赖关系，排出实施顺序链。依赖分析三条规则：
+**Part B `[ORDER-PLAN]`**：先按**三层优先级框架**确定大跨层执行顺序，每层内按三条依赖规则确定细粒度顺序。
+
+#### 三层优先级框架
+
+改变 kernel 结构的优化必须先做完（因为上层改动会迫使下层返工），稳定代码上的微优化放到最后（避免被上层改动破坏）。如果某层所有优化点都被标记为"不适用"，直接跳到下一层。
+
+| 层次 | 定义 | 典型优化项 | 执行理由 |
+|------|------|-----------|---------|
+| **L0 算法层** | 改变计算等价性、减少扫描遍数、改变数据流 | Pass 融合（归约遍数 + 输出遍数）、Online 修正公式、数学等价变换 | 改变 kernel 结构 → 后续所有预算和循环都需重算 |
+| **L1 架构层** | 调整 tile 参数、减少 DMA 头开销 | block_N/block_M 扩展（UB 预算反推）、多行 Tile 粒度 | 改变循环次数，是 Double Buffer 的前置依赖 |
+| **L2 流水层** | 重叠搬运与计算 | Double Buffer、T.Pipelined、num_stages | 依赖循环结构和 tile 参数已稳定 |
+| **L3 细节层** | 不改变结构的指令/配置级微调 | 指令融合（mul_add_dst、rsqrt）、Fixed Core、pass_configs 微调、Host 侧优化 | 在稳定代码上做微优化，避免被上层改动破坏 |
+
+#### 层内依赖规则
+
+层内按以下三条依赖规则排序：
 1. **布局依赖**：改变 layout 的优化排在依赖此 layout 的优化之前
 2. **数量依赖**：涉及预算的优化排在改变 buffer 数量的优化之后
 3. **配置依赖**：涉及 pass_configs 的优化在相关功能实施后才改动
 
+#### 输出模板
+
+每条输出前加层次标签，便于回溯优化策略的演进：
+
 ```
 [ORDER-PLAN] 实施顺序：
-1. [#N] [名称] — 前置依赖: [无] — 理由: [...]
-2. [#M] [名称] — 前置依赖: [#N] — 理由: [...]
+1. [L0] [#1] Pass 融合 — 前置依赖: [无] — 理由: 最高收益 (33% GM 节省)，改变 kernel 架构
+2. [L1] [#2] block_N 扩展 — 前置依赖: [#1] — 理由: 融合后 UB 占用变化，需重新计算预算
+3. [L2] [#3] Double Buffer — 前置依赖: [#1, #2] — 理由: 需在确定循环结构和 tile 参数后实施
+4. [L3] [#4] 指令融合 mul_add — 前置依赖: [#2] — 理由: 代码结构稳定后做微优化
+5. [L3] [#6] Fixed Core — 前置依赖: [#1-4] — 理由: 不改变 kernel 结构
 ```
 
 ### Step 4: 逐项实施

--- a/.agents/skills/tilelang-perf-optimization/references/optimization-guide.md
+++ b/.agents/skills/tilelang-perf-optimization/references/optimization-guide.md
@@ -51,14 +51,63 @@
 ```
 > `pass_configs`（`AUTO_SYNC`、`MEMORY_PLANNING` 等）是其他优化的**伴随修改**，不是独立步骤。需要改动时在对应优化点内部一并处理（如 Double Buffer 时同步设 `AUTO_SYNC=False`）。
 
+### 1.5 Roofline 瓶颈分析（Vector 核强制前置步骤）
+
+**目的**：在动手优化之前，用 Arithmetic Intensity 判定算子的瓶颈类型，避免在错误维度上用力。Memory-Bound 算子做指令融合、Compute-Bound 算子做 Pass 融合都是方向性错误。
+
+**计算步骤**：
+
+1. **GM 流量统计**：统计 kernel 所有 pass 的 GM 读取/写入总字节数。多 pass 架构要算每遍读取的所有 tensor（含 weight、参数 tile）。
+2. **有效 FLOPs 统计**：统计每次 kernel 执行的浮点操作数（add/mul/cmp 各算 1 FLOP，cast 可近似算 0.5 FLOP）。
+3. **Arithmetic Intensity**：`AI = FLOPs / GM_Bytes`（单位 FLOP/Byte）。
+4. **对照硬件平衡点**：
+
+   | 核类型 | 平衡点 (FLOP/Byte) | 说明 |
+   |--------|-------------------|------|
+   | AIV (Vector) | 10-20 | Vector pipe 单位带宽吞吐 |
+   | AIC (Cube) | 30-50 | Matrix pipe 单位带宽吞吐 |
+   | Mix | 取主路径 | 按实际耗时主导核判定 |
+
+5. **判定结果**：
+
+   | 判定 | 条件 | 主要优化方向 |
+   |------|------|-------------|
+   | 强 Memory-Bound | AI < 平衡点 / 2 | 减少 GM 流量：归约/输出遍数融合、tile 扩展、数据复用 |
+   | 弱 Memory-Bound | 平衡点/2 ≤ AI ≤ 平衡点 | GM 流量 + 计算吞吐并行 |
+   | Compute-Bound | AI > 平衡点 × 2 | 提升计算吞吐：指令融合、分块计算、Double Buffer 重叠 |
+
+6. **理论最小时间**：`T_min = GM_Bytes / HBM_Bandwidth`（910B ≈ 1.6 TB/s）。当前实测时间 / T_min 即为当前效率指标。
+
+**示例**（add_rms_norm_dynamic_quant, 3-pass, M=128, N=4096, fp16）：
+
+- GM 读取：3 pass × (2 input + 1 gamma + 2 scale tensors) × size = 6.12 MB
+- GM 写入：xOut (fp16) + y1Out/y2Out (int8) + 2×scale (fp32) = 1.50 MB
+- 总流量：7.62 MB
+- FLOPs：128 × 4096 × 15 ≈ 7.86 MFLOPS
+- AI ≈ 1.03 → **强 Memory-Bound** → 主攻 GM 流量
+- T_min ≈ 4.8 μs，实测 91.9 μs → 效率仅 5.2%，优化空间巨大
+
+> **约束**：Vector 核必须先做 Roofline 分析后才能选优化方向。Cube 核如果已有明确优化路径（如 GEMM 已知 Compute-Bound），可跳过。
+
 ---
 
 ## 二、核内优化
 
-> **优化顺序**：
-> - **Cube 型算子**：执行 Cube 核内优化（2.1 Split-K 切分策略、2.2 Double Buffer、2.3 MTE2 预取、2.4 Full-Load、2.5 小数据块合并载入）+ 2.9 Fixed Core
-> - **Vector 型算子**：执行 Vector 核内优化（2.2 Double Buffer Vector 侧、2.6 指令向量化、2.7 指令融合、2.8 稀疏访存优化）+ 2.9 Fixed Core；归约维度需分块扫描时额外参考 [归约遍数融合](vector-practices/vector_reduce_pass_fusion.md)
-> - **CV 融合型算子**：先执行 Cube 核内优化 → 再执行 Vector 核内优化 → 最后执行核间优化（见第三章）+ 2.9 Fixed Core
+> **优化顺序（三层优先级框架）**：
+>
+> 先按层推进大跨层顺序（先层内再层间），层内按"§1 优化优先级与算子类型对应"表的三条依赖规则（layout / buffer 数量 / pass_configs）排序。某一层所有优化点不适用则跳过。
+>
+> | 层次 | 定义 | 典型优化项 |
+> |------|------|-----------|
+> | **L0 算法层** | 改变计算等价性/数据流 | Pass 融合（归约遍数 + 输出遍数）、Online 修正公式、数学等价变换 |
+> | **L1 架构层** | 调整 tile 参数/减少 DMA 头开销 | 2.11 UB 预算（block_N/M 扩展）、2.13 多行 Tile 粒度扩展 |
+> | **L2 流水层** | 重叠搬运与计算 | 2.2 Double Buffer、2.3 MTE2 预取（Cube）、T.Pipelined/num_stages |
+> | **L3 细节层** | 不改变结构的指令/配置级微调 | 2.6 指令向量化、2.7 指令融合、2.8 稀疏访存、2.9 Fixed Core、2.10 pass_configs 微调、2.12 Host 侧优化 |
+>
+> 按算子类型选择覆盖范围：
+> - **Cube 型算子**：L0 (GEMM 等价变换) → L1 (2.1 Split-K) → L2 (2.2-2.5) → L3 (2.6-2.12)
+> - **Vector 型算子**：L0 (归约遍数融合，参见 [归约遍数融合](vector-practices/vector_reduce_pass_fusion.md)) → L1 (2.11/2.13) → L2 (2.2) → L3 (2.6-2.12)
+> - **CV 融合型算子**：先 Cube 侧 L0→L3，再 Vector 侧 L0→L3，最后核间优化（见第三章）
 
 ### 2.1 Split-K 切分策略（Cube 核）
 


### PR DESCRIPTION
# tilelang-perf-optimization 修改

## 一、修改背景

针对现有的 skill 文档内容，对于以下方面进行修改：

1. **缺 Roofline 瓶颈分析**：Step 2 仅判断算子类型（Cube/Vector/混合），不判断瓶颈类型
2. **缺层次优先级框架**：ORDER-PLAN 只有三条依赖规则，没有大跨层的"算法→架构→流水→细节"顺序

---

## 二、修改项设计

### 2.1 修改项 1A：SKILL.md Step 2.5 Roofline 瓶颈分析

**文件**：`.agents/skills/tilelang-perf-optimization/SKILL.md`

**定位**：Step 2（算子类型判断）和 Step 3（识别优化点）之间插入 Step 2.5

**设计理由**：

对于待开发的算子性能瓶颈类型缺少该部分分析，加入该部分内容即可以为开发者提供性能优化方向，也能为Agent优化项识别提供方向：

- Memory-Bound 算子上做指令融合（方向错：瓶颈在 GM，不在 Vector pipe）
- Compute-Bound 算子上做 Pass 融合（方向错：多读 GM 反而降低性能）

**核心机制**：

```
AI = FLOPs / GM_Bytes

判定表：
  AI < 平衡点 / 2  → 强 Memory-Bound → 主攻 GM 流量
  平衡点/2 ≤ AI ≤ 平衡点 → 弱 Memory-Bound → GM + 计算并行
  AI > 平衡点 × 2  → Compute-Bound → 主攻计算吞吐
```

**输出位置**：写入 `optimization_log.md` 的 Roofline 段落，作为后续 Part A 优化点筛选的**强约束**——Memory-Bound 算子只列 GM 流量类优化，Compute-Bound 算子反过来。

**强制范围**：Vector 核强制，Cube 核建议（GEMM 等典型 Compute-Bound 可跳过）。

---

### 2.2 修改项 1B：SKILL.md Step 3 ORDER-PLAN 三层优先级框架

**文件**：`.agents/skills/tilelang-perf-optimization/SKILL.md`

**定位**：重写 Step 3 Part B `[ORDER-PLAN]` 段落

**设计理由**：

原有的依赖规则只提供了优化点识别并没有考虑优化之间的优先级顺序。实战中 perf-tuner 需要自行推理出"Pass 融合必须在块参数扩展之前"，不确定性高，容易先做细节再做算法导致返工。

**引入三层框架**：

| 层次 | 定义 | 典型优化项 | 执行理由 |
|------|------|-----------|---------|
| **L0 算法层** | 改变计算等价性、数据流 | Pass 融合、Online 修正公式 | 改变 kernel 结构 → 后续预算需重算 |
| **L1 架构层** | 调 tile 参数、减少 DMA 头开销 | block_N/M 扩展、多行 Tile | 改变循环次数，是 DB 的前置 |
| **L2 流水层** | 重叠搬运与计算 | Double Buffer、num_stages | 依赖循环结构稳定 |
| **L3 细节层** | 不改变结构的微调 | 指令融合、Fixed Core、pass_configs | 在稳定代码上做微优化 |

**两条规则互补**：

- **三层框架**：解决大跨层顺序（先层内再层间）
- **三条依赖规则**：解决层内细粒度顺序（布局/数量/配置）

**输出格式改动**：每条 ORDER-PLAN 前加层次标签，便于回溯策略演进：

```
[ORDER-PLAN] 实施顺序：
1. [L0] [#1] Pass 融合 — 前置依赖: [无]
2. [L1] [#2] block_N 扩展 — 前置依赖: [#1]
3. [L2] [#3] Double Buffer — 前置依赖: [#1, #2]
4. [L3] [#4] 指令融合 mul_add — 前置依赖: [#2]
```

---

### 2.3 修改项 2A：optimization-guide.md 新增 §1.5 Roofline 瓶颈分析

**文件**：`.agents/skills/tilelang-perf-optimization/references/optimization-guide.md`

**定位**：§1（优化优先级）之后、§2（核内优化）之前插入 §1.5

**设计理由**：

SKILL.md 是流程指引（告诉 perf-tuner "做什么"），optimization-guide.md 是方法手册（告诉 perf-tuner "怎么做"）。Step 2.5 引入 Roofline 后，optimization-guide 必须提供**详细计算方法**（FLOPs 怎么数、平衡点对应表、理论最小时间公式）和**实战示例**（用 add_rms_norm_dynamic_quant 的真实数据）。

**与 SKILL.md 的分工**：

- SKILL.md Step 2.5：定义流程入口、判定结果表、输出位置约束（高层指引）
- optimization-guide §1.5：提供详细计算步骤、硬件常量、完整示例（操作手册）

**实战示例**：add_rms_norm_dynamic_quant 3-pass 架构：
- GM 总流量 7.62 MB（3 pass 含 5 tensor/passed）
- FLOPs 7.86 MFLOPS
- AI ≈ 1.03 → 强 Memory-Bound
- T_min ≈ 4.8 μs vs 实测 91.9 μs → 效率 5.2%，优化空间巨大

---

### 2.4 修改项 3A：optimization-guide.md §2 优化顺序提示块改写

**文件**：`.agents/skills/tilelang-perf-optimization/references/optimization-guide.md`

**定位**：§2 的 `> **优化顺序**` 提示块重写为三层框架落地版

**设计理由**：

原提示块直接列出算子类型对应的条目号（如"Vector 型算子：2.2 / 2.6 / 2.7 / 2.8 + 2.9 + 归约遍数融合"），没有给出执行顺序。perf-tuner 读后不知道先做哪个。

**改写后结构**：

1. **先展示三层框架表格**（L0/L1/L2/L3 每层的定义和典型优化项，与 SKILL.md Step 3 保持一致）
2. **再按算子类型给出覆盖范围**：
   - Cube 型：L0 (GEMM 等价) → L1 (2.1 Split-K) → L2 (2.2-2.5) → L3 (2.6-2.12)
   - Vector 型：L0 (归约遍数融合) → L1 (2.11/2.13) → L2 (2.2) → L3 (2.6-2.12)
   - CV 融合型：先 Cube 侧 L0→L3，再 Vector 侧 L0→L3，最后核间优化

**与 SKILL.md 的一致性**：两层文件使用相同的 L0/L1/L2/L3 命名和定义，perf-tuner 在 SKILL.md 看流程、在 guide 看条目号对照时不会产生歧义。

---

## 三、设计决策

| 决策 | 理由 |
|------|------|
| Roofline 作为 Step 2.5（而非 Step 3 内部） | 让瓶颈判定成为**前置强制门槛**，而不是优化点筛选的附带输出 |
| 三层框架独立呈现（不替换原三条依赖规则） | 跨层 vs 层内问题正交，保留层内规则避免信息损失 |
| ORDER-PLAN 加层次标签 | 便于回溯历史优化日志的策略演进（如 `[L0] [#1]` vs `[#1]`） |
| Vector 强制、Cube 建议 | Cube 型典型算子（GEMM）已有明确的 Compute-Bound 共识，强制分析是浪费 |

## 四、预期影响

### 4.1 对 perf-tuner 行为的影响

| 修改前 | 修改后 |
|--------|--------|
| Step 2 判断为 Vector 后直接进入 Step 3，开始逐条列优化点 | Step 2.5 先做 Roofline 判定，再进入 Step 3；Part A 清单受瓶颈类型约束 |
| ORDER-PLAN 按三条规则排序，可能把细节层优化（指令融合）排到架构层优化（block_N 扩展）之前 | ORDER-PLAN 强制先 L0（算法）→ L1（架构）→ L2（流水）→ L3（细节） |
| 优化点对 Memory-Bound / Compute-Bound 一视同仁 | 按瓶颈类型筛选优化点，避免方向性浪费 |

### 4.2 可验证的改进指标

下次遇到类似 Memory-Bound Vector 算子（如 RMSNorm、LayerNorm、Softmax 变体）优化时，应观察到：

1. `optimization_log.md` 出现 `Roofline 分析` 段落（AI 值 + 判定结论 + T_min）
2. `ORDER-PLAN` 中带层次标签（`[L0]` / `[L1]` / `[L2]` / `[L3]`）
3. L0 层优化出现在 ORDER-PLAN 顶部（如 Pass 融合、Online 修正）
4. L3 层微优化（指令融合等）排在所有 L0/L1/L2 之后

---

## 五、修改范围汇总

| 文件 | 修改类型 | 位置 |
|------|---------|------|
| `SKILL.md` | 插入 | Step 2 与 Step 3 之间新增 Step 2.5（L66-L93）|
| `SKILL.md` | 重写 | Step 3 Part B ORDER-PLAN 段落（L123-L154） |
| `references/optimization-guide.md` | 插入 | §1 与 §2 之间新增 §1.5（L54-L91） |
| `references/optimization-guide.md` | 改写 | §2 的优化顺序提示块（L96-L110） |


## 六、后续迭代方向

基于 add_rms_norm_dynamic_quant 优化日志中记录但本次未纳入的内容：

1. **DMA 头开销量化**（需更多案例）→ 落入 §2.11 UB 预算优化
2. **block_M 扩展陷阱反模式**（需更多案例）→ 落入 `performance-antipatterns.md`
3. **vector_output_pass_fusion.md 关联 SKILL.md** → 用户决策后可加入 Step 3 最佳实践参考表
4. **cann_bench 对比评测流程** → 可作为 Stage 3 性能验证的标准化方法写入 SKILL.md Step 5

---

*文档维护：每次实战优化后应回顾本文档，将新的反例和验证数据补充进去。*
