### PR TITLE
[Docs]：update arith_progression docstring, add dtype coverage tests and API doc

### DIFF
--- a/docs/api_docs/T.tile.arith_progression.md
+++ b/docs/api_docs/T.tile.arith_progression.md
@@ -38,20 +38,9 @@ def arith_progression(
 |------|:------:|:-----------:|:----------:|
 | Ascend A2 / A3 | float16, float32, int16, int32 | 同 buffer | 同 buffer |
 
-> uint16、uint32 在 static_assert 中列出，但 ascendc 后端编译失败（硬件指令不支持），仅 pto 后端可用，故不列入主表。
+> uint16、uint32 仅 pto 后端支持
 >
-> float16 在 pto 后端编译失败（"half precision operation is not allowed in aicore function"），仅 ascendc 后端可用。
-
-**dtype × backend 支持矩阵：**
-
-| dtype | ascendc | pto |
-|-------|:---:|:---:|
-| float16 | ✅ | ❌ |
-| float32 | ✅ | ✅ |
-| int16 | ✅ | ✅ |
-| int32 | ✅ | ✅ |
-| uint16 | ❌ | ✅ |
-| uint32 | ❌ | ✅ |
+> float16 仅 ascendc 后端支持
 
 #### 2.3.2 Shape 支持
 

--- a/docs/api_docs/T.tile.arith_progression.md
+++ b/docs/api_docs/T.tile.arith_progression.md
@@ -1,0 +1,96 @@
+# T.tile.arith_progression
+
+## 1. 功能说明
+
+生成等差数列：`buffer[i] = first_value + i * diff_value`（i = 0, 1, ..., count-1）
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def arith_progression(
+    buffer: Buffer,
+    first_value: PrimExpr,
+    diff_value: PrimExpr,
+    count: PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| buffer | 输出 | 存放等差数列 | 张量（tensor） | 必填 |
+| first_value | 输入 | 等差数列的首个元素值，须与 buffer 的 dtype 一致 | 标量（scalar） | 必填 |
+| diff_value | 输入 | 等差数列元素之间的差值（须 ≥ 0），须与 buffer 的 dtype 一致 | 标量（scalar） | 必填 |
+| count | 输入 | 等差数列的长度（元素个数），须 > 0 | 整数 | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 buffer 元素访问（BufferLoad）或 Python 标量/表达式（PrimExpr）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | buffer | first_value | diff_value |
+|------|:------:|:-----------:|:----------:|
+| Ascend A2 / A3 | float16, float32, int16, int32 | 同 buffer | 同 buffer |
+
+> uint16、uint32 在 static_assert 中列出，但 ascendc 后端编译失败（硬件指令不支持），仅 pto 后端可用，故不列入主表。
+>
+> float16 在 pto 后端编译失败（"half precision operation is not allowed in aicore function"），仅 ascendc 后端可用。
+
+**dtype × backend 支持矩阵：**
+
+| dtype | ascendc | pto |
+|-------|:---:|:---:|
+| float16 | ✅ | ❌ |
+| float32 | ✅ | ✅ |
+| int16 | ✅ | ✅ |
+| int32 | ✅ | ✅ |
+| uint16 | ❌ | ✅ |
+| uint32 | ❌ | ✅ |
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D（count 决定写入元素数，不受 buffer shape 约束；buffer 大小须 ≥ `count * sizeof(dtype)`）
+
+### 2.4 约束条件
+
+1. first_value、diff_value 的数据类型須与 buffer 的元素类型保持一致
+2. diff_value 须 ≥ 0（硬件约束，运行时检查；编译期不触发）
+3. count 须 > 0（硬件约束，运行时检查；编译期不触发）
+4. buffer 的容量必须 ≥ `count * sizeof(dtype)`
+5. 仅支持 ND 格式（硬件约束）
+
+#### 2.4.1 pto 后端已知限制
+
+| 限制 | 原因 | 影响 |
+|------|------|------|
+| diff_value 固定为 1 | pto codegen 的 TCI 调用未传递 diff_value | diff_value ≠ 1 时结果错误（步长始终为 1） |
+| count 被忽略 | pto codegen 的 TCI 调用未传递 count | 部分写入（count < buffer size）时写满整个 buffer |
+
+## 3. 示例代码
+
+**示例 1：float16 等差数列，步长 0.5**
+
+```python
+buf = T.alloc_ub((256,), "float16")
+T.tile.arith_progression(buf, 0.0, 0.5, 256)  # [0.0, 0.5, 1.0, ..., 127.5]
+```
+
+**示例 2：int32 等差数列，步长 2**
+
+```python
+buf = T.alloc_ub((128,), "int32")
+T.tile.arith_progression(buf, 1, 2, 128)  # [1, 3, 5, ..., 255]
+```
+
+**示例 3：部分写入 buffer**
+
+```python
+buf = T.alloc_ub((512,), "float32")
+T.tile.arith_progression(buf, 0.0, 1.0, 300)  # buffer 有 512 空间，只写入前 300 个元素
+```

--- a/docs/api_docs/T.tile.arith_progression.md
+++ b/docs/api_docs/T.tile.arith_progression.md
@@ -13,7 +13,7 @@ def arith_progression(
     buffer: Buffer,
     first_value: PrimExpr,
     diff_value: PrimExpr,
-    count: PrimExpr,
+    count: PrimExpr | None = None,
 )
 ```
 
@@ -24,7 +24,7 @@ def arith_progression(
 | buffer | 输出 | 存放等差数列 | 张量（tensor） | 必填 |
 | first_value | 输入 | 等差数列的首个元素值，须与 buffer 的 dtype 一致 | 标量（scalar） | 必填 |
 | diff_value | 输入 | 等差数列元素之间的差值（须 ≥ 0），须与 buffer 的 dtype 一致 | 标量（scalar） | 必填 |
-| count | 输入 | 等差数列的长度（元素个数），须 > 0 | 整数 | 必填 |
+| count | 输入 | 等差数列的长度（元素个数），须 > 0。省略时由 `math.prod(buffer.shape)` 自动推导 | 整数 | 可选 |
 
 > **类型说明**：
 > - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）

--- a/testing/python/language/test_tilelang_ascend_language_arith_progression_dtype_coverage.py
+++ b/testing/python/language/test_tilelang_ascend_language_arith_progression_dtype_coverage.py
@@ -1,0 +1,203 @@
+"""
+T.tile.arith_progression dtype coverage tests.
+
+Tests dtype coverage, parameter combinations, partial buffer writes,
+and unsupported dtype compilation errors for T.tile.arith_progression.
+
+Existing coverage in test_tilelang_ascend_language_elementwise.py:
+- test_generate_arithmetic_progression: int32, shape=1024, step=1 (low_priority)
+
+This file supplements with:
+1. Supported dtype coverage (float16/float32/int16/int32 x ascendc/pto, uint16/uint32 x pto)
+2. Parameter combinations on ascendc (first_value/diff_value variations)
+3. Partial buffer writes on ascendc (count < buffer size)
+4. Unsupported dtype compilation errors (uint16/uint32 x ascendc, float16 x pto)
+
+Note: pto parameter combinations and partial writes are not tested here because
+pto codegen has known bugs (does not pass diff_value/count to TCI).
+See docs/api_docs/T.tile.arith_progression.md section 2.4.1 for details.
+"""
+
+import pytest
+import tilelang
+import tilelang.language as T
+import torch
+
+tilelang.disable_cache()
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+DTYPE_TORCH_MAP = {
+    "float16": torch.float16,
+    "float32": torch.float32,
+    "int16": torch.int16,
+    "int32": torch.int32,
+    "uint16": torch.uint16,
+    "uint32": torch.uint32,
+}
+
+
+def _torch_arange(start, end, step, dtype):
+    if dtype in (torch.uint16, torch.uint32):
+        ref = torch.arange(start, end, step, dtype=torch.int32)
+        return ref.to(dtype)
+    return torch.arange(start, end, step, dtype=dtype)
+
+
+def _build_seq(first_value, diff_value, count, torch_dtype):
+    if diff_value == 0:
+        return torch.full((count,), first_value, dtype=torch_dtype)
+    return _torch_arange(first_value, first_value + count * diff_value, diff_value, torch_dtype)
+
+
+def _make_kernel(N, block_size, dtype, first_value, diff_value, count):
+    num_blocks = N // block_size
+    VEC_NUM = 2
+
+    @T.prim_func
+    def main(output: T.Tensor((N,), dtype)):
+        with T.Kernel(num_blocks, is_npu=True) as (cid, vid):
+            start_idx = cid * block_size + vid * block_size // VEC_NUM
+            seq_ub = T.alloc_shared((block_size // VEC_NUM,), dtype)
+            T.tile.arith_progression(seq_ub, first_value, diff_value, count)
+            T.copy(seq_ub, output[start_idx])
+
+    return main
+
+
+def _make_partial_write_kernel(buf_size, write_count, dtype, first_value, diff_value):
+    @T.prim_func
+    def main(output: T.Tensor((buf_size,), dtype)):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            seq_ub = T.alloc_shared((buf_size,), dtype)
+            T.tile.arith_progression(seq_ub, first_value, diff_value, write_count)
+            T.copy(seq_ub, output[0])
+
+    return main
+
+
+def _run_one(dtype, target, N=1024, block_size=64, first_value=0, diff_value=1):
+    torch_dtype = DTYPE_TORCH_MAP[dtype]
+    count = block_size // 2
+    func = _make_kernel(N, block_size, dtype, first_value, diff_value, count)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    output = torch.zeros(N, dtype=torch_dtype).npu()
+    torch.npu.synchronize()
+    result = func(output)
+
+    seq = _build_seq(first_value, diff_value, count, torch_dtype)
+    ref_result = seq.repeat(N // count)
+    torch.testing.assert_close(result.cpu(), ref_result, rtol=0, atol=0)
+
+
+def _run_partial_write(dtype, target, buf_size=256, write_count=100, first_value=5, diff_value=2):
+    torch_dtype = DTYPE_TORCH_MAP[dtype]
+    func = _make_partial_write_kernel(buf_size, write_count, dtype, first_value, diff_value)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    output = torch.zeros(buf_size, dtype=torch_dtype).npu()
+    torch.npu.synchronize()
+    result = func(output)
+
+    ref = _build_seq(first_value, diff_value, write_count, torch_dtype)
+    torch.testing.assert_close(result.cpu()[:write_count], ref, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "float32",
+        pytest.param("int32", marks=pytest.mark.low_priority),
+        pytest.param("int16", marks=pytest.mark.low_priority),
+    ],
+)
+@pytest.mark.parametrize(
+    "target",
+    [
+        "ascendc",
+        pytest.param("pto", marks=pytest.mark.low_priority),
+    ],
+)
+def test_arith_progression_dtype(dtype, target):
+    _run_one(dtype, target)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pytest.param("float16", marks=pytest.mark.low_priority),
+    ],
+)
+@pytest.mark.parametrize("target", ["ascendc"])
+def test_arith_progression_dtype_float16_ascendc(dtype, target):
+    _run_one(dtype, target)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pytest.param("uint16", marks=pytest.mark.low_priority),
+        pytest.param("uint32", marks=pytest.mark.low_priority),
+    ],
+)
+@pytest.mark.parametrize("target", ["pto"])
+def test_arith_progression_dtype_uint_pto(dtype, target):
+    _run_one(dtype, target)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "float32",
+        "int32",
+        pytest.param("int16", marks=pytest.mark.low_priority),
+    ],
+)
+@pytest.mark.parametrize("target", ["ascendc"])
+@pytest.mark.parametrize(
+    "first_value,diff_value",
+    [
+        pytest.param(10, 2, marks=pytest.mark.low_priority),
+        pytest.param(0, 0, marks=pytest.mark.low_priority),
+        pytest.param(100, 5, marks=pytest.mark.low_priority),
+    ],
+)
+def test_arith_progression_param_combinations(dtype, target, first_value, diff_value):
+    _run_one(dtype, target, first_value=first_value, diff_value=diff_value)
+
+
+@pytest.mark.low_priority
+@pytest.mark.parametrize("dtype", ["float32", "int32"])
+@pytest.mark.parametrize("target", ["ascendc"])
+def test_arith_progression_partial_write(dtype, target):
+    _run_partial_write(dtype, target, buf_size=256, write_count=100, first_value=5, diff_value=2)
+
+
+@pytest.mark.parametrize(
+    "dtype,target",
+    [
+        ("uint16", "ascendc"),
+        pytest.param("uint32", "ascendc", marks=pytest.mark.low_priority),
+        pytest.param("float16", "pto", marks=pytest.mark.low_priority),
+    ],
+)
+def test_arith_progression_unsupported_dtype_raises(dtype, target):
+    @T.prim_func
+    def main(output: T.Tensor((64,), dtype)):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            seq_ub = T.alloc_shared((64,), dtype)
+            T.tile.arith_progression(seq_ub, 0, 1, 64)
+            T.copy(seq_ub, output[0])
+
+    with pytest.raises(RuntimeError, match="Compilation Failed"):  # noqa: B017
+        tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-n", "8"])

--- a/testing/python/language/test_tilelang_ascend_language_arith_progression_dtype_coverage.py
+++ b/testing/python/language/test_tilelang_ascend_language_arith_progression_dtype_coverage.py
@@ -8,14 +8,19 @@ Existing coverage in test_tilelang_ascend_language_elementwise.py:
 - test_generate_arithmetic_progression: int32, shape=1024, step=1 (low_priority)
 
 This file supplements with:
-1. Supported dtype coverage (float16/float32/int16/int32 x ascendc/pto, uint16/uint32 x pto)
+1. Supported dtype coverage (float32/int32 x ascendc/pto, float16 x ascendc)
 2. Parameter combinations on ascendc (first_value/diff_value variations)
 3. Partial buffer writes on ascendc (count < buffer size)
-4. Unsupported dtype compilation errors (uint16/uint32 x ascendc, float16 x pto)
+4. Unsupported dtype compilation errors (uint16 x ascendc, float16 x pto)
+5. Count parameter omission (auto-derivation via math.prod(buffer.shape))
 
 Note: pto parameter combinations and partial writes are not tested here because
 pto codegen has known bugs (does not pass diff_value/count to TCI).
 See docs/api_docs/T.tile.arith_progression.md section 2.4.1 for details.
+
+Test suite follows the simplification principle for direct-intrinsic APIs
+(mentor z00520135 review on PR4 atomic_add): since arith_progression has no
+type-specific processing logic, only representative dtypes are tested.
 """
 
 import pytest
@@ -23,7 +28,13 @@ import tilelang
 import tilelang.language as T
 import torch
 
-tilelang.disable_cache()
+
+@pytest.fixture(scope="module", autouse=True)
+def _disable_cache():
+    tilelang.disable_cache()
+    yield
+    tilelang.enable_cache()
+
 
 pass_configs = {
     tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
@@ -114,7 +125,6 @@ def _run_partial_write(dtype, target, buf_size=256, write_count=100, first_value
     [
         "float32",
         pytest.param("int32", marks=pytest.mark.low_priority),
-        pytest.param("int16", marks=pytest.mark.low_priority),
     ],
 )
 @pytest.mark.parametrize(
@@ -142,21 +152,8 @@ def test_arith_progression_dtype_float16_ascendc(dtype, target):
 @pytest.mark.parametrize(
     "dtype",
     [
-        pytest.param("uint16", marks=pytest.mark.low_priority),
-        pytest.param("uint32", marks=pytest.mark.low_priority),
-    ],
-)
-@pytest.mark.parametrize("target", ["pto"])
-def test_arith_progression_dtype_uint_pto(dtype, target):
-    _run_one(dtype, target)
-
-
-@pytest.mark.parametrize(
-    "dtype",
-    [
         "float32",
-        "int32",
-        pytest.param("int16", marks=pytest.mark.low_priority),
+        pytest.param("int32", marks=pytest.mark.low_priority),
     ],
 )
 @pytest.mark.parametrize("target", ["ascendc"])
@@ -165,7 +162,6 @@ def test_arith_progression_dtype_uint_pto(dtype, target):
     [
         pytest.param(10, 2, marks=pytest.mark.low_priority),
         pytest.param(0, 0, marks=pytest.mark.low_priority),
-        pytest.param(100, 5, marks=pytest.mark.low_priority),
     ],
 )
 def test_arith_progression_param_combinations(dtype, target, first_value, diff_value):
@@ -173,7 +169,7 @@ def test_arith_progression_param_combinations(dtype, target, first_value, diff_v
 
 
 @pytest.mark.low_priority
-@pytest.mark.parametrize("dtype", ["float32", "int32"])
+@pytest.mark.parametrize("dtype", ["float32"])
 @pytest.mark.parametrize("target", ["ascendc"])
 def test_arith_progression_partial_write(dtype, target):
     _run_partial_write(dtype, target, buf_size=256, write_count=100, first_value=5, diff_value=2)
@@ -183,7 +179,6 @@ def test_arith_progression_partial_write(dtype, target):
     "dtype,target",
     [
         ("uint16", "ascendc"),
-        pytest.param("uint32", "ascendc", marks=pytest.mark.low_priority),
         pytest.param("float16", "pto", marks=pytest.mark.low_priority),
     ],
 )
@@ -197,6 +192,34 @@ def test_arith_progression_unsupported_dtype_raises(dtype, target):
 
     with pytest.raises(RuntimeError, match="Compilation Failed"):  # noqa: B017
         tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+
+def test_arith_progression_count_omitted():
+    """Verify that omitting count auto-derives math.prod(buffer.shape).
+
+    The result should match the equivalent call with explicit count.
+    """
+    dtype = "float32"
+    target = "ascendc"
+    torch_dtype = DTYPE_TORCH_MAP[dtype]
+    buf_size = 64
+    first_value = 10
+    diff_value = 1
+
+    @T.prim_func
+    def main(output: T.Tensor((buf_size,), dtype)):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            seq_ub = T.alloc_shared((buf_size,), dtype)
+            T.tile.arith_progression(seq_ub, first_value, diff_value)
+            T.copy(seq_ub, output[0])
+
+    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+    output = torch.zeros(buf_size, dtype=torch_dtype).npu()
+    torch.npu.synchronize()
+    result = func(output)
+
+    ref = _build_seq(first_value, diff_value, buf_size, torch_dtype)
+    torch.testing.assert_close(result.cpu(), ref, rtol=0, atol=0)
 
 
 if __name__ == "__main__":

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -388,11 +388,12 @@ def clear(buffer: Buffer | tir.Var):
     return fill(buffer, 0)
 
 
-def arith_progression(buffer: Buffer, first_value: PrimExpr, diff_value: PrimExpr, count: PrimExpr):
+def arith_progression(buffer: Buffer, first_value: PrimExpr, diff_value: PrimExpr, count: PrimExpr | None = None):
     """Generates an arithmetic progression sequence in a buffer.
 
     Writes ``count`` elements to ``buffer`` such that
     ``buffer[i] = first_value + i * diff_value`` (i = 0, 1, ..., count-1).
+    When ``count`` is omitted, it is inferred as ``math.prod(buffer.shape)``.
 
     Args:
         buffer: The destination buffer where the sequence will be stored.
@@ -403,11 +404,15 @@ def arith_progression(buffer: Buffer, first_value: PrimExpr, diff_value: PrimExp
         diff_value: The difference (step) between consecutive values.
             Must be >= 0 and have the same dtype as ``buffer``.
         count: The number of elements to generate. Must be > 0 and
-            not exceed ``buffer`` capacity.
+            not exceed ``buffer`` capacity. If None, inferred as
+            ``math.prod(buffer.shape)``.
 
     Returns:
         A TVM intrinsic call that performs the arithmetic progression operation.
     """
+    if count is None:
+        count = math.prod(buffer.shape)
+
     return tir.call_intrin(
         "handle",
         tir.op.Op.get("tl.ascend_arith_progression"),

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -391,11 +391,19 @@ def clear(buffer: Buffer | tir.Var):
 def arith_progression(buffer: Buffer, first_value: PrimExpr, diff_value: PrimExpr, count: PrimExpr):
     """Generates an arithmetic progression sequence in a buffer.
 
+    Writes ``count`` elements to ``buffer`` such that
+    ``buffer[i] = first_value + i * diff_value`` (i = 0, 1, ..., count-1).
+
     Args:
         buffer: The destination buffer where the sequence will be stored.
+            Supports float16, float32, int16, int32. float16 is ascendc-only;
+            uint16, uint32 are pto-only.
         first_value: The starting value of the arithmetic progression.
+            Must have the same dtype as ``buffer``.
         diff_value: The difference (step) between consecutive values.
-        count: The number of elements to generate.
+            Must be >= 0 and have the same dtype as ``buffer``.
+        count: The number of elements to generate. Must be > 0 and
+            not exceed ``buffer`` capacity.
 
     Returns:
         A TVM intrinsic call that performs the arithmetic progression operation.


### PR DESCRIPTION
## 改动内容

针对 `T.tile.arith_progression` API 完成文档校验、测试用例补充、docstring 更新和函数签名改进。

### 1. Docstring + 函数签名更新（修改）

- `tilelang/language/ascend_tile.py` 中 `arith_progression` 函数
- 在原版基础上补充，不删除原有内容：
  - 功能公式说明（`buffer[i] = first_value + i * diff_value`）
  - dtype 支持（float16/float32/int16/int32，float16 ascendc-only，uint16/uint32 pto-only）
  - 参数约束（first_value/diff_value 须与 buffer dtype 一致，diff_value >= 0，count > 0）
  - **count 参数改为可选**（采纳 reviewer liggest 建议）：`count: PrimExpr | None = None`，省略时由 `math.prod(buffer.shape)` 自动推导（与 `createvecindex` 一致），向后兼容

### 2. 测试用例（新增）

- `testing/python/language/test_tilelang_ascend_language_arith_progression_dtype_coverage.py`
- **13 个用例**（13 PASSED + 0 SKIPPED），不重复 `elementwise.py` 中已有的 `test_generate_arithmetic_progression`（int32, shape=1024, step=1）
- LP 分层标记：PR 合入时跑 3 个，每日 CI 跑 13 个

| 测试函数 | 用例数 | PR执行 | LP | 覆盖内容 |
|---------|:---:|:---:|:---:|---------|
| `test_arith_progression_dtype` | 4 | 1 | 3 | float32/int32 × ascendc/pto，1D shape |
| `test_arith_progression_dtype_float16_ascendc` | 1 | 0 | 1 | float16 × ascendc（pto 不支持） |
| `test_arith_progression_param_combinations` | 4 | 0 | 4 | (first=10,diff=2)/(first=0,diff=0) × float32/int32 × ascendc |
| `test_arith_progression_partial_write` | 1 | 0 | 1 | count < buffer_size 部分写入 × float32 × ascendc |
| `test_arith_progression_unsupported_dtype_raises` | 2 | 1 | 1 | uint16×ascendc + float16×pto 编译失败（异常边界） |
| `test_arith_progression_count_omitted` | 1 | 1 | 0 | 省略 count，验证 `math.prod(buffer.shape)` 自动推导 |
| **合计** | **13** | **3** | **10** | |

测试精简原则：arith_progression 是直调底层 API，前端无类型分支处理逻辑，dtype 覆盖选典型类型（float32/float16/int32），不冗余测试相同 codegen 路径的 dtype。

### 3. API 文档（新增）

- `docs/api_docs/T.tile.arith_progression.md`

校验完成版文档，包含：功能说明 / 函数原型 / 参数说明 / DataType 支持 / Shape 支持 / 约束条件 / pto 后端已知限制 / 示例代码。

## 测试结果

- **13 PASSED + 0 SKIPPED**（CI 全绿，0 FAILED）

## 已知限制（文档约束已写明）

| 限制 | 文档位置 | 说明 |
|------|---------|------|
| uint16/uint32 ascendc 不支持 | 2.3.1 支持矩阵 | CANN SDK `static_assert` 不含 uint，硬件指令不支持 |
| float16 pto 不支持 | 2.3.1 支持矩阵 | PTO ISA `TCI` 函数不允许 half 标量运算 |
| pto diff_value 固定为 1 | 2.4.1 pto 已知限制 | pto codegen 的 TCI 调用未传递 diff_value |
| pto count 被忽略 | 2.4.1 pto 已知限制 | pto codegen 的 TCI 调用未传递 count |
| count/diff_value 约束编译期不触发 | 2.4 约束 2、3 | ASCENDC_ASSERT 为运行时检查，编译期不触发 |

## 校验过程中发现的 framework bug

本次校验过程中发现 2 个 pto codegen bug，均不影响本 PR 合入（已通过文档约束 + 删除 pto bug 组合测试处理），详细根因分析记录在 `api/bug_investigation/arith_progression_bug.md`，后续可单独 PR 修复。

| # | Bug | 根因 | 影响范围 | 当前处理 | pto 是否受影响 |
|---|-----|------|---------|---------|:---:|
| 1 | pto diff_value 未传递 | `codegen_ascend_pto.cc:2604` 的 TCI 调用只传 first_value，未传 diff_value | pto 后端所有 dtype，diff_value ≠ 1 时结果错误（step 固定为 1） | 文档 2.4.1 记录，删除 pto 参数组合测试 | 是 |
| 2 | pto count 未传递 | 同上，TCI 调用未传 count | pto 后端所有 dtype，部分写入时写满整个 buffer | 文档 2.4.1 记录，删除 pto 部分写入测试 | 是 |

### 修复尝试说明

- 未尝试修复：根因在 PTO ISA 的 `TCI` 函数签名（`3rdparty/pto-isa/include/pto/npu/a2a3/TCI.hpp`），函数内部硬编码 `step=1`，`validCol` 从 buffer 的 `GetValidCol()` 取而非用户指定的 count。修复需要改 3rdparty PTO ISA 或在 pto codegen 生成 workaround，超出本 PR 范围
- ascendc 后端完全正常，不受影响

### 后续待办

| 优先级 | Bug | 待办 |
|--------|-----|------|
| 中 | pto diff_value 未传递 | 修 `codegen_ascend_pto.cc` 的 TCI 调用，传递 diff_value |
| 中 | pto count 未传递 | 修 `codegen_ascend_pto.cc` 的 TCI 调用，传递 count |

## 文件改动

| 文件 | 类型 | 改动 |
|------|------|------|
| `tilelang/language/ascend_tile.py` | 修改 | docstring 补充 + count 参数改为可选（`count=None`，省略时 `math.prod(buffer.shape)` 自动推导） |
| `testing/python/language/test_tilelang_ascend_language_arith_progression_dtype_coverage.py` | 新增 | 13 个测试用例（含 count 省略验证） |
| `docs/api_docs/T.tile.arith_progression.md` | 新增 | API 文档（count 标为可选） |
