### PR TITLE
[Fix] Complete buffer ownership in expert attention kernels 🤖

### DIFF
--- a/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-schedule-sync.md
+++ b/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-schedule-sync.md
@@ -167,6 +167,38 @@ T.set_flag("mte2", "v", 0)
 T.wait_flag("mte2", "v", 0)
 ```
 
+`set_flag` / `wait_flag` 应按“物理缓冲 ownership”设计，而不是只做一次 producer →
+consumer 就绪通知。只要同一缓冲会被下一轮复用，就必须同时有 consumer → producer
+归还方向：
+
+```python
+# 初始化：consumer 预先把缓冲归还给 producer。
+T.set_flag("MTE1", "MTE2", SIG_L1)
+
+for task in T.serial(task_count):
+    T.wait_flag("MTE1", "MTE2", SIG_L1)  # MTE2 获得可写 ownership
+    T.copy(src[task], l1_buf)
+    T.set_flag("MTE2", "MTE1", SIG_L1)   # producer → consumer
+
+    T.wait_flag("MTE2", "MTE1", SIG_L1)  # MTE1 获得可读 ownership
+    # 完成这一 task 对 l1_buf 的全部读取；可以跨多个内层循环。
+    T.copy(l1_buf, l0_buf)
+    T.set_flag("MTE1", "MTE2", SIG_L1)   # consumer → 下一轮 producer
+
+# 销毁：消费最后一次归还，确保 token 生命周期闭合。
+T.wait_flag("MTE1", "MTE2", SIG_L1)
+```
+
+`T.barrier_all()` 只为它之前已经发出的本地异步操作建立完成边界。它不是缓冲区
+ownership token，也不能保护 barrier **之后**的 store，防止下一 task 过早复用同一缓冲。
+跨流水线复用必须使用与实际 producer/consumer 匹配的双向 flag 生命周期。
+
+event ID 属于有向 `(src_pipe, dst_pipe)` pair，不是所有 pipe 共享的全局编号。
+为新缓冲分配 ID 时，应在它的正、反两个 pair 中选择未占用的 ID；不必为了
+全局数字唯一而跳到更高 ID。反向 pair 是独立的编号空间；同一 ownership
+slot 通常在正反两个 pair 中使用相同数字，但 `FREE` 和 `READY` 等不同语义应保留
+独立名称，且两个方向仍分别需要匹配的 `set_flag` / `wait_flag`。
+
 ### 核间同步
 
 | API | 说明 |

--- a/.agents/skills/tilelang-perf-optimization/references/best-practices/flash_attn_optimize.md
+++ b/.agents/skills/tilelang-perf-optimization/references/best-practices/flash_attn_optimize.md
@@ -120,12 +120,18 @@ T.barrier_all()  # 再次所有流水同步
 #### Expert 优化
 
 ```python
-# Intra-core Flag：Cube 核内部流水线同步
-SIG_K_L1 = 0    # K 搬运到 L1 的信号
-SIG_P_L1 = 1    # P 搬运到 L1 的信号
-SIG_V_L1 = 2    # V 搬运到 L1 的信号
-SIG_L0AB = 3    # L0A/L0B 双缓冲基址
-SIG_L0C = 5     # L0C 双缓冲基址
+# Intra-core Flag：每个有向 pipe pair 独立编号
+# MTE2 <-> MTE1
+SIG_K_L1 = 0    # K 的 L1 ownership
+SIG_P_L1 = 1    # P 的 L1 ownership
+SIG_V_L1 = 2    # V 的 L1 ownership
+SIG_Q_L1 = 3    # Q 的持久 L1 ownership
+
+# MTE1 <-> M
+SIG_L0AB = 0    # L0A/L0B 双缓冲基址，使用 ID 0、1
+
+# M <-> FIX
+SIG_L0C = 0     # L0C 双缓冲基址，使用 ID 0、1
 
 # Cross-core Semaphore：Cube ↔ Vector 同步
 SEM_WS1_C2V = 0  # workspace_1 (QK^T) 就绪
@@ -140,6 +146,7 @@ T.set_cross_flag("MTE2", SEM_WS2_C2V)
 T.set_flag("MTE1", "MTE2", SIG_K_L1)
 T.set_flag("MTE1", "MTE2", SIG_P_L1)
 T.set_flag("MTE1", "MTE2", SIG_V_L1)
+T.set_flag("MTE1", "MTE2", SIG_Q_L1)
 T.set_flag("M", "MTE1", SIG_L0AB)
 T.set_flag("M", "MTE1", SIG_L0AB + 1)
 T.set_flag("FIX", "M", SIG_L0C)
@@ -158,7 +165,20 @@ T.set_flag("MTE1", "M", SIG_L0AB + side)  # 通知 L0 数据就绪
 T.wait_flag("MTE1", "M", SIG_L0AB + side)  # 等待 L0 数据就绪
 T.mma(l0a[side, :, :], l0b[side, :, :], l0c[side, :, :], init=True)
 T.set_flag("M", "MTE1", SIG_L0AB + side)  # 通知 L0 缓冲可重用
+
+# 持久化 Q 缓冲也必须形成双向 ownership 闭环。
+T.wait_flag("MTE1", "MTE2", SIG_Q_L1)  # MTE2 等待 q_l1 可写
+T.copy(Q[...], q_l1)
+T.set_flag("MTE2", "MTE1", SIG_Q_L1)   # Q 就绪，交给 MTE1
+T.wait_flag("MTE2", "MTE1", SIG_Q_L1)
+for k in T.serial(num_outer):
+    # 所有从 q_l1 到 L0A 的读取都在这个 ownership 区间内
+    ...
+T.set_flag("MTE1", "MTE2", SIG_Q_L1)   # 全部读取结束，允许下一 task 重载 Q
 ```
+
+作用域退出前，必须用对应方向的 `wait_flag` 消耗每个缓冲区最后归还的 token；初始化、
+每轮 acquire/release 和销毁必须构成完整生命周期。
 
 **收益**：
 - 精确控制数据流，避免不必要的等待
@@ -371,6 +391,9 @@ for _k in T.serial(T.ceildiv(seq_len, block_N)):
 r_factors = T.alloc_ub([num_stages, block_M // 2, 1], accum_dtype)
 sumexp_is = T.alloc_ub([num_stages, block_M // 2, 1], accum_dtype)
 
+# acc_s_half 初始归 V 所有。
+T.set_flag("MTE3", "V", SIG_S_HALF)
+
 for k in T.serial(num_outer):
     # Softmax 批次：计算 num_stages 个分块的 r_factors 和 sumexp_is
     for i in T.serial(batch_iters):
@@ -390,9 +413,13 @@ for k in T.serial(num_outer):
         # 计算 sumexp_is[i] = rowsum(exp(S - m_cur))
         T.reduce_sum(work_ub, sumexp_is[i, :, :], dim=-1)
         
-        # 存储 softmax 后的注意力分数
+        # 存储 softmax 后的注意力分数：V 写 UB，MTE3 读 UB，再归还给 V
+        T.wait_flag("MTE3", "V", SIG_S_HALF)
         T.copy(work_ub, acc_s_half)
+        T.set_flag("V", "MTE3", SIG_S_HALF)
+        T.wait_flag("V", "MTE3", SIG_S_HALF)
         T.copy(acc_s_half, workspace_2[cid, i, ...])
+        T.set_flag("MTE3", "V", SIG_S_HALF)
         if (i + 1) % cross_interval == 0 or i == batch_iters - 1:
             T.set_cross_flag("MTE3", SEM_WS2_V2C)
     
@@ -415,7 +442,14 @@ for k in T.serial(num_outer):
         T.copy(workspace_3[cid, i, ...], io_buf)
         T.copy(io_buf, work_ub)
         T.tile.add(acc_o, acc_o, work_ub)
+
+# 作用域退出前消费最后一次 MTE3 → V 归还。
+T.wait_flag("MTE3", "V", SIG_S_HALF)
 ```
+
+如果最终 Output store 也复用 `acc_s_half`，它必须进入同一个
+`MTE3 → V → MTE3 → V` ownership 闭环。把 `T.barrier_all()` 放在最终 store **之前**，
+只能等待此前已发出的操作，不能保护该 store 的 MTE3 读取不被下一 task 的 V 写覆盖。
 
 **收益**：
 - 批量计算减少同步次数
@@ -494,6 +528,9 @@ T.tile.mul(work_ub, work_ub, sm_scale)    # 计算
 T.copy(work_ub, acc_s_half)               # 结果存储
 ```
 
+复用物理缓冲的前提是完整的 ownership 生命周期。上例中的 `io_buf` 和
+`acc_s_half` 都必须由各自的双向 flag 保护；仅靠源码顺序或 store 前的 barrier 不足以保护下次复用。
+
 **收益**：
 - 减少内存占用
 - 简化数据流管理
@@ -526,7 +563,7 @@ T.copy(work_ub, acc_s_half)               # 结果存储
 
 **权衡**：strided DMA 理论上略慢于连续 DMA，但省下的是整块 Transpose kernel，净收益极大正；实测 main_kernel 未见劣化。
 
-**注意冷启动**：手写 flag 同步的 expert kernel 可能有低概率冷启动竞争，被布局/时序改动暴露。用 `msprof` 或精度校验时以**热身后**（warmup+repeat 的最后一次）的输出为准，连跑多次判稳定，不要被单次冷启动异常误导。
+**正确性要求**：手写 flag 同步的 expert kernel 在任意一次运行中出现数值错误，都应视为同步或数据流缺陷。warmup 只用于稳定性能测量，不能作为忽略首次错误的理由；精度回归应校验每次运行，并通过重复或并发压力测试放大低概率竞态。
 
 #### (b) Sq==1 decode 窄块 kernel
 
@@ -787,20 +824,25 @@ NUM_CORES = torch.npu.get_device_properties(0).cube_core_num
 
 ### Intra-core Flag（Cube 核内部）
 
-| ID | 名称 | 说明 |
-|----|------|------|
-| 0 | SIG_K_L1 | K 搬运到 L1 的信号 |
-| 1 | SIG_P_L1 | P 搬运到 L1 的信号 |
-| 2 | SIG_V_L1 | V 搬运到 L1 的信号 |
-| 3-4 | SIG_L0AB | L0A/L0B 双缓冲（side=0/1） |
-| 5-6 | SIG_L0C | L0C 双缓冲（side=0/1） |
+event ID 的完整身份包含有向 `(src_pipe, dst_pipe)` pair。每个有向 pair 都从
+0 独立编号；反向 pair 是另一个编号空间。同一 ownership slot 通常在正反两个
+pair 中使用相同数字，便于审查；`FREE` 和 `READY` 等不同语义仍应保留独立名称。
+
+| Ownership | 有向 pair | ID | 名称 |
+|-----------|-----------|----|------|
+| K L1 | MTE1→MTE2 / MTE2→MTE1 | 0 | SIG_K_L1 |
+| P L1 | MTE1→MTE2 / MTE2→MTE1 | 1 | SIG_P_L1 |
+| V L1 | MTE1→MTE2 / MTE2→MTE1 | 2 | SIG_V_L1 |
+| Q L1 | MTE1→MTE2 / MTE2→MTE1 | 3 | SIG_Q_L1 |
+| L0AB slot 0/1 | M→MTE1 / MTE1→M | 0-1 | SIG_L0AB |
+| L0C slot 0/1 | FIX→M / M→FIX | 0-1 | SIG_L0C |
 
 ### Intra-core Flag（Vector 核内部）
 
-| ID | 名称 | 说明 |
-|----|------|------|
-| 0 | SIG_IO_UB | IO 缓冲信号 |
-| 1 | SIG_S_HALF | Softmax 结果信号 |
+| Ownership | 有向 pair | ID | 名称 |
+|-----------|-----------|----|------|
+| IO UB | V→MTE2 / MTE2→V | 0 | SIG_IO_UB |
+| fp16 store UB | MTE3→V / V→MTE3 | 0 | SIG_S_HALF |
 
 ### Cross-core Semaphore（Cube ↔ Vector）
 

--- a/docs/TileLang-Ascend Programming Guide.md
+++ b/docs/TileLang-Ascend Programming Guide.md
@@ -2346,6 +2346,9 @@ Expert编程模式可以复用Developer模式的Reduce类计算原语。
 
   详细功能，详见AscendC文档：https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/83RC1alpha002/API/ascendcopapi/atlasascendc_api_07_0271.html
 
+  **边界**：该屏障只等待它之前已经发出的本地异步操作。它不等价于缓冲区
+  ownership handoff，也不能保护屏障之后的 store，防止后续 task 复用同一物理缓冲。
+
 - `T.pipe_barrier(pipe: _pipe):`
 
   **参数**：
@@ -2365,6 +2368,22 @@ Expert编程模式可以复用Developer模式的Reduce类计算原语。
   **功能**：在计算单元（块/核心）内执行全局同步。
 
   详细功能，详见AscendC文档：https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/83RC1alpha002/API/ascendcopapi/atlasascendc_api_07_0204.html
+
+手动同步并复用同一物理缓冲时，应为 producer → consumer 的“数据就绪”和
+consumer → producer 的“缓冲归还”分别使用匹配的 `set_flag` / `wait_flag`。完整生命周期包括：
+
+1. consumer 在作用域入口预先归还 token；
+2. producer 获取 token、写缓冲并通知 consumer；
+3. consumer 获取 token、完成所有读取并归还给下一轮 producer；
+4. 作用域退出前消费最后一次归还的 token。
+
+例如，MTE2 写 L1、MTE1 读取后，正向使用 `MTE2 → MTE1`，反向归还使用
+`MTE1 → MTE2`。若 MTE1 在多个内层循环中持续读取该 L1 缓冲，必须在最后一次读取
+之后再归还，而不是在第一次读取后立即归还。
+
+event ID 按有向 pipe pair 分配，只需在同一 pair 内避免同时占用；反向 pair 是另一个
+独立编号空间。同一 ownership slot 通常在正反两个 pair 中使用相同数字，便于阅读和
+审查；不同方向的信号若表达不同语义（例如 `FREE` 和 `READY`），仍应保留独立名称。
 
 ## 5. 调试诊断
 

--- a/docs/tutorials/t_pipelined.md
+++ b/docs/tutorials/t_pipelined.md
@@ -140,25 +140,33 @@ In flat pattern, use `T.Pipelined` for inter-core pipeline, and manually impleme
 
 ```python
 # ✅ Recommended: T.Pipelined for inter-core, manual for intra-core
+T.set_flag("MTE1", "MTE2", SIG_K_L1)  # init: k_l1 is free for MTE2
+
 for k in T.Pipelined(num_iters, num_stages=4):
     # T.Pipelined handles inter-core sync automatically
 
     # Manual intra-core double buffering (side = 0, 1)
     for side in T.serial(2):
+        T.wait_flag("MTE1", "MTE2", SIG_K_L1)
         T.copy(K[side], k_l1)
         T.set_flag("MTE2", "MTE1", SIG_K_L1)
-        T.wait_flag("MTE1", "MTE2", SIG_K_L1)
 
+        T.wait_flag("MTE2", "MTE1", SIG_K_L1)
         T.copy(k_l1, l0b[side])
-        T.set_flag("MTE1", "MTE2", SIG_K_L1)
         T.set_flag("MTE1", "M", SIG_L0AB + side)
+        T.set_flag("MTE1", "MTE2", SIG_K_L1)
 
         T.wait_flag("MTE1", "M", SIG_L0AB + side)
         T.wait_flag("FIX", "M", SIG_L0C + side)
         T.mma(l0a[side], l0b[side], l0c[side], init=(side == 0))
         T.set_flag("M", "MTE1", SIG_L0AB + side)
         T.set_flag("M", "FIX", SIG_L0C + side)
+
+T.wait_flag("MTE1", "MTE2", SIG_K_L1)  # destroy: consume final return token
 ```
+
+The two directions form one ownership cycle for the physical `k_l1` region. A barrier or a
+one-way ready flag is insufficient when a later iteration overwrites that region.
 
 Benefits of flat pattern:
 - **Clear separation**: `T.Pipelined` handles inter-core sync, manual code handles intra-core

--- a/examples/attention_sink/example_gqa_sink_fwd_varlen/example_gqa_sink_fwd_varlen.py
+++ b/examples/attention_sink/example_gqa_sink_fwd_varlen/example_gqa_sink_fwd_varlen.py
@@ -8,7 +8,7 @@ Based on fa_opt multi-buffer pipeline port (flash_attn_bhsd_expert_h16_d128.py):
   - Fixed Core + workspace [core_num, num_stages, ...] (L2 cache residency)
   - Multi-buffer pipeline with 6-flag batched cross-core sync
   - T.mma + L0A/L0B/L0C double-buffer + ZN/NZ layout
-  - Fine-grained intra-core flags (Cube: 7, Vector: 5) replacing barrier_all
+  - Fine-grained intra-core flags with complete buffer ownership
 
 Performance (B=8, H=64, G=16, Sq=Sk=2048, D=128, causal, fp16, 910B3):
   ~12 ms (1.06x GPU baseline 11.4 ms)
@@ -104,23 +104,28 @@ def gqa_sink_fwd(
     FLAG_O_READY = 4  # Cube GEMM2 -> Vector O-accum : O written to ws3
     FLAG_WS3_FREE = 5  # Vector O-accum -> Cube GEMM2 : ws3 consumed (free)
 
-    # Step 3: Intra-core signal IDs (C Scope) — L0 double-buffer pipeline sync.
-    # Separate namespace from cross_flags (set_flag/wait_flag vs
-    # set_cross_flag/wait_cross_flag), matching fa_opt SIG_*.
+    # Local event IDs are allocated per directed pipe pair. Different meanings keep
+    # distinct names even when their directed pairs allow the same numeric ID.
+    # MTE2 <-> MTE1
     SIG_K_L1 = 0  # MTE2 writes k_l1, MTE1 reads it
     SIG_P_L1 = 1  # MTE2 writes acc_s_l1 (P), MTE1 reads it
     SIG_V_L1 = 2  # MTE2 writes v_l1, MTE1 reads it
-    SIG_L0AB = 3  # double-buffer base: slot 0 = SIG_L0AB, slot 1 = SIG_L0AB + 1
-    SIG_L0C = 5  # double-buffer base: slot 0 = SIG_L0C,  slot 1 = SIG_L0C + 1
+    SIG_Q_L1 = 3
 
-    # Step 4: Intra-core signal IDs (V Scope) — fine-grained MTE2/MTE3/V sync.
-    # Separate physical namespace from C-scope IDs (AIV vs AIC). fa_opt uses 2
-    # (SIG_IO_UB/SIG_S_HALF); we need 5 because of mask DMA + O-accum batch.
+    # MTE1 <-> M
+    SIG_L0AB = 0  # double-buffer slots 0 and 1
+
+    # M <-> FIX
+    SIG_L0C = 0  # double-buffer slots 0 and 1
+
+    # MTE2 <-> V
     SIG_IO_UB = 0  # MTE2 writes acc_s_ub_ (ws1->UB), V reads it (axpy)
     SIG_MASK_UB = 1  # MTE2 writes mask_half (Mask->UB), V reads it (cast)
-    SIG_S_HALF = 2  # V writes acc_s_half (cast P), MTE3 reads it (->ws2)
-    SIG_O_UB = 3  # MTE2 writes acc_o_ub (ws3->UB), V reads it (add)
-    SIG_O_HALF = 4  # V writes acc_o_half (cast O), MTE3 reads it (->Output)
+    SIG_O_UB = 2  # MTE2 writes acc_o_ub (ws3->UB), V reads it (add)
+
+    # V <-> MTE3
+    SIG_S_HALF = 0  # V writes acc_s_half (cast P), MTE3 reads it (->ws2)
+    SIG_O_HALF = 1  # V writes acc_o_half (cast O), MTE3 reads it (->Output)
 
     @T.prim_func
     def main(
@@ -245,11 +250,11 @@ def gqa_sink_fwd(
                 # Step 2 init: pretend ws2 is free so the first Vector softmax
                 # batch (k=0) can start writing P before Cube GEMM2 consumes it.
                 T.set_cross_flag("MTE2", FLAG_WS2_FREE)
-                # Step 3 init: pretend consumer already released L0 buffers
-                # (fa_opt L137-145) — enables pipeline start at k=0.
+                # Step 3 init: consumers pre-release the Cube-side buffers.
                 T.set_flag("MTE1", "MTE2", SIG_K_L1)
                 T.set_flag("MTE1", "MTE2", SIG_P_L1)
                 T.set_flag("MTE1", "MTE2", SIG_V_L1)
+                T.set_flag("MTE1", "MTE2", SIG_Q_L1)
                 T.set_flag("M", "MTE1", SIG_L0AB)
                 T.set_flag("M", "MTE1", SIG_L0AB + 1)
                 T.set_flag("FIX", "M", SIG_L0C)
@@ -265,9 +270,11 @@ def gqa_sink_fwd(
                     kv_seqlen = kv_seqlens[bz]
                     kv_head_idx = by // groups
 
-                    # Load Q tile
+                    # Load Q tile and keep MTE1 ownership across all KV batches.
+                    T.wait_flag("MTE1", "MTE2", SIG_Q_L1)
                     T.copy(Q[bz, by, bx * _BM : (bx + 1) * _BM, :], q_l1)
-                    T.barrier_all()
+                    T.set_flag("MTE2", "MTE1", SIG_Q_L1)
+                    T.wait_flag("MTE2", "MTE1", SIG_Q_L1)
 
                     # Causal loop range: skip KV blocks entirely masked by causal
                     # NOTE: T.if_then_else used because Python if/else doesn't
@@ -371,11 +378,14 @@ def gqa_sink_fwd(
                         # ws2 consumed by this GEMM2 batch → free for next Vector
                         T.set_cross_flag("MTE2", FLAG_WS2_FREE)
 
-                # Step 3 destroy: consume outstanding init-direction flags
-                # (fa_opt L232-239) — balances the init set_flags at scope start.
+                    # MTE1 no longer reads q_l1; return it before the next task reloads Q.
+                    T.set_flag("MTE1", "MTE2", SIG_Q_L1)
+
+                # Step 3 destroy: consume outstanding return-direction flags.
                 T.wait_flag("MTE1", "MTE2", SIG_K_L1)
                 T.wait_flag("MTE1", "MTE2", SIG_P_L1)
                 T.wait_flag("MTE1", "MTE2", SIG_V_L1)
+                T.wait_flag("MTE1", "MTE2", SIG_Q_L1)
                 T.wait_flag("M", "MTE1", SIG_L0AB)
                 T.wait_flag("M", "MTE1", SIG_L0AB + 1)
                 T.wait_flag("FIX", "M", SIG_L0C)

--- a/examples/flash_attention/fa_opt/flash_attn_bhsd_expert_h16_d128.py
+++ b/examples/flash_attention/fa_opt/flash_attn_bhsd_expert_h16_d128.py
@@ -1,6 +1,6 @@
 import argparse
 import tilelang
-from tilelang import DataType, language as T
+from tilelang import language as T
 from tilelang.intrinsics import make_zn_layout, make_nz_layout
 
 import torch
@@ -69,16 +69,25 @@ def flash_attention_fwd(
     SEM_WS3_C2V = 4
     SEM_WS3_V2C = 5
 
-    # Intra-core signal IDs (C Scope)
+    # Local event IDs are allocated per directed pipe pair. Different meanings keep
+    # distinct names even when their directed pairs allow the same numeric ID.
+    # MTE2 <-> MTE1
     SIG_K_L1 = 0
     SIG_P_L1 = 1
     SIG_V_L1 = 2
-    SIG_L0AB = 3  # double-buffer base: slot 0 = SIG_L0AB, slot 1 = SIG_L0AB + 1
-    SIG_L0C = 5  # double-buffer base: slot 0 = SIG_L0C,  slot 1 = SIG_L0C + 1
+    SIG_Q_L1 = 3
 
-    # Intra-core signal IDs (V Scope)
+    # MTE1 <-> M
+    SIG_L0AB = 0  # double-buffer slots 0 and 1
+
+    # M <-> FIX
+    SIG_L0C = 0  # double-buffer slots 0 and 1
+
+    # MTE2 <-> V
     SIG_IO_UB = 0
-    SIG_S_HALF = 1
+
+    # V <-> MTE3
+    SIG_S_HALF = 0
 
     def task_range(cid_val):
         """Return (start, count) for core cid_val."""
@@ -139,6 +148,7 @@ def flash_attention_fwd(
                 T.set_flag("MTE1", "MTE2", SIG_K_L1)
                 T.set_flag("MTE1", "MTE2", SIG_P_L1)
                 T.set_flag("MTE1", "MTE2", SIG_V_L1)
+                T.set_flag("MTE1", "MTE2", SIG_Q_L1)
                 T.set_flag("M", "MTE1", SIG_L0AB)
                 T.set_flag("M", "MTE1", SIG_L0AB + 1)
                 T.set_flag("FIX", "M", SIG_L0C)
@@ -151,8 +161,10 @@ def flash_attention_fwd(
                     bz = task_id // (num_seq_blocks * heads_q)
                     kv_by = by // (heads_q // heads_kv)
 
+                    T.wait_flag("MTE1", "MTE2", SIG_Q_L1)
                     T.copy(Q[bz, by, bx * block_M : (bx + 1) * block_M, :], q_l1)
-                    T.barrier_all()
+                    T.set_flag("MTE2", "MTE1", SIG_Q_L1)
+                    T.wait_flag("MTE2", "MTE1", SIG_Q_L1)
 
                     for k in T.serial(num_outer):
                         _remaining = num_iters - k * num_stages
@@ -229,10 +241,14 @@ def flash_attention_fwd(
 
                         T.set_cross_flag("MTE2", SEM_WS2_C2V)
 
+                    # MTE1 no longer reads q_l1; return it before the next task reloads Q.
+                    T.set_flag("MTE1", "MTE2", SIG_Q_L1)
+
                 # destroy: consume outstanding init-direction flags
                 T.wait_flag("MTE1", "MTE2", SIG_K_L1)
                 T.wait_flag("MTE1", "MTE2", SIG_P_L1)
                 T.wait_flag("MTE1", "MTE2", SIG_V_L1)
+                T.wait_flag("MTE1", "MTE2", SIG_Q_L1)
                 T.wait_flag("M", "MTE1", SIG_L0AB)
                 T.wait_flag("M", "MTE1", SIG_L0AB + 1)
                 T.wait_flag("FIX", "M", SIG_L0C)
@@ -323,11 +339,15 @@ def flash_attention_fwd(
                     T.tile.broadcast(buf_2d, sumexp)
                     T.tile.div(acc_o, acc_o, buf_2d)
 
+                    # Reuse the softmax store buffer only after MTE3 returns ownership.
+                    T.wait_flag("MTE3", "V", SIG_S_HALF)
                     T.copy(acc_o, acc_s_half)
-                    T.barrier_all()
+                    T.set_flag("V", "MTE3", SIG_S_HALF)
+                    T.wait_flag("V", "MTE3", SIG_S_HALF)
                     T.copy(
                         acc_s_half, Output[bz, by, bx * block_M + vid * block_M // 2 : bx * block_M + vid * block_M // 2 + block_M // 2, :]
                     )
+                    T.set_flag("MTE3", "V", SIG_S_HALF)
 
                 # destroy: consume outstanding init-direction flags
                 T.wait_flag("V", "MTE2", SIG_IO_UB)

--- a/examples/generative_recommendation/mtgr_ragged_segment_attention.py
+++ b/examples/generative_recommendation/mtgr_ragged_segment_attention.py
@@ -57,16 +57,27 @@ def mtgr_ragged_segment_attention_kernel(
     SEM_WS3_C2V = 4
     SEM_WS3_V2C = 5
 
+    # Local event IDs are allocated per directed pipe pair. Different meanings keep
+    # distinct names even when their directed pairs allow the same numeric ID.
+    # MTE2 <-> MTE1
     SIG_K_L1 = 0
     SIG_P_L1 = 1
     SIG_V_L1 = 2
-    SIG_L0AB = 3
-    SIG_L0C = 5
-    SIG_Q_L1 = 7
+    SIG_Q_L1 = 3
 
+    # MTE1 <-> M
+    SIG_L0AB = 0  # double-buffer slots 0 and 1
+
+    # M <-> FIX
+    SIG_L0C = 0  # double-buffer slots 0 and 1
+
+    # MTE2 <-> V
     SIG_IO_UB = 0
-    SIG_S_HALF = 1
-    SIG_O_READY = 3
+
+    # V <-> MTE3
+    # acc_s_half and o_acc_half alias one physical UB region, so every access
+    # shares one ownership token even when the O store is issued in row slices.
+    SIG_STORE_UB = 0
 
     @T.prim_func
     def main(
@@ -212,6 +223,7 @@ def mtgr_ragged_segment_attention_kernel(
                 T.set_flag("MTE1", "MTE2", SIG_K_L1)
                 T.set_flag("MTE1", "MTE2", SIG_P_L1)
                 T.set_flag("MTE1", "MTE2", SIG_V_L1)
+                T.set_flag("MTE1", "MTE2", SIG_Q_L1)
                 T.set_flag("M", "MTE1", SIG_L0AB)
                 T.set_flag("M", "MTE1", SIG_L0AB + 1)
                 T.set_flag("FIX", "M", SIG_L0C)
@@ -256,7 +268,8 @@ def mtgr_ragged_segment_attention_kernel(
                     gap_size = T.if_then_else((q_start >= last_seg_start) & (gap_k_end > gap_k_start), gap_k_end - gap_k_start, 0)
                     num_effective_k = num_k_tiles - gap_size
 
-                    # 载入 Q
+                    # 载入 Q，并在所有 KV batch 完成前保持 MTE1 ownership。
+                    T.wait_flag("MTE1", "MTE2", SIG_Q_L1)
                     T.copy(Q[q_packed_start : q_packed_start + q_tile_size_live, h_i, :], q_l1[:, :])
                     T.set_flag("MTE2", "MTE1", SIG_Q_L1)
                     T.wait_flag("MTE2", "MTE1", SIG_Q_L1)
@@ -388,10 +401,14 @@ def mtgr_ragged_segment_attention_kernel(
                                 T.set_cross_flag("FIX", SEM_WS3_C2V)
                         T.set_cross_flag("MTE2", SEM_WS2_C2V)
 
+                    # MTE1 不再读取 q_l1；归还 ownership 后，下一个 task 才能重载 Q。
+                    T.set_flag("MTE1", "MTE2", SIG_Q_L1)
+
                 # 回收初始化的 Signal
                 T.wait_flag("MTE1", "MTE2", SIG_K_L1)
                 T.wait_flag("MTE1", "MTE2", SIG_P_L1)
                 T.wait_flag("MTE1", "MTE2", SIG_V_L1)
+                T.wait_flag("MTE1", "MTE2", SIG_Q_L1)
                 T.wait_flag("M", "MTE1", SIG_L0AB)
                 T.wait_flag("M", "MTE1", SIG_L0AB + 1)
                 T.wait_flag("FIX", "M", SIG_L0C)
@@ -404,7 +421,7 @@ def mtgr_ragged_segment_attention_kernel(
                 T.set_cross_flag("MTE2", SEM_WS1_V2C)
                 T.set_cross_flag("MTE2", SEM_WS3_V2C)
                 T.set_flag("V", "MTE2", SIG_IO_UB)
-                T.set_flag("MTE3", "V", SIG_S_HALF)
+                T.set_flag("MTE3", "V", SIG_STORE_UB)
 
                 for core_index in T.serial(my_iters):
                     pid = cid + core_index * core_num
@@ -555,13 +572,13 @@ def mtgr_ragged_segment_attention_kernel(
                             T.tile.axpy(buf_2d, work_ub, sm_scale)
                             T.tile.exp(work_ub, buf_2d)
 
-                            T.wait_flag("MTE3", "V", SIG_S_HALF)
+                            T.wait_flag("MTE3", "V", SIG_STORE_UB)
                             T.copy(work_ub, acc_s_half)
-                            T.set_flag("V", "MTE3", SIG_S_HALF)
+                            T.set_flag("V", "MTE3", SIG_STORE_UB)
 
-                            T.wait_flag("V", "MTE3", SIG_S_HALF)
+                            T.wait_flag("V", "MTE3", SIG_STORE_UB)
                             T.copy(acc_s_half, workspace_2[cid, i, vid * half_M : vid * half_M + half_M, :])
-                            T.set_flag("MTE3", "V", SIG_S_HALF)
+                            T.set_flag("MTE3", "V", SIG_STORE_UB)
 
                             if (i + 1) % cross_interval == 0 or i == batch_iters - 1:
                                 T.set_cross_flag("MTE3", SEM_WS2_V2C)
@@ -600,13 +617,14 @@ def mtgr_ragged_segment_attention_kernel(
                             acc_o[row_start : row_start + sub_M, :],
                             bcast_buf[row_start : row_start + sub_M, :],
                         )
+                        T.wait_flag("MTE3", "V", SIG_STORE_UB)
                         T.copy(
                             acc_o[row_start : row_start + sub_M, :],
                             o_acc_half[row_start : row_start + sub_M, :],
                         )
-                        T.set_flag("V", "MTE3", SIG_O_READY + sub)
+                        T.set_flag("V", "MTE3", SIG_STORE_UB)
 
-                        T.wait_flag("V", "MTE3", SIG_O_READY + sub)
+                        T.wait_flag("V", "MTE3", SIG_STORE_UB)
                         valid_rows_sub = T.if_then_else(
                             q_tile_size_live >= vid * half_M + row_start + sub_M,
                             sub_M,
@@ -628,9 +646,10 @@ def mtgr_ragged_segment_attention_kernel(
                                     :,
                                 ],
                             )
+                        T.set_flag("MTE3", "V", SIG_STORE_UB)
 
                 T.wait_flag("V", "MTE2", SIG_IO_UB)
-                T.wait_flag("MTE3", "V", SIG_S_HALF)
+                T.wait_flag("MTE3", "V", SIG_STORE_UB)
 
     return main
 

--- a/examples/gqa_fwd_varlen/gqa_fwd_varlen.py
+++ b/examples/gqa_fwd_varlen/gqa_fwd_varlen.py
@@ -103,7 +103,9 @@ def flashattn(
     Iter 2: CV pipeline rewrite following fa_opt/flash_attn_bhsd_expert_h16_d128.py.
     - num_stages=14 multi-stage pipeline (batch KV iterations)
     - T.mma + L0A/L0B/L0C double buffering (replaces T.gemm_v0)
-    - T.set_flag/wait_flag fine-grained intra-core sync (replaces T.barrier_all)
+    - T.set_flag/wait_flag fine-grained intra-core ownership (replaces T.barrier_all)
+    - Persistent q_l1 and the reused fp16 store buffer use complete bidirectional
+      ownership lifecycles across logical tasks.
     - T.tile.broadcast + T.tile.axpy vectorized softmax (replaces per-row loop)
     - T.annotate_layout ZN/NZ layout optimization
     - Mask integration: mask applied after exp via T.tile.mul, synced with barrier_all
@@ -182,19 +184,27 @@ def flashattn(
     SEM_WS3_C2V = 4  # workspace_3 (PV output) ready: Cube -> Vector
     SEM_WS3_V2C = 5  # workspace_3 consumed: Vector -> Cube
 
-    # Intra-core signal IDs (C Scope)
+    # Local event IDs are allocated per directed pipe pair. Different meanings keep
+    # distinct names even when their directed pairs allow the same numeric ID.
+    # MTE2 <-> MTE1
     SIG_K_L1 = 0
     SIG_P_L1 = 1
     SIG_V_L1 = 2
-    SIG_L0AB = 3  # double-buffer base: slot 0 = SIG_L0AB, slot 1 = SIG_L0AB + 1
-    SIG_L0C = 5  # double-buffer base: slot 0 = SIG_L0C,  slot 1 = SIG_L0C + 1
+    SIG_Q_L1 = 3
 
-    # Intra-core signal IDs (V Scope)
-    # io_buf double-buffered: slot 0 = SIG_IO_UB, slot 1 = SIG_IO_UB + 1
+    # MTE1 <-> M
+    SIG_L0AB = 0  # double-buffer slots 0 and 1
+
+    # M <-> FIX
+    SIG_L0C = 0  # double-buffer slots 0 and 1
+
+    # MTE2 <-> V
     SIG_IO_UB = 0
-    SIG_S_HALF = 2
-    SIG_MASK_FREE = 3  # V -> MTE2: buf_2d released after exp (mask can overwrite)
-    SIG_MASK_READY = 4  # MTE2 -> V: mask loaded into buf_2d (mul can proceed)
+    SIG_MASK_FREE = 2  # V -> MTE2: buf_2d released after exp
+    SIG_MASK_READY = 2  # MTE2 -> V: mask loaded into buf_2d
+
+    # V <-> MTE3
+    SIG_S_HALF = 0
 
     @T.prim_func
     def main(
@@ -263,6 +273,7 @@ def flashattn(
                 T.set_flag("MTE1", "MTE2", SIG_K_L1)
                 T.set_flag("MTE1", "MTE2", SIG_P_L1)
                 T.set_flag("MTE1", "MTE2", SIG_V_L1)
+                T.set_flag("MTE1", "MTE2", SIG_Q_L1)
                 T.set_flag("M", "MTE1", SIG_L0AB)
                 T.set_flag("M", "MTE1", SIG_L0AB + 1)
                 T.set_flag("FIX", "M", SIG_L0C)
@@ -275,8 +286,10 @@ def flashattn(
                     bz = task_id // (num_q_blocks * heads)
                     kv_head_idx = by // groups  # GQA
 
+                    T.wait_flag("MTE1", "MTE2", SIG_Q_L1)
                     T.copy(Q[bz, by, bx * block_M : (bx + 1) * block_M, :], q_l1)
-                    T.barrier_all()
+                    T.set_flag("MTE2", "MTE1", SIG_Q_L1)
+                    T.wait_flag("MTE2", "MTE1", SIG_Q_L1)
 
                     for k in T.serial(num_outer):
                         _remaining = max_kv_iters - k * num_stages
@@ -364,10 +377,14 @@ def flashattn(
 
                         T.set_cross_flag("MTE2", SEM_WS2_C2V)
 
+                    # MTE1 no longer reads q_l1; return it before the next task reloads Q.
+                    T.set_flag("MTE1", "MTE2", SIG_Q_L1)
+
                 # destroy: consume outstanding init-direction flags
                 T.wait_flag("MTE1", "MTE2", SIG_K_L1)
                 T.wait_flag("MTE1", "MTE2", SIG_P_L1)
                 T.wait_flag("MTE1", "MTE2", SIG_V_L1)
+                T.wait_flag("MTE1", "MTE2", SIG_Q_L1)
                 T.wait_flag("M", "MTE1", SIG_L0AB)
                 T.wait_flag("M", "MTE1", SIG_L0AB + 1)
                 T.wait_flag("FIX", "M", SIG_L0C)
@@ -503,8 +520,10 @@ def flashattn(
                     T.tile.div(acc_o, acc_o, buf_2d)
 
                     # Write back (vid half)
+                    T.wait_flag("MTE3", "V", SIG_S_HALF)
                     T.copy(acc_o, acc_s_half)  # fp32 -> fp16
-                    T.barrier_all()
+                    T.set_flag("V", "MTE3", SIG_S_HALF)
+                    T.wait_flag("V", "MTE3", SIG_S_HALF)
                     T.copy(
                         acc_s_half,
                         Output[
@@ -514,6 +533,7 @@ def flashattn(
                             :,
                         ],
                     )
+                    T.set_flag("MTE3", "V", SIG_S_HALF)
 
                 # destroy: consume outstanding init-direction flags
                 T.wait_flag("V", "MTE2", SIG_IO_UB)

--- a/examples/mha_sink_fwd_bhsd/mha_sink_fwd_bhsd.py
+++ b/examples/mha_sink_fwd_bhsd/mha_sink_fwd_bhsd.py
@@ -64,6 +64,8 @@ def flashattn(
 
     Expert CV pipeline directly ported from gqa_fwd_varlen (verified 17.78ms).
     Differences: MHA (no GQA), 2D mask (no batch dim), attention sink integration.
+    Persistent q_l1 and reused UB buffers use bidirectional ownership lifecycles
+    across logical tasks.
 
     Args:
         batch: batch size (compile-time).
@@ -146,19 +148,29 @@ def flashattn(
     SEM_WS3_C2V = 4  # workspace_3 (PV output) ready: Cube -> Vector
     SEM_WS3_V2C = 5  # workspace_3 consumed: Vector -> Cube
 
-    # Intra-core signal IDs (C Scope) — identical to gqa_fwd_varlen
+    # Local event IDs are allocated per directed pipe pair. Different meanings keep
+    # distinct names even when their directed pairs allow the same numeric ID.
+    # MTE2 <-> MTE1
     SIG_K_L1 = 0
     SIG_P_L1 = 1
     SIG_V_L1 = 2
-    SIG_L0AB = 3  # double-buffer base: slot 0 = SIG_L0AB, slot 1 = SIG_L0AB + 1
-    SIG_L0C = 5  # double-buffer base: slot 0 = SIG_L0C,  slot 1 = SIG_L0C + 1
+    SIG_Q_L1 = 3
 
-    # Intra-core signal IDs (V Scope) — identical to gqa_fwd_varlen + sink sync
-    SIG_IO_UB = 0  # io_buf double-buffer: slot 0 = SIG_IO_UB, slot 1 = SIG_IO_UB + 1
-    SIG_S_HALF = 2
-    SIG_MASK_FREE = 3  # V -> MTE2: buf_2d released after exp (mask can overwrite)
-    SIG_MASK_READY = 4  # MTE2 -> V: mask loaded into buf_2d (mul can proceed)
-    SIG_SINK_READY = 5  # MTE2 -> V: sinks_half_ub loaded from GM (sink load sync)
+    # MTE1 <-> M
+    SIG_L0AB = 0  # double-buffer slots 0 and 1
+
+    # M <-> FIX
+    SIG_L0C = 0  # double-buffer slots 0 and 1
+
+    # MTE2 <-> V
+    SIG_IO_UB = 0  # double-buffer slots 0 and 1
+    SIG_MASK_FREE = 2  # V -> MTE2: buf_2d released after exp
+    SIG_MASK_READY = 2  # MTE2 -> V: mask loaded into buf_2d
+    SIG_SINK_FREE = 3  # V -> MTE2: sinks_half_ub is reusable
+    SIG_SINK_READY = 3  # MTE2 -> V: sinks_half_ub contains the current sink
+
+    # V <-> MTE3
+    SIG_S_HALF = 0
 
     @T.prim_func
     def main(
@@ -231,6 +243,7 @@ def flashattn(
                 T.set_flag("MTE1", "MTE2", SIG_K_L1)
                 T.set_flag("MTE1", "MTE2", SIG_P_L1)
                 T.set_flag("MTE1", "MTE2", SIG_V_L1)
+                T.set_flag("MTE1", "MTE2", SIG_Q_L1)
                 T.set_flag("M", "MTE1", SIG_L0AB)
                 T.set_flag("M", "MTE1", SIG_L0AB + 1)
                 T.set_flag("FIX", "M", SIG_L0C)
@@ -257,8 +270,10 @@ def flashattn(
                     eff_kv_iters = T.floordiv(_last_vis, block_N) + 1
                     eff_num_outer = T.ceildiv(eff_kv_iters, num_stages)
 
+                    T.wait_flag("MTE1", "MTE2", SIG_Q_L1)
                     T.copy(Q[bz, by, bx * block_M : (bx + 1) * block_M, :], q_l1)
-                    T.barrier_all()
+                    T.set_flag("MTE2", "MTE1", SIG_Q_L1)
+                    T.wait_flag("MTE2", "MTE1", SIG_Q_L1)
 
                     for k in T.serial(eff_num_outer):
                         _remaining = eff_kv_iters - k * num_stages
@@ -346,10 +361,14 @@ def flashattn(
 
                         T.set_cross_flag("MTE2", SEM_WS2_C2V)
 
+                    # MTE1 no longer reads q_l1; return it before the next task reloads Q.
+                    T.set_flag("MTE1", "MTE2", SIG_Q_L1)
+
                 # destroy: consume outstanding init-direction flags
                 T.wait_flag("MTE1", "MTE2", SIG_K_L1)
                 T.wait_flag("MTE1", "MTE2", SIG_P_L1)
                 T.wait_flag("MTE1", "MTE2", SIG_V_L1)
+                T.wait_flag("MTE1", "MTE2", SIG_Q_L1)
                 T.wait_flag("M", "MTE1", SIG_L0AB)
                 T.wait_flag("M", "MTE1", SIG_L0AB + 1)
                 T.wait_flag("FIX", "M", SIG_L0C)
@@ -363,6 +382,7 @@ def flashattn(
                 # init: pretend both io_buf slots are free (consumer already released)
                 T.set_flag("V", "MTE2", SIG_IO_UB)
                 T.set_flag("V", "MTE2", SIG_IO_UB + 1)
+                T.set_flag("V", "MTE2", SIG_SINK_FREE)
                 T.set_flag("MTE3", "V", SIG_S_HALF)
 
                 for t in T.serial(my_count):
@@ -396,6 +416,9 @@ def flashattn(
                     # otherwise V may read sinks_half_ub before MTE2 finishes loading
                     # (race condition → non-deterministic output). Same pattern as gqa's
                     # mask load (SIG_MASK_READY). wait_flag(src="MTE2", dst="V") = V waits.
+                    # The reverse V→MTE2 edge keeps the next task from overwriting the buffer
+                    # before the current Vector copy has finished reading it.
+                    T.wait_flag("V", "MTE2", SIG_SINK_FREE)
                     T.copy(
                         Sinks[by, bx * block_M + vid * half_M : bx * block_M + vid * half_M + half_M],
                         sinks_half_ub,
@@ -403,6 +426,7 @@ def flashattn(
                     T.set_flag("MTE2", "V", SIG_SINK_READY)  # MTE2: signal load done
                     T.wait_flag("MTE2", "V", SIG_SINK_READY)  # V: wait for MTE2 load
                     T.copy(sinks_half_ub, sinks_fp32_1d)  # fp16 -> fp32 (1D, V pipeline)
+                    T.set_flag("V", "MTE2", SIG_SINK_FREE)
                     # broadcast 1D [half_M] -> 2D [half_M, 1] (ascend_tile.py:2066-2073, axis=1)
                     T.tile.broadcast(sinks_ub, sinks_fp32_1d)
 
@@ -583,8 +607,10 @@ def flashattn(
                     T.tile.div(acc_o, acc_o, buf_2d)
 
                     # Write back (vid half)
+                    T.wait_flag("MTE3", "V", SIG_S_HALF)
                     T.copy(acc_o, acc_s_half)  # fp32 -> fp16
-                    T.barrier_all()
+                    T.set_flag("V", "MTE3", SIG_S_HALF)
+                    T.wait_flag("V", "MTE3", SIG_S_HALF)
                     T.copy(
                         acc_s_half,
                         Output[
@@ -594,10 +620,12 @@ def flashattn(
                             :,
                         ],
                     )
+                    T.set_flag("MTE3", "V", SIG_S_HALF)
 
                 # destroy: consume outstanding init-direction flags
                 T.wait_flag("V", "MTE2", SIG_IO_UB)
                 T.wait_flag("V", "MTE2", SIG_IO_UB + 1)
+                T.wait_flag("V", "MTE2", SIG_SINK_FREE)
                 T.wait_flag("MTE3", "V", SIG_S_HALF)
 
     return main

--- a/examples_experiment/example_gqa_bwd/design.md
+++ b/examples_experiment/example_gqa_bwd/design.md
@@ -571,19 +571,42 @@ Scope("V") only:
 - Vector 核写 GM: 使用 `"MTE3"` 通路（UB → GM）
 - Vector 核通知 Cube: 使用 `"V"` 或 `"MTE3"` 通路
 
-### 8.2 核内同步 (Barrier)
+### 8.2 核内同步与缓冲区 Ownership
 
-Expert 模式下，每次 `T.copy` 和 `T.gemm_v0` 前后都需要 `T.barrier_all()`:
+Expert 模式不能简单地在每次 `T.copy` / `T.mma` 前后插入 `T.barrier_all()`。
+可复用物理缓冲必须按实际 producer/consumer 建立双向 ownership：正向通知数据就绪，
+反向通知缓冲可被下一轮覆盖。
+
+Forward v4 的 `q_l1` 由 MTE2 写入，并由 MTE1 在多个 KV batch 中持续读取，因此
+ownership 区间覆盖整个 task：
+
+Forward v4 中的本地 event ID 按有向 pipe pair 独立编号：MTE2↔MTE1 的
+K/P/V/Q ownership 使用 0..3，MTE1↔M 的 L0AB 双缓冲和 M↔FIX 的 L0C
+双缓冲都在各自 pair 内使用 0..1。反向 pair 使用相同数字表示同一 ownership
+slot，但两个方向仍是独立 event，必须分别完成 `set_flag` / `wait_flag` 配对。
 
 ```python
-# 典型 Cube 核操作序列
-T.copy(GM_src, L1_dst)
-T.barrier_all()                    # 等待搬运完成
-T.gemm_v0(L1_A, L1_B, L0C_C, init=True)
-T.barrier_all()                    # 等待 GEMM 完成
-T.copy(L0C_C, GM_dst)
-T.barrier_all()                    # 等待写出完成
+# init: q_l1 初始可由 MTE2 写入
+T.set_flag("MTE1", "MTE2", SIG_Q_L1)
+
+for task in T.serial(my_count):
+    T.wait_flag("MTE1", "MTE2", SIG_Q_L1)
+    T.copy(Q[...], q_l1)
+    T.set_flag("MTE2", "MTE1", SIG_Q_L1)
+
+    T.wait_flag("MTE2", "MTE1", SIG_Q_L1)
+    for k in T.serial(task_outer):
+        # 本 task 的所有 q_l1 → L0A 读取
+        ...
+    T.set_flag("MTE1", "MTE2", SIG_Q_L1)
+
+# destroy: 消费最后一次归还的 token
+T.wait_flag("MTE1", "MTE2", SIG_Q_L1)
 ```
+
+`T.barrier_all()` 只等待它之前发出的本地异步操作。它不能保护 barrier 之后的 store，
+也不能替代跨流水线的 ownership handoff。只有确实需要一次性排空多个本地流水线时，
+才应使用全流水屏障。
 
 ### 8.3 Backward Kernel 同步协议
 

--- a/examples_experiment/example_gqa_bwd/example_gqa_bwd.py
+++ b/examples_experiment/example_gqa_bwd/example_gqa_bwd.py
@@ -276,6 +276,7 @@ def flashattn_fwd_v4(
     - L0 double buffering with [2, ...] syntax for GEMM1 and GEMM2
     - Batched iterations (num_stages per batch)
     - Fine-grained flag sync (set_flag/wait_flag) within C and V scopes
+    - Persistent q_l1 ownership spans all KV batches in one logical task
     - Batched softmax (r_factors + sumexp_is, decoupled from O accumulation)
     """
     assert heads % groups == 0
@@ -310,16 +311,25 @@ def flashattn_fwd_v4(
     SEM_WS3_C2V = 4
     SEM_WS3_V2C = 5
 
-    # Intra-core signal IDs (C Scope)
+    # Local event IDs are allocated per directed pipe pair. Different meanings keep
+    # distinct names even when their directed pairs allow the same numeric ID.
+    # MTE2 <-> MTE1
     SIG_K_L1 = 0
     SIG_P_L1 = 1
     SIG_V_L1 = 2
-    SIG_L0AB = 3  # double-buffer base: slot 0 = SIG_L0AB, slot 1 = SIG_L0AB+1
-    SIG_L0C = 5  # double-buffer base: slot 0 = SIG_L0C,  slot 1 = SIG_L0C+1
+    SIG_Q_L1 = 3
 
-    # Intra-core signal IDs (V Scope)
+    # MTE1 <-> M
+    SIG_L0AB = 0  # double-buffer slots 0 and 1
+
+    # M <-> FIX
+    SIG_L0C = 0  # double-buffer slots 0 and 1
+
+    # MTE2 <-> V
     SIG_IO_UB = 0
-    SIG_S_HALF = 1
+
+    # V <-> MTE3
+    SIG_S_HALF = 0
 
     def task_range(cid_val):
         start = cid_val * q_tasks + T.if_then_else(cid_val < r_tasks, cid_val, r_tasks)
@@ -417,6 +427,7 @@ def flashattn_fwd_v4(
                 T.set_flag("MTE1", "MTE2", SIG_K_L1)
                 T.set_flag("MTE1", "MTE2", SIG_P_L1)
                 T.set_flag("MTE1", "MTE2", SIG_V_L1)
+                T.set_flag("MTE1", "MTE2", SIG_Q_L1)
                 T.set_flag("M", "MTE1", SIG_L0AB)
                 T.set_flag("M", "MTE1", SIG_L0AB + 1)
                 T.set_flag("FIX", "M", SIG_L0C)
@@ -429,8 +440,10 @@ def flashattn_fwd_v4(
                     bz = task_id // (num_seq_blocks * heads)
                     kv_by = by // groups
 
+                    T.wait_flag("MTE1", "MTE2", SIG_Q_L1)
                     T.copy(Q[bz, by, bx * block_M : (bx + 1) * block_M, :], q_l1)
-                    T.barrier_all()
+                    T.set_flag("MTE2", "MTE1", SIG_Q_L1)
+                    T.wait_flag("MTE2", "MTE1", SIG_Q_L1)
 
                     _task_iters = T.ceildiv((bx + 1) * block_M, block_N) if is_causal else num_iters
                     _task_outer = T.ceildiv(_task_iters, num_stages)
@@ -520,10 +533,14 @@ def flashattn_fwd_v4(
 
                         T.set_cross_flag("MTE2", SEM_WS2_C2V)
 
+                    # MTE1 no longer reads q_l1; return it before the next task reloads Q.
+                    T.set_flag("MTE1", "MTE2", SIG_Q_L1)
+
                 # Destroy: consume outstanding init-direction flags
                 T.wait_flag("MTE1", "MTE2", SIG_K_L1)
                 T.wait_flag("MTE1", "MTE2", SIG_P_L1)
                 T.wait_flag("MTE1", "MTE2", SIG_V_L1)
+                T.wait_flag("MTE1", "MTE2", SIG_Q_L1)
                 T.wait_flag("M", "MTE1", SIG_L0AB)
                 T.wait_flag("M", "MTE1", SIG_L0AB + 1)
                 T.wait_flag("FIX", "M", SIG_L0C)


### PR DESCRIPTION
## 问题

`examples/gqa_fwd_varlen/perf_gqa_fwd_varlen.py` 单独运行时能通过，现有 CI 也一直
能通过（bench runner 最多并行 8 个任务）。将 32 个相同的 GQA 进程同时跑在一张
NPU 上时，可以复现数值错误。

这个 kernel 会连续计算多个输出块，并在各块之间复用同一块片上临时内存。原实现
会等待当前结果准备好再开始写回，却没有等待写回完成就允许下一块计算复用这块内存。
极端负载不均时，下一块数据可能覆盖仍在写回的上一块数据，最终造成静默的数值错误。

修复后，下一块计算必须等当前输出完全写回后，才能复用这块临时内存。

这套同步结构最早来自我在 #698 中提交的 FA Expert 实现，后来被多个 attention
example 复用。因此这次除了修复 GQA，也一并审计并修复了同源实现。

## 修改

- 为 GQA、FA expert、MHA sink 和 MTGR 的输出缓冲补上“写回完成后才能复用”的同步。
- 审计同源实现时，还发现 6 个 kernel 的 Q 缓冲也缺少反向同步：上一项任务尚未完成
  读取时，下一项任务就可能开始覆盖。这个问题也一并修复。
- MHA sink 的 `sinks_half_ub` 同样缺少 V→MTE2 的归还路径，也在同一轮 ownership
  审计中补齐。
- 更新相关教程、Programming Guide、设计文档和 agent reference，明确可复用缓冲区
  必须同时具备“数据就绪”和“使用完毕”两个方向的同步。
- 修正同源代码将 event ID 视为全局编号的误导：本地 event ID 按有向 pipe pair
  独立分配，可在不同 pair 中复用，避免给派生实现制造并不存在的 8-lock 上限。

Q 缓冲和 `sinks_half_ub` 问题是在同源代码审计中发现的独立问题，不是 #1588 中
GQA 数值错误的直接原因。

<details>
<summary>同步实现与审计范围</summary>

### Output 缓冲

`acc_s_half` 由 V pipeline 写入，再由 MTE3 读取并写入 `Output`。原来的顺序是：

```text
V 写入 acc_s_half
T.barrier_all()
MTE3 从 acc_s_half 写回 Output
下一项任务由 V 覆写 acc_s_half
```

store 前的 `T.barrier_all()` 可以保证 MTE3 读到 V 已经写好的数据，但不能保证 MTE3
读完以后 V 才再次覆写。修复后使用完整的双向 ownership 生命周期：

```text
V 获得缓冲 → V 写入 → 交给 MTE3 → MTE3 写回 Output → 归还给 V
```

也就是补上原来缺失的 MTE3→V 反向背压。

### Q 缓冲

`q_l1` 由 MTE2 写入，并在当前任务的多个 KV batch 中持续被 MTE1 读取。修复后，
MTE1 会一直持有该缓冲，直到当前任务最后一次读取完成，再将它归还给 MTE2，允许
下一项任务加载新的 Q。

### Event ID 编号

这批同源实现沿用了原始代码中全局递增 event ID 的编号方式，容易让后续作者误以为
整个 kernel 只有 8 个 event ID。例如已有 lock 使用 0 到 6 后，看起来新增 lock 只能
使用 7。

实际上，本地 event 由有向 `(src_pipe, dst_pipe, event_id)` 三元组标识，每个有向 pipe
pair 都有独立的 0 到 7 编号空间；反向 pair 也属于另一个空间。因此最终代码按 pair
分别从 0 开始编号：

```text
MTE2 ↔ MTE1 : K/P/V/Q = 0/1/2/3
MTE1 ↔ M    : L0AB slots = 0/1
M ↔ FIX     : L0C slots = 0/1
MTE2 ↔ V    : 从 0 开始按缓冲分配
V ↔ MTE3    : 从 0 开始按缓冲分配
```

同一 ownership slot 在正反两个有向 pair 中使用相同数字只是为了便于审查；两个方向
仍是独立 event，也没有合并语义。`SIG_MASK_FREE` 和 `SIG_MASK_READY`、
`SIG_SINK_FREE` 和 `SIG_SINK_READY` 因此保留为不同变量。

全局唯一编号本身是保守可用的，但会给这批派生代码制造并不存在的 8-lock 上限，容易
促使后续实现合并无关 lock 或改用更重的 barrier。相关代码注释和文档现已改为按有向
pipe pair 理解和分配 event ID。

### 影响范围

| 实现 | Q 缓冲 | Output 缓冲 |
|---|---:|---:|
| FA expert | 修复 | 修复 |
| GQA varlen | 修复 | 修复 |
| MHA sink | 修复 | 修复 |
| GQA attention sink | 修复 | 原本已完整 |
| GQA-bwd forward v4 | 修复 | 原本已有 store 后 drain |
| MTGR ragged segment attention | 修复 | 修复 |

MHA sink 还额外补齐了 `sinks_half_ub` 的 MTE2→V ready 与 V→MTE2 free 生命周期。
MTGR 中别名到同一 UB 区域的 `acc_s_half` / `o_acc_half` 共用同一个 V↔MTE3 ownership lock。

</details>

## 验证

- **32 进程同卡正确性**：6 个修改过的 kernel 分别运行 32 个并发进程，共 `192/192` 通过，零数值错误、零异常退出。
- **单进程性能**：`msprof op` A/B 覆盖全部 6 个 kernel，未观察到可确认的性能回退。
- **重点复测**：对初测波动最大的 GQA-bwd forward v4 追加 8 组平衡 A/B（每次 20 次 warmup）；配对几何平均差异为 `-0.61%`，95% 置信区间为 `[-3.02%, +1.86%]`，排除 `≥2%` 的稳定回退。

Closes #1588



