### PR TITLE
[CI] Report a manifest entry whose operator moved instead of failing on it

### DIFF
--- a/ci/operator_test_manifest.yaml
+++ b/ci/operator_test_manifest.yaml
@@ -38,6 +38,10 @@ mappings:
   # examples/batch_gemm
   examples/batch_gemm/batch_gemm.py: examples/batch_gemm/test_batch_gemm.py
 
+  # examples/cann-bench
+  examples/cann-bench/cummin/example_cummin.py: examples/cann-bench/cummin/test_example_cummin.py
+  examples/cann-bench/group_norm/example_group_norm.py: examples/cann-bench/group_norm/test_example_group_norm.py
+
   # examples/causal_conv1d
   examples/causal_conv1d/causal_conv1d.py: examples/causal_conv1d/test_causal_conv1d.py
   examples/causal_conv1d/causal_conv1d_pto.py: examples/causal_conv1d/test_causal_conv1d_pto.py
@@ -47,9 +51,6 @@ mappings:
 
   # examples/cross_entropy_loss
   examples/cross_entropy_loss/example_cross_entro.py: examples/cross_entropy_loss/test_example_cross_entro.py
-
-  # examples/cummin
-  examples/cummin/example_cummin.py: examples/cummin/test_example_cummin.py
 
   # examples/deepseek_v4
   examples/deepseek_v4/act_quant.py: examples/deepseek_v4/test_act_quant.py
@@ -106,9 +107,6 @@ mappings:
   # examples/gqa_fwd_varlen
   examples/gqa_fwd_varlen/gqa_fwd_varlen.py: examples/gqa_fwd_varlen/test_gqa_fwd_varlen.py
   examples/gqa_fwd_varlen/perf_gqa_fwd_varlen.py: examples/gqa_fwd_varlen/test_perf_gqa_fwd_varlen.py
-
-  # examples/group_norm
-  examples/group_norm/example_group_norm.py: examples/group_norm/test_example_group_norm.py
 
   # examples/lightning_indexer
   examples/lightning_indexer/example_lightning_indexer.py: examples/lightning_indexer/test_example_lightning_indexer.py

--- a/scripts/ci/resolve_operator_tests.py
+++ b/scripts/ci/resolve_operator_tests.py
@@ -71,13 +71,23 @@ def _validate_relative_path(value: str, field: str) -> PurePosixPath:
     return path
 
 
-def load_mappings(repo_root: Path, manifest_path: Path) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
-    """Return the mappings that are live, and those still waiting on their test.
+def load_mappings(repo_root: Path, manifest_path: Path) -> tuple[list[tuple[str, str]], list[tuple[str, str]], list[tuple[str, str]]]:
+    """Return the mappings that are live, those waiting on their test, and those
+    whose operator is gone.
 
     Registering a source excludes it from the legacy runner, so a mapping whose
     test has not landed yet must not take effect: it is a plan, not a migration.
     Holding it back keeps the example running and keeps Pytest from being
     pointed at a file that does not exist.
+
+    An entry whose source no longer exists is reported rather than raised on.
+    It is out of date, not malformed, and the two want different handling: the
+    checks below are about a manifest that cannot be read the way it claims, and
+    stopping on those is what keeps a half-built skip list from letting every
+    migrated operator run twice. A moved operator costs nothing to skip - there
+    is no file at that path for the runner to find, so no run to suppress - and
+    raising on it stopped every unrelated pull request in the repository until
+    somebody noticed the entry, which is not where the cost belongs.
     """
     if not manifest_path.is_absolute():
         manifest_path = repo_root / manifest_path
@@ -89,6 +99,7 @@ def load_mappings(repo_root: Path, manifest_path: Path) -> tuple[list[tuple[str,
     seen_tests: set[str] = set()
     active: list[tuple[str, str]] = []
     pending: list[tuple[str, str]] = []
+    stale: list[tuple[str, str]] = []
 
     for source, test in mappings:
         source_path = _validate_relative_path(source, "source")
@@ -104,17 +115,17 @@ def load_mappings(repo_root: Path, manifest_path: Path) -> tuple[list[tuple[str,
             raise ManifestError(f"source must be a Python file: {source}")
         if test_path.suffix != ".py" or not test_path.name.startswith("test_"):
             raise ManifestError(f"test must be named test_*.py: {test}")
-        if not (repo_root / Path(*source_path.parts)).is_file():
-            raise ManifestError(f"source does not exist: {source}")
         seen_sources.add(source)
         seen_tests.add(test)
 
-        if (repo_root / Path(*test_path.parts)).is_file():
+        if not (repo_root / Path(*source_path.parts)).is_file():
+            stale.append((source, test))
+        elif (repo_root / Path(*test_path.parts)).is_file():
             active.append((source, test))
         else:
             pending.append((source, test))
 
-    return active, pending
+    return active, pending, stale
 
 
 def _shell_invoked_tests(repo_root: Path) -> set[str]:
@@ -242,13 +253,21 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     try:
-        mappings, pending = load_mappings(args.repo_root.resolve(), args.manifest)
+        mappings, pending, stale = load_mappings(args.repo_root.resolve(), args.manifest)
     except (ManifestError, OSError) as error:
         print(f"operator test manifest error: {error}", file=sys.stderr)
         return 1
 
     if args.command == "validate":
         print(f"Validated {len(mappings)} operator test mapping(s)")
+        if stale:
+            print(
+                f"{len(stale)} mapping(s) whose operator no longer exists at the "
+                "registered path; each one is inert and its operator runs in the "
+                "legacy runner until the entry is repointed or removed:"
+            )
+            for source, test in stale:
+                print(f"  {source} -> {test}")
         if pending:
             print(
                 f"{len(pending)} mapping(s) reserved but not migrated yet; the "
@@ -264,7 +283,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     elif args.command == "list-sources":
         _print_lines(source for source, _ in mappings)
     elif args.command == "check-orphans":
-        unregistered = find_unregistered_tests(args.repo_root.resolve(), mappings, pending)
+        # A stale entry still names its test, so the test is not unclaimed; it is
+        # claimed by an entry that has nothing left to run. Reporting it here as
+        # well would say the same thing twice, in the place that is about tests
+        # nobody registered.
+        unregistered = find_unregistered_tests(args.repo_root.resolve(), mappings, pending + stale)
         if unregistered:
             print(f"{len(unregistered)} operator test(s) matching no manifest entry:")
             for item in unregistered:


### PR DESCRIPTION
# 描述

## 问题

`ci/operator_test_manifest.yaml` 里某条登记的算子文件如果被移走或删除，整个 CI 会停。

#1542 把 `cummin` 和 `group_norm` 移到了 `examples/cann-bench/` 下，登记表里那两条还是旧路径。从那次合入开始，**每一个走全量路径的 PR 都在一分半后失败**，报的是一个跟它毫无关系的算子：

```
operator test manifest error: source does not exist: examples/cummin/example_cummin.py
Operator test manifest is invalid
##[error]Process completed with exit code 1.
```

#1600 就是其中之一 —— 它改的是 `axpy` 的 docstring。

原因是这条检查写在 `load_mappings()` 里，而所有子命令都走这个函数，所以 `validate` / `list` / `list-tests` / `list-sources` / `check-orphans` 会一起退出 1；`bench_test.sh` 再把它变成整个 run 的 `exit 1`。

## 改动

把「源文件不存在」从 `raise` 改成第三个分类，与 live / reserved 并列，由 `validate` 报出来，不进任何列表，修改后调整移动文件并不会影响全局报错，另外建议后续人员调整example尽量同步调整manifest。

```python
if not (repo_root / source).is_file():
    stale.append((source, test))       # 新增
elif (repo_root / test).is_file():
    active.append((source, test))
else:
    pending.append((source, test))
```

顺带把 `cummin` / `group_norm` 两条重新指向 #1542 移动后的位置。

## 影响范围

只改两个文件，不涉及 `.github/workflows/ci_cd.yml`，不改变任何测试的执行方式。生效条目数、总登记数都不变。