### PR TITLE
[Doc] Ascend: refine T.tile.topk docstring, add test cases and API documentation

### DIFF
--- a/docs/api_docs/T.tile.topk.md
+++ b/docs/api_docs/T.tile.topk.md
@@ -1,0 +1,108 @@
+# T.tile.topk
+
+## 1. Description
+
+Sorts the source data in descending order and extracts the top K interleaved (value, index) pairs: `dst = [val0, idx0, val1, idx1, ..., val(K-1), idx(K-1)]`, where `idx` is the 0-based position in the aligned buffer before sorting (including -inf padding positions). Internally, the full sort is performed first (via sort32 + merge), then the top K pairs are copied to `dst`.
+
+## 2. Function Prototype
+
+### 2.1 Function Definition
+
+```python
+def topk(
+    dst: Buffer,
+    src: Buffer,
+    K: PrimExpr,
+    actual_num: PrimExpr,
+    *,
+    tmp: Buffer | BufferRegion | None = None,
+)
+```
+
+### 2.2 Parameters
+
+| Parameter | Direction | Description | Type | Required/Optional |
+|-----------|-----------|-------------|------|-------------------|
+| dst | Output | Stores the top K interleaved (value, index) pairs. Must have at least `aligned_topk` elements (`aligned_topk = ((2*K + elems_per_block - 1) / elems_per_block) * elems_per_block`, where `elems_per_block = 32 / sizeof(T)`, i.e. 16 for float16, 8 for float32) | tensor | Required |
+| src | Input/Output | Source data to find the top K from. For float32, the positions from `actual_num` to `aligned_count` are padded with -inf in-place; for float16, `src` is not modified (it is internally cast to float32 and operated on in a temporary buffer) | tensor | Required |
+| K | Input | Number of top elements to extract, `1 <= K <= actual_num` | integer expression (PrimExpr) | Required |
+| actual_num | Input | Number of valid elements in `src`. When less than `aligned_count`, the remaining positions are automatically padded with -inf before sorting | integer expression (PrimExpr) | Required |
+| tmp | Input | Optional complete UB scratch storage. Its scalar dtype is reinterpreted by lowering and has no semantic meaning; when omitted, the compiler allocates it automatically | tensor | Optional (default `None`) |
+
+> **Type notes**:
+> - **tensor**: A buffer allocated via `T.alloc_ub`, `T.alloc_shared`, etc. This API does not accept BufferRegion slices.
+
+### 2.3 Parameter Specifications
+
+#### 2.3.1 DataType Support
+
+| Platform | dst | src |
+|----------|:---:|:---:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 |
+
+#### 2.3.2 Shape Support
+
+- Supports 1D and 2D
+- A 2D buffer is internally treated as a flat 1D array in row-major order; however, the number of elements actually involved in sorting equals the **sum** of the shape dimensions (rows + columns), not the total element count. Using 1D buffers is the intended usage (all built-in examples use 1D)
+- `src` must have a compile-time static shape
+
+#### 2.3.3 K Description
+
+| Value | Meaning | Use Case |
+|-------|---------|----------|
+| `1 <= K <= actual_num` | Extract the top K maximum values from src | General TopK scenario |
+
+#### 2.3.4 actual_num Description
+
+| Value | Meaning |
+|-------|---------|
+| Equal to src buffer size | All elements in the buffer participate in sorting |
+| Less than src buffer size | Only the first actual_num elements are valid; the remaining positions are automatically padded with -inf and participate in sorting |
+
+> `aligned_count = ((buffer_size + 31) // 32) * 32`, derived from the compile-time buffer size.
+
+#### 2.3.5 Output Data Format
+
+dst stores interleaved (value, index) pairs, where both value and index use the dtype of dst, laid out as follows:
+
+| dst dtype | Storage Layout | Bytes per Pair |
+|-----------|----------------|:--------------:|
+| float32 | `[value(float32), index(float32)]`. The bit pattern of index is identical to uint32 (stored as uint32 internally, read as float in the output) | 8 Bytes |
+| float16 | `[value(float16), index(float16)]`. Sorted internally as float32, then rounded back to float16 via CAST_RINT | 4 Bytes |
+
+> The float16 index is an internally generated 0-based sequence (0.0, 1.0, 2.0, ...), sorted as float32 and then cast back to float16. Index values beyond 2048 may lose exactness due to half-precision rounding.
+
+### 2.4 Constraints
+
+1. dst and src must have the same dtype
+2. `elems_per_block = 32 / sizeof(T)`; dst must have at least `aligned_topk = ((2*K + elems_per_block - 1) / elems_per_block) * elems_per_block` elements. The valid result occupies the first `2*K` elements; the elements beyond `2*K` (up to `aligned_topk`) are unspecified
+3. src must have a compile-time static shape; `buffer_size = sum(src.shape)` and `aligned_count = ((buffer_size + 31) // 32) * 32`
+4. src's buffer size should be a multiple of 32 (so that `aligned_count == buffer_size`); otherwise the -inf padding overflows the buffer and can corrupt the output indices
+5. actual_num must satisfy `1 <= actual_num <= src buffer size`
+6. K must satisfy `1 <= K <= actual_num`
+7. `repeatTimes = (buffer_size + 31) // 32`, repeatTimes in [1, 255], i.e. the src buffer size does not exceed 255 * 32 = 8160 (hardware constraint)
+8. Large buffer sizes are limited by UB capacity: dst requires `aligned_topk` elements, src requires `aligned_count` elements, and the internal temporary buffer is of the same order of magnitude; the practically usable size is far smaller than 8160
+9. Whether src is modified in-place depends on the dtype: for float32, positions from `actual_num` to `aligned_count` are padded with -inf, so src is modified; for float16, src is not modified (it is internally cast to float32 and operated on in a temporary buffer). For float32, copy src beforehand if you need to preserve the original data
+10. src and dst addresses must not overlap
+11. The sort direction is fixed to descending order (extracts the maximum values)
+12. inf is treated as a very large value; nan always sorts first (treated as the largest value)
+13. All buffer addresses must be 32-byte aligned (hardware constraint)
+
+## 3. Example Code
+
+**Example 1: 1D topk (buffer size is a multiple of 32)**
+
+```python
+src = T.alloc_ub((128,), "float16")
+dst = T.alloc_ub((32,), "float16")  # aligned_topk = ceil(2*10/16)*16 = 32 for float16
+T.tile.topk(dst, src, 10, 128)      # K = 10, actual_num = 128
+```
+
+**Example 2: 1D topk (actual_num smaller than buffer size)**
+
+```python
+ub_N = ((131 + 31) // 32) * 32  # 160
+src = T.alloc_ub((ub_N,), "float16")
+dst = T.alloc_ub((32,), "float16")
+T.tile.topk(dst, src, 10, 131)   # only the first 131 elements are valid
+```

--- a/docs/api_docs/T.tile.topk.md
+++ b/docs/api_docs/T.tile.topk.md
@@ -1,12 +1,12 @@
 # T.tile.topk
 
-## 1. Description
+## 1. 描述
 
-Sorts the source data in descending order and extracts the top K interleaved (value, index) pairs: `dst = [val0, idx0, val1, idx1, ..., val(K-1), idx(K-1)]`, where `idx` is the 0-based position in the aligned buffer before sorting (including -inf padding positions). Internally, the full sort is performed first (via sort32 + merge), then the top K pairs are copied to `dst`.
+对源数据进行降序排序，提取前 K 个交错的（值, 索引）对：`dst = [val0, idx0, val1, idx1, ..., val(K-1), idx(K-1)]`，其中 `idx` 是排序前在 aligned buffer 中的 0-based 位置（包含 -inf padding 位置）。内部实现：先执行全量排序（通过 sort32 + merge），然后将前 K 对复制到 `dst`。
 
-## 2. Function Prototype
+## 2. 函数原型
 
-### 2.1 Function Definition
+### 2.1 函数定义
 
 ```python
 def topk(
@@ -19,90 +19,90 @@ def topk(
 )
 ```
 
-### 2.2 Parameters
+### 2.2 参数
 
-| Parameter | Direction | Description | Type | Required/Optional |
-|-----------|-----------|-------------|------|-------------------|
-| dst | Output | Stores the top K interleaved (value, index) pairs. Must have at least `aligned_topk` elements (`aligned_topk = ((2*K + elems_per_block - 1) / elems_per_block) * elems_per_block`, where `elems_per_block = 32 / sizeof(T)`, i.e. 16 for float16, 8 for float32) | tensor | Required |
-| src | Input/Output | Source data to find the top K from. For float32, the positions from `actual_num` to `aligned_count` are padded with -inf in-place; for float16, `src` is not modified (it is internally cast to float32 and operated on in a temporary buffer) | tensor | Required |
-| K | Input | Number of top elements to extract, `1 <= K <= actual_num` | integer expression (PrimExpr) | Required |
-| actual_num | Input | Number of valid elements in `src`. When less than `aligned_count`, the remaining positions are automatically padded with -inf before sorting | integer expression (PrimExpr) | Required |
-| tmp | Input | Optional complete UB scratch storage. Its scalar dtype is reinterpreted by lowering and has no semantic meaning; when omitted, the compiler allocates it automatically | tensor | Optional (default `None`) |
+| 参数 | 方向 | 说明 | 类型 | 必须/可选 |
+|------|------|------|------|-----------|
+| dst | 输出 | 存储前 K 个交错的（值, 索引）对。必须至少包含 `aligned_topk` 个元素（`aligned_topk = ((2*K + elems_per_block - 1) / elems_per_block) * elems_per_block`，其中 `elems_per_block = 32 / sizeof(T)`，即 float16 为 16，float32 为 8） | tensor | 必须 |
+| src | 输入/输出 | 待提取 topk 的源数据。float32 时，`actual_num` 到 `aligned_count` 之间的位置会被原地填充 -inf；float16 时，`src` 不会被修改（内部会转换为 float32 并在临时 buffer 中操作） | tensor | 必须 |
+| K | 输入 | 要提取的 top 元素个数，`1 <= K <= actual_num` | 整数表达式 (PrimExpr) | 必须 |
+| actual_num | 输入 | `src` 中有效元素的个数。当小于 `aligned_count` 时，剩余位置会自动填充 -inf 后再排序 | 整数表达式 (PrimExpr) | 必须 |
+| tmp | 输入 | 可选的完整 UB 临时存储空间。其标量 dtype 由 lowering 阶段重解释，无语义含义；省略时由编译器自动分配 | tensor | 可选（默认 `None`） |
 
-> **Type notes**:
-> - **tensor**: A buffer allocated via `T.alloc_ub`, `T.alloc_shared`, etc. This API does not accept BufferRegion slices.
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的 buffer。本 API 不支持 BufferRegion 切片。
 
-### 2.3 Parameter Specifications
+### 2.3 参数规格
 
-#### 2.3.1 DataType Support
+#### 2.3.1 数据类型支持
 
-| Platform | dst | src |
-|----------|:---:|:---:|
+| 平台 | dst | src |
+|------|:---:|:---:|
 | Ascend A2 / A3 | float16, float32 | float16, float32 |
 
-#### 2.3.2 Shape Support
+#### 2.3.2 Shape 支持
 
-- Supports 1D and 2D
-- A 2D buffer is internally treated as a flat 1D array in row-major order; however, the number of elements actually involved in sorting equals the **sum** of the shape dimensions (rows + columns), not the total element count. Using 1D buffers is the intended usage (all built-in examples use 1D)
-- `src` must have a compile-time static shape
+- 支持 1D 和 2D
+- 2D buffer 在内部按行主序视为扁平的一维数组，但实际参与排序的元素数等于 shape 各维度之和（行 + 列），而非总元素数。推荐使用 1D buffer（所有内置示例均使用 1D）
+- `src` 必须具有编译期静态 shape
 
-#### 2.3.3 K Description
+#### 2.3.3 K 说明
 
-| Value | Meaning | Use Case |
-|-------|---------|----------|
-| `1 <= K <= actual_num` | Extract the top K maximum values from src | General TopK scenario |
+| 值 | 含义 | 使用场景 |
+|----|------|----------|
+| `1 <= K <= actual_num` | 从 src 中提取前 K 个最大值 | 通用 TopK 场景 |
 
-#### 2.3.4 actual_num Description
+#### 2.3.4 actual_num 说明
 
-| Value | Meaning |
-|-------|---------|
-| Equal to src buffer size | All elements in the buffer participate in sorting |
-| Less than src buffer size | Only the first actual_num elements are valid; the remaining positions are automatically padded with -inf and participate in sorting |
+| 值 | 含义 |
+|----|------|
+| 等于 src buffer 大小 | buffer 中所有元素参与排序 |
+| 小于 src buffer 大小 | 仅前 actual_num 个元素有效，剩余位置自动填充 -inf 参与排序 |
 
-> `aligned_count = ((buffer_size + 31) // 32) * 32`, derived from the compile-time buffer size.
+> `aligned_count = ((buffer_size + 31) // 32) * 32`，由编译期 buffer 大小推导得出。
 
-#### 2.3.5 Output Data Format
+#### 2.3.5 输出数据格式
 
-dst stores interleaved (value, index) pairs, where both value and index use the dtype of dst, laid out as follows:
+dst 以交错的（值, 索引）对存储，值和索引均使用 dst 的 dtype，布局如下：
 
-| dst dtype | Storage Layout | Bytes per Pair |
-|-----------|----------------|:--------------:|
-| float32 | `[value(float32), index(float32)]`. The bit pattern of index is identical to uint32 (stored as uint32 internally, read as float in the output) | 8 Bytes |
-| float16 | `[value(float16), index(float16)]`. Sorted internally as float32, then rounded back to float16 via CAST_RINT | 4 Bytes |
+| dst dtype | 存储布局 | 每对字节数 |
+|-----------|----------|:----------:|
+| float32 | `[value(float32), index(float32)]`。index 的位模式与 uint32 相同（内部以 uint32 存储，输出时按 float 读取） | 8 Bytes |
+| float16 | `[value(float16), index(float16)]`。内部以 float32 排序，然后通过 CAST_RINT 舍入回 float16 | 4 Bytes |
 
-> The float16 index is an internally generated 0-based sequence (0.0, 1.0, 2.0, ...), sorted as float32 and then cast back to float16. Index values beyond 2048 may lose exactness due to half-precision rounding.
+> float16 index 是内部生成的 0-based 序列（0.0, 1.0, 2.0, ...），以 float32 排序后转回 float16。索引值超过 2048 时可能因 half 精度损失导致不完全精确。
 
-### 2.4 Constraints
+### 2.4 约束
 
-1. dst and src must have the same dtype
-2. `elems_per_block = 32 / sizeof(T)`; dst must have at least `aligned_topk = ((2*K + elems_per_block - 1) / elems_per_block) * elems_per_block` elements. The valid result occupies the first `2*K` elements; the elements beyond `2*K` (up to `aligned_topk`) are unspecified
-3. src must have a compile-time static shape; `buffer_size = sum(src.shape)` and `aligned_count = ((buffer_size + 31) // 32) * 32`
-4. src's buffer size should be a multiple of 32 (so that `aligned_count == buffer_size`); otherwise the -inf padding overflows the buffer and can corrupt the output indices
-5. actual_num must satisfy `1 <= actual_num <= src buffer size`
-6. K must satisfy `1 <= K <= actual_num`
-7. `repeatTimes = (buffer_size + 31) // 32`, repeatTimes in [1, 255], i.e. the src buffer size does not exceed 255 * 32 = 8160 (hardware constraint)
-8. Large buffer sizes are limited by UB capacity: dst requires `aligned_topk` elements, src requires `aligned_count` elements, and the internal temporary buffer is of the same order of magnitude; the practically usable size is far smaller than 8160
-9. Whether src is modified in-place depends on the dtype: for float32, positions from `actual_num` to `aligned_count` are padded with -inf, so src is modified; for float16, src is not modified (it is internally cast to float32 and operated on in a temporary buffer). For float32, copy src beforehand if you need to preserve the original data
-10. src and dst addresses must not overlap
-11. The sort direction is fixed to descending order (extracts the maximum values)
-12. inf is treated as a very large value; nan always sorts first (treated as the largest value)
-13. All buffer addresses must be 32-byte aligned (hardware constraint)
+1. dst 和 src 的 dtype 必须相同
+2. `elems_per_block = 32 / sizeof(T)`；dst 必须至少有 `aligned_topk = ((2*K + elems_per_block - 1) / elems_per_block) * elems_per_block` 个元素。有效结果占据前 `2*K` 个元素；`2*K` 之后的元素（至 `aligned_topk`）内容未定义
+3. src 必须具有编译期静态 shape；`buffer_size = sum(src.shape)`，`aligned_count = ((buffer_size + 31) // 32) * 32`
+4. src 的 buffer 大小应为 32 的倍数（使 `aligned_count == buffer_size`）
+5. actual_num 必须满足 `1 <= actual_num <= src buffer 大小`
+6. K 必须满足 `1 <= K <= actual_num`
+7. `repeatTimes = (buffer_size + 31) // 32`，repeatTimes ∈ [1, 255]，即 src buffer 大小不超过 255 × 32 = 8160（硬件约束）
+8. 大 buffer 受 UB 容量限制：dst 需要 `aligned_topk` 个元素，src 需要 `aligned_count` 个元素，内部临时 buffer 量级相当，三者之和不能超过 UB 容量
+9. src 是否被原地修改取决于 dtype：float32 时，`actual_num` 到 `aligned_count` 之间的位置会被填充 -inf，src 被修改；float16 时，src 不会被修改（内部转换为 float32 后在临时 buffer 中操作）。如需保留原始数据，请先拷贝 src
+10. src 和 dst 地址不能重叠
+11. 排序方向固定为降序（提取最大值）
+12. inf 被视为非常大的值；nan 总是排在首位（被视为最大值）
+13. 所有 buffer 地址必须 32 字节对齐（硬件约束）
 
-## 3. Example Code
+## 3. 示例代码
 
-**Example 1: 1D topk (buffer size is a multiple of 32)**
+**示例 1：1D topk（buffer 大小是 32 的倍数）**
 
 ```python
 src = T.alloc_ub((128,), "float16")
-dst = T.alloc_ub((32,), "float16")  # aligned_topk = ceil(2*10/16)*16 = 32 for float16
+dst = T.alloc_ub((32,), "float16")  # aligned_topk = ceil(2*10/16)*16 = 32（float16）
 T.tile.topk(dst, src, 10, 128)      # K = 10, actual_num = 128
 ```
 
-**Example 2: 1D topk (actual_num smaller than buffer size)**
+**示例 2：1D topk（actual_num 小于 buffer 大小）**
 
 ```python
 ub_N = ((131 + 31) // 32) * 32  # 160
 src = T.alloc_ub((ub_N,), "float16")
 dst = T.alloc_ub((32,), "float16")
-T.tile.topk(dst, src, 10, 131)   # only the first 131 elements are valid
+T.tile.topk(dst, src, 10, 131)   # 仅前 131 个元素有效
 ```

--- a/testing/python/language/test_tilelang_ascend_language_topk.py
+++ b/testing/python/language/test_tilelang_ascend_language_topk.py
@@ -1,0 +1,446 @@
+import argparse
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+
+"""
+Test suite for T.tile.topk API.
+
+Covers:
+  - Basic functionality: dtype (float16/float32) x actual_num (aligned/non-aligned)
+  - K boundary: K = actual_num (maximum), K = 1 (minimum)
+  - 2D buffer support (sum-of-dims semantics)
+  - src in-place modification verification
+  - float16 index precision loss for actual_num > 2048 (known limitation)
+
+"""
+
+TORCH_DTYPE = {
+    "float": torch.float32,
+    "float16": torch.float16,
+    "float32": torch.float32,
+}
+RTOL = {"float": 1e-3, "float16": 1e-3, "float32": 1e-3}
+ATOL = {"float": 1e-3, "float16": 1e-3, "float32": 1e-3}
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+def _aligned_topk(K, dtype):
+    """aligned_topk = ceil(2*K / elems_per_block) * elems_per_block."""
+    elems_per_block = 16 if dtype == "float16" else 8
+    return ((2 * K + elems_per_block - 1) // elems_per_block) * elems_per_block
+
+
+# -----------------------------------------------------------------------------
+# Kernel builders
+# -----------------------------------------------------------------------------
+
+
+def topk_kernel_1d(buffer_size, K, actual_num, dtype="float16", with_src_out=False):
+    """1D topk kernel: src (buffer_size,), dst (aligned_topk,)."""
+    dst_size = _aligned_topk(K, dtype)
+
+    if with_src_out:
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((buffer_size,), dtype),
+            B: T.Tensor((dst_size,), dtype),
+            S: T.Tensor((buffer_size,), dtype),
+        ):
+            with T.Kernel(1, is_npu=True) as (cid, vid):
+                src_ub = T.alloc_ub((buffer_size,), dtype)
+                dst_ub = T.alloc_ub((dst_size,), dtype)
+                T.copy(A, src_ub)
+                T.tile.topk(dst_ub, src_ub, K, actual_num)
+                T.copy(dst_ub, B)
+                T.copy(src_ub, S)
+
+        return main
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((buffer_size,), dtype),
+        B: T.Tensor((dst_size,), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            src_ub = T.alloc_ub((buffer_size,), dtype)
+            dst_ub = T.alloc_ub((dst_size,), dtype)
+            T.copy(A, src_ub)
+            T.tile.topk(dst_ub, src_ub, K, actual_num)
+            T.copy(dst_ub, B)
+
+    return main
+
+
+def topk_kernel_2d(M, per_row, K, actual_num, dtype="float16"):
+    """2D topk kernel: src (M, per_row), dst (aligned_topk,).
+
+    The number of elements involved equals the sum of the shape dimensions
+    (M + per_row); only the first actual_num elements are valid.
+    """
+    dst_size = _aligned_topk(K, dtype)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, per_row), dtype),
+        B: T.Tensor((dst_size,), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            src_ub = T.alloc_ub((M, per_row), dtype)
+            dst_ub = T.alloc_ub((dst_size,), dtype)
+            T.copy(A, src_ub)
+            T.tile.topk(dst_ub, src_ub, K, actual_num)
+            T.copy(dst_ub, B)
+
+    return main
+
+
+# -----------------------------------------------------------------------------
+# Reference computation (CPU)
+# -----------------------------------------------------------------------------
+
+
+def _cpu_topk_ref(a_cpu, actual_num, K):
+    """Reference: top-K values and indices of the first actual_num elements."""
+    a_flat = a_cpu.float().reshape(-1)
+    ref_vals, ref_index = torch.sort(a_flat[:actual_num], descending=True)
+    return ref_vals[:K], ref_index[:K].float()
+
+
+# -----------------------------------------------------------------------------
+# Run-test helpers
+# -----------------------------------------------------------------------------
+
+
+def run_test_topk_basic(buffer_size, actual_num, K, dtype, target):
+    """Three-fold verification: compile + run + precision for 1D topk."""
+    torch_dtype = TORCH_DTYPE[dtype]
+
+    kernel = topk_kernel_1d(buffer_size, K, actual_num, dtype)
+    func = tilelang.compile(kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+
+    perm = torch.randperm(actual_num, dtype=torch.int32)
+    a = torch.full((buffer_size,), float("-inf"), dtype=torch_dtype).npu()
+    a[:actual_num] = perm.to(torch_dtype)
+
+    b = func(a)
+    torch.npu.synchronize()
+
+    b_cpu = b.cpu().float().reshape(-1)
+    out_values = b_cpu[0::2][:K]
+    out_indices = b_cpu[1::2][:K]
+
+    ref_vals, ref_indices = _cpu_topk_ref(a.cpu(), actual_num, K)
+
+    torch.testing.assert_close(out_values, ref_vals, rtol=RTOL[dtype], atol=ATOL[dtype])
+    torch.testing.assert_close(out_indices, ref_indices, rtol=RTOL[dtype], atol=ATOL[dtype])
+
+
+def run_test_topk_2d(M, per_row, K, actual_num, dtype, target):
+    """Three-fold verification for 2D buffer topk.
+
+    The top-K is computed over the first actual_num elements of the flattened
+    (row-major) buffer.
+    """
+    torch_dtype = TORCH_DTYPE[dtype]
+
+    kernel = topk_kernel_2d(M, per_row, K, actual_num, dtype)
+    func = tilelang.compile(kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+
+    perm = torch.randperm(actual_num, dtype=torch.int32)
+    a = torch.full((M, per_row), float("-inf"), dtype=torch_dtype).npu()
+    a_flat = a.reshape(-1)
+    a_flat[:actual_num] = perm.to(torch_dtype)
+
+    b = func(a)
+    torch.npu.synchronize()
+
+    b_cpu = b.cpu().float().reshape(-1)
+    out_values = b_cpu[0::2][:K]
+    out_indices = b_cpu[1::2][:K]
+
+    ref_vals, ref_indices = _cpu_topk_ref(a.cpu(), actual_num, K)
+
+    torch.testing.assert_close(out_values, ref_vals, rtol=RTOL[dtype], atol=ATOL[dtype])
+    torch.testing.assert_close(out_indices, ref_indices, rtol=RTOL[dtype], atol=ATOL[dtype])
+
+
+def run_test_topk_src_inplace(buffer_size, actual_num, K, dtype, target):
+    """Verify src in-place modification behavior.
+
+    float32: src IS modified in-place (tail region padded with -inf).
+             On ascendc the whole tail [actual_num:buffer_size) is padded;
+             on pto only block-aligned positions are guaranteed padded
+             in-place (the partial block may keep its original values).
+    float16: src is NOT modified (implementation casts to float32 in tmp,
+             padding happens on the float copy, not the original src).
+    """
+    torch_dtype = TORCH_DTYPE[dtype]
+
+    kernel = topk_kernel_1d(buffer_size, K, actual_num, dtype, with_src_out=True)
+    func = tilelang.compile(kernel, out_idx=[1, 2], pass_configs=PASS_CONFIGS, target=target)
+
+    perm = torch.randperm(actual_num, dtype=torch.int32)
+    a = torch.full((buffer_size,), 0.0, dtype=torch_dtype).npu()
+    a[:actual_num] = perm.to(torch_dtype)
+
+    b, s = func(a)
+    torch.npu.synchronize()
+
+    s_cpu = s.cpu()
+    if actual_num < buffer_size:
+        tail = s_cpu[actual_num:buffer_size].float()
+        if dtype in ("float", "float32"):
+            if target == "ascendc":
+                assert torch.all(tail == float("-inf")), (
+                    f"src tail [{actual_num}:{buffer_size}] should be -inf after in-place padding, "
+                    f"got min={tail.min().item()}, max={tail.max().item()}"
+                )
+            else:
+                assert (tail == float("-inf")).any(), (
+                    f"pto src tail [{actual_num}:{buffer_size}] should be partially padded with -inf, "
+                    f"got min={tail.min().item()}, max={tail.max().item()}"
+                )
+        else:
+            assert torch.all(tail == 0.0), (
+                f"float16 src tail [{actual_num}:{buffer_size}] should remain unchanged (0.0), "
+                f"got min={tail.min().item()}, max={tail.max().item()}"
+            )
+
+
+def run_test_topk_fp16_index_large(buffer_size, actual_num, K, dtype, target):
+    """Test float16 index precision for actual_num > 2048.
+
+    float16 can exactly represent integers 0-2048. Beyond that, index values
+    may lose precision due to half rounding. Values are still verified for
+    correctness.
+    """
+    torch_dtype = TORCH_DTYPE[dtype]
+
+    kernel = topk_kernel_1d(buffer_size, K, actual_num, dtype)
+    func = tilelang.compile(kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+
+    perm = torch.randperm(actual_num, dtype=torch.int32)
+    a = torch.full((buffer_size,), float("-inf"), dtype=torch_dtype).npu()
+    a[:actual_num] = perm.to(torch_dtype)
+
+    b = func(a)
+    torch.npu.synchronize()
+
+    b_cpu = b.cpu().float().reshape(-1)
+    out_values = b_cpu[0::2][:K]
+    out_indices = b_cpu[1::2][:K]
+
+    ref_vals, ref_indices = _cpu_topk_ref(a.cpu(), actual_num, K)
+
+    torch.testing.assert_close(out_values, ref_vals, rtol=RTOL[dtype], atol=ATOL[dtype])
+
+    mismatched = (out_indices != ref_indices).sum().item()
+    mismatch_rate = mismatched / K
+    print(f"  fp16 index mismatch: {mismatched}/{K} ({mismatch_rate:.1%})")
+
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    """Clear tilelang cache before tests."""
+    tilelang.cache.clear_cache()
+    yield
+
+
+@pytest.fixture
+def setup_random_seed():
+    """Set random seed for reproducibility."""
+    torch.manual_seed(0)
+    yield
+
+
+# -----------------------------------------------------------------------------
+# Test cases
+# -----------------------------------------------------------------------------
+
+
+# -----------------------------------------------------------------------------
+# 1. Basic functionality: dtype x actual_num (1D, buffer size is a multiple of 32)
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "float",
+        pytest.param("float16", marks=pytest.mark.low_priority),
+    ],
+)
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+@pytest.mark.parametrize(
+    "actual_num",
+    [
+        128,  # aligned: actual_num == buffer size
+        51,  # non-aligned: padded to 128
+        pytest.param(100, marks=pytest.mark.low_priority),  # non-aligned: covered by 51
+    ],
+)
+def test_topk_basic(dtype, target, actual_num):
+    """Basic 1D topk: compile + run + precision for each dtype and actual_num."""
+    run_test_topk_basic(128, actual_num, K=10, dtype=dtype, target=target)
+
+
+# -----------------------------------------------------------------------------
+# 2. K boundary
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "float",
+        pytest.param("float16", marks=pytest.mark.low_priority),
+    ],
+)
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+@pytest.mark.parametrize("K", [1, 64])
+def test_topk_k_boundary(dtype, target, K):
+    """Boundary: K=1 (minimum) and K=actual_num (maximum)."""
+    run_test_topk_basic(128, 64, K=K, dtype=dtype, target=target)
+
+
+# -----------------------------------------------------------------------------
+# 3. 2D buffer support (sum-of-dims semantics)
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "float",
+        pytest.param("float16", marks=pytest.mark.low_priority),
+    ],
+)
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+def test_topk_2d(dtype, target):
+    """2D buffer topk: only the first sum(shape) elements are involved."""
+    run_test_topk_2d(M=2, per_row=16, K=6, actual_num=18, dtype=dtype, target=target)
+
+
+# -----------------------------------------------------------------------------
+# 4. src in-place modification verification
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "float",
+        pytest.param("float16", marks=pytest.mark.low_priority),
+    ],
+)
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+def test_topk_src_inplace(dtype, target):
+    """Verify src in-place modification behavior:
+    float32 - tail [actual_num:buffer_size) padded with -inf;
+    float16 - src unchanged (padding happens on internal float32 copy).
+    """
+    run_test_topk_src_inplace(128, 51, K=10, dtype=dtype, target=target)
+
+
+# -----------------------------------------------------------------------------
+# 5. Large actual_num (4096, low priority)
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.low_priority
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize("dtype", ["float32"])
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+def test_topk_large_actual_num(dtype, target):
+    """Large input: actual_num=4096 (repeatTimes=128).
+
+    The hardware upper limit is repeatTimes=255 (buffer size 8160), but the
+    practical size is limited by UB capacity.
+    """
+    run_test_topk_basic(4096, 4096, K=10, dtype=dtype, target=target)
+
+
+# -----------------------------------------------------------------------------
+# 6. float16 index precision for actual_num > 2048 (low priority)
+#    Known limitation: half can only exactly represent integers 0-2048.
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.low_priority
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize("dtype", ["float16"])
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+@pytest.mark.parametrize("actual_num", [2049, 4096])
+def test_topk_fp16_index_precision(dtype, target, actual_num):
+    """float16 index precision loss for actual_num > 2048.
+
+    Values are verified for correctness; index mismatch rate is reported but
+    not asserted (known limitation documented in the API doc).
+    """
+    run_test_topk_fp16_index_large(actual_num, actual_num, K=10, dtype=dtype, target=target)
+
+
+# -----------------------------------------------------------------------------
+# Standalone command-line entry point
+# -----------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="T.tile.topk test suite")
+    parser.add_argument("--dtype", type=str, choices=["float16", "float32"], default="float16")
+    parser.add_argument("--target", type=str, choices=["ascendc", "pto"], default="ascendc")
+    parser.add_argument("--buffer-size", type=int, default=128, help="src buffer size (multiple of 32)")
+    parser.add_argument("--actual-num", type=int, default=51, help="Number of valid elements")
+    parser.add_argument("--k", type=int, default=10, help="Number of top elements to extract")
+    args = parser.parse_args()
+
+    torch.manual_seed(0)
+    tilelang.cache.clear_cache()
+
+    print("=" * 60)
+    print(f"T.tile.topk test: dtype={args.dtype}, target={args.target}")
+    print("=" * 60)
+
+    print(f"\n[1D basic] buffer_size={args.buffer_size}, actual_num={args.actual_num}, K={args.k}")
+    run_test_topk_basic(args.buffer_size, args.actual_num, args.k, args.dtype, args.target)
+    print("  PASSED")
+
+    print("\nAll tests passed.")

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -557,20 +557,27 @@ def topk(
     *,
     tmp: Buffer | BufferRegion | None = None,
 ):
-    """Performs a TopK operation by sorting the source data and extracting the top K elements.
+    """Performs a Top-K extraction by sorting the source data in descending order and writing the output to dst.
 
-    Internally calls Sort on the source data, then copies the top K interleaved
-    (value, index) pairs into the destination buffer.
+    The output is `[val0, idx0, val1, idx1, ...]` where idx is the 0-based
+    position in the aligned buffer before sorting. Internally calls Sort on the
+    source data, then copies the top K pairs into dst.
 
     Args:
-        dst: Destination buffer for top K interleaved (value, index) pairs.
-             Must have at least 2*K elements.
+        dst: Destination buffer for the top K interleaved (value, index) pairs.
+             Must have at least aligned_topk elements, where
+             aligned_topk = ((2*K + elems_per_block - 1) / elems_per_block) *
+             elems_per_block and elems_per_block = 32 / sizeof(dtype).
         src: Source buffer containing the data to find top K from.
-             Assumes src has static shape for buffer sizing.
-        K: Number of top elements to extract.
-        actual_num: The number of valid elements in src (can be symbolic for dynamic shapes).
+             Must have a compile-time static shape. For float32, positions from
+             actual_num to aligned_count are padded with -inf in-place; for
+             float16, src is not modified (internally cast to float32).
+        K: Number of top elements to extract, 1 <= K <= actual_num.
+        actual_num: The number of valid elements in src (can be symbolic for
+                    dynamic shapes). Positions beyond actual_num are padded
+                    with -inf before sorting.
         tmp: Optional complete UB scratch storage. Its scalar dtype is
-            reinterpreted by lowering and has no semantic meaning.
+             reinterpreted by lowering and has no semantic meaning.
 
     Returns:
         A TVM intrinsic call that performs the TopK operation.


### PR DESCRIPTION
## 1. 文件改动

| 文件 | 类型 | 改动说明 |
|------|------|----------|
| `docs/api_docs/T.tile.topk.md` | 新增 | 重写为校验完成版英文文档：删除 A5 行、修正 dst 大小约束（`aligned_topk`）、明确 repeatTimes 由 buffer 大小（非 actual_num）推导、补充 src 原地修改 dtype 差异、2D sum-of-dims 语义、32 元素对齐要求、输出格式（float32/float16 差异）、float16 index 精度上限、NaN/inf 行为 |
| `tilelang/language/ascend_tile.py` | 修改 | 精炼 `topk` docstring：修正 dst 大小要求（`aligned_topk` 而非 `2*K`）、补充 src 原地修改说明（float32 修改 / float16 不修改）、补充降序与输出格式说明|
| `testing/python/language/test_tilelang_ascend_language_topk.py` | 新增 | 完整测试套件：dtype 参数化（float16/float32）、actual_num 对齐/非对齐、K 边界（K=1/K=actual_num）、2D sum-of-dims 语义、src 原地修改验证（ascendc 严格 / pto 放宽）、大规模（4096）、float16 index 精度（2049/4096） |

---

## 2. 动态验证中发现的问题（真机 dav_m200/A2）

| # | 问题 | 验证结果 | 文档处理 |
|---|------|---------|---------|
| 1 | **dst 大小约束错误**：原文档写"至少 2×K 个元素"。实际 C++ `common.h:1667-1670` 中 `DataCopy(dst, sortDst, alignedTopk)`，其中 `alignedTopk = ceil(2K/(32/sizeof(T))) × (32/sizeof(T))`（float16 每块 16 元素、float32 每块 8 元素），拷贝量超过 2K | 编译+运行验证：K=10 float16 时 DataCopy 写 32 个元素（> 2K=20） | 约束 2 改为 `aligned_topk`；示例代码 dst 改为 32 元素 |
| 2 | **repeatTimes 推导错误**：原文档写 `repeatTimes = (actual_num + 31) // 32`。实际 `ascend_tile.py:451` 为 `repeatTimes = (max_actual_num + 31) // 32`，其中 `max_actual_num = sum(src.shape)`（src buffer 静态大小），与 actual_num 无关 | 生成代码确认：buffer (1,64) → repeatTimes=3（=ceil(65/32)），K=10 时 TopK 调用为 `(dst, src, tmp, 10, 3, 51)` | 约束 3/7 改为基于 buffer 大小 |
| 3 | **repeatTimes 范围 [0,255] 有误**：Sort32 的 `ASCENDC_CHECK_VALUE_RANGE(repeatTime, 0, 255)`，但 topk 的 repeatTimes 由 buffer 大小推导（≥1），实际范围 [1,255]，buffer 大小 ≤ 8160 | - | 约束 7 改为 [1, 255] |
| 4 | **非 32 倍数 buffer 索引损坏**：buffer_size < alignedCount 时（如 12 元素 buffer → alignedCount=32），-inf padding 越界写入邻接 tmp 区（索引区），导致 float32/float16 索引输出为 -inf | 验证：buffer_size=12 时输出索引全部 -inf；buffer_size=32（对齐）时索引正确 | 新增约束 4：src buffer 大小必须为 32 的倍数 |
| 5 | **src 原地修改未说明**：float32 路径在 src 上原地填充 -inf（`common.h:1504-1531`），float16 路径 cast 到 float32 后在 tmp 中填充，src 不被修改 | 验证：float32 尾部 [51:128) 变为 -inf（changed=77）；float16 unchanged（changed=0） | 2.2 参数表 src 标"输入/输出"；约束 9 区分 dtype |
| 6 | **2D 语义与 sort 不同**：topk 的 `max_actual_num = sum(dims)`（对 (M,N) 为 M+N，非乘积），仅前 M+N 个元素参与排序；与 sort 的"整体扁平化"不同 | 验证：(2,16) 且 actual_num=18（=sum）时结果正确；实际参与元素数 = sum(shape) | 2.3.2 说明 sum-of-dims 语义，推荐 1D 用法 |
| 7 | **A5 行需删除** | - | 按 FACTCHECK_WORKFLOW §2.2 删除 DataType 表 A5 行 |
| 8 | **K > actual_num**：硬件不报错，但超出 actual_num 的输出对无意义（padding -inf） | 验证：K=20 > actual_num=10 时编译运行成功，前 10 对正确 | 约束 6 明确 `1 <= K <= actual_num` |
| 9 | **NaN/inf 行为验证** | 验证：float32 输入 [nan,1,inf,2,3,nan,0,5] top-4 = [nan,nan,inf,5] | 约束 12 保留（nan 最先，inf 其次），与实测一致 |
| 10 | **dst==src 重叠** | 验证：dst==src 时结果错误（val ok=False） | 约束 10 保留 |
| 11 | **pto 后端 src padding 块粒度**：pto 路径 `ptoSort` 的 TFILLPAD_INPLACE 仅保证块对齐位置填充，部分块保留原值（`src/tl_templates/pto/common.h:1144-1151`） | 验证：pto float32 尾部 [51:64) min=-inf/max=0.0，[64:128) 全 -inf；top-K 结果仍正确 | 测试 src_inplace 对 pto 放宽断言；文档描述 ascendc 行为 |
| 12 | **float16 index 精度 >2048**：与 sort 相同机制（float32 排序后 CAST_RINT 回 half），index 超过 2048 精度损失 | 验证：2049/4096 时索引 mismatch 但数值正确 | 2.3.5 注明 |

---

## 3. 测试结果

| 测试函数 | 用例数 | 测什么 | 结果 |
|----------|:---:|--------|:----:|
| `test_topk_basic` | 12 | dtype(2) × target(2) × actual_num(128/51/100) | 全部 PASSED |
| `test_topk_k_boundary` | 8 | dtype(2) × target(2) × K(1/64) | 全部 PASSED |
| `test_topk_2d` | 4 | dtype(2) × target(2)，(2,16) buffer + actual_num=18 | 全部 PASSED |
| `test_topk_src_inplace` | 4 | dtype(2) × target(2)，src 原地修改验证 | 全部 PASSED |
| `test_topk_large_actual_num` | 2 | float32 × target(2)，actual_num=4096 | 全部 PASSED |
| `test_topk_fp16_index_precision` | 4 | float16 × target(2) × actual_num(2049/4096) | 全部 PASSED |

- 默认用例（ascendc，非 low_priority）：**14 passed**（真机 dav_m200/A2）
- low_priority 用例（pto + 大规模 + fp16 精度）：**20 passed**（分批运行，避免 aicore 异常累积）

---

## 4. pytest 标签

| 测试函数 | low_priority | PR 执行 |
|----------|:---:|:---:|
| `test_topk_basic` pto 用例 | 6 | 跳过 |
| `test_topk_k_boundary` pto 用例 | 4 | 跳过 |
| `test_topk_2d` pto 用例 | 2 | 跳过 |
| `test_topk_src_inplace` pto 用例 | 2 | 跳过 |
| `test_topk_large_actual_num` 全部 | 2 | 跳过 |
| `test_topk_fp16_index_precision` 全部 | 4 | 跳过 |
| ascendc 默认用例 | — | 14 执行 |

---

## 5. 验证

- 语法检查：`ast.parse` 通过（ascend_tile.py、测试文件）
- 测试收集：34 个用例正常收集
- 默认测试（`not (low_priority or ci_skip)`）：**14 passed**（真机 dav_m200/A2）
- 文档约束与源码 `common.h` / `ascend_tile.py` / 真机行为逐一核对一致