### PR TITLE
[Docs]: update broadcast docstring, add dtype coverage tests and API doc

### DIFF
--- a/docs/api_docs/T.tile.broadcast.md
+++ b/docs/api_docs/T.tile.broadcast.md
@@ -1,0 +1,83 @@
+# T.tile.broadcast
+
+## 1. 功能说明
+
+将输入张量沿指定维度广播到目标 shape：`dst[i, j] = src[i, 0]`（axis=1）或 `dst[i, j] = src[0, j]`（axis=0）
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def broadcast(
+    dst: Buffer | BufferRegion,
+    src: Buffer | BufferRegion,
+    axis: int | None = None,
+    *,
+    tmp: Buffer | BufferRegion | None = None,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放广播结果 | 张量（tensor，scope 必须为 UB） | 必填 |
+| src | 输入 | 待广播的源张量 | 张量（tensor，scope 必须为 UB） | 必填 |
+| axis | 输入 | 广播维度：0 表示沿行方向广播，1 表示沿列方向广播；None 时根据 shape 自动推断 | 整数（0 或 1）/ None | 可选（默认 `None`） |
+| tmp | 输入 | 可选的临时缓冲区，供后端内部使用 | 张量（tensor，scope 为 `shared.ub`） | 可选（默认 `None`） |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src |
+|------|:---:|:---:|
+| Ascend A2 / A3 | int8, uint8, int16, uint16, float16, bfloat16, float32, int32, uint32 | 同 dst |
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+> **已知限制**：
+> - 2D axis=1（src=(M,1)→dst=(M,N)）当 M≥2 时，ascendc、pto 均不支持
+> - 1D axis=0 在 pto 后端不支持
+
+### 2.4 约束条件
+
+1. dst 与 src 的 dtype 必须一致
+2. axis 仅支持 0 或 1；axis=None 时根据 src/dst 的 shape 自动推断广播轴
+3. 广播维度上 src 的 size 必须为 1，非广播维度上 src 和 dst 的 size 必须相同
+4. 1D src 广播到 2D dst 时，自动推断广播轴；无法推断时抛出 `ValueError`
+5. 不支持 src 与 dst 地址重叠（硬件约束）
+6. 仅支持 ND 格式（硬件约束）
+7. dim=2 且 axis=0 时，srcShape[1] 必须 32 字节对齐（即元素个数 × 元素大小 % 32 == 0）（硬件约束，非对齐时静默出错而非报错）
+
+## 3. 示例代码
+
+**示例 1：1D src 广播到 2D dst（axis 自动推断）**
+
+```python
+src = T.alloc_ub((16,), "float16")
+dst = T.alloc_ub((4, 16), "float16")
+T.tile.broadcast(dst, src)  # axis=0 自动推断：src[16] → dst[4,16]
+```
+
+**示例 2：axis=0，沿列方向广播**
+
+```python
+src = T.alloc_ub((1, 16), "float32")
+dst = T.alloc_ub((8, 16), "float32")
+T.tile.broadcast(dst, src, axis=0)  # src[1,16] → dst[8,16]
+```
+
+**示例 3：1D src 广播到 1D dst（需要 src 为 [1]）**
+
+```python
+src = T.alloc_ub((1,), "float16")
+dst = T.alloc_ub((256,), "float16")
+T.tile.broadcast(dst, src, axis=0)
+```

--- a/testing/python/language/test_tilelang_ascend_language_tile_broadcast_dtype_coverage.py
+++ b/testing/python/language/test_tilelang_ascend_language_tile_broadcast_dtype_coverage.py
@@ -1,0 +1,310 @@
+"""
+T.tile.broadcast dtype coverage tests.
+
+Existing coverage in test_tilelang_ascend_language_explicit_tmp.py:
+- float32 x ascendc (2D axis=0, explicit tmp runtime)
+- uint8 x ascendc (workspace policy, codegen only)
+- float32 x ascendc (zero workspace codegen)
+
+This file supplements with:
+1. Full dtype coverage for 2D axis=0 (src=(1,N) -> dst=(M,N))
+2. 1D-to-2D auto-infer (axis=None)
+3. 1D axis=0 (ascendc only; pto not supported)
+4. Exception boundary tests (dtype mismatch, shape mismatch, invalid axis, 1D uninferable)
+
+Known limitations (documented in docs/api_docs/T.tile.broadcast.md):
+- 2D axis=1 (src=(M,1) -> dst=(M,N)) when M>=2: not supported (CANN BrcLast bug)
+- 1D axis=0 on pto: not supported (pto codegen bug)
+"""
+
+import pytest
+import tilelang
+import tilelang.language as T
+import torch
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _disable_cache():
+    tilelang.disable_cache()
+    yield
+    tilelang.enable_cache()
+
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+TORCH_DTYPE_MAP = {
+    "float16": torch.float16,
+    "float32": torch.float32,
+    "bfloat16": torch.bfloat16,
+    "int8": torch.int8,
+    "uint8": torch.uint8,
+    "int16": torch.int16,
+    "uint16": torch.uint16,
+    "int32": torch.int32,
+    "uint32": torch.uint32,
+}
+
+
+def _gen_input(dtype, shape):
+    torch_dtype = TORCH_DTYPE_MAP[dtype]
+    n = 1
+    for s in shape:
+        n *= s
+    if dtype in ("float16", "float32", "bfloat16"):
+        a = torch.arange(n, dtype=torch.float32).to(torch_dtype)
+    else:
+        high = min(n, 100)
+        if dtype in ("uint16", "uint32"):
+            a = torch.randint(0, high, shape, dtype=torch.int32).to(torch_dtype)
+        else:
+            a = torch.randint(0, high, shape, dtype=torch_dtype)
+    return a.npu()
+
+
+# ---------------------------------------------------------------------------
+# Functional: 2D axis=0 (src=(1,N) -> dst=(M,N))
+# ---------------------------------------------------------------------------
+
+
+def _make_2d_axis0(dtype, M=8, N=64):
+    @T.prim_func
+    def main(
+        A: T.Tensor((1, N), dtype),  # type: ignore
+        B: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (_, vid):
+            src_ub = T.alloc_ub((1, N), dtype)
+            dst_ub = T.alloc_ub((M, N), dtype)
+            if vid == 0:
+                T.copy(A, src_ub)
+                T.tile.broadcast(dst_ub, src_ub, axis=0)
+                T.copy(dst_ub, B)
+
+    return main
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "float32",
+        pytest.param("float16", marks=pytest.mark.low_priority),
+        pytest.param("int8", marks=pytest.mark.low_priority),
+        pytest.param("uint8", marks=pytest.mark.low_priority),
+        pytest.param("int16", marks=pytest.mark.low_priority),
+        pytest.param("uint16", marks=pytest.mark.low_priority),
+        pytest.param("bfloat16", marks=pytest.mark.low_priority),
+        pytest.param("int32", marks=pytest.mark.low_priority),
+        pytest.param("uint32", marks=pytest.mark.low_priority),
+    ],
+)
+@pytest.mark.parametrize(
+    "target",
+    [
+        "ascendc",
+        pytest.param("pto", marks=pytest.mark.low_priority),
+    ],
+)
+def test_broadcast_2d_axis0(dtype, target):
+    M, N = 8, 64
+    program = _make_2d_axis0(dtype, M, N)
+    kernel = tilelang.compile(program, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+    a = _gen_input(dtype, (1, N))
+    b = kernel(a)
+    torch.npu.synchronize()
+    ref = a.expand(M, N)
+    if dtype in ("uint16", "uint32"):
+        torch.testing.assert_close(b.cpu(), ref.cpu(), rtol=0, atol=0)
+    else:
+        rtol = 1e-2 if dtype in ("float16", "float32", "bfloat16") else 0
+        atol = 1e-2 if dtype in ("float16", "float32", "bfloat16") else 0
+        torch.testing.assert_close(b, ref, rtol=rtol, atol=atol)
+
+
+# ---------------------------------------------------------------------------
+# Functional: 1D-to-2D auto-infer (axis=None, src=(N,) -> dst=(M,N))
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "ascendc",
+        pytest.param("pto", marks=pytest.mark.low_priority),
+    ],
+)
+def test_broadcast_1d_to_2d_auto_infer(target):
+    M, N = 8, 64
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), "float32"),  # type: ignore
+        B: T.Tensor((M, N), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (_, vid):
+            src_ub = T.alloc_ub((N,), "float32")
+            dst_ub = T.alloc_ub((M, N), "float32")
+            if vid == 0:
+                T.copy(A, src_ub)
+                T.tile.broadcast(dst_ub, src_ub)
+                T.copy(dst_ub, B)
+
+    kernel = tilelang.compile(main, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+    a = torch.arange(N, dtype=torch.float32).npu()
+    b = kernel(a)
+    torch.npu.synchronize()
+    ref = a.expand(M, N)
+    torch.testing.assert_close(b, ref, rtol=1e-2, atol=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# Functional: 1D axis=0 (src=(1,) -> dst=(N,))
+# ---------------------------------------------------------------------------
+
+
+def test_broadcast_1d_axis0_ascendc():
+    N = 64
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((1,), "float32"),  # type: ignore
+        B: T.Tensor((N,), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (_, vid):
+            src_ub = T.alloc_ub((1,), "float32")
+            dst_ub = T.alloc_ub((N,), "float32")
+            if vid == 0:
+                T.copy(A, src_ub)
+                T.tile.broadcast(dst_ub, src_ub, axis=0)
+                T.copy(dst_ub, B)
+
+    kernel = tilelang.compile(main, out_idx=[-1], pass_configs=PASS_CONFIGS, target="ascendc")
+    a = torch.tensor([42.0], dtype=torch.float32).npu()
+    b = kernel(a)
+    torch.npu.synchronize()
+    ref = a.expand(N)
+    torch.testing.assert_close(b, ref, rtol=1e-2, atol=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# Exception boundary: dtype mismatch (default — no LP)
+# ---------------------------------------------------------------------------
+
+
+def test_broadcast_dtype_mismatch_raises():
+    """dst and src dtype must match; mismatch should fail at compile time."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((1, 64), "float16"),  # type: ignore
+        B: T.Tensor((8, 64), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (_, vid):
+            src_ub = T.alloc_ub((1, 64), "float16")
+            dst_ub = T.alloc_ub((8, 64), "float32")
+            if vid == 0:
+                T.copy(A, src_ub)
+                T.tile.broadcast(dst_ub, src_ub, axis=0)
+                T.copy(dst_ub, B)
+
+    with pytest.raises(RuntimeError, match="Compilation Failed"):  # noqa: B017
+        tilelang.compile(main, out_idx=[-1], pass_configs=PASS_CONFIGS, target="ascendc")
+
+
+# ---------------------------------------------------------------------------
+# Exception boundary: shape mismatch (default — no LP)
+# ---------------------------------------------------------------------------
+
+
+def test_broadcast_shape_mismatch_axis0_raises():
+    """src[0] != 1 and shapes don't match on axis=0 should raise during TIR construction."""
+
+    with pytest.raises(RuntimeError, match="DiagnosticError"):
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((2, 64), "float32"),  # type: ignore
+            B: T.Tensor((8, 64), "float32"),  # type: ignore
+        ):
+            with T.Kernel(1, is_npu=True) as (_, vid):
+                src_ub = T.alloc_ub((2, 64), "float32")
+                dst_ub = T.alloc_ub((8, 64), "float32")
+                if vid == 0:
+                    T.copy(A, src_ub)
+                    T.tile.broadcast(dst_ub, src_ub, axis=0)
+                    T.copy(dst_ub, B)
+
+
+def test_broadcast_shape_mismatch_axis1_raises():
+    """src[1] != 1 and shapes don't match on axis=1 should raise during TIR construction."""
+
+    with pytest.raises(RuntimeError, match="DiagnosticError"):
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((8, 2), "float32"),  # type: ignore
+            B: T.Tensor((8, 64), "float32"),  # type: ignore
+        ):
+            with T.Kernel(1, is_npu=True) as (_, vid):
+                src_ub = T.alloc_ub((8, 2), "float32")
+                dst_ub = T.alloc_ub((8, 64), "float32")
+                if vid == 0:
+                    T.copy(A, src_ub)
+                    T.tile.broadcast(dst_ub, src_ub, axis=1)
+                    T.copy(dst_ub, B)
+
+
+# ---------------------------------------------------------------------------
+# Exception boundary: invalid axis (default — no LP)
+# ---------------------------------------------------------------------------
+
+
+def test_broadcast_invalid_axis_raises():
+    """axis must be 0 or 1; axis=2 should raise during TIR construction."""
+
+    with pytest.raises(RuntimeError, match="DiagnosticError"):
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((1, 64), "float32"),  # type: ignore
+            B: T.Tensor((8, 64), "float32"),  # type: ignore
+        ):
+            with T.Kernel(1, is_npu=True) as (_, vid):
+                src_ub = T.alloc_ub((1, 64), "float32")
+                dst_ub = T.alloc_ub((8, 64), "float32")
+                if vid == 0:
+                    T.copy(A, src_ub)
+                    T.tile.broadcast(dst_ub, src_ub, axis=2)
+                    T.copy(dst_ub, B)
+
+
+# ---------------------------------------------------------------------------
+# Exception boundary: 1D uninferable (default — no LP)
+# ---------------------------------------------------------------------------
+
+
+def test_broadcast_1d_uninferable_raises():
+    """1D src that can't be inferred to 2D dst should raise during TIR construction."""
+
+    with pytest.raises(RuntimeError, match="DiagnosticError"):
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((4,), "float32"),  # type: ignore
+            B: T.Tensor((8, 16), "float32"),  # type: ignore
+        ):
+            with T.Kernel(1, is_npu=True) as (_, vid):
+                src_ub = T.alloc_ub((4,), "float32")
+                dst_ub = T.alloc_ub((8, 16), "float32")
+                if vid == 0:
+                    T.copy(A, src_ub)
+                    T.tile.broadcast(dst_ub, src_ub)
+                    T.copy(dst_ub, B)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-n", "8"])

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -2313,11 +2313,13 @@ def broadcast(
     This function performs a broadcast copy from the source buffer (`src`) to the
     destination buffer (`dst`). It automatically infers the broadcasting axis
     based on the shapes of the input buffers, or uses the explicitly provided axis.
+    Supports int8, uint8, int16, uint16, float16, bfloat16, float32, int32,
+    uint32. Both ``dst`` and ``src`` must be in UB and have the same dtype.
 
     Args:
-        dst: Destination buffer (must be in UB).
-        src: Source buffer (must be in UB).
-        axis: Broadcasting axis (0 or 1). If None, auto-inferred.
+        dst: Destination buffer (must be in UB). Same dtype as ``src``.
+        src: Source buffer (must be in UB). Same dtype as ``dst``.
+        axis: Broadcasting axis (0 or 1). If None, auto-inferred from shapes.
         tmp: Optional complete target-specific scratch storage. It must be a
             one-dimensional, static, contiguous fixed-width scalar buffer in
             ``shared.ub``, or an equivalent 32-byte-aligned buffer region. Its


### PR DESCRIPTION
## 改动内容

针对 `T.tile.broadcast` API 完成文档校验、测试用例补充和 docstring 更新。

### 1. Docstring 更新（修改）

- `tilelang/language/ascend_tile.py` 中 `broadcast` 函数的 docstring
- 在原版基础上补充，不删除原有内容：
  - dtype 支持列表（9 个 dtype）
  - UB scope 约束 + dtype 一致性说明

### 2. 测试用例（新增）

- `testing/python/language/test_tilelang_ascend_language_tile_broadcast_dtype_coverage.py`
- **26 个用例**（26 PASSED + 0 SKIPPED），不重复 `test_tilelang_ascend_language_explicit_tmp.py` 和 `test_tilelang_ascend_language_elementwise.py` 中已有的测试（float32×ascendc explicit tmp runtime、codegen only 测试）
- LP 分层标记：PR 合入时跑 8 个，每日 CI 跑 26 个

| 测试函数 | 用例数 | PR执行 | LP | 类型 | 覆盖内容 |
|---------|:---:|:---:|:---:|------|---------|
| `test_broadcast_2d_axis0` | 18 | 1 | 17 | 全量泛化 | 9 dtype × ascendc/pto (2D axis=0) |
| `test_broadcast_1d_to_2d_auto_infer` | 2 | 1 | 1 | 全量泛化 | 1D→2D axis=None 自动推断 |
| `test_broadcast_1d_axis0_ascendc` | 1 | 1 | 0 | 全量泛化 | 1D axis=0 × ascendc |
| `test_broadcast_dtype_mismatch_raises` | 1 | 1 | 0 | 异常边界 | dst/src dtype 不一致编译失败 |
| `test_broadcast_shape_mismatch_axis0_raises` | 1 | 1 | 0 | 异常边界 | axis=0 shape 不匹配抛异常 |
| `test_broadcast_shape_mismatch_axis1_raises` | 1 | 1 | 0 | 异常边界 | axis=1 shape 不匹配抛异常 |
| `test_broadcast_invalid_axis_raises` | 1 | 1 | 0 | 异常边界 | axis=2 非法值抛异常 |
| `test_broadcast_1d_uninferable_raises` | 1 | 1 | 0 | 异常边界 | 1D→2D 无法推断抛异常 |

LP 标记策略：
- dtype：float32 默认执行，其余 8 个 dtype 标 `low_priority`
- target：ascendc 默认执行，pto 标 `low_priority`
- 异常边界测试：全部默认执行（用例少，关键覆盖）

### 3. API 文档（新增）

- `docs/api_docs/T.tile.broadcast.md`

## 测试结果

- **26 PASSED + 0 SKIPPED**（CI 全绿，0 FAILED）

## 校验发现

真机测试发现 dtype 支持范围超出校验文档：校验文档原版仅列 int8/uint8/float16/float32（4 个），真机三重验证（编译+运行+精度）确认 int16/uint16/bfloat16/int32/uint32 在 ascendc + pto 后端均实际支持。CANN `BroadcastImpl` 的 `static_assert(SupportBytes<T, 1, 2, 4, 8>())` 按 `sizeof(T)` 分派，9 个 dtype 均在范围内。已补充至文档。

## 已知限制（文档 Shape 支持已标注）

| 限制 | 说明 |
|------|------|
| 2D axis=1 M≥2 | ascendc、pto 均不支持（CANN BrcLast 路径 bug，仅第一行正确） |
| 1D axis=0 pto | pto 后端不支持（pto codegen 生成错误指令），ascendc 不受影响 |

详细根因分析记录在 `api/bug_investigation/broadcast_bug.md`，包含修复尝试记录。

## 文件改动

| 文件 | 类型 | 改动 |
|------|------|------|
| `tilelang/language/ascend_tile.py` | 修改 | docstring 补充 dtype 列表 + scope 约束 |
| `testing/python/language/test_tilelang_ascend_language_tile_broadcast_dtype_coverage.py` | 新增 | 26 个测试用例 |
| `docs/api_docs/T.tile.broadcast.md` | 新增 | API 文档（dtype 表 9 个 + 已知限制） |
