### PR TITLE
[Doc] Ascend: refine T.tile.add/sub/mul/div docstring, add test cases and API documentation

### DIFF
--- a/docs/TileLang-Ascend Programming Guide.md
+++ b/docs/TileLang-Ascend Programming Guide.md
@@ -1507,8 +1507,8 @@ Expert编程模式可以复用Developer模式的Reduce类计算原语。
 | ---------- | ---------------------------------------- | ------------------------------------------------------------ |
 | 加法       | T.tile.add(dst, src0, src1)              | element-wise加法，dst = src0 + src1                          |
 | 减法       | T.tile.sub(dst, src0, src1)              | element-wise减法，dst = src0 - src1                          |
-| 乘法       | T.tile.mul(dst, src0, src1)              | element-wise法乘，dst = src0 * src1                          |
-| 除法       | T.tile.div(dst, src0, src1)              | element-wise法乘，dst = src0 / src1                          |
+| 乘法       | T.tile.mul(dst, src0, src1)              | element-wise乘法，dst = src0 * src1                          |
+| 除法       | T.tile.div(dst, src0, src1)              | element-wise除法，dst = src0 / src1（仅支持浮点 dtype）      |
 | 最大值     | T.tile.max(dst, src0, src1)              | element-wise 求max，dst = max(src0, src1)                    |
 | 最小值     | T.tile.min(dst, src0, src1)              | element-wise 求min，dst = min(src0, src1)                    |
 | 指数       | T.tile.exp(dst, src0)                    | element-wise 取自然指数，dst = exp(src0)                     |
@@ -1536,11 +1536,13 @@ Expert编程模式可以复用Developer模式的Reduce类计算原语。
 
   **参数**：
 
-  - dst：计算结果存放目的buffer
+  - dst：计算结果存放目的buffer，可与 src0/src1 别名（原地运算）
   - src0: 操作数1，数据类型为buffer类型
   - src1: 操作数2，数据类型可以为buffer类型，也可以是scalar类型
 
   **功能**：element-wise加法，dst = src0 + src1
+
+  **支持类型**：float16、float32、int16、int32（dst/src0/src1 必须一致）
 
   **举例**：
 
@@ -1556,11 +1558,13 @@ Expert编程模式可以复用Developer模式的Reduce类计算原语。
 
   **参数**：
 
-  - dst：计算结果存放目的buffer
-  - src0: 操作数1，数据类型为buffer类型
-  - src1: 操作数2，数据类型可以为buffer类型，也可以是scalar类型
+  - dst：计算结果存放目的buffer，可与 src0/src1 别名（原地运算）
+  - src0: 操作数1（被减数），数据类型为buffer类型
+  - src1: 操作数2（减数），数据类型可以为buffer类型，也可以是scalar类型
 
   **功能**：element-wise减法，dst = src0 - src1
+
+  **支持类型**：float16、float32、int16、int32（dst/src0/src1 必须一致）
 
   **举例**：
 
@@ -1576,11 +1580,13 @@ Expert编程模式可以复用Developer模式的Reduce类计算原语。
 
   **参数**：
 
-  - dst：计算结果存放目的buffer
+  - dst：计算结果存放目的buffer，可与 src0/src1 别名（原地运算）
   - src0: 操作数1，数据类型为buffer类型
   - src1: 操作数2，数据类型可以为buffer类型，也可以是scalar类型
 
-  **功能**：element-wise法乘，dst = src0 * src1
+  **功能**：element-wise乘法，dst = src0 * src1
+
+  **支持类型**：float16、float32、int16、int32（dst/src0/src1 必须一致）
 
   **举例**：
 
@@ -1596,11 +1602,13 @@ Expert编程模式可以复用Developer模式的Reduce类计算原语。
 
   **参数**：
 
-  - dst：计算结果存放目的buffer
-  - src0: 操作数1，数据类型为buffer类型
-  - src1: 操作数2，数据类型可以为buffer类型，也可以是scalar类型
+  - dst：计算结果存放目的buffer，可与 src0/src1 别名（原地运算）
+  - src0: 操作数1（被除数），数据类型为buffer类型
+  - src1: 操作数2（除数），数据类型可以为buffer类型，也可以是scalar类型
 
-  **功能**：element-wise法乘，dst = src0 / src1
+  **功能**：element-wise除法，dst = src0 / src1
+
+  **支持类型**：仅 float16、float32（整数 dtype 不支持）；scalar 除法通过乘以倒数实现，非 2 的幂次除数有额外舍入误差
 
   **举例**：
 

--- a/docs/api_docs/T.tile.add.md
+++ b/docs/api_docs/T.tile.add.md
@@ -42,17 +42,17 @@ def add(
 
 - 支持 1D 和 2D
 - 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
-- 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
+- 更高维 buffer 需通过切片降维为 1D/2D 的切片传入
 
 ### 2.4 约束条件
 
 1. dst 与 src0 的大小必须一致（Python 断言，报错信息 "size must be same"）
-2. src1 为 BufferRegion 时，其大小必须与 dst 一致（Python 断言）
+2. src1 为切片（BufferRegion）时，其大小必须与 dst 一致（Python 断言）
 3. src1 为 Buffer 时大小不做校验：小于 dst 时产生越界读取，大于 dst 时仅前 dst 大小个元素参与运算（不报错）
 4. dst、src0、src1（tensor 形式）的 dtype 必须一致；dtype 不一致会在编译期报错
 5. 操作数地址需 32 字节对齐（硬件约束）
 6. 仅支持整行/整 buffer 的连续区域；2D 列偏移切片（如 `buf[0, 8:40]`）会产生错误结果或触发 aicore 异常（507015），不支持
-7. src1 为 BufferLoad 时仅支持 1D 单索引（如 `buf[i]`）；多维 BufferLoad 只取第一个索引，结果错误（当前未校验）
+7. src1 为 buffer 元素访问时仅支持 1D 单索引（如 `buf[i]`）；多维元素访问只取第一个索引，结果错误（实测行为，两后端一致）
 
 ## 3. 示例代码
 

--- a/docs/api_docs/T.tile.add.md
+++ b/docs/api_docs/T.tile.add.md
@@ -1,0 +1,91 @@
+# T.tile.add
+
+## 1. 功能说明
+
+对两个操作数逐元素执行加法：`dst[i] = src0[i] + src1[i]`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def add(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion | BufferLoad | PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二个源操作数，支持 tensor、buffer 单元素（BufferLoad）或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 buffer 元素访问（BufferLoad，仅支持 1D 单索引）或 Python 标量/表达式（PrimExpr）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | float16, float32, int16, int32 | float16, float32, int16, int32 | 同 dst |
+
+- src1 为 tensor 时，dtype 必须与 dst 一致；src1 为 scalar 时自动转换为 buffer 的 dtype
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
+- 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
+
+#### 2.3.3 src1 形式说明
+
+| src1 形式 | 底层实现 | 说明 |
+|-----------|---------|------|
+| tensor（Buffer/BufferRegion） | `AscendC::Add` | 逐元素相加，dst/src0/src1 大小须一致 |
+| scalar（PrimExpr/float/int） | `AscendC::Adds` | dst[i] = src0[i] + 标量，标量自动转换为 buffer dtype |
+| BufferLoad（1D 单元素） | `AscendC::Adds`（`GetValue(index)` 取标量） | dst[i] = src0[i] + buffer[index] |
+
+### 2.4 约束条件
+
+1. dst 与 src0 的大小必须一致（Python 断言，报错信息 "size must be same"）
+2. src1 为 BufferRegion 时，其大小必须与 dst 一致（Python 断言）
+3. src1 为 Buffer 时大小不做校验：小于 dst 时产生越界读取，大于 dst 时仅前 dst 大小个元素参与运算（不报错）
+4. dst、src0、src1（tensor 形式）的 dtype 必须一致；dtype 不一致会在编译期报错
+5. 操作数地址需 32 字节对齐（硬件约束）
+6. 仅支持整行/整 buffer 的连续区域；2D 列偏移切片（如 `buf[0, 8:40]`）会产生错误结果或触发 aicore 异常（507015），不支持
+7. src1 为 BufferLoad 时仅支持 1D 单索引（如 `buf[i]`）；多维 BufferLoad 只取第一个索引，结果错误（当前未校验）
+
+## 3. 示例代码
+
+**示例 1：tensor-tensor 加法**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+src1 = T.alloc_ub((256,), "float16")
+dst  = T.alloc_ub((256,), "float16")
+T.tile.add(dst, src0, src1)
+```
+
+**示例 2：tensor-scalar 加法**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst  = T.alloc_ub((256,), "float16")
+T.tile.add(dst, src0, 2.0)
+```
+
+**示例 3：tensor-BufferLoad 加法**
+
+```python
+src0  = T.alloc_ub((256,), "float16")
+scalar_ub = T.alloc_ub((8,), "float16")
+dst   = T.alloc_ub((256,), "float16")
+T.tile.add(dst, src0, scalar_ub[3])  # dst[i] = src0[i] + scalar_ub[3]
+```

--- a/docs/api_docs/T.tile.add.md
+++ b/docs/api_docs/T.tile.add.md
@@ -46,8 +46,8 @@ def add(
 
 ### 2.4 约束条件
 
-1. dst 与 src0 的大小必须一致（Python 断言，报错信息 "size must be same"）
-2. src1 为切片（BufferRegion）时，其大小必须与 dst 一致（Python 断言）
+1. dst 与 src0 的大小必须一致
+2. src1 为切片（BufferRegion）时，其大小必须与 dst 一致
 3. src1 为 Buffer 时大小不做校验：小于 dst 时产生越界读取，大于 dst 时仅前 dst 大小个元素参与运算（不报错）
 4. dst、src0、src1（tensor 形式）的 dtype 必须一致；dtype 不一致会在编译期报错
 5. 操作数地址需 32 字节对齐（硬件约束）

--- a/docs/api_docs/T.tile.add.md
+++ b/docs/api_docs/T.tile.add.md
@@ -22,7 +22,7 @@ def add(
 |--------|----------|------|------|----------|
 | dst | 输出 | 存放运算结果 | 张量（tensor） | 必填 |
 | src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
-| src1 | 输入 | 第二个源操作数，支持 tensor、buffer 单元素（BufferLoad）或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+| src1 | 输入 | 第二个源操作数，支持 tensor 或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
 
 > **类型说明**：
 > - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
@@ -43,14 +43,6 @@ def add(
 - 支持 1D 和 2D
 - 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
 - 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
-
-#### 2.3.3 src1 形式说明
-
-| src1 形式 | 底层实现 | 说明 |
-|-----------|---------|------|
-| tensor（Buffer/BufferRegion） | `AscendC::Add` | 逐元素相加，dst/src0/src1 大小须一致 |
-| scalar（PrimExpr/float/int） | `AscendC::Adds` | dst[i] = src0[i] + 标量，标量自动转换为 buffer dtype |
-| BufferLoad（1D 单元素） | `AscendC::Adds`（`GetValue(index)` 取标量） | dst[i] = src0[i] + buffer[index] |
 
 ### 2.4 约束条件
 

--- a/docs/api_docs/T.tile.div.md
+++ b/docs/api_docs/T.tile.div.md
@@ -1,0 +1,95 @@
+# T.tile.div
+
+## 1. 功能说明
+
+对两个操作数逐元素执行除法：`dst[i] = src0[i] / src1[i]`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def div(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion | BufferLoad | PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一个源操作数（被除数） | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二个源操作数（除数），支持 tensor、buffer 单元素（BufferLoad）或 scalar；除数为 0 时行为与 IEEE 754 不一致（实测：非零/0 得 ±inf，0/0 得 +inf 而非 NaN） | 张量（tensor）/ 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 buffer 元素访问（BufferLoad，仅支持 1D 单索引）或 Python 标量/表达式（PrimExpr）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | float16, float32 | float16, float32 | 同 dst |
+
+- 仅支持浮点 dtype；整数 dtype（int16/int32）全部形式均不支持：ascendc 编译失败，pto 的 scalar/BufferLoad 形式可编译但结果错误
+- src1 为 tensor 时，dtype 必须与 dst 一致；src1 为 scalar 时自动转换为 buffer 的 dtype
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
+- 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
+
+#### 2.3.3 src1 形式说明
+
+| src1 形式 | 底层实现 | 说明 |
+|-----------|---------|------|
+| tensor（Buffer/BufferRegion） | `AscendC::Div` | 逐元素相除，dst/src0/src1 大小须一致 |
+| scalar（PrimExpr/float/int） | `AscendC::Muls`（标量取倒数） | dst[i] = src0[i] * (1.0f / src1)，非 2 的幂次除数有额外舍入误差 |
+| BufferLoad（1D 单元素） | `AscendC::Muls`（`GetValue(index)` 取倒数） | dst[i] = src0[i] * (1.0f / buffer[index]) |
+
+### 2.4 约束条件
+
+1. dst 与 src0 的大小必须一致（Python 断言，报错信息 "size must be same"）
+2. src1 为 BufferRegion 时，其大小必须与 dst 一致（Python 断言）
+3. src1 为 Buffer 时大小不做校验：小于 dst 时产生越界读取，大于 dst 时仅前 dst 大小个元素参与运算（不报错）
+4. dst、src0、src1（tensor 形式）的 dtype 必须一致；dtype 不一致会在编译期报错
+5. 操作数地址需 32 字节对齐（硬件约束）
+6. 仅支持整行/整 buffer 的连续区域；2D 列偏移切片（如 `buf[0, 8:40]`）会产生错误结果或触发 aicore 异常（507015），不支持
+7. src1 为 BufferLoad 时仅支持 1D 单索引（如 `buf[i]`）；多维 BufferLoad 只取第一个索引，结果错误（当前未校验）
+8. 整数 dtype 不支持（硬件约束，`AscendC::Div` 的 static_assert 仅 half/float）
+9. scalar/BufferLoad 除法通过乘以倒数实现（`Muls(dst, src0, 1.0f / src1)`）：2 的幂次除数精确，其余除数引入舍入误差
+10. 标量仅支持作为 src1（右操作数）：除法不可交换，`标量 / Buffer` 形式（如 `2.0 / buf`）当前无法表达；Ascend C `Divs` 接口原生支持（flexible scalar），TileLang 前端暂未暴露该形式（缺口记录）
+
+## 3. 示例代码
+
+**示例 1：tensor-tensor 除法**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+src1 = T.alloc_ub((256,), "float16")
+dst  = T.alloc_ub((256,), "float16")
+T.tile.div(dst, src0, src1)
+```
+
+**示例 2：tensor-scalar 除法**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst  = T.alloc_ub((256,), "float16")
+T.tile.div(dst, src0, 2.0)  # dst[i] = src0[i] / 2.0
+```
+
+**示例 3：tensor-BufferLoad 除法（Flash Attention 归一化模式）**
+
+```python
+acc_o = T.alloc_ub((128, 64), "float16")
+sumexp = T.alloc_ub((128,), "float16")
+for h_i in range(128):
+    T.tile.div(acc_o[h_i, :], acc_o[h_i, :], sumexp[h_i])  # acc_o[h_i, :] /= sumexp[h_i]
+```

--- a/docs/api_docs/T.tile.div.md
+++ b/docs/api_docs/T.tile.div.md
@@ -22,7 +22,7 @@ def div(
 |--------|----------|------|------|----------|
 | dst | 输出 | 存放运算结果 | 张量（tensor） | 必填 |
 | src0 | 输入 | 第一个源操作数（被除数） | 张量（tensor） | 必填 |
-| src1 | 输入 | 第二个源操作数（除数），支持 tensor、buffer 单元素（BufferLoad）或 scalar；除数为 0 时行为与 IEEE 754 不一致（实测：非零/0 得 ±inf，0/0 得 +inf 而非 NaN） | 张量（tensor）/ 标量（scalar） | 必填 |
+| src1 | 输入 | 第二个源操作数（除数），支持 tensor 或 scalar；除数为 0 时行为与 IEEE 754 不一致（实测：非零/0 得 ±inf，0/0 得 +inf 而非 NaN） | 张量（tensor）/ 标量（scalar） | 必填 |
 
 > **类型说明**：
 > - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
@@ -44,14 +44,6 @@ def div(
 - 支持 1D 和 2D
 - 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
 - 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
-
-#### 2.3.3 src1 形式说明
-
-| src1 形式 | 底层实现 | 说明 |
-|-----------|---------|------|
-| tensor（Buffer/BufferRegion） | `AscendC::Div` | 逐元素相除，dst/src0/src1 大小须一致 |
-| scalar（PrimExpr/float/int） | `AscendC::Muls`（标量取倒数） | dst[i] = src0[i] * (1.0f / src1)，非 2 的幂次除数有额外舍入误差 |
-| BufferLoad（1D 单元素） | `AscendC::Muls`（`GetValue(index)` 取倒数） | dst[i] = src0[i] * (1.0f / buffer[index]) |
 
 ### 2.4 约束条件
 

--- a/docs/api_docs/T.tile.div.md
+++ b/docs/api_docs/T.tile.div.md
@@ -43,17 +43,17 @@ def div(
 
 - 支持 1D 和 2D
 - 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
-- 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
+- 更高维 buffer 需通过切片降维为 1D/2D 的切片传入
 
 ### 2.4 约束条件
 
 1. dst 与 src0 的大小必须一致（Python 断言，报错信息 "size must be same"）
-2. src1 为 BufferRegion 时，其大小必须与 dst 一致（Python 断言）
+2. src1 为切片（BufferRegion）时，其大小必须与 dst 一致（Python 断言）
 3. src1 为 Buffer 时大小不做校验：小于 dst 时产生越界读取，大于 dst 时仅前 dst 大小个元素参与运算（不报错）
 4. dst、src0、src1（tensor 形式）的 dtype 必须一致；dtype 不一致会在编译期报错
 5. 操作数地址需 32 字节对齐（硬件约束）
 6. 仅支持整行/整 buffer 的连续区域；2D 列偏移切片（如 `buf[0, 8:40]`）会产生错误结果或触发 aicore 异常（507015），不支持
-7. src1 为 BufferLoad 时仅支持 1D 单索引（如 `buf[i]`）；多维 BufferLoad 只取第一个索引，结果错误（当前未校验）
+7. src1 为 buffer 元素访问时仅支持 1D 单索引（如 `buf[i]`）；多维元素访问只取第一个索引，结果错误（实测行为，两后端一致）
 8. 整数 dtype 不支持（硬件约束，`AscendC::Div` 的 static_assert 仅 half/float）
 9. scalar/BufferLoad 除法通过乘以倒数实现（`Muls(dst, src0, 1.0f / src1)`）：2 的幂次除数精确，其余除数引入舍入误差
 10. 标量仅支持作为 src1（右操作数）：除法不可交换，`标量 / Buffer` 形式（如 `2.0 / buf`）当前无法表达；Ascend C `Divs` 接口原生支持（flexible scalar），TileLang 前端暂未暴露该形式（缺口记录）

--- a/docs/api_docs/T.tile.div.md
+++ b/docs/api_docs/T.tile.div.md
@@ -22,7 +22,7 @@ def div(
 |--------|----------|------|------|----------|
 | dst | 输出 | 存放运算结果 | 张量（tensor） | 必填 |
 | src0 | 输入 | 第一个源操作数（被除数） | 张量（tensor） | 必填 |
-| src1 | 输入 | 第二个源操作数（除数），支持 tensor 或 scalar；除数为 0 时行为与 IEEE 754 不一致（实测：非零/0 得 ±inf，0/0 得 +inf 而非 NaN） | 张量（tensor）/ 标量（scalar） | 必填 |
+| src1 | 输入 | 第二个源操作数（除数），支持 tensor 或 scalar；除数为 0 时行为未定义 | 张量（tensor）/ 标量（scalar） | 必填 |
 
 > **类型说明**：
 > - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
@@ -47,8 +47,8 @@ def div(
 
 ### 2.4 约束条件
 
-1. dst 与 src0 的大小必须一致（Python 断言，报错信息 "size must be same"）
-2. src1 为切片（BufferRegion）时，其大小必须与 dst 一致（Python 断言）
+1. dst 与 src0 的大小必须一致
+2. src1 为切片（BufferRegion）时，其大小必须与 dst 一致
 3. src1 为 Buffer 时大小不做校验：小于 dst 时产生越界读取，大于 dst 时仅前 dst 大小个元素参与运算（不报错）
 4. dst、src0、src1（tensor 形式）的 dtype 必须一致；dtype 不一致会在编译期报错
 5. 操作数地址需 32 字节对齐（硬件约束）

--- a/docs/api_docs/T.tile.mul.md
+++ b/docs/api_docs/T.tile.mul.md
@@ -1,0 +1,91 @@
+# T.tile.mul
+
+## 1. 功能说明
+
+对两个操作数逐元素执行乘法：`dst[i] = src0[i] * src1[i]`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def mul(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion | BufferLoad | PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二个源操作数，支持 tensor、buffer 单元素（BufferLoad）或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 buffer 元素访问（BufferLoad，仅支持 1D 单索引）或 Python 标量/表达式（PrimExpr）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | float16, float32, int16, int32 | float16, float32, int16, int32 | 同 dst |
+
+- src1 为 tensor 时，dtype 必须与 dst 一致；src1 为 scalar 时自动转换为 buffer 的 dtype
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
+- 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
+
+#### 2.3.3 src1 形式说明
+
+| src1 形式 | 底层实现 | 说明 |
+|-----------|---------|------|
+| tensor（Buffer/BufferRegion） | `AscendC::Mul` | 逐元素相乘，dst/src0/src1 大小须一致 |
+| scalar（PrimExpr/float/int） | `AscendC::Muls` | dst[i] = src0[i] * 标量，标量自动转换为 buffer dtype |
+| BufferLoad（1D 单元素） | `AscendC::Muls`（`GetValue(index)` 取标量） | dst[i] = src0[i] * buffer[index] |
+
+### 2.4 约束条件
+
+1. dst 与 src0 的大小必须一致（Python 断言，报错信息 "size must be same"）
+2. src1 为 BufferRegion 时，其大小必须与 dst 一致（Python 断言）
+3. src1 为 Buffer 时大小不做校验：小于 dst 时产生越界读取，大于 dst 时仅前 dst 大小个元素参与运算（不报错）
+4. dst、src0、src1（tensor 形式）的 dtype 必须一致；dtype 不一致会在编译期报错
+5. 操作数地址需 32 字节对齐（硬件约束）
+6. 仅支持整行/整 buffer 的连续区域；2D 列偏移切片（如 `buf[0, 8:40]`）会产生错误结果或触发 aicore 异常（507015），不支持
+7. src1 为 BufferLoad 时仅支持 1D 单索引（如 `buf[i]`）；多维 BufferLoad 只取第一个索引，结果错误（当前未校验）
+
+## 3. 示例代码
+
+**示例 1：tensor-tensor 乘法**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+src1 = T.alloc_ub((256,), "float16")
+dst  = T.alloc_ub((256,), "float16")
+T.tile.mul(dst, src0, src1)
+```
+
+**示例 2：tensor-scalar 乘法**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst  = T.alloc_ub((256,), "float16")
+T.tile.mul(dst, src0, 0.5)  # dst[i] = src0[i] * 0.5
+```
+
+**示例 3：tensor-BufferLoad 乘法**
+
+```python
+src0  = T.alloc_ub((256,), "float16")
+scalar_ub = T.alloc_ub((8,), "float16")
+dst   = T.alloc_ub((256,), "float16")
+T.tile.mul(dst, src0, scalar_ub[3])  # dst[i] = src0[i] * scalar_ub[3]
+```

--- a/docs/api_docs/T.tile.mul.md
+++ b/docs/api_docs/T.tile.mul.md
@@ -22,7 +22,7 @@ def mul(
 |--------|----------|------|------|----------|
 | dst | 输出 | 存放运算结果 | 张量（tensor） | 必填 |
 | src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
-| src1 | 输入 | 第二个源操作数，支持 tensor、buffer 单元素（BufferLoad）或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+| src1 | 输入 | 第二个源操作数，支持 tensor 或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
 
 > **类型说明**：
 > - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
@@ -43,14 +43,6 @@ def mul(
 - 支持 1D 和 2D
 - 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
 - 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
-
-#### 2.3.3 src1 形式说明
-
-| src1 形式 | 底层实现 | 说明 |
-|-----------|---------|------|
-| tensor（Buffer/BufferRegion） | `AscendC::Mul` | 逐元素相乘，dst/src0/src1 大小须一致 |
-| scalar（PrimExpr/float/int） | `AscendC::Muls` | dst[i] = src0[i] * 标量，标量自动转换为 buffer dtype |
-| BufferLoad（1D 单元素） | `AscendC::Muls`（`GetValue(index)` 取标量） | dst[i] = src0[i] * buffer[index] |
 
 ### 2.4 约束条件
 

--- a/docs/api_docs/T.tile.mul.md
+++ b/docs/api_docs/T.tile.mul.md
@@ -46,8 +46,8 @@ def mul(
 
 ### 2.4 约束条件
 
-1. dst 与 src0 的大小必须一致（Python 断言，报错信息 "size must be same"）
-2. src1 为切片（BufferRegion）时，其大小必须与 dst 一致（Python 断言）
+1. dst 与 src0 的大小必须一致
+2. src1 为切片（BufferRegion）时，其大小必须与 dst 一致
 3. src1 为 Buffer 时大小不做校验：小于 dst 时产生越界读取，大于 dst 时仅前 dst 大小个元素参与运算（不报错）
 4. dst、src0、src1（tensor 形式）的 dtype 必须一致；dtype 不一致会在编译期报错
 5. 操作数地址需 32 字节对齐（硬件约束）

--- a/docs/api_docs/T.tile.mul.md
+++ b/docs/api_docs/T.tile.mul.md
@@ -42,17 +42,17 @@ def mul(
 
 - 支持 1D 和 2D
 - 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
-- 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
+- 更高维 buffer 需通过切片降维为 1D/2D 的切片传入
 
 ### 2.4 约束条件
 
 1. dst 与 src0 的大小必须一致（Python 断言，报错信息 "size must be same"）
-2. src1 为 BufferRegion 时，其大小必须与 dst 一致（Python 断言）
+2. src1 为切片（BufferRegion）时，其大小必须与 dst 一致（Python 断言）
 3. src1 为 Buffer 时大小不做校验：小于 dst 时产生越界读取，大于 dst 时仅前 dst 大小个元素参与运算（不报错）
 4. dst、src0、src1（tensor 形式）的 dtype 必须一致；dtype 不一致会在编译期报错
 5. 操作数地址需 32 字节对齐（硬件约束）
 6. 仅支持整行/整 buffer 的连续区域；2D 列偏移切片（如 `buf[0, 8:40]`）会产生错误结果或触发 aicore 异常（507015），不支持
-7. src1 为 BufferLoad 时仅支持 1D 单索引（如 `buf[i]`）；多维 BufferLoad 只取第一个索引，结果错误（当前未校验）
+7. src1 为 buffer 元素访问时仅支持 1D 单索引（如 `buf[i]`）；多维元素访问只取第一个索引，结果错误（实测行为，两后端一致）
 
 ## 3. 示例代码
 

--- a/docs/api_docs/T.tile.sub.md
+++ b/docs/api_docs/T.tile.sub.md
@@ -47,8 +47,8 @@ def sub(
 
 ### 2.4 约束条件
 
-1. dst 与 src0 的大小必须一致（Python 断言，报错信息 "size must be same"）
-2. src1 为切片（BufferRegion）时，其大小必须与 dst 一致（Python 断言）
+1. dst 与 src0 的大小必须一致
+2. src1 为切片（BufferRegion）时，其大小必须与 dst 一致
 3. src1 为 Buffer 时大小不做校验：小于 dst 时产生越界读取，大于 dst 时仅前 dst 大小个元素参与运算（不报错）
 4. dst、src0、src1（tensor 形式）的 dtype 必须一致；dtype 不一致会在编译期报错
 5. 操作数地址需 32 字节对齐（硬件约束）

--- a/docs/api_docs/T.tile.sub.md
+++ b/docs/api_docs/T.tile.sub.md
@@ -43,17 +43,17 @@ def sub(
 
 - 支持 1D 和 2D
 - 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
-- 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
+- 更高维 buffer 需通过切片降维为 1D/2D 的切片传入
 
 ### 2.4 约束条件
 
 1. dst 与 src0 的大小必须一致（Python 断言，报错信息 "size must be same"）
-2. src1 为 BufferRegion 时，其大小必须与 dst 一致（Python 断言）
+2. src1 为切片（BufferRegion）时，其大小必须与 dst 一致（Python 断言）
 3. src1 为 Buffer 时大小不做校验：小于 dst 时产生越界读取，大于 dst 时仅前 dst 大小个元素参与运算（不报错）
 4. dst、src0、src1（tensor 形式）的 dtype 必须一致；dtype 不一致会在编译期报错
 5. 操作数地址需 32 字节对齐（硬件约束）
 6. 仅支持整行/整 buffer 的连续区域；2D 列偏移切片（如 `buf[0, 8:40]`）会产生错误结果或触发 aicore 异常（507015），不支持
-7. src1 为 BufferLoad 时仅支持 1D 单索引（如 `buf[i]`）；多维 BufferLoad 只取第一个索引，结果错误（当前未校验）
+7. src1 为 buffer 元素访问时仅支持 1D 单索引（如 `buf[i]`）；多维元素访问只取第一个索引，结果错误（实测行为，两后端一致）
 8. src1 为 BufferLoad 且 dtype 为 int16/int32 时，仅 pto 后端支持（ascendc codegen 生成 float 标量与 int 张量混用导致编译失败）
 9. 标量仅支持作为 src1（右操作数）：减法不可交换，`标量 - Buffer` 形式（如 `2.0 - buf`）当前无法表达；Ascend C `Subs` 接口原生支持（flexible scalar），TileLang 前端暂未暴露该形式（缺口记录）
 

--- a/docs/api_docs/T.tile.sub.md
+++ b/docs/api_docs/T.tile.sub.md
@@ -1,0 +1,94 @@
+# T.tile.sub
+
+## 1. 功能说明
+
+对两个操作数逐元素执行减法：`dst[i] = src0[i] - src1[i]`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def sub(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion | BufferLoad | PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一个源操作数（被减数） | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二个源操作数（减数），支持 tensor、buffer 单元素（BufferLoad）或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 buffer 元素访问（BufferLoad，仅支持 1D 单索引）或 Python 标量/表达式（PrimExpr）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | float16, float32, int16, int32 | float16, float32, int16, int32 | 同 dst |
+
+- src1 为 tensor 时，dtype 必须与 dst 一致；src1 为 scalar 时自动转换为 buffer 的 dtype
+- src1 为 BufferLoad 时：float16/float32 两个后端均支持；int16/int32 仅 pto 后端支持（ascendc 编译失败）
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
+- 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
+
+#### 2.3.3 src1 形式说明
+
+| src1 形式 | 底层实现 | 说明 |
+|-----------|---------|------|
+| tensor（Buffer/BufferRegion） | `AscendC::Sub` | 逐元素相减，dst/src0/src1 大小须一致 |
+| scalar（PrimExpr/float/int） | `AscendC::Adds`（标量取负） | dst[i] = src0[i] - 标量，等价于 `Adds(dst, src0, -src1)` |
+| BufferLoad（1D 单元素） | `AscendC::Adds`（`GetValue(index)` 取负） | dst[i] = src0[i] - buffer[index] |
+
+### 2.4 约束条件
+
+1. dst 与 src0 的大小必须一致（Python 断言，报错信息 "size must be same"）
+2. src1 为 BufferRegion 时，其大小必须与 dst 一致（Python 断言）
+3. src1 为 Buffer 时大小不做校验：小于 dst 时产生越界读取，大于 dst 时仅前 dst 大小个元素参与运算（不报错）
+4. dst、src0、src1（tensor 形式）的 dtype 必须一致；dtype 不一致会在编译期报错
+5. 操作数地址需 32 字节对齐（硬件约束）
+6. 仅支持整行/整 buffer 的连续区域；2D 列偏移切片（如 `buf[0, 8:40]`）会产生错误结果或触发 aicore 异常（507015），不支持
+7. src1 为 BufferLoad 时仅支持 1D 单索引（如 `buf[i]`）；多维 BufferLoad 只取第一个索引，结果错误（当前未校验）
+8. src1 为 BufferLoad 且 dtype 为 int16/int32 时，仅 pto 后端支持（ascendc codegen 生成 float 标量与 int 张量混用导致编译失败）
+9. 标量仅支持作为 src1（右操作数）：减法不可交换，`标量 - Buffer` 形式（如 `2.0 - buf`）当前无法表达；Ascend C `Subs` 接口原生支持（flexible scalar），TileLang 前端暂未暴露该形式（缺口记录）
+
+## 3. 示例代码
+
+**示例 1：tensor-tensor 减法**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+src1 = T.alloc_ub((256,), "float16")
+dst  = T.alloc_ub((256,), "float16")
+T.tile.sub(dst, src0, src1)
+```
+
+**示例 2：tensor-scalar 减法**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst  = T.alloc_ub((256,), "float16")
+T.tile.sub(dst, src0, 2.0)  # dst[i] = src0[i] - 2.0
+```
+
+**示例 3：tensor-BufferLoad 减法**
+
+```python
+src0  = T.alloc_ub((256,), "float16")
+scalar_ub = T.alloc_ub((8,), "float16")
+dst   = T.alloc_ub((256,), "float16")
+T.tile.sub(dst, src0, scalar_ub[3])  # dst[i] = src0[i] - scalar_ub[3]
+```

--- a/docs/api_docs/T.tile.sub.md
+++ b/docs/api_docs/T.tile.sub.md
@@ -22,7 +22,7 @@ def sub(
 |--------|----------|------|------|----------|
 | dst | 输出 | 存放运算结果 | 张量（tensor） | 必填 |
 | src0 | 输入 | 第一个源操作数（被减数） | 张量（tensor） | 必填 |
-| src1 | 输入 | 第二个源操作数（减数），支持 tensor、buffer 单元素（BufferLoad）或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+| src1 | 输入 | 第二个源操作数（减数），支持 tensor 或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
 
 > **类型说明**：
 > - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
@@ -44,14 +44,6 @@ def sub(
 - 支持 1D 和 2D
 - 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
 - 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
-
-#### 2.3.3 src1 形式说明
-
-| src1 形式 | 底层实现 | 说明 |
-|-----------|---------|------|
-| tensor（Buffer/BufferRegion） | `AscendC::Sub` | 逐元素相减，dst/src0/src1 大小须一致 |
-| scalar（PrimExpr/float/int） | `AscendC::Adds`（标量取负） | dst[i] = src0[i] - 标量，等价于 `Adds(dst, src0, -src1)` |
-| BufferLoad（1D 单元素） | `AscendC::Adds`（`GetValue(index)` 取负） | dst[i] = src0[i] - buffer[index] |
 
 ### 2.4 约束条件
 

--- a/testing/python/language/test_tilelang_ascend_language_tile_arith.py
+++ b/testing/python/language/test_tilelang_ascend_language_tile_arith.py
@@ -1,0 +1,503 @@
+import argparse
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+
+"""
+Test suite for T.tile.add/sub/mul/div APIs.
+
+Covers:
+  - tensor-tensor form (AscendC::Add/Sub/Mul/Div):
+    float16/float32 default, int16/int32 low_priority
+  - scalar form (AscendC::Adds/Muls, sub via negated scalar, div via reciprocal):
+    float16/float32 default, int16/int32 low_priority
+  - BufferLoad scalar form (1D single element):
+    float16/float32 default; int16/int32 add/mul low_priority;
+    sub int16/int32 is ascendc compile-fail -> pto only
+  - 2D whole-row slice regions (BufferRegion, flash-attention style)
+  - in-place aliasing (dst==src0 / dst==src1 / src0==src1)
+  - size mismatch validation (dst vs src0, src1 BufferRegion) and the
+    unvalidated src1-Buffer size case
+  - div integer dtype unsupported (compile error on both backends)
+
+See api/api_docs/T.tile.{add,sub,mul,div}.md for the verified constraint set.
+"""
+
+TORCH_DTYPE = {
+    "float16": torch.float16,
+    "float32": torch.float32,
+    "int16": torch.int16,
+    "int32": torch.int32,
+}
+RTOL = 1e-2
+ATOL = 1e-2
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+# -----------------------------------------------------------------------------
+# Kernel builders
+# -----------------------------------------------------------------------------
+
+
+def _make_data(M, N, dtype):
+    """Random a and positive b; b >= 0.5 keeps the division bounded."""
+    torch_dt = TORCH_DTYPE[dtype]
+    if dtype.startswith("float"):
+        a = torch.randn(M, N, dtype=torch_dt)
+        b = torch.rand(M, N, dtype=torch_dt) + 0.5
+    else:
+        a = torch.randint(-100, 100, (M, N), dtype=torch_dt)
+        b = torch.randint(1, 100, (M, N), dtype=torch_dt)
+    return a, b
+
+
+def binary_tensor_kernel(op, M, N, dtype):
+    """dst/src0/src1 are whole 2D buffers."""
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype), C: T.Tensor((M, N), dtype)):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((M, N), dtype)
+            b_ub = T.alloc_ub((M, N), dtype)
+            c_ub = T.alloc_ub((M, N), dtype)
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            getattr(T.tile, op)(c_ub, a_ub, b_ub)
+            T.copy(c_ub, C)
+
+    return main
+
+
+def binary_scalar_kernel(op, M, N, scalar, dtype):
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), C: T.Tensor((M, N), dtype)):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((M, N), dtype)
+            c_ub = T.alloc_ub((M, N), dtype)
+            T.copy(A, a_ub)
+            getattr(T.tile, op)(c_ub, a_ub, scalar)
+            T.copy(c_ub, C)
+
+    return main
+
+
+def binary_buffload_kernel(op, M, N, m, dtype):
+    """src1 is a 1D scalar buffer element (S[3])."""
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), S: T.Tensor((m,), dtype), C: T.Tensor((M, N), dtype)):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((M, N), dtype)
+            s_ub = T.alloc_ub((m,), dtype)
+            c_ub = T.alloc_ub((M, N), dtype)
+            T.copy(A, a_ub)
+            T.copy(S, s_ub)
+            getattr(T.tile, op)(c_ub, a_ub, s_ub[3])
+            T.copy(c_ub, C)
+
+    return main
+
+
+def binary_row_slice_kernel(op, M, N, m, dtype):
+    """2D whole-row slices as dst/src0 (flash-attention style)."""
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), S: T.Tensor((m,), dtype), C: T.Tensor((M, N), dtype)):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((M, N), dtype)
+            s_ub = T.alloc_ub((m,), dtype)
+            c_ub = T.alloc_ub((M, N), dtype)
+            T.copy(A, a_ub)
+            T.copy(S, s_ub)
+            for h_i in range(M):
+                getattr(T.tile, op)(c_ub[h_i, :], a_ub[h_i, :], s_ub[h_i % m])
+            T.copy(c_ub, C)
+
+    return main
+
+
+def binary_inplace_kernel(op, form, M, N, dtype):
+    """In-place aliasing: dst==src0, dst==src1, or src0==src1 (distinct GM outs)."""
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype), C: T.Tensor((M, N), dtype)):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((M, N), dtype)
+            b_ub = T.alloc_ub((M, N), dtype)
+            c_ub = T.alloc_ub((M, N), dtype)
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            if form == "dst=src0":
+                getattr(T.tile, op)(a_ub, a_ub, b_ub)
+                T.copy(a_ub, C)
+            elif form == "dst=src1":
+                getattr(T.tile, op)(b_ub, a_ub, b_ub)
+                T.copy(b_ub, C)
+            else:  # "src0=src1"
+                getattr(T.tile, op)(c_ub, b_ub, b_ub)
+                T.copy(c_ub, C)
+
+    return main
+
+
+def binary_tensor_mismatch_kernel(dtype):
+    """dst/src0 sizes differ -> Python assert at trace time."""
+
+    @T.prim_func
+    def main(A: T.Tensor((64,), dtype), B: T.Tensor((128,), dtype), C: T.Tensor((64,), dtype)):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((64,), dtype)
+            b_ub = T.alloc_ub((128,), dtype)
+            c_ub = T.alloc_ub((64,), dtype)
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            T.tile.add(c_ub, b_ub, a_ub)
+            T.copy(c_ub, C)
+
+    return main
+
+
+def binary_region_mismatch_kernel(dtype):
+    """src1 BufferRegion size differs -> Python assert at trace time."""
+
+    @T.prim_func
+    def main(A: T.Tensor((64,), dtype), B: T.Tensor((128,), dtype), C: T.Tensor((64,), dtype)):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((64,), dtype)
+            b_ub = T.alloc_ub((128,), dtype)
+            c_ub = T.alloc_ub((64,), dtype)
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            T.tile.add(c_ub, a_ub, b_ub[0:32])
+            T.copy(c_ub, C)
+
+    return main
+
+
+def binary_buffer_mismatch_kernel(dtype):
+    """src1 Buffer size differs -> NOT validated, only dst.size elements used."""
+
+    @T.prim_func
+    def main(A: T.Tensor((64,), dtype), B: T.Tensor((128,), dtype), C: T.Tensor((64,), dtype)):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((64,), dtype)
+            b_ub = T.alloc_ub((128,), dtype)
+            c_ub = T.alloc_ub((64,), dtype)
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            T.tile.add(c_ub, a_ub, b_ub)
+            T.copy(c_ub, C)
+
+    return main
+
+
+# -----------------------------------------------------------------------------
+# Run-test helpers
+# -----------------------------------------------------------------------------
+
+
+def run_test_tensor(op, M, N, dtype, target):
+    a, b = _make_data(M, N, dtype)
+    kernel = binary_tensor_kernel(op, M, N, dtype)
+    func = tilelang.compile(kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+    out = func(a.npu(), b.npu())
+    torch.npu.synchronize()
+    ref = {"add": a + b, "sub": a - b, "mul": a * b, "div": a / b}[op]
+    torch.testing.assert_close(out.cpu().float(), ref.cpu().float(), rtol=RTOL, atol=ATOL)
+
+
+def run_test_scalar(op, M, N, scalar, dtype, target):
+    a, _ = _make_data(M, N, dtype)
+    kernel = binary_scalar_kernel(op, M, N, scalar, dtype)
+    func = tilelang.compile(kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+    out = func(a.npu())
+    torch.npu.synchronize()
+    ref = {"add": a + scalar, "sub": a - scalar, "mul": a * scalar, "div": a / scalar}[op]
+    torch.testing.assert_close(out.cpu().float(), ref.cpu().float(), rtol=RTOL, atol=ATOL)
+
+
+def run_test_buffload(op, M, N, m, dtype, target):
+    a, b = _make_data(M, N, dtype)
+    if dtype.startswith("float"):
+        values = [1.5, 2.0, 0.5, 3.0, 4.0, -1.0, 0.25, 0.75]
+    else:
+        values = [1, 2, 3, 4, 5, 6, 7, 8]
+    s = torch.tensor(values, dtype=TORCH_DTYPE[dtype])[:m]
+    kernel = binary_buffload_kernel(op, M, N, m, dtype)
+    func = tilelang.compile(kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+    out = func(a.npu(), s.npu())
+    torch.npu.synchronize()
+    ref = {"add": a + s[3], "sub": a - s[3], "mul": a * s[3], "div": a / s[3]}[op]
+    torch.testing.assert_close(out.cpu().float(), ref.cpu().float(), rtol=RTOL, atol=ATOL)
+
+
+def run_test_row_slice(op, M, N, m, dtype, target):
+    a, _ = _make_data(M, N, dtype)
+    if dtype.startswith("float"):
+        values = [1.5, 2.0, 0.5, 3.0, 4.0, -1.0, 0.25, 0.75]
+    else:
+        values = [1, 2, 3, 4, 5, 6, 7, 8]
+    s = torch.tensor(values, dtype=TORCH_DTYPE[dtype])[:m]
+    kernel = binary_row_slice_kernel(op, M, N, m, dtype)
+    func = tilelang.compile(kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+    out = func(a.npu(), s.npu())
+    torch.npu.synchronize()
+    ref = torch.stack(
+        [{"add": a[h] + s[h % m], "sub": a[h] - s[h % m], "mul": a[h] * s[h % m], "div": a[h] / s[h % m]}[op] for h in range(M)]
+    )
+    torch.testing.assert_close(out.cpu().float(), ref.cpu().float(), rtol=RTOL, atol=ATOL)
+
+
+def run_test_inplace(op, form, M, N, dtype, target):
+    a, b = _make_data(M, N, dtype)
+    kernel = binary_inplace_kernel(op, form, M, N, dtype)
+    func = tilelang.compile(kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+    out = func(a.npu(), b.npu())
+    torch.npu.synchronize()
+    if form in ("dst=src0", "dst=src1"):
+        ref = {"add": a + b, "sub": a - b, "mul": a * b, "div": a / b}[op]
+    else:  # src0=src1
+        ref = {"add": b + b, "sub": b - b, "mul": b * b, "div": b / b}[op]
+    torch.testing.assert_close(out.cpu().float(), ref.cpu().float(), rtol=RTOL, atol=ATOL)
+
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    """Clear tilelang cache before tests."""
+    tilelang.cache.clear_cache()
+    yield
+
+
+@pytest.fixture
+def setup_random_seed():
+    """Set random seed for reproducibility."""
+    torch.manual_seed(0)
+    yield
+
+
+# -----------------------------------------------------------------------------
+# Test cases: tensor-tensor form
+# -----------------------------------------------------------------------------
+
+TENSOR_INT_DTYPES = [
+    pytest.param("int16", marks=pytest.mark.low_priority),
+    pytest.param("int32", marks=pytest.mark.low_priority),
+]
+FLOAT_DTYPES = ["float32", pytest.param("float16", marks=pytest.mark.low_priority)]
+# add/sub/mul/div share the same binary_op path; only `add` stays in the
+# PR-triggered set as the representative, sub/mul/div run in the full suite.
+ARITH_OPS = [
+    "add",
+    pytest.param("sub", marks=pytest.mark.low_priority),
+    pytest.param("mul", marks=pytest.mark.low_priority),
+]
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize("op", ARITH_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES + TENSOR_INT_DTYPES)
+@pytest.mark.parametrize("target", ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)])
+def test_tile_arith_tensor(op, dtype, target):
+    """Tensor-tensor form: float16/float32/int16/int32."""
+    run_test_tensor(op, 64, 128, dtype, target)
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.low_priority
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_tile_arith_tensor_div(dtype, target):
+    """Tensor-tensor div: floating point only."""
+    run_test_tensor("div", 64, 128, dtype, target)
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.low_priority
+@pytest.mark.parametrize("dtype", ["int16", "int32"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_tile_arith_div_int_compile_error(dtype, target):
+    """Div with integer dtypes fails to compile (AscendC Div static_assert)."""
+    with pytest.raises(RuntimeError):
+        kernel = binary_tensor_kernel("div", 64, 128, dtype)
+        tilelang.compile(kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+
+
+# -----------------------------------------------------------------------------
+# Test cases: scalar form
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize("op", ARITH_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES + TENSOR_INT_DTYPES)
+@pytest.mark.parametrize("target", ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)])
+def test_tile_arith_scalar(op, dtype, target):
+    """Scalar immediate: dst = src0 op scalar."""
+    scalar = 2 if dtype in ("int16", "int32") else 2.0
+    run_test_scalar(op, 64, 128, scalar, dtype, target)
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.low_priority
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_tile_arith_scalar_div(dtype, target):
+    """Scalar div (implemented as multiply by reciprocal)."""
+    run_test_scalar("div", 64, 128, 2.0, dtype, target)
+
+
+# -----------------------------------------------------------------------------
+# Test cases: BufferLoad scalar form
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize("op", ARITH_OPS + [pytest.param("div", marks=pytest.mark.low_priority)])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("target", ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)])
+def test_tile_arith_buffload(op, dtype, target):
+    """1D BufferLoad scalar: dst = src0 op S[3]."""
+    run_test_buffload(op, 64, 128, 8, dtype, target)
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.low_priority
+@pytest.mark.parametrize("op", ["add", "mul"])
+@pytest.mark.parametrize("dtype", ["int16", "int32"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_tile_arith_buffload_int_add_mul(op, dtype, target):
+    """BufferLoad scalar with integer dtypes: add/mul work on both backends."""
+    run_test_buffload(op, 64, 128, 8, dtype, target)
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.low_priority
+@pytest.mark.parametrize("target", [pytest.param("pto", marks=pytest.mark.low_priority)])
+def test_tile_arith_buffload_sub_int(target):
+    """BufferLoad scalar sub with int16 on pto works.
+
+    ascendc is excluded here: its codegen mixes a float scalar with int
+    tensors (codegen_ascend.cc SubsOpCodegen) -> no matching Adds overload.
+    See doc constraint 8 and the separate compile-error test below.
+    """
+    run_test_buffload("sub", 64, 128, 8, "int16", target)
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.low_priority
+def test_tile_arith_buffload_sub_int_ascendc_compile_fail():
+    """BufferLoad scalar sub with int16 fails to compile on ascendc."""
+    with pytest.raises(RuntimeError):
+        kernel = binary_buffload_kernel("sub", 64, 128, 8, "int16")
+        tilelang.compile(kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target="ascendc")
+
+
+# -----------------------------------------------------------------------------
+# Test cases: 2D whole-row slices
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize("op", ARITH_OPS + [pytest.param("div", marks=pytest.mark.low_priority)])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("target", ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)])
+def test_tile_arith_row_slice_2d(op, dtype, target):
+    """2D whole-row slice regions with a per-row BufferLoad scalar."""
+    run_test_row_slice(op, 4, 128, 4, dtype, target)
+
+
+# -----------------------------------------------------------------------------
+# Test cases: in-place aliasing
+# -----------------------------------------------------------------------------
+
+INPLACE_FORMS = [
+    "dst=src0",
+    pytest.param("dst=src1", marks=pytest.mark.low_priority),
+    pytest.param("src0=src1", marks=pytest.mark.low_priority),
+]
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize("op", ARITH_OPS + [pytest.param("div", marks=pytest.mark.low_priority)])
+@pytest.mark.parametrize("form", INPLACE_FORMS)
+@pytest.mark.parametrize("target", ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)])
+def test_tile_arith_inplace(op, form, target):
+    """dst may alias src0 / src1; src0 may alias src1 (separate GM outputs)."""
+    run_test_inplace(op, form, 4, 128, "float32", target)
+
+
+# -----------------------------------------------------------------------------
+# Test cases: size validation
+# -----------------------------------------------------------------------------
+
+
+def test_tile_arith_size_mismatch_src0():
+    """dst vs src0 size mismatch raises at trace time (Python assert)."""
+    with pytest.raises(RuntimeError):
+        binary_tensor_mismatch_kernel("float16")
+
+
+def test_tile_arith_size_mismatch_region():
+    """src1 BufferRegion size mismatch raises at trace time (Python assert)."""
+    with pytest.raises(RuntimeError):
+        binary_region_mismatch_kernel("float16")
+
+
+@pytest.mark.usefixtures("setup_random_seed")
+@pytest.mark.parametrize("target", ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)])
+def test_tile_arith_buffer_size_unvalidated(target):
+    """src1 Buffer size is NOT validated: only dst.size elements are used.
+
+    a(64) + b(128): the kernel silently computes a + b[0:64].
+    """
+    dtype = "float16"
+    torch.manual_seed(0)
+    a = torch.randn(64, dtype=torch.float16)
+    b = torch.rand(128, dtype=torch.float16) + 0.5
+    kernel = binary_buffer_mismatch_kernel(dtype)
+    func = tilelang.compile(kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target=target)
+    out = func(a.npu(), b.npu())
+    torch.npu.synchronize()
+    torch.testing.assert_close(out.cpu().float(), (a + b[:64]).float(), rtol=RTOL, atol=ATOL)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="T.tile.add/sub/mul/div test suite")
+    parser.add_argument("--target", type=str, choices=["ascendc", "pto"], default="ascendc")
+    parser.add_argument("--op", type=str, choices=["add", "sub", "mul", "div"], default="add")
+    parser.add_argument("--mode", type=str, choices=["tensor", "scalar", "buffload", "slice", "inplace"], default="tensor")
+    args = parser.parse_args()
+
+    torch.manual_seed(0)
+    tilelang.cache.clear_cache()
+
+    print("=" * 60)
+    print(f"T.tile.{args.op} test: target={args.target}, mode={args.mode}")
+    print("=" * 60)
+
+    if args.mode == "tensor":
+        run_test_tensor(args.op, 64, 128, "float32", args.target)
+    elif args.mode == "scalar":
+        run_test_scalar(args.op, 64, 128, 2.0, "float32", args.target)
+    elif args.mode == "buffload":
+        run_test_buffload(args.op, 64, 128, 8, "float32", args.target)
+    elif args.mode == "slice":
+        run_test_row_slice(args.op, 4, 128, 4, "float32", args.target)
+    else:
+        run_test_inplace(args.op, "dst=src0", 4, 128, "float32", args.target)
+    print(f"  {args.op} ({args.mode}) PASSED")
+
+    print("\nAll requested cases passed.")

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1026,45 +1026,85 @@ def binary_op(
 
 
 def add(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, src1: Buffer | BufferRegion | BufferLoad | PrimExpr):
-    """Performs element-wise addition: dst = src0 + src1.
+    """Performs element-wise addition: `dst[i] = src0[i] + src1[i]`.
 
     Args:
-        dst: The destination buffer.
-        src0: The first source buffer.
-        src1: The second source operand (Buffer, BufferLoad, or Scalar).
+        dst: The destination buffer; it may alias src0 or src1 (in-place).
+        src0: The first source, a buffer or a contiguous region of it.
+        src1: The second operand: a buffer, a 1D buffer element (BufferLoad), or a scalar.
+
+    Notes:
+        - dst and src0 must have equal sizes; all tensor operands must share
+          the same dtype, while a scalar src1 is auto-cast to the buffer dtype.
+        - Supported dtypes: float16, float32, int16, int32.
+        - Operand addresses must be 32-byte aligned (hardware constraint).
     """
     return binary_op(dst, src0, src1, "add")
 
 
-def sub(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, src1: Buffer | BufferRegion | BufferLoad):
-    """Performs element-wise subtraction: dst = src0 - src1.
+def sub(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, src1: Buffer | BufferRegion | BufferLoad | PrimExpr):
+    """Performs element-wise subtraction: `dst[i] = src0[i] - src1[i]`.
 
     Args:
-        dst: The destination buffer.
-        src0: The first source buffer.
-        src1: The second source operand (Buffer or BufferLoad).
+        dst: The destination buffer; it may alias src0 or src1 (in-place).
+        src0: The first source, a buffer or a contiguous region of it.
+        src1: The second operand: a buffer, a 1D buffer element (BufferLoad), or a scalar.
+
+    Notes:
+        - dst and src0 must have equal sizes; all tensor operands must share
+          the same dtype, while a scalar src1 is auto-cast to the buffer dtype.
+        - Supported dtypes: float16, float32, int16, int32. A BufferLoad src1
+          with int16/int32 is supported on the pto backend only (ascendc fails
+          to compile).
+        - A scalar src1 is applied via `AscendC::Adds(dst, src0, -src1)`.
+        - A scalar is supported as src1 (right operand) only: subtraction is
+          non-commutative, so `scalar - buffer` (e.g. `2.0 - buf`) cannot be
+          expressed. AscendC `Subs` supports a scalar on either side (flexible
+          scalar); the TileLang frontend does not expose that form yet.
+        - Operand addresses must be 32-byte aligned (hardware constraint).
     """
     return binary_op(dst, src0, src1, "sub")
 
 
 def mul(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, src1: Buffer | BufferRegion | BufferLoad | PrimExpr):
-    """Performs element-wise multiplication: dst = src0 * src1.
+    """Performs element-wise multiplication: `dst[i] = src0[i] * src1[i]`.
 
     Args:
-        dst: The destination buffer.
-        src0: The first source buffer.
-        src1: The second source operand (Buffer, BufferLoad, or Scalar).
+        dst: The destination buffer; it may alias src0 or src1 (in-place).
+        src0: The first source, a buffer or a contiguous region of it.
+        src1: The second operand: a buffer, a 1D buffer element (BufferLoad), or a scalar.
+
+    Notes:
+        - dst and src0 must have equal sizes; all tensor operands must share
+          the same dtype, while a scalar src1 is auto-cast to the buffer dtype.
+        - Supported dtypes: float16, float32, int16, int32.
+        - Operand addresses must be 32-byte aligned (hardware constraint).
     """
     return binary_op(dst, src0, src1, "mul")
 
 
-def div(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, src1: Buffer | BufferRegion | BufferLoad):
-    """Performs element-wise division: dst = src0 / src1.
+def div(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, src1: Buffer | BufferRegion | BufferLoad | PrimExpr):
+    """Performs element-wise division: `dst[i] = src0[i] / src1[i]`.
 
     Args:
-        dst: The destination buffer.
-        src0: The first source buffer.
-        src1: The second source operand (Buffer or BufferLoad).
+        dst: The destination buffer; it may alias src0 or src1 (in-place).
+        src0: The first source, a buffer or a contiguous region of it.
+        src1: The second operand: a buffer, a 1D buffer element (BufferLoad), or a scalar.
+
+    Notes:
+        - dst and src0 must have equal sizes; all tensor operands must share
+          the same dtype, while a scalar src1 is auto-cast to the buffer dtype.
+        - Only float16 and float32 are supported (hardware constraint);
+          integer dtypes are not supported: ascendc fails to compile, and the
+          pto backend may compile a scalar/BufferLoad src1 but gives wrong
+          results.
+        - A scalar src1 is applied via `AscendC::Muls(dst, src0, 1.0f / src1)`,
+          so non-power-of-two divisors introduce an extra rounding error.
+        - A scalar is supported as src1 (right operand) only: division is
+          non-commutative, so `scalar / buffer` (e.g. `2.0 / buf`) cannot be
+          expressed. AscendC `Divs` supports a scalar on either side (flexible
+          scalar); the TileLang frontend does not expose that form yet.
+        - Operand addresses must be 32-byte aligned (hardware constraint).
     """
     return binary_op(dst, src0, src1, "div")
 


### PR DESCRIPTION
## 1. 文件改动

| 文件 | 类型 | 改动说明 |
|------|------|----------|
| `tilelang/language/ascend_tile.py` | 修改 | 4 个函数（1042-1083 行）：补全 sub/div 的 `src1` 类型注解（补 `PrimExpr`，源码 `binary_op` 支持 scalar 而注解漏写）；docstring 按 Google style 重写（每函数加 Notes 段：大小断言、dtype 一致性、scalar 自动转换、32 字节对齐、原地别名可用；sub 补充 BufferLoad×int16/int32 的 backend 差异；div 补充仅浮点 dtype（static_assert）与 scalar 倒数乘法语义） |
| `testing/python/language/test_tilelang_ascend_language_tile_arith.py` | 新增 | 完整测试套件（130 用例）：tensor-tensor / scalar / BufferLoad 三种 src1 形式 × dtype(4) × target(2)、2D 整行切片（flash-attention 模式）、原地别名 3 种形式、大小断言（dst/src0、src1 区域）与 src1-Buffer 大小不校验语义、div 整数 dtype 编译失败断言、sub BufferLoad×int 的 backend 差异 |
| `docs/api_docs/T.tile.add.md` | 新增 | 功能说明 / 函数原型 / 参数规格 / 约束 / 示例 |
| `docs/api_docs/T.tile.sub.md` | 新增 | 同上，含 BufferLoad×int16/int32 仅 pto 的后端差异（约束 8） |
| `docs/api_docs/T.tile.mul.md` | 新增 | 同上 |
| `docs/api_docs/T.tile.div.md` | 新增 | 同上 ,含整数 dtype 不支持（约束 8）与 scalar 倒数乘法（约束 9） |
| `docs/TileLang-Ascend Programming Guide.md` | 修改 | 4.1.3.2.1 数学计算：修正 mul/div 表格行 "法乘" 笔误、div 行注明仅浮点；基础算术段 add/sub/mul/div 参数补"可与 src0/src1 别名（原地运算）"、补"支持类型"行（div 注明仅浮点 + scalar 倒数语义） |

---

## 2. 测试用例

### 2.1 约束测试（动态验证，真机 dav_c220/A2 / Ascend910B3）

| 验证项 | 测什么 | 结果 |
|--------|--------|:----:|
| tensor-tensor 各 dtype | add/sub/mul × {f16,f32,i16,i32}、div × {f16,f32}，ascendc/pto | 全部通过；div × {i16,i32} 两后端编译失败（Div static_assert 仅 half/float） |
| scalar（PrimExpr）各 dtype | add/sub/mul/div × 4 dtype，ascendc/pto | add/sub/mul 全通过；div {i16,i32}：ascendc 编译失败 / pto 可编译但结果错误 |
| BufferLoad scalar | 1D 标量 buffer `S[3]`，4 ops × 4 dtype × 2 backend | add/mul 全通过；sub {i16,i32}：ascendc 编译失败（codegen `-(float)S.GetValue()` 标量类型不匹配）/ pto 通过；div {i16,i32}：ascendc 编译失败 / pto 结果错误 |
| 2D 整行切片 | `c_ub[h, :]`×`a_ub[h, :]`×`s_ub[h]`（flash-attention 模式），f16/f32 × 2 backend | 全部通过 |
| 连续多行区域 | `a_ub[2:6, :]` 整行区域，f16 × 2 backend | 全部通过 |
| 原地别名 | dst==src0 / dst==src1 / src0==src1，单独输出张量 | 均可正确运算（初测"失败"系测试 harness 对同一张量既作输入又作输出的行为，见 §4 问题 10） |
| 大小断言 | dst≠src0、src1 区域≠dst | 两处均在 trace 期抛错（"size must be same"） |
| src1-Buffer 大小不校验 | dst=64 / src1 Buffer=128 | 无断言、不报错，仅计算前 64 个元素（结果 = a+b[0:64]） |
| 列偏移切片 | `a_ub[:, 8:40]`（16B 偏移）、`[:, 16:48]`（32B 偏移） | 错误结果或 aicore 异常 507015，不支持 |
| 多维 BufferLoad | `s_ub[1, 3]` 作标量 | 只取第一个索引（`indices_1[0]`=1 → 取 `s_ub[0,1]`），结果错误（未校验） |
| 计数对齐 | 1D n ∈ {8, 16, 100, 232}（16B~464B，非 32B 倍数） | 全部通过，count 无 32 字节倍数要求 |
| 混合 dtype tensor | dst=f16, src1=f32 | 两后端均编译失败 |
| 参数三形式 × 具体实现 | Buffer→ascend_add（AscendC::Add）；scalar→ascend_adds（Adds）；BufferLoad→ascend_adds+GetValue | 与 codegen（codegen_ascend.cc 522-549、codegen_ascend_pto.cc 888-913）一致 |

### 2.2 语言测试 `test_tilelang_ascend_language_tile_arith.py`（130 用例）

| 测试函数 | 用例数 | 测什么 |
|----------|:---:|--------|
| `test_tile_arith_tensor` | 24 | add/sub/mul tensor-tensor × dtype(4) × target(2) |
| `test_tile_arith_tensor_div` | 4 | div tensor-tensor × dtype(f16/f32) × target(2) |
| `test_tile_arith_div_int_compile_error` | 4 | div × int16/int32 × target(2) 均编译失败（pytest.raises） |
| `test_tile_arith_scalar` | 24 | add/sub/mul scalar × dtype(4) × target(2) |
| `test_tile_arith_scalar_div` | 4 | div scalar(2.0) × dtype(f16/f32) × target(2) |
| `test_tile_arith_buffload` | 16 | 4 ops BufferLoad(S[3]) × dtype(f16/f32) × target(2) |
| `test_tile_arith_buffload_int_add_mul` | 8 | add/mul BufferLoad × int16/int32 × target(2) |
| `test_tile_arith_buffload_sub_int` | 1 | sub BufferLoad × int16，仅 pto（ascendc 见下条） |
| `test_tile_arith_buffload_sub_int_ascendc_compile_fail` | 1 | 同上 ascendc 编译失败（pytest.raises） |
| `test_tile_arith_row_slice_2d` | 16 | 2D 整行切片 × 4 ops × dtype(f16/f32) × target(2) |
| `test_tile_arith_inplace` | 24 | 原地别名（dst=src0/dst=src1/src0=src1）× 4 ops × target(2) |
| `test_tile_arith_size_mismatch_src0` | 1 | dst vs src0 大小不一致 → trace 期抛错 |
| `test_tile_arith_size_mismatch_region` | 1 | src1 区域大小不一致 → trace 期抛错 |
| `test_tile_arith_buffer_size_unvalidated` | 2 | src1-Buffer 大小不校验语义（结果 = a+b[0:64]）× target(2) |

---

## 3. 测试结果

- **约束测试**：动态验证完成（真机 dav_c220/A2，见 2.1 表）
- **语言测试**：130 PASSED（真机 dav_c220/A2，全量单次运行 0:16:16）

### 3.1 pytest 标签

| 测试函数 | low_priority | PR 执行 |
|----------|:---:|:---:|
| `test_tile_arith_tensor` pto / float16 / int16 / int32 用例 | 21 | 3（add/sub/mul × float32 × ascendc） |
| `test_tile_arith_tensor_div` float16 / pto 用例 | 3 | 1（float32 × ascendc） |
| `test_tile_arith_div_int_compile_error` 全部 | 4 | 0 |
| `test_tile_arith_scalar` pto / float16 / int16 / int32 用例 | 21 | 3 |
| `test_tile_arith_scalar_div` float16 / pto 用例 | 3 | 1 |
| `test_tile_arith_buffload` pto / float16 用例 | 12 | 4（4 ops × float32 × ascendc） |
| `test_tile_arith_buffload_int_add_mul` 全部 | 8 | 0 |
| `test_tile_arith_buffload_sub_int` | 1 | 0 |
| `test_tile_arith_buffload_sub_int_ascendc_compile_fail` | 1 | 0 |
| `test_tile_arith_row_slice_2d` float16 / pto 用例 | 12 | 4 |
| `test_tile_arith_inplace` pto / dst=src1 / src0=src1 用例 | 20 | 4（4 ops × dst=src0 × ascendc） |
| `test_tile_arith_size_mismatch_src0` | 0 | 1 |
| `test_tile_arith_size_mismatch_region` | 0 | 1 |
| `test_tile_arith_buffer_size_unvalidated` pto 用例 | 1 | 1 |
| 合计 | 107 | 23 |

---

## 4. 校验过程中发现的问题

1. **sub/div 类型注解漏掉 `PrimExpr`**：`binary_op` 对 4 个算子走同一实现且均支持 scalar（`isinstance(src1, (PrimExpr, float, int))` 分支），但 sub/div 的签名注解只写 `Buffer | BufferRegion | BufferLoad` → 补全为与 add/mul 一致。

2. **div 的整数 dtype 实际全不可用**：AscendC `Div` static_assert 仅 half/float（dav_c220/kernel_operator_vec_binary_impl.h:179）。ascendc 的两个整数形式均编译失败；pto 的 tensor 形式编译失败、scalar/BufferLoad 形式可编译但结果错误 → 文档 dtype 表仅列 float16/float32，约束 8 注明整数 dtype 行为。

3. **scalar 除法是"乘倒数"而非真除**：`DivsOpcodegen`（codegen_ascend.cc:1844）生成 `AscendC::Muls(dst, src0, 1.0f/src1)`，2 的幂次除数精确，3 等除数有额外舍入 → 文档约束 9 与 docstring Notes 记录该精度语义。

4. **sub/div 的 BufferLoad×int 的 backend 差异**：`SubsOpCodegen`/`DivsOpcodegen` 对 BufferLoad 分支生成 `-(float)S.GetValue(i)` / `1.0f/(float)S.GetValue(i)`（float 标量），与 int16/int32 张量拼 `Adds`/`Muls` 无匹配重载 → ascendc 编译失败；pto 的 `BinaryVecOpsCodegen` 无该类型问题（sub 正确、div 结果错误）→ 文档按 backend 分列（sub 约束 8、div 约束 8），测试拆分为 pto 正确性用例 + ascendc 编译失败断言。

5. **src1 为 Buffer 时大小不校验**：`binary_op` 只对 dst vs src0、src1 为 BufferRegion 时做 `assert size`；src1 为 Buffer 时静默按 dst 大小计算（不报错）→ 文档约束 3 明确该行为，测试用例断言结果 = a + b[0:64]。

6. **2D 列偏移切片整体不可用**：`_handle_buffer_region` 将区域按扁平连续流解释（offset + prod(extent)），列偏移切片语义错误：偏移未对齐时 aicore 异常（507015），偏移 0 时静默算错 → 文档约束 6 明确仅支持整行/整 buffer 连续区域。

7. **多维 BufferLoad 只取第一个索引**：`binary_op` 传 `indices_1[0]`，`s_ub[1, 3]` 实际取 `s_ub[1]`（验证：结果与 a+`s[0,1]` 吻合）→ 文档约束 7 注明仅支持 1D 单索引。

8. **计数无 32 字节倍数要求**：n=8/16/100/232（16B~464B）在 ascends 计数模式（COUNTER mask）下全部正确 → 文档不写尾部对齐约束（与 Sort32/Compare 的 256B 对齐不同，后者有 codegen ICHECK）。

9. **原地别名（dst==src0、dst==src1、src0==src1）可用**：单独输出张量时 3 种别名 × 4 ops × 2 backend 全部正确（docstring 参数说明补充"may alias"；fused_sigmoid/flash_attn 等 example 的原地用法得到佐证）。

10. **初测"原地失败"实为测试 harness 现象**：当同一 GM 张量既作输入又作输出（`func(a.npu(), b.npu())`，B 标 out_idx）时，返回结果异常（输出 = a 或全 0，表现为 src1 读到 0）；改用独立输出张量后完全正确 → 非 API 缺陷，不属于 constraints（现有 example 均用独立输出张量），测试统一采用三张量签名。

11. **乘除笔误**：Programming Guide 表格 mul/div 行 "element-wise法乘"（应为乘法/除法）→ 修正。

### 4.1 质量复查补充记录（2026-08-17，审查文档交付后第二遍核对）

| # | 问题类型 | 问题 | 修正 |
|---|---------|------|------|
| 1 | 语义模糊 | 测试标量字面量在 int dtype 下被 torch 截断（0.5→0 等），意图与数据不符 | 按 dtype 分支生成整数列表；重跑 buffload/row_slice 42 用例通过 |
| 2 | 文档与源码一致性 | div docstring "integer dtypes fail to compile"：pto 的 scalar/BufferLoad 形式可编译但结果错误，仅 ascendc 全形式编译失败 | docstring 改为分后端描述 |
| 3 | 文档与源码一致性 | Programming Guide div "整数 dtype 编译失败"同上 | 改为"（整数 dtype 不支持）" |
| 4 | 界限不清 | div 除零描述"未定义"过于含糊 | 实测精确化：非零/0 → ±inf、**0/0 → +inf（非 IEEE NaN）**，两后端一致，写入中英文 2.2 |
| 5 | 验证方法 | 同进程 aicore 异常会污染后续用例，probe 首轮误报 int-scalar 失败 | 独立进程复验为 PASS；正式测试不受影响 |

**补充实证**：1D 切片 8B/16B 偏移 → 507015、32B → PASS（约束 5 成立）；int scalar 作用于 f16 自动转换 PASS；float scalar(2.5) 作用于 int16 截断为 2（两后端）。

---

## 6. 验证

- 约束测试：动态验证完成（真机 dav_c220/A2，见 2.1 表）
- 语言测试 `test_tilelang_ascend_language_tile_arith.py`：**130 PASSED**（全量单次运行 0:16:16，真机 dav_c220/A2；另分批运行各子集确认无累积异常）
- 语法检查：`ast.parse` 通过（ascend_tile.py、测试文件）
- ruff check：ascend_tile.py + 测试文件通过（B017 盲断言改为 `pytest.raises(RuntimeError)`，W292 补行尾换行）

