### PR TITLE
[Doc] Ascend: refine T.tile.merge_sort docstring, add test cases and API documentation

### DIFF
--- a/docs/TileLang-Ascend Programming Guide.md
+++ b/docs/TileLang-Ascend Programming Guide.md
@@ -2125,28 +2125,22 @@ Expert编程模式可以复用Developer模式的Reduce类计算原语。
   - `dst`与 `src` 数据类型相同，仅支持float32和float16数据类型
   - `src` 的大小需要满足32或32的整数倍
 
-- `T.tile.merge_sort(dst, src0, src1, src2=None, src3=None):`
+- `T.tile.merge_sort(dst, src0, src1, src2=None, src3=None, tmp=None):`
 
   **参数**：
 
   - dst：归并结果输出缓冲区
-  - tmp：临时缓冲区，用于归并计算的中间结果存储
   - src0：第一个已排序的源数据缓冲区
   - src1：第二个已排序的源数据缓冲区
   - src2：第三个已排序的源数据缓冲区（可选，3-way 或 4-way 归并时需要）
   - src3：第四个已排序的源数据缓冲区（可选，4-way 归并时需要）
+  - tmp：可选临时缓冲区（ascendc 后端不使用；pto 后端不传时自动分配，显式传入须为非空 buffer）
 
   **功能**：将多个已排序的数据块合并为一个有序结果，支持 2-way、3-way 和 4-way 归并排序。
 
-  **数据格式**：输入/输出格式均为 value-index pair：`[value0, index0, value1, index1, value2, index2, ...]`，按降序排列。
-
-  数据类型为float，每个结构占据8Bytes：
+  **数据格式**：输入/输出格式均为 value-index pair：`[value0, index0, value1, index1, value2, index2, ...]`，按降序排列。数据类型为 float32，每个结构（value + index）占据 8 Bytes：
 
   ![image-tilelang_ascend_mergesort2](./images/zh-cn_image_0000002449970177.png)
-
-  数据类型为half，每个结构也占据8Bytes，中间有2Bytes保留：
-  
-  ![image-tilelang_ascend_mergesort2](./images/zh-cn_image_0000002449890293.png)
 
   **举例**：
 
@@ -2162,12 +2156,12 @@ Expert编程模式可以复用Developer模式的Reduce类计算原语。
   ```
 
   **注意事项**：
-  - `tmp` 缓冲区大小需与 `dst` 相同
+  - 目前仅支持 `float32`，不支持 `float16`
   - 输入缓冲区必须已按降序排序
   - 所有缓冲区的数据格式必须为 value-index pair（每 2 个 float 表示一个元素）
+  - dst 大小至少为所有 src 大小之和
+  - pto 后端要求各 src 大小相同（不等长归并仅 ascendc 支持）
   - 建议配合 `T.tile.sort32` 一起使用
-
-  更详细说明，详见AscendC文档：https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/83RC1alpha002/API/ascendcopapi/atlasascendc_api_07_0232.html
 
 - `T.tile.topk(dst, src, K, actual_num):`
 

--- a/docs/api_docs/T.tile.merge_sort.md
+++ b/docs/api_docs/T.tile.merge_sort.md
@@ -1,12 +1,12 @@
 # T.tile.merge_sort
 
-## 1. Description
+## 1. 功能说明
 
-Merges 2/3/4 descending-sorted queues into a single descending-sorted queue: `dst = MrgSort(src0, src1, [src2], [src3])`. Both input and output use the interleaved (value, index) pair format (each element occupies 2 buffer positions): `src = [val0, idx0, val1, idx1, ...]`, and `dst[i]` is the i-th largest (value, index) pair globally. The blockLen (valid element count) of each source is derived automatically from its buffer size.
+对 2/3/4 条已按降序排好的队列执行多路归并，合并为 1 条降序队列：`dst = MrgSort(src0, src1, [src2], [src3])`。输入输出均采用 (value, index) 交错对格式（每个元素占 2 个 buffer 位置）：`src = [val0, idx0, val1, idx1, ...]`，`dst[i]` 为全局第 i 大的 (value, index) 对。每条 src 的 blockLen（有效元素数）由 buffer 大小自动推算。
 
-## 2. Function Prototype
+## 2. 函数原型
 
-### 2.1 Function Definition
+### 2.1 函数定义
 
 ```python
 def merge_sort(
@@ -20,66 +20,66 @@ def merge_sort(
 )
 ```
 
-### 2.2 Parameters
+### 2.2 参数说明
 
-| Parameter | Direction | Description | Type | Required/Optional |
-|-----------|-----------|-------------|------|-------------------|
-| dst | Output | Stores the merged (value, index) interleaved pairs. Its size must be at least the sum of all source buffer sizes | tensor | Required |
-| src0 | Input | First source queue, sorted in descending order | tensor | Required |
-| src1 | Input | Second source queue, sorted in descending order | tensor | Required |
-| src2 | Input | Third source queue, sorted in descending order (for 3-way or 4-way merge) | tensor / None | Optional (default `None`) |
-| src3 | Input | Fourth source queue, sorted in descending order (for 4-way merge only) | tensor / None | Optional (default `None`) |
-| tmp | Input | Optional temporary buffer. The ascendc backend does not use it (an explicitly passed tmp is omitted from the emitted call); the pto backend needs a workspace — when omitted (None) it allocates a workspace of 1× the dst size automatically, and an explicitly passed tmp must be a non-empty buffer large enough to hold it (a zero-length tmp raises an error) | tensor / None | Optional (default `None`) |
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放归并排序后的 (value, index) 交错对，大小至少为所有 src 大小之和 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一条已按降序排序的源队列 | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二条已按降序排序的源队列 | 张量（tensor） | 必填 |
+| src2 | 输入 | 第三条已按降序排序的源队列（3 路或 4 路归并时使用） | 张量（tensor）/ None | 可选（默认 `None`） |
+| src3 | 输入 | 第四条已按降序排序的源队列（仅 4 路归并时使用） | 张量（tensor）/ None | 可选（默认 `None`） |
+| tmp | 输入 | 可选临时缓冲区。ascendc 后端不使用（显式传入也会在 codegen 中省略）；pto 后端需要 workspace，不传（None）时由编译器自动分配，显式传入时必须是足以容纳所需大小的非空 buffer | 张量（tensor）/ None | 可选（默认 `None`） |
 
-> **Type notes**:
-> - **tensor**: A buffer allocated via `T.alloc_ub`, `T.alloc_shared`, etc., or a slice (BufferRegion) of such a buffer
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
 
-### 2.3 Parameter Specifications
+### 2.3 参数规格
 
-#### 2.3.1 DataType Support
+#### 2.3.1 DataType 支持
 
-| Platform | dst | src0 | src1 | src2 | src3 |
-|----------|:---:|:----:|:----:|:----:|:----:|
+| 平台 | dst | src0 | src1 | src2 | src3 |
+|------|:---:|:----:|:----:|:----:|:----:|
 | Ascend A2 / A3 | float32 | float32 | float32 | float32 | float32 |
 
-> **Note**: Only `float32` is supported. `float16` inputs produce incorrect results in the current implementation (the ascendc backend triggers an aicore exception). To sort half data, cast it to float32 with `T.cast` first.
+> **注意**：仅支持 `float32`，不支持 `float16`。如需对 half 数据排序，请先用 `T.cast` 转为 float32。
 
-#### 2.3.2 Shape Support
+#### 2.3.2 Shape 支持
 
-- Supports 1D buffers and slices of 1D buffers; the slice start must be 32-byte aligned
-- Supports whole-row slices of 2D buffers (e.g. `buf[0, :]`, `buf[1, :]`)
-- Column-offset slices of 2D buffers (e.g. `buf[0, 8:136]`) are NOT supported: codegen emits a wrong address and the result is unreliable; multi-row region slices (e.g. `buf[0:2, :]`) are supported on ascendc only (pto fails to compile)
-- The merge width is determined automatically by whether src2 / src3 is None:
+- 支持 1D buffer，以及 1D buffer 的切片（slice），切片起始需满足 32 字节对齐
+- 支持 2D buffer 的整行切片（如 `buf[0, :]`、`buf[1, :]`）
+- **不支持** 2D buffer 的列偏移切片（如 `buf[0, 8:136]`）；多行区域切片（如 `buf[0:2, :]`）仅 ascendc 支持
+- 归并路数由 src2、src3 是否为 None 自动确定：
 
-| src2 | src3 | Merge Width | Availability |
-|------|------|-------------|--------------|
-| None | None | 2-way | Supported on both ascendc and pto |
-| Not None | None | 3-way | Supported on both ascendc and pto |
-| Not None | Not None | 4-way | Supported on both ascendc and pto |
+| src2 | src3 | 归并路数 | 可用性 |
+|------|------|---------|--------|
+| None | None | 2 路 | ascendc / pto 均支持 |
+| 非 None | None | 3 路 | ascendc / pto 均支持 |
+| 非 None | 非 None | 4 路 | ascendc / pto 均支持 |
 
-#### 2.3.3 blockLen Description
+#### 2.3.3 blockLen 说明
 
-The blockLen (valid element count) of each source queue is derived from its buffer size: `blockLen = buffer_size // 2` (value-index pair format, each element occupies 2 buffer positions).
+每条源队列的 blockLen（有效元素数）由 buffer 大小自动推算：`blockLen = buffer_size // 2`（value-index 对格式，每个元素占 2 个 buffer 位置）。
 
-- **ascendc**: blockLen ∈ [1, 4095]; sources may have different blockLens (unequal-length merge)
-- **pto**: blockLen ∈ [4, 4088], and all sources must have the same blockLen (equal-length merge); unequal lengths or out-of-range values fail at compile time or at runtime
+- **ascendc**：blockLen ∈ [1, 4095]，各 src 的 blockLen 可以不同（不等长归并）
+- **pto**：blockLen ∈ [4, 4088]，且各 src 的 blockLen 必须相同（等长归并）
 
-### 2.4 Constraints
+### 2.4 约束条件
 
-1. The number of source queues must be 2, 3 or 4 (determined by whether src2 / src3 is None); `num_ways < 2` or `> 4` raises a `ValueError`
-2. All sources and dst must have the same dtype, float32; a dtype mismatch raises a compile error
-3. dst size must be at least the sum of all source buffer sizes (2-way: `dst >= src0 + src1`; a dst larger than the sum also works, as verified). If dst is smaller than the sum, the kernel does not report an error but produces wrong results (out-of-bounds writes into adjacent UB memory)
-4. Each source queue must already be sorted in descending order (typically the output of `T.tile.sort32` / `T.tile.sort`)
-5. blockLen = src size / 2; the ascendc backend supports blockLen ∈ [1, 4095] (AscendC MrgSort elementLengths assertion), the pto backend supports blockLen ∈ [4, 4088] (hardware constraint). blockLen = 0 (an empty src buffer) raises a compile-time divide-by-zero error
-6. dst and src addresses must be 32-byte aligned (hardware constraint; verified: 1D slice offsets of 4/8/16 bytes trigger aicore exceptions, 32 bytes and above work; whole buffers allocated with `T.alloc_ub` / `T.alloc_shared` satisfy this naturally)
-7. Stable merge: when scores are equal, sources are consumed in src0 → src1 → src2 → src3 order, preserving the original order inside each source queue
-8. The pto backend requires all sources to have the same size (equal-length merge); unequal-length merges are supported on the ascendc backend only (pto fails to compile with "no matching function")
-9. NaN inputs have no deterministic ordering semantics; their output positions are not guaranteed (hardware behavior)
-10. tmp parameter: the ascendc backend ignores it (an explicitly passed tmp is omitted from codegen); the pto backend needs a workspace — when omitted (None) it is allocated automatically, and an explicitly passed tmp must be a non-empty buffer large enough to hold the required size (a zero-length tmp raises an error)
+1. src 数量必须为 2、3 或 4（由 src2、src3 是否为 None 判断），`num_ways < 2` 或 `> 4` 时抛 `ValueError`
+2. 所有 src 与 dst 的 dtype 必须同为 float32
+3. dst 大小必须**至少**为所有 src 大小之和（2 路：`dst >= src0 + src1`）
+4. 每条源队列必须已经按降序排好（通常是 `T.tile.sort32` / `T.tile.sort` 的输出）
+5. blockLen = src 大小 / 2；ascendc 支持 blockLen ∈ [1, 4095]（AscendC MrgSort elementLengths 上限），pto 支持 blockLen ∈ [4, 4088]（硬件约束）。src buffer 大小不能为 0
+6. dst 与 src 地址需 32 字节对齐（硬件约束；`T.alloc_ub` / `T.alloc_shared` 分配的完整 buffer 天然满足）
+7. 稳定排序：score 相同时，跨队列按 src0 → src1 → src2 → src3 顺序，队列内保持原始顺序
+8. 不等长归并仅 ascendc 后端支持；pto 后端要求各 src 大小相同
+9. NaN 输入无确定顺序语义，输出位置不受保证（硬件行为）
+10. tmp 参数：ascendc 后端不使用；pto 后端需要 workspace——不传（None）时自动分配，显式传入时必须是足以容纳所需大小的非空 buffer
 
-## 3. Example Code
+## 3. 示例代码
 
-**Example 1: 2-way merge**
+**示例 1：2 路归并**
 
 ```python
 src0 = T.alloc_ub((64,), "float32")
@@ -88,7 +88,7 @@ dst  = T.alloc_ub((128,), "float32")
 T.tile.merge_sort(dst, src0, src1)
 ```
 
-**Example 2: 3-way merge**
+**示例 2：3 路归并**
 
 ```python
 src0 = T.alloc_ub((64,), "float32")

--- a/docs/api_docs/T.tile.merge_sort.md
+++ b/docs/api_docs/T.tile.merge_sort.md
@@ -1,0 +1,99 @@
+# T.tile.merge_sort
+
+## 1. Description
+
+Merges 2/3/4 descending-sorted queues into a single descending-sorted queue: `dst = MrgSort(src0, src1, [src2], [src3])`. Both input and output use the interleaved (value, index) pair format (each element occupies 2 buffer positions): `src = [val0, idx0, val1, idx1, ...]`, and `dst[i]` is the i-th largest (value, index) pair globally. The blockLen (valid element count) of each source is derived automatically from its buffer size.
+
+## 2. Function Prototype
+
+### 2.1 Function Definition
+
+```python
+def merge_sort(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion,
+    src2: Buffer | BufferRegion | None = None,
+    src3: Buffer | BufferRegion | None = None,
+    *,
+    tmp: Buffer | BufferRegion | None = None,
+)
+```
+
+### 2.2 Parameters
+
+| Parameter | Direction | Description | Type | Required/Optional |
+|-----------|-----------|-------------|------|-------------------|
+| dst | Output | Stores the merged (value, index) interleaved pairs. Its size must be at least the sum of all source buffer sizes | tensor | Required |
+| src0 | Input | First source queue, sorted in descending order | tensor | Required |
+| src1 | Input | Second source queue, sorted in descending order | tensor | Required |
+| src2 | Input | Third source queue, sorted in descending order (for 3-way or 4-way merge) | tensor / None | Optional (default `None`) |
+| src3 | Input | Fourth source queue, sorted in descending order (for 4-way merge only) | tensor / None | Optional (default `None`) |
+| tmp | Input | Optional temporary buffer. The ascendc backend does not use it (an explicitly passed tmp is omitted from the emitted call); the pto backend needs a workspace — when omitted (None) it allocates a workspace of 1× the dst size automatically, and an explicitly passed tmp must be a non-empty buffer large enough to hold it (a zero-length tmp raises an error) | tensor / None | Optional (default `None`) |
+
+> **Type notes**:
+> - **tensor**: A buffer allocated via `T.alloc_ub`, `T.alloc_shared`, etc., or a slice (BufferRegion) of such a buffer
+
+### 2.3 Parameter Specifications
+
+#### 2.3.1 DataType Support
+
+| Platform | dst | src0 | src1 | src2 | src3 |
+|----------|:---:|:----:|:----:|:----:|:----:|
+| Ascend A2 / A3 | float32 | float32 | float32 | float32 | float32 |
+
+> **Note**: Only `float32` is supported. `float16` inputs produce incorrect results in the current implementation (the ascendc backend triggers an aicore exception). To sort half data, cast it to float32 with `T.cast` first.
+
+#### 2.3.2 Shape Support
+
+- Supports 1D buffers and slices of 1D buffers; the slice start must be 32-byte aligned
+- Supports whole-row slices of 2D buffers (e.g. `buf[0, :]`, `buf[1, :]`)
+- Column-offset slices of 2D buffers (e.g. `buf[0, 8:136]`) are NOT supported: codegen emits a wrong address and the result is unreliable; multi-row region slices (e.g. `buf[0:2, :]`) are supported on ascendc only (pto fails to compile)
+- The merge width is determined automatically by whether src2 / src3 is None:
+
+| src2 | src3 | Merge Width | Availability |
+|------|------|-------------|--------------|
+| None | None | 2-way | Supported on both ascendc and pto |
+| Not None | None | 3-way | Supported on both ascendc and pto |
+| Not None | Not None | 4-way | Supported on both ascendc and pto |
+
+#### 2.3.3 blockLen Description
+
+The blockLen (valid element count) of each source queue is derived from its buffer size: `blockLen = buffer_size // 2` (value-index pair format, each element occupies 2 buffer positions).
+
+- **ascendc**: blockLen ∈ [1, 4095]; sources may have different blockLens (unequal-length merge)
+- **pto**: blockLen ∈ [4, 4088], and all sources must have the same blockLen (equal-length merge); unequal lengths or out-of-range values fail at compile time or at runtime
+
+### 2.4 Constraints
+
+1. The number of source queues must be 2, 3 or 4 (determined by whether src2 / src3 is None); `num_ways < 2` or `> 4` raises a `ValueError`
+2. All sources and dst must have the same dtype, float32; a dtype mismatch raises a compile error
+3. dst size must be at least the sum of all source buffer sizes (2-way: `dst >= src0 + src1`; a dst larger than the sum also works, as verified). If dst is smaller than the sum, the kernel does not report an error but produces wrong results (out-of-bounds writes into adjacent UB memory)
+4. Each source queue must already be sorted in descending order (typically the output of `T.tile.sort32` / `T.tile.sort`)
+5. blockLen = src size / 2; the ascendc backend supports blockLen ∈ [1, 4095] (AscendC MrgSort elementLengths assertion), the pto backend supports blockLen ∈ [4, 4088] (hardware constraint). blockLen = 0 (an empty src buffer) raises a compile-time divide-by-zero error
+6. dst and src addresses must be 32-byte aligned (hardware constraint; verified: 1D slice offsets of 4/8/16 bytes trigger aicore exceptions, 32 bytes and above work; whole buffers allocated with `T.alloc_ub` / `T.alloc_shared` satisfy this naturally)
+7. Stable merge: when scores are equal, sources are consumed in src0 → src1 → src2 → src3 order, preserving the original order inside each source queue
+8. The pto backend requires all sources to have the same size (equal-length merge); unequal-length merges are supported on the ascendc backend only (pto fails to compile with "no matching function")
+9. NaN inputs have no deterministic ordering semantics; their output positions are not guaranteed (hardware behavior)
+10. tmp parameter: the ascendc backend ignores it (an explicitly passed tmp is omitted from codegen); the pto backend needs a workspace — when omitted (None) it is allocated automatically, and an explicitly passed tmp must be a non-empty buffer large enough to hold the required size (a zero-length tmp raises an error)
+
+## 3. Example Code
+
+**Example 1: 2-way merge**
+
+```python
+src0 = T.alloc_ub((64,), "float32")
+src1 = T.alloc_ub((64,), "float32")
+dst  = T.alloc_ub((128,), "float32")
+T.tile.merge_sort(dst, src0, src1)
+```
+
+**Example 2: 3-way merge**
+
+```python
+src0 = T.alloc_ub((64,), "float32")
+src1 = T.alloc_ub((64,), "float32")
+src2 = T.alloc_ub((64,), "float32")
+dst  = T.alloc_ub((192,), "float32")
+T.tile.merge_sort(dst, src0, src1, src2)
+```

--- a/testing/python/language/test_tilelang_ascend_language_merge_sort.py
+++ b/testing/python/language/test_tilelang_ascend_language_merge_sort.py
@@ -1,0 +1,414 @@
+import argparse
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+
+"""
+Test suite for T.tile.merge_sort API.
+
+Covers:
+  - Basic functionality: 2/3/4-way merge (verify 4-way is supported)
+  - dtype: float32 only (float16 is NOT supported by the current implementation:
+    ascendc raises aicore exception, pto produces wrong results)
+  - Unequal block lengths (ascendc only; pto compile fails)
+  - BufferRegion slices as sources (2D buffer row slices)
+  - Stability: equal scores keep source order (src0 -> src1 -> ...) and
+    in-block order
+  - blockLen boundaries per backend: ascendc [1, 4095], pto [4, 4088]
+
+low_priority trimming:
+  - pto: ascendc executes by default; pto is marked low_priority
+  - large merge sizes / stability / boundaries: low_priority when overlapping
+"""
+
+TORCH_DTYPE = {"float32": torch.float32}
+RTOL = 1e-3
+ATOL = 1e-3
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+# -----------------------------------------------------------------------------
+# Kernel builders
+# -----------------------------------------------------------------------------
+
+
+def merge_sort_kernel_2way(n0, n1, dtype="float32"):
+    """2-way merge_sort kernel: src sizes 2*n0, 2*n1; dst 2*(n0+n1)."""
+
+    @T.prim_func
+    def main(
+        A0: T.Tensor((2 * n0,), dtype),  # type: ignore
+        A1: T.Tensor((2 * n1,), dtype),  # type: ignore
+        B: T.Tensor((2 * (n0 + n1),), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            src0 = T.alloc_ub((2 * n0,), dtype)
+            src1 = T.alloc_ub((2 * n1,), dtype)
+            dst = T.alloc_ub((2 * (n0 + n1),), dtype)
+            T.copy(A0, src0)
+            T.copy(A1, src1)
+            T.tile.merge_sort(dst, src0, src1)
+            T.copy(dst, B)
+
+    return main
+
+
+def merge_sort_kernel_3way(n, dtype="float32"):
+    """3-way merge_sort kernel: all src sizes 2*n; dst 6*n."""
+
+    @T.prim_func
+    def main(
+        A0: T.Tensor((2 * n,), dtype),  # type: ignore
+        A1: T.Tensor((2 * n,), dtype),  # type: ignore
+        A2: T.Tensor((2 * n,), dtype),  # type: ignore
+        B: T.Tensor((6 * n,), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            src0 = T.alloc_ub((2 * n,), dtype)
+            src1 = T.alloc_ub((2 * n,), dtype)
+            src2 = T.alloc_ub((2 * n,), dtype)
+            dst = T.alloc_ub((6 * n,), dtype)
+            T.copy(A0, src0)
+            T.copy(A1, src1)
+            T.copy(A2, src2)
+            T.tile.merge_sort(dst, src0, src1, src2)
+            T.copy(dst, B)
+
+    return main
+
+
+def merge_sort_kernel_4way(n, dtype="float32"):
+    """4-way merge_sort kernel: all src sizes 2*n; dst 8*n."""
+
+    @T.prim_func
+    def main(
+        A0: T.Tensor((2 * n,), dtype),  # type: ignore
+        A1: T.Tensor((2 * n,), dtype),  # type: ignore
+        A2: T.Tensor((2 * n,), dtype),  # type: ignore
+        A3: T.Tensor((2 * n,), dtype),  # type: ignore
+        B: T.Tensor((8 * n,), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            src0 = T.alloc_ub((2 * n,), dtype)
+            src1 = T.alloc_ub((2 * n,), dtype)
+            src2 = T.alloc_ub((2 * n,), dtype)
+            src3 = T.alloc_ub((2 * n,), dtype)
+            dst = T.alloc_ub((8 * n,), dtype)
+            T.copy(A0, src0)
+            T.copy(A1, src1)
+            T.copy(A2, src2)
+            T.copy(A3, src3)
+            T.tile.merge_sort(dst, src0, src1, src2, src3)
+            T.copy(dst, B)
+
+    return main
+
+
+def merge_sort_kernel(sizes, dtype="float32"):
+    """N-way merge_sort kernel from element-count list `sizes`.
+
+    Each source buffer has `2 * size` elements (value, index pairs).
+    dst has `2 * sum(sizes)` elements.
+    """
+    assert len(sizes) in (2, 3, 4)
+    if len(sizes) == 2:
+        return merge_sort_kernel_2way(sizes[0], sizes[1], dtype)
+    if len(sizes) == 3:
+        assert sizes[0] == sizes[1] == sizes[2]
+        return merge_sort_kernel_3way(sizes[0], dtype)
+    assert sizes[0] == sizes[1] == sizes[2] == sizes[3]
+    return merge_sort_kernel_4way(sizes[0], dtype)
+
+
+def merge_sort_kernel_region(M, per_row, dtype="float32"):
+    """2D src buffer (M, per_row); sources are row slices of it.
+    Requires M == 2 (i.e., a 2-way merge on two row slices).
+    """
+    total = M * per_row
+
+    @T.prim_func
+    def main(A: T.Tensor((M, per_row), dtype), B: T.Tensor((total,), dtype)):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            src = T.alloc_ub((M, per_row), dtype)
+            dst = T.alloc_ub((total,), dtype)
+            T.copy(A, src)
+            T.tile.merge_sort(dst, src[0, :], src[1, :])
+            T.copy(dst, B)
+
+    return main
+
+
+# -----------------------------------------------------------------------------
+# Data generation
+# -----------------------------------------------------------------------------
+
+
+def make_sorted_block(n, dtype="float32", seed=0, k_distinct=None):
+    """Create a block of n (value, index) pairs sorted in descending order.
+
+    With k_distinct, values are drawn from k_distinct distinct ints so that
+    ties are guaranteed (for stability testing).
+    """
+    torch.manual_seed(seed)
+    if k_distinct is not None:
+        vals = torch.randint(0, k_distinct, (n,)).float()
+    else:
+        vals = torch.randn(n)
+    idx = torch.argsort(vals, descending=True, stable=True)
+    pairs = torch.zeros(n * 2, dtype=TORCH_DTYPE[dtype])
+    pairs[0::2] = vals[idx]
+    pairs[1::2] = idx.float()
+    return pairs
+
+
+def cpu_merge_ref(blocks):
+    """Stable k-way merge reference matching hardware MrgSort semantics.
+
+    Equal (value) scores are ordered by source order first (all elements of
+    src0 before any element of src1), then by in-block original order. Since
+    each block is pre-sorted by (descending value, ascending original index),
+    the merged order is: sort by (value desc, block order, in-block order).
+    """
+    elems = []
+    for bi, b in enumerate(blocks):
+        for j in range(len(b) // 2):
+            elems.append((b[2 * j].item(), bi, b[2 * j + 1].float().item()))
+    elems.sort(key=lambda e: (-e[0], e[1], e[2]))
+    result = torch.zeros(2 * len(elems), dtype=torch.float32)
+    result[0::2] = torch.tensor([v for v, _, _ in elems])
+    result[1::2] = torch.tensor([i for _, _, i in elems])
+    return result
+
+
+# -----------------------------------------------------------------------------
+# Run-test helpers
+# -----------------------------------------------------------------------------
+
+
+def run_test_merge(block_len, num_ways, dtype="float32", target="ascendc", seeds=None):
+    """Three-fold verification: compile + run + precision for N-way merge."""
+    sizes = [block_len] * num_ways
+    seeds = seeds or list(range(num_ways))
+    blocks = [make_sorted_block(s, dtype, seed=seeds[i]) for i, s in enumerate(sizes)]
+
+    kernel = merge_sort_kernel(sizes, dtype)
+    func = tilelang.compile(kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+
+    out = func(*[b.npu() for b in blocks])
+    torch.npu.synchronize()
+
+    out_cpu = out.cpu().float().reshape(-1)
+    ref = cpu_merge_ref(blocks)
+
+    torch.testing.assert_close(out_cpu[0::2], ref[0::2], rtol=RTOL, atol=ATOL)
+    torch.testing.assert_close(out_cpu[1::2], ref[1::2], rtol=0, atol=0)
+
+
+def run_test_merge_unequal(sizes, dtype="float32", target="ascendc", seeds=None):
+    """Merge with different block lengths per source."""
+    seeds = seeds or list(range(len(sizes)))
+    blocks = [make_sorted_block(s, dtype, seed=seeds[i]) for i, s in enumerate(sizes)]
+
+    kernel = merge_sort_kernel(sizes, dtype)
+    func = tilelang.compile(kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+
+    out = func(*[b.npu() for b in blocks])
+    torch.npu.synchronize()
+
+    out_cpu = out.cpu().float().reshape(-1)
+    ref = cpu_merge_ref(blocks)
+
+    torch.testing.assert_close(out_cpu[0::2], ref[0::2], rtol=RTOL, atol=ATOL)
+    torch.testing.assert_close(out_cpu[1::2], ref[1::2], rtol=0, atol=0)
+
+
+def run_test_merge_stability(block_len, dtype="float32", target="ascendc"):
+    """Verify stability: equal values keep source order + in-block order.
+
+    Values are drawn from a small integer range to force ties.
+    """
+    blocks = [make_sorted_block(block_len, dtype, seed=i, k_distinct=8) for i in range(3)]
+
+    kernel = merge_sort_kernel([block_len] * 3, dtype)
+    func = tilelang.compile(kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+
+    out = func(*[b.npu() for b in blocks])
+    torch.npu.synchronize()
+
+    out_cpu = out.cpu().float().reshape(-1)
+    ref = cpu_merge_ref(blocks)
+
+    torch.testing.assert_close(out_cpu[0::2], ref[0::2], rtol=RTOL, atol=ATOL)
+    torch.testing.assert_close(out_cpu[1::2], ref[1::2], rtol=0, atol=0)
+
+
+def run_test_merge_region(M, per_row, dtype="float32", target="ascendc"):
+    """Use row slices of a 2D buffer as the sources."""
+    per_row = per_row // 2 * 2  # even: block_len = per_row // 2
+    seeds = list(range(M))
+    blocks = [make_sorted_block(per_row // 2, dtype, seed=seeds[i]) for i in range(M)]
+    a = torch.stack(blocks)
+
+    kernel = merge_sort_kernel_region(M, per_row, dtype)
+    func = tilelang.compile(kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+
+    out = func(a.npu())
+    torch.npu.synchronize()
+
+    out_cpu = out.cpu().float().reshape(-1)
+    ref = cpu_merge_ref(blocks)
+
+    torch.testing.assert_close(out_cpu[0::2], ref[0::2], rtol=RTOL, atol=ATOL)
+    torch.testing.assert_close(out_cpu[1::2], ref[1::2], rtol=0, atol=0)
+
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    """Clear tilelang cache before tests."""
+    tilelang.cache.clear_cache()
+    yield
+
+
+@pytest.fixture
+def setup_random_seed():
+    """Set random seed for reproducibility."""
+    torch.manual_seed(0)
+    yield
+
+
+# -----------------------------------------------------------------------------
+# Test cases
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+@pytest.mark.parametrize("num_ways", [2, 3, 4])
+def test_merge_sort_basic(target, num_ways):
+    """2/3/4-way merge: compile + run + precision."""
+    run_test_merge(block_len=64, num_ways=num_ways, target=target)
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+@pytest.mark.parametrize(
+    "block_len",
+    [
+        16,
+        64,
+        pytest.param(128, marks=pytest.mark.low_priority),
+    ],
+)
+def test_merge_sort_2way_sizes(target, block_len):
+    """2-way merge with different block lengths."""
+    run_test_merge(block_len=block_len, num_ways=2, target=target)
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize(
+    "sizes",
+    [
+        (16, 8),
+        (48, 16),
+    ],
+)
+def test_merge_sort_unequal_ascendc(sizes):
+    """Unequal block lengths are supported on the ascendc backend."""
+    run_test_merge_unequal(list(sizes), target="ascendc")
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+def test_merge_sort_region(target):
+    """BufferRegion row slices as sources."""
+    run_test_merge_region(M=2, per_row=128, target=target)
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.low_priority
+@pytest.mark.parametrize(
+    "target",
+    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+)
+def test_merge_sort_stability(target):
+    """Equal values keep source order and in-block order (stable merge)."""
+    run_test_merge_stability(block_len=64, target=target)
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize(
+    "target,expected_block_len",
+    [
+        ("ascendc", 1),  # ascendc accepts blockLen=1
+        pytest.param("pto", 4, marks=pytest.mark.low_priority),  # pto needs >=4
+    ],
+)
+def test_merge_sort_min_blocklen(target, expected_block_len):
+    """Minimum block length per backend.
+
+    ascendc accepts blockLen=1; pto requires blockLen >= 4 (32-byte tile).
+    """
+    run_test_merge(block_len=expected_block_len, num_ways=2, target=target)
+
+
+@pytest.mark.low_priority
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize(
+    "target,block_len",
+    [
+        ("ascendc", 4095),  # hardware elementLengths upper bound
+        pytest.param("pto", 4088, marks=pytest.mark.low_priority),  # pto segfaults for block_len >= 4092
+    ],
+)
+def test_merge_sort_max_blocklen(target, block_len):
+    """Maximum block length. pto limit is lower (tested 4088 OK, >=4092 crashes)."""
+    run_test_merge(block_len=block_len, num_ways=2, target=target)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="T.tile.merge_sort test suite")
+    parser.add_argument("--target", type=str, choices=["ascendc", "pto"], default="ascendc")
+    parser.add_argument("--num-ways", type=int, choices=[2, 3, 4], default=3)
+    parser.add_argument("--block-len", type=int, default=64, help="elements per source block")
+    args = parser.parse_args()
+
+    torch.manual_seed(0)
+    tilelang.cache.clear_cache()
+
+    print("=" * 60)
+    print(f"T.tile.merge_sort test: target={args.target}, {args.num_ways}-way, block_len={args.block_len}")
+    print("=" * 60)
+
+    run_test_merge(block_len=args.block_len, num_ways=args.num_ways, target=args.target)
+    print("  merge PASSED")
+
+    run_test_merge_unequal([args.block_len, args.block_len // 2], target=args.target)
+    print("  unequal PASSED")
+
+    run_test_merge_stability(block_len=args.block_len, target=args.target)
+    print("  stability PASSED")
+
+    print("\nAll tests passed.")

--- a/testing/python/language/test_tilelang_ascend_language_merge_sort.py
+++ b/testing/python/language/test_tilelang_ascend_language_merge_sort.py
@@ -296,82 +296,75 @@ def setup_random_seed():
 
 
 @pytest.mark.usefixtures("setup_random_seed")
-@pytest.mark.parametrize(
-    "target",
-    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
-)
-@pytest.mark.parametrize("num_ways", [2, 3, 4])
-def test_merge_sort_basic(target, num_ways):
-    """2/3/4-way merge: compile + run + precision."""
-    run_test_merge(block_len=64, num_ways=num_ways, target=target)
+def test_merge_sort_basic_ascendc():
+    """2/3/4-way merge on ascendc: compile + run + precision."""
+    for num_ways in (2, 3, 4):
+        run_test_merge(block_len=64, num_ways=num_ways, target="ascendc")
 
 
 @pytest.mark.usefixtures("setup_random_seed")
+def test_merge_sort_sizes_ascendc():
+    """Block lengths and unequal sources on ascendc."""
+    for block_len in (16, 64):
+        run_test_merge(block_len=block_len, num_ways=2, target="ascendc")
+    run_test_merge_unequal([16, 8], target="ascendc")
+    run_test_merge_unequal([48, 16], target="ascendc")
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+def test_merge_sort_edges_ascendc():
+    """Boundary shapes on ascendc: min blockLen and BufferRegion slices."""
+    run_test_merge(block_len=1, num_ways=2, target="ascendc")
+    run_test_merge_region(M=2, per_row=128, target="ascendc")
+
+
+@pytest.mark.low_priority
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize("num_ways", [2, 3, 4])
+def test_merge_sort_basic_pto(num_ways):
+    """2/3/4-way merge on pto (low_priority)."""
+    run_test_merge(block_len=64, num_ways=num_ways, target="pto")
+
+
+@pytest.mark.low_priority
+@pytest.mark.usefixtures("setup_random_seed")
 @pytest.mark.parametrize(
-    "target",
-    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
-)
-@pytest.mark.parametrize(
-    "block_len",
+    "target,block_len",
     [
-        16,
-        64,
-        pytest.param(128, marks=pytest.mark.low_priority),
+        ("ascendc", 128),  # ascendc large block len
+        ("pto", 16),
+        ("pto", 64),
+        ("pto", 128),
     ],
 )
-def test_merge_sort_2way_sizes(target, block_len):
-    """2-way merge with different block lengths."""
+def test_merge_sort_2way_sizes_low(target, block_len):
+    """2-way merge with block lengths on both backends (low_priority)."""
     run_test_merge(block_len=block_len, num_ways=2, target=target)
 
 
-@pytest.mark.usefixtures("setup_random_seed")
-@pytest.mark.parametrize(
-    "sizes",
-    [
-        (16, 8),
-        (48, 16),
-    ],
-)
-def test_merge_sort_unequal_ascendc(sizes):
-    """Unequal block lengths are supported on the ascendc backend."""
-    run_test_merge_unequal(list(sizes), target="ascendc")
-
-
-@pytest.mark.usefixtures("setup_random_seed")
-@pytest.mark.parametrize(
-    "target",
-    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
-)
-def test_merge_sort_region(target):
-    """BufferRegion row slices as sources."""
-    run_test_merge_region(M=2, per_row=128, target=target)
-
-
-@pytest.mark.usefixtures("setup_random_seed")
 @pytest.mark.low_priority
+@pytest.mark.usefixtures("setup_random_seed")
+def test_merge_sort_region_pto():
+    """BufferRegion row slices as sources on pto (low_priority)."""
+    run_test_merge_region(M=2, per_row=128, target="pto")
+
+
+@pytest.mark.low_priority
+@pytest.mark.usefixtures("setup_random_seed")
+def test_merge_sort_min_blocklen_pto():
+    """Minimum block length for pto (>=4, 32-byte tile) (low_priority)."""
+    run_test_merge(block_len=4, num_ways=2, target="pto")
+
+
+@pytest.mark.low_priority
+@pytest.mark.usefixtures("setup_random_seed")
 @pytest.mark.parametrize(
     "target",
-    ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)],
+    ["ascendc", "pto"],
 )
 def test_merge_sort_stability(target):
     """Equal values keep source order and in-block order (stable merge)."""
     run_test_merge_stability(block_len=64, target=target)
-
-
-@pytest.mark.usefixtures("setup_random_seed")
-@pytest.mark.parametrize(
-    "target,expected_block_len",
-    [
-        ("ascendc", 1),  # ascendc accepts blockLen=1
-        pytest.param("pto", 4, marks=pytest.mark.low_priority),  # pto needs >=4
-    ],
-)
-def test_merge_sort_min_blocklen(target, expected_block_len):
-    """Minimum block length per backend.
-
-    ascendc accepts blockLen=1; pto requires blockLen >= 4 (32-byte tile).
-    """
-    run_test_merge(block_len=expected_block_len, num_ways=2, target=target)
 
 
 @pytest.mark.low_priority

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -460,29 +460,43 @@ def merge_sort(
     *,
     tmp: Buffer | BufferRegion | None = None,
 ):
-    """Performs a 2/3/4-way merge sort operation.
+    """Performs a 2/3/4-way merge sort on sorted input blocks.
 
-    This intrinsic invokes the underlying implementation to perform merge sort
-    on multiple sorted blocks using AscendC::MrgSort hardware API.
-    blockLen is calculated from each source buffer size.
-
-    Hardware MrgSort format: 4 floats per element
-    - Position 0: sort key (value)
-    - Position 1: data (index)
-    - Position 2-3: reserved/padding
-    - blockLen = number of elements = buffer_size / 4
+    Merges multiple descending-sorted blocks via the AscendC MrgSort hardware
+    API and writes the combined descending-sorted stream to dst. Each block is
+    a sequence of interleaved (value, index) pairs occupying two buffer
+    positions per element: ``[val0, idx0, val1, idx1, ...]``.
 
     Args:
-        dst: The destination buffer or buffer region where the merged result will be stored.
-        src0: First source buffer or buffer region.
-        src1: Second source buffer or buffer region.
-        src2: Third source buffer or buffer region (optional, for 3-way or 4-way merge).
-        src3: Fourth source buffer or buffer region (optional, for 4-way merge).
+        dst: Destination buffer or region for the merged (value, index)
+            pairs. Must have at least the sum of all source buffer sizes.
+        src0: First source buffer or region, sorted in descending order.
+        src1: Second source buffer or region, sorted in descending order.
+        src2: Third source buffer or region for 3-way or 4-way merge,
+            sorted in descending order (optional).
+        src3: Fourth source buffer or region for 4-way merge, sorted in
+            descending order (optional).
         tmp: Optional complete UB scratch storage. Its scalar dtype is
-            reinterpreted by lowering and has no semantic meaning.
+            reinterpreted by lowering and has no semantic meaning. The
+            ascendc backend omits it; the pto backend allocates it
+            automatically when omitted.
 
     Returns:
         A TVM intrinsic call that performs the merge sort operation.
+
+    Notes:
+        - blockLen (element count) of each source is derived as
+          ``buffer_size // 2``. The ascendc backend accepts
+          blockLen in [1, 4095]; the pto backend requires equal
+          block lengths in [4, 4088].
+        - Only float32 is supported; float16 inputs are not supported.
+        - Equal scores are ordered stably: sources are consumed in
+          src0 → src1 → src2 → src3 order, preserving the order inside
+          each source block.
+        - Slice sources must be 32-byte aligned. Column-offset slices
+          of 2D buffers (e.g. ``buf[0, 8:136]``) generate a wrong
+          address and are not supported; use 1D slices or whole-row
+          slices (e.g. ``buf[0, :]``) instead.
     """
 
     def retrieve_shape(object: Buffer | BufferRegion) -> list[int]:

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -494,9 +494,9 @@ def merge_sort(
           src0 → src1 → src2 → src3 order, preserving the order inside
           each source block.
         - Slice sources must be 32-byte aligned. Column-offset slices
-          of 2D buffers (e.g. ``buf[0, 8:136]``) generate a wrong
-          address and are not supported; use 1D slices or whole-row
-          slices (e.g. ``buf[0, :]``) instead.
+          of 2D buffers (e.g. ``buf[0, 8:136]``) are not supported;
+          use 1D slices or whole-row slices (e.g. ``buf[0, :]``)
+          instead.
     """
 
     def retrieve_shape(object: Buffer | BufferRegion) -> list[int]:


### PR DESCRIPTION
## 1. 文件改动

| 文件 | 类型 | 改动说明 |
|------|------|----------|
| `tilelang/language/ascend_tile.py` | 修改 | 重写 `merge_sort` 函数 docstring：删除与实现矛盾的 "Hardware MrgSort format: 4 floats per element / buffer_size / 4" 描述（实际为 2 floats value-index 对、`blockLen = buffer_size // 2`）、补充 backend 差异（ascendc blockLen [1,4095] / pto 等长 [4,4088]）、float32-only、稳定排序语义、切片 32 字节对齐与 2D 列偏移切片限制、按 Google style 重构（43 行 → 33 行 + Notes） |
| `testing/python/language/test_tilelang_ascend_language_merge_sort.py` | 新增 | 完整测试套件：2/3/4-way 归并、blockLen 边界（ascendc min=1/max=4095，pto min=4/max=4088）、不等长（ascendc only）、BufferRegion 整行切片、稳定排序、pytest 标签（pto/大尺寸/稳定性标 low_priority）；PR 阶段合并为 3 个用例（函数内顺序执行多场景） |
| `docs/api_docs/T.tile.merge_sort.md` | 新增 | 校验完成版英文 API 文档（Description / Function Prototype / Parameter Specifications / Constraints / Example Code） |
| `docs/TileLang-Ascend Programming Guide.md` | 修改 | merge_sort 段落同步：签名补 `tmp=None` 参数、删除 half 布局描述（仅 float32）、数据格式合并为单行、注意事项更新（tmp 语义、dst 至少为 src 之和、pto 等长要求）、删除过时的 "更详细说明" 行 |

---

## 2. 测试用例

### 2.1 约束测试（动态验证，真机 dav_m200/A2 / Ascend910B3）

| 验证项 | 测什么 | 结果 |
|--------|--------|:----:|
| 2/3/4-way 可用性 | 真机 ascendc/pto 各路数与不等长（48,16） | **4-way 可用**（旧文档"全平台不支持"错误） |
| float16 支持性 | ascendc/pto × n=32..2048 | **float16 不可用**：ascendc aicore 异常（507015）/ pto 结果错 |
| pto 不等长 | (48,16) / (16,8) | pto 编译失败（no matching function），ascendc OK |
| pto blockLen 边界 | n ∈ {1,2,3,4} 与 {3072..4096} 扫描 | pto 下限 4、上限 4088（≥4092 静默 segfault） |
| blockLen=0 | 空 src buffer | 编译期 Divide by zero 错误 |
| dst 大小语义 | dst=64(<256) / dst=288(>256) | 不足时结果错（越界写 UB）；大于总和正常 → "至少"成立 |
| src 对齐 | 1D 切片 offset=1/2/4/8/16 元素 | 4/8/16 字节 aicore 异常，32 字节起正常 → src 需 32 字节对齐 |
| 2D 列偏移切片 | `buf[0, 8:136]` | codegen 生成错误地址（`src[2]` 应为 `src[8]`），**不支持** |
| 稳定排序 | 确定性用例 + 3-way 重复值 | 跨队列 src0→src3 优先、队列内保序 |
| NaN 行为 | 含 nan/inf/-inf 输入 | NaN 输出在最前但 index 顺序不定 |
| int32 等 dtype | int32 ascendc | 编译失败（MrgSort 断言仅 half/float） |
| 混合 dtype | src0 float32 + src1 float16 | 编译失败 |
| tmp=0 长度 | pto 显式传 0 长度 tmp | InternalError（源码 ICHECK，非自动分配） |

### 2.2 语言测试 `test_tilelang_ascend_language_merge_sort.py`（16 用例）

PR 阶段 3 个用例（函数内循环执行多场景，覆盖与拆分前 9 个用例一致）：

| 测试函数 | 用例数 | 测什么 |
|----------|:---:|--------|
| `test_merge_sort_basic_ascendc` | 1 | 2/3/4-way 归并 × blockLen=64 |
| `test_merge_sort_sizes_ascendc` | 1 | blockLen 16/64 + 不等长 (16,8)/(48,16) |
| `test_merge_sort_edges_ascendc` | 1 | min blockLen=1 + BufferRegion 整行切片 |

low_priority 13 个用例（本地全量验证）：

| 测试函数 | 用例数 | 测什么 |
|----------|:---:|--------|
| `test_merge_sort_basic_pto` | 3 | 2/3/4-way 归并 × pto |
| `test_merge_sort_2way_sizes_low` | 4 | blockLen(128 ascendc + 16/64/128 pto) |
| `test_merge_sort_region_pto` | 1 | BufferRegion 整行切片 × pto |
| `test_merge_sort_min_blocklen_pto` | 1 | pto 最小 blockLen=4 |
| `test_merge_sort_stability` | 2 | 3-way 重复值稳定排序（ascendc/pto） |
| `test_merge_sort_max_blocklen` | 2 | ascendc=4095 / pto=4088 |

---

## 3. 测试结果

- **约束测试**：动态验证完成（真机 dav_m200/A2，见 2.1 表）
- **语言测试**：3 个 PR 用例 PASSED（真机 dav_m200/A2，合并后本地复验）；低优先级 13 个用例此前已分批 PASSED

### 3.1 pytest 标签

| 测试函数 | low_priority | PR 执行 |
|----------|:---:|:---:|
| ascendc PR 用例（basic/sizes/edges 合并后 3 个） | 0 | 3 执行 |
| `test_merge_sort_basic_pto` | 3 | 跳过 |
| `test_merge_sort_2way_sizes_low` | 4 | 跳过 |
| `test_merge_sort_region_pto` | 1 | 跳过 |
| `test_merge_sort_min_blocklen_pto` | 1 | 跳过 |
| `test_merge_sort_stability` 全部 | 2 | 跳过 |
| `test_merge_sort_max_blocklen` 全部 | 2 | 跳过 |

---

## 4. 校验过程中发现的问题

| # | 问题 | 验证结果 | 文档处理 |
|---|------|---------|---------|
| 1 | **4 路归并并非全平台不支持**：原文档称 "Ascend C MrgSort4 在所有架构上标记为 NOT_SUPPORT"。真机 ascendc/pto 4-way 均正确 | 2/3/4-way float32 在 ascendc + pto 全部 精度 OK | 文档改为 2/3/4 路均可用 |
| 2 | **float16 实际不可用**：原文档宣称 float16, float32 均支持。ascendc float16 触发 aicore 异常（507015），pto float16 返回错误结果 | float16 2-way：ascendc 崩溃 / pto 结果错（n=32..2048 全失败） | 文档仅列 float32，附注明确 float16 不受支持 |
| 3 | **PTO 不等长 src 编译失败**：TileLang pto codegen 只生成等长 `MergeSort<T, SrcCols, DstCols>` | (48,16) 不等长：ascendc OK / pto 编译失败 | 约束注明 pto 要求等长 |
| 4 | **PTO blockLen 上下限更窄**：pto 最小 4、最大约 4088（n=4092+ 静默 segfault） | n=1..3 pto 编译失败；n=4092+ pto segfault | 按 backend 分列 |
| 5 | **blockLen=0 编译期除零** | size=0 ascendc 编译报 InternalError | 下限写 1 |
| 6 | **dst 不足不报错但结果错误** | dst=64 vs 需要 256：RUN OK 但元素重复 | 约束改为"至少为 src 之和" |
| 7 | **非对齐 src 结果错误** | offset-1 切片：vals=False idx=False | 保留 8 字节对齐要求（复核后为 32 字节） |
| 8 | **稳定排序语义确认** | 确定性用例：跨队列全部元素先出、队列内保序 | 约束精确描述 |
| 9 | **NaN 行为** | nan 用例：值集合一致，NaN 的 index 顺序不定 | 约束注明 |
| 10 | **int32 等 dtype 编译失败** | int32 ascendc 编译失败 | 仅 float32 |
| 11 | **虚构 repeatTimes 约束删除** | merge_sort 无 repeatTimes 概念（那是 sort32 的参数） | 删除 |
| 12 | **旧 build 行为不一致** | 重编前 `Unresolved call Op(tir.tvm_access_ptr)`；重编后 codegen 正确 | 环境问题，非代码缺陷 |

---

## 5. 校验完成版文档信息核对

| 章节 | 状态 |
|------|:----:|
| Description | ✅ 与实现一致的 value-index pair 格式描述 |
| Function Definition | ✅ `merge_sort(dst, src0, src1, src2=None, src3=None, tmp=None)` 与源码一致 |
| Parameters | ✅ 6 参数 + tmp 两后端语义说明 |
| DataType | ✅ 仅 float32（float16 实测不可用） |
| blockLen | ✅ ascendc [1,4095] / pto 等长 [4,4088] |
| Constraints | ✅ 10 条约束，含 dst 大小、32 字节对齐、切片限制、稳定排序、NaN |
| 中英一致性 | ✅ 中英文档约束数字/范围/后端差异逐条核对一致 |
| 编程指南同步 | ✅ merge_sort 段落与中英文档口径一致 |

---

## 6. 验证

- 语法检查：`ast.parse` 通过
- ruff format：通过（与 CI ruff 0.16.3 一致）
- 语言测试：PR 3 用例合并后真机 PASSED（dav_m200/A2），low_priority 13 用例此前分批 PASSED
