### PR TITLE
[Docs]: Update axpy docstring, strengthen tests and add API doc

### DIFF
--- a/docs/language/tile_axpy.md
+++ b/docs/language/tile_axpy.md
@@ -1,0 +1,71 @@
+# T.tile.axpy
+
+## 1. 功能说明
+
+将源 buffer 与标量相乘后逐元素加到目标 buffer 上：`dst[i] = scalar * src[i] + dst[i]`
+
+dst 同时作为输入和输出，原地更新 dst 的内容。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def axpy(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    scalar_value: PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输入/输出 | 目标 buffer，同时作为累加器输入 Y 和输出 | 张量（tensor） | 必填 |
+| src0 | 输入 | 源 buffer X | 张量（tensor） | 必填 |
+| scalar_value | 输入 | 标量系数 alpha | 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub` 分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：Python 标量或标量表达式（PrimExpr），调用时会按目标数据类型进行转换
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | scalar_value |
+|------|:---:|:----:|:------------:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 | 与 dst 数据类型兼容的标量表达式 |
+
+> **数据类型约束**：当前 Ascend C 和 PTO 后端均要求 `dst` 与 `src0` 的数据类型相同。
+
+#### 2.3.2 Shape 支持
+
+- 支持 Buffer 和 BufferRegion；已验证二维 Buffer 和一维切片
+- `dst` 与 `src0` 的元素总数必须相同
+
+### 2.4 约束条件
+
+1. `dst` 为 read-write 语义，调用后其内容被原地更新
+2. `dst` 与 `src0` 的元素总数必须相同
+3. 当前 Ascend C 和 PTO 后端要求 `dst` 与 `src0` 的数据类型相同
+4. 操作数应位于 Unified Buffer，起始地址需满足 32 字节对齐要求
+
+## 3. 示例代码
+
+**示例 1：标量乘加**
+
+```python
+dst = T.alloc_ub((128,), "float16")
+src = T.alloc_ub((128,), "float16")
+T.tile.axpy(dst, src, 2.0)  # dst = 2.0 * src + dst
+```
+
+**示例 2：累加缩放**
+
+```python
+acc = T.alloc_ub((64, 128), "float16")
+grad = T.alloc_ub((64, 128), "float16")
+T.tile.axpy(acc, grad, 0.1)  # acc = 0.1 * grad + acc（梯度累加）
+```

--- a/docs/language/tile_axpy.md
+++ b/docs/language/tile_axpy.md
@@ -38,7 +38,7 @@ def axpy(
 |------|:---:|:----:|:------------:|
 | Ascend A2 / A3 | float16, float32 | float16, float32 | 与 dst 数据类型兼容的标量表达式 |
 
-> **数据类型约束**：当前 Ascend C 和 PTO 后端均要求 `dst` 与 `src0` 的数据类型相同。
+> **数据类型约束**：当前 `T.tile.axpy` 要求 `dst` 与 `src0` 的数据类型相同。这是 TileLang 当前实现的限制，而非底层能力限制：底层 Ascend C 高阶 [Axpy](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/latest/API/ascendcopapi/docs/zh/api/SIMD-API/%E9%AB%98%E9%98%B6API/%E6%95%B0%E5%AD%A6%E8%AE%A1%E7%AE%97/Axpy%E6%8E%A5%E5%8F%A3/Axpy-80.md) 接口与 PTO [TAXPY](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/latest/compiler/ptoisa/docs/isa/TAXPY_zh.md) 指令均支持 `dst` 为 `float32`、`src0` 与标量为 `float16` 的混合精度组合；当前 Ascend C codegen 显式要求两个 buffer 同 dtype，PTO codegen 生成单一模板类型的调用，均未接入该混合精度能力。混合精度支持作为已知实现缺口记录，待后续单独 PR/Issue 补齐。
 
 #### 2.3.2 Shape 支持
 
@@ -49,7 +49,7 @@ def axpy(
 
 1. `dst` 为 read-write 语义，调用后其内容被原地更新
 2. `dst` 与 `src0` 的元素总数必须相同
-3. 当前 Ascend C 和 PTO 后端要求 `dst` 与 `src0` 的数据类型相同
+3. 当前 `T.tile.axpy` 要求 `dst` 与 `src0` 的数据类型相同（底层 Ascend C `Axpy` 接口与 PTO `TAXPY` 指令支持 `dst` 为 `float32`、`src0` 与标量为 `float16` 的混合精度组合，属当前 TileLang 实现缺口，待后续补齐）
 4. 操作数应位于 Unified Buffer，起始地址需满足 32 字节对齐要求
 
 ## 3. 示例代码

--- a/docs/language/tile_axpy.md
+++ b/docs/language/tile_axpy.md
@@ -2,7 +2,7 @@
 
 ## 1. 功能说明
 
-将源 buffer 与标量相乘后逐元素加到目标 buffer 上：`dst[i] = scalar * src[i] + dst[i]`
+将源 buffer `src0` 与标量 `scalar_value` 相乘后逐元素加到目标 buffer `dst` 上：`dst[i] = scalar_value * src0[i] + dst[i]`
 
 dst 同时作为输入和输出，原地更新 dst 的内容。
 

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -357,8 +357,9 @@ def axpy(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-        A: T.Tensor((M, N), dtype),  # type: ignore
-        B: T.Tensor((M, N), dtype),  # type: ignore
+    A: T.Tensor((M, N), dtype),  # type: ignore
+    InitialDst: T.Tensor((M, N), dtype),  # type: ignore
+    B: T.Tensor((M, N), dtype),  # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
@@ -366,7 +367,7 @@ def axpy(M, N, block_M, block_N, dtype="float"):
 
             a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
             b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-            T.tile.fill(b_ub, 0)
+            T.copy(InitialDst[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
 
             T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
 
@@ -381,13 +382,15 @@ def run_test_axpy(M, N, block_M, block_N, dtype, target):
     func = axpy(M, N, block_M, block_N, dtype)
     func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
 
-    a = torch.randn(M, N, dtype=torch.float32 if dtype == "float" else torch.float16).npu()
+    torch_dtype = torch.float32 if dtype == "float" else torch.float16
+    a = torch.randn(M, N, dtype=torch_dtype).npu()
+    initial_dst = torch.randn(M, N, dtype=torch_dtype).npu()
 
     torch.npu.synchronize()
 
-    b = func(a)
+    b = func(a, initial_dst)
 
-    ref_b = a * 2.0
+    ref_b = a * 2.0 + initial_dst
     torch.testing.assert_close(b, ref_b, rtol=1e-2, atol=1e-2)
 
 

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -394,8 +394,8 @@ def run_test_axpy(M, N, block_M, block_N, dtype, target):
     torch.testing.assert_close(b, ref_b, rtol=1e-2, atol=1e-2)
 
 
-@pytest.mark.parametrize("dtype", ["float", "float16"])
-@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("dtype", ["float", pytest.param("float16", marks=pytest.mark.low_priority)])
+@pytest.mark.parametrize("target", ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)])
 @pytest.mark.parametrize("shape", [(1024, 1024)])
 def test_axpy(dtype, target, shape):
     M, N = shape

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -357,9 +357,9 @@ def axpy(M, N, block_M, block_N, dtype="float"):
 
     @T.prim_func
     def main(
-    A: T.Tensor((M, N), dtype),  # type: ignore
-    InitialDst: T.Tensor((M, N), dtype),  # type: ignore
-    B: T.Tensor((M, N), dtype),  # type: ignore
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        InitialDst: T.Tensor((M, N), dtype),  # type: ignore
+        B: T.Tensor((M, N), dtype),  # type: ignore
     ):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1338,8 +1338,13 @@ def axpy(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, scalar_value: 
 
     Note:
         - Supports float16 and float32 on Ascend A2/A3.
-        - The destination and source must have the same data type in the
-          current Ascend C and PTO backends.
+        - The destination and source must have the same data type. This is a
+          current TileLang implementation limitation rather than a hardware
+          one: the underlying Ascend C Axpy API and the PTO TAXPY
+          instruction also support dst=float32 with src0/scalar_value=
+          float16, but the Ascend C codegen enforces identical dtypes and
+          the PTO codegen emits a single-type template call. Mixed-dtype
+          support is a known implementation gap.
         - The destination and source must contain the same number of elements.
         - Operands must reside in Unified Buffer and satisfy its alignment
           requirements.

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1324,15 +1324,25 @@ def leaky_relu(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, scalar_v
 
 
 def axpy(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, scalar_value: PrimExpr):  # noqa: F821
-    """Performs element-wise AXPY operation: dst = scalar_value * src0 + dst.
+    """Performs element-wise AXPY and updates the destination in place.
 
-    Note: This operation updates the destination buffer in-place by adding
-    the scaled source buffer.
+    For each element, computes:
+    ``dst[i] = scalar_value * src0[i] + dst[i]``.
 
     Args:
-        dst: The destination buffer (acts as both operand Y and output).
-        src0: The source buffer X.
-        scalar_value: The scalar alpha.
+        dst: The destination buffer or buffer region. It acts as both the
+            accumulator input and output.
+        src0: The source buffer or buffer region.
+        scalar_value: The scalar multiplier, converted to the destination
+            data type during code generation.
+
+    Note:
+        - Supports float16 and float32 on Ascend A2/A3.
+        - The destination and source must have the same data type in the
+          current Ascend C and PTO backends.
+        - The destination and source must contain the same number of elements.
+        - Operands must reside in Unified Buffer and satisfy its alignment
+          requirements.
     """
     return scalar_op(dst, src0, scalar_value, "axpy")
 


### PR DESCRIPTION
## 1. 文件改动

| 文件 | 类型 | 改动说明 |
|------|------|----------|
| `tilelang/language/ascend_tile.py` | 修改 | 更新 `axpy` docstring：补充原地更新语义、完整计算公式、参数类型、A2/A3 dtype 支持、Ascend C/PTO 同 dtype 约束、元素数量约束和 Unified Buffer 要求 |
| `testing/python/language/test_tilelang_ascend_language_elementwise.py` | 修改 | 增强已有 `test_axpy`：不再将 `dst` 初始化为全 0，而是传入非零随机初值，完整验证 `dst = scalar_value * src0 + dst`，覆盖 Ascend C/PTO × float32/float16 |
| `docs/language/tile_axpy.md` | 新增 | 新增并完成 `T.tile.axpy` API 文档事实核查，包含功能说明、函数原型、参数规格、约束和示例；删除未经当前实现支持的 PTO 混合精度与 A5 内容 |

---

## 2. 测试与事实核查

### 2.1 动态验证（真机 Ascend A2 / 910B3）

| 验证项 | 验证方式 | 结果 |
|--------|----------|:----:|
| 完整 AXPY 语义 | 使用非零随机 `initial_dst`，参考结果为 `src0 * 2.0 + initial_dst` | **通过** |
| Ascend C dtype | float32、float16 | **通过** |
| PTO dtype | float32、float16 | **通过** |
| BufferRegion | 一维整行切片，Ascend C/PTO | **通过** |
| PTO 混合精度 | `src0=float16`、`dst=float32` 编译探针 | **不支持**：编译报 `no matching function for call to 'axpy'` |

### 2.2 语言测试（6 个参数化用例）

| 测试函数 | 用例数 | 类型 | 验证内容 |
|----------|:------:|------|----------|
| `test_axpy` | 4 | 本 PR 增强 | target（Ascend C/PTO）× dtype（float32/float16），验证非零初始 `dst` 的完整累加语义 |
| `test_axpy_slice` | 2 | 已有用例回归 | BufferRegion 一维切片 × target（Ascend C/PTO） |


### 2.3 测试用例统计与 LP 分层

本 PR 无新增测试函数：增强既有 `test_axpy`（4 用例，验证非零初始 dst 的完整累加语义），并为其低优先级参数打标；`test_axpy_slice`（2 用例）保持默认执行。

LP 分层标记（已落地）：PR 触发执行 3 个（test_axpy 1 + test_axpy_slice 2），定时任务触发执行 6 个（3 个标 low_priority 仅定时执行）

| 测试函数 | 用例数 | PR执行 | LP | 类型 | 覆盖内容 |
|---|:---:|:---:|:---:|---|---|
| `test_axpy` | 4 | 1 | 3 | 语义增强 | 完整累加语义 dst = scalar_value * src0 + dst：float32/float16 × ascendc/pto，float32@ascendc 为核心 |
| `test_axpy_slice` | 2 | 2 | 0 | 既有回归 | BufferRegion 一维切片 × ascendc/pto（本 PR 未改动，默认执行） |

LP 标记策略（已落地，与仓库现有惯例一致）：

- dtype：float32 默认执行，float16 标 low_priority
- target：ascendc 默认执行，pto 标 low_priority

---

## 3. 测试结果

```text
test_axpy:
4 passed

test_axpy_slice:
2 passed

combined:
6 passed, 1 warning
```

其中 warning 为 CANNLab 环境中 `torch_npu` 动态库文件所有者不一致提示，不影响编译、运行或精度结果。

---

## 4. 校验过程中发现并修正的问题

1. **已有测试没有完整验证累加语义**

   原测试先将 `dst` 填充为 0，参考结果仅为 `src0 * 2.0`，只能验证标量乘法，无法证明原有 `dst` 参与计算。

   本 PR 改为传入非零随机 `initial_dst`，参考结果为：

   ```text
   dst = scalar_value * src0 + initial_dst
   ```

2. **PTO 混合精度声明与当前实现不符**

   初始文档声明 PTO 支持 `src0=float16、dst=float32`。静态检查发现 PTO `axpy<T>` 模板使用同一个类型 `T` 表示 `dst` 和 `src0`，未实现混合类型转换。

   真机编译探针进一步确认该组合编译失败：

   ```text
   no matching function for call to 'axpy'
   ```

   因此文档改为：当前 Ascend C 和 PTO 后端均要求 `dst` 与 `src0` 的 dtype 相同。

3. **Ascend C 与 PTO 的同 dtype 约束来源不同**

   - Ascend C codegen 显式检查 `dst` 与 `src0` dtype 相同。
   - PTO codegen 未显式检查，但生成的单类型模板调用无法接受不同 dtype。

4. **Shape 描述缺少证据边界**

   已动态验证二维 Buffer 和一维 BufferRegion 切片；源码通过元素总数检查 `dst` 与 `src0` 是否兼容。

   文档只记录已验证范围，不再将“仅支持 1D/2D”表述为未经证实的排他性限制。

5. **A5 内容超出本次事实核查范围**

   按事实核查流程删除 A5、bfloat16、int64 和 uint64 内容，仅保留 A2/A3 的 float16、float32 支持情况。

6. **公式变量名与函数签名不一致**

   原公式使用 `scalar` 和 `src`，函数参数实际为 `scalar_value` 和 `src0`。

   已统一为：

   ```text
   dst[i] = scalar_value * src0[i] + dst[i]
   ```

7. **地址与存储位置约束**

   `axpy` 操作数使用 Unified Buffer；文档按 Ascend C 对应接口及 UB 通用要求记录 32 字节起始地址对齐约束。未将高阶 Axpy 接口的 `sharedTmpBuffer` 约束误写入当前 TileLang 三参数接口。

---

## 5. 验证

### 5.1 语法与静态检查

```text
python -m py_compile tilelang/language/ascend_tile.py
python -m py_compile testing/python/language/test_tilelang_ascend_language_elementwise.py
git diff --check
```

以上检查通过。

### 5.2 真机测试

```text
python -m pytest \
  testing/python/language/test_tilelang_ascend_language_elementwise.py::test_axpy \
  testing/python/language/test_tilelang_ascend_language_elementwise.py::test_axpy_slice \
  -v -s
```

结果：

```text
6 passed, 1 warning
```