### PR TITLE
[Docs]: update gather docstring, add dtype coverage tests and API doc

### DIFF
--- a/docs/api_docs/T.tile.gather.md
+++ b/docs/api_docs/T.tile.gather.md
@@ -1,0 +1,79 @@
+# T.tile.gather
+
+## 1. 功能说明
+
+根据字节地址偏移从源 buffer 中按元素收集到目的 buffer：`dst[i] = src[(src_base_addr + src_offset[i]) / sizeof(dtype)]`，其中 src_base_addr 和 src_offset 的单位均为字节（Bytes），需除以元素字节大小转换为元素下标。src_base_addr 必须按元素宽度对齐。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def gather(
+    dst: Buffer | BufferRegion,
+    src: Buffer | BufferRegion,
+    src_offset: Buffer | BufferRegion,
+    src_base_addr: PrimExpr,
+    *,
+    tmp: Buffer | BufferRegion | None = None,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 收集结果的存放位置 | 张量（tensor） | 必填 |
+| src | 输入 | 源数据表 | 张量（tensor） | 必填 |
+| src_offset | 输入 | 每个元素在 src 中对应的字节地址偏移 | 张量（tensor） | 必填 |
+| src_base_addr | 输入 | src 的起始基地址偏移，单位为字节（Bytes） | 整数 | 必填 |
+| tmp | 输入 | 可选的 UB 临时缓冲区，由 lowering 重解释 dtype，无语义意义 | 张量（tensor） | 可选 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src | src_offset |
+|------|:---:|:---:|:----------:|
+| Ascend A2 / A3 | float16, float32, bfloat16, int16, uint16, int32, uint32 | 同 dst | uint32 |
+
+#### 2.3.2 Shape 支持
+
+- 无限制，支持任意维度
+- pto 后端要求处理元素数 ≥ 512
+
+### 2.4 约束条件
+
+1. dst 与 src 的 dtype 必须相同
+2. src_offset 的 dtype 必须为 uint32
+3. count（处理元素个数）由 `min(dst_size, offset_size)` 自动推导，dst 至少需容纳 count 个元素
+4. src_offset 中的偏移值必须保证 src 元素类型位宽对齐（如 float16 需 2 字节对齐，float32 需 4 字节对齐）（硬件约束）
+5. src_base_addr 必须按元素宽度对齐（如 float16 需 2 字节对齐，float32 需 4 字节对齐）
+6. 偏移后的地址不能超出 src 的 buffer 范围（硬件约束）
+7. 所有操作数地址需 32 字节对齐（硬件约束）
+8. A2/A3 平台：src_offset 中的地址偏移不能超出 uint32_t 的范围（硬件约束）
+
+> **pto 后端限制**：`src_base_addr` 参数在 pto 后端被忽略（codegen 假定为 0），非零 `src_base_addr` 仅在 ascendc 后端生效。
+
+## 3. 示例代码
+
+**示例 1：基本 gather（逆序收集）**
+
+```python
+x_ub = T.alloc_ub((128,), "float16")
+offset_ub = T.alloc_ub((128,), "uint32")
+dst_ub = T.alloc_ub((128,), "float16")
+T.tile.gather(dst_ub, x_ub, offset_ub, 0)
+```
+
+**示例 2：带基地址偏移的 gather**
+
+```python
+table_ub = T.alloc_ub((512,), "float16")
+offset_ub = T.alloc_ub((128,), "uint32")
+dst_ub = T.alloc_ub((128,), "float16")
+T.tile.gather(dst_ub, table_ub, offset_ub, 64)
+```

--- a/testing/python/language/test_tilelang_ascend_language_tile_gather_dtype_coverage.py
+++ b/testing/python/language/test_tilelang_ascend_language_tile_gather_dtype_coverage.py
@@ -1,0 +1,161 @@
+"""
+T.tile.gather dtype coverage tests.
+
+Existing coverage in test_tilelang_ascend_language_elementwise.py:
+- int16/int32/uint16/uint32/float/float16/bfloat16 x ascendc/pto x 2D (128, 1024),
+  src_base_addr=0 (test_gather)
+- 2D BufferRegion (slice) path x ascendc (test_gather_slice)
+- 2D larger src x ascendc (test_gather_larger_src)
+- tmp parameter (test_tilelang_ascend_language_explicit_tmp.py)
+
+This file supplements with:
+1. Non-zero src_base_addr test (float32 x ascendc, base=64)
+   - ftcheck example 2; pto ignores base_addr (documented limitation)
+2. Exception boundary tests (constraint violations)
+   - dst != src dtype (constraint 1)
+   - src_offset != uint32 (constraint 2, ascendc enforces)
+
+dtype x backend support matrix (verified on real hardware):
+| dtype    | ascendc | pto  |
+|----------|---------|------|
+| float16  | PASS    | PASS |
+| float32  | PASS    | PASS |
+| bfloat16 | PASS    | PASS |
+| int16    | PASS    | PASS |
+| uint16   | PASS    | PASS |
+| int32    | PASS    | PASS |
+| uint32   | PASS    | PASS |
+| int8     | FAIL*   | FAIL |
+| uint8    | FAIL*   | FAIL |
+
+* int8/uint8 on ascendc: compile passes but result incorrect (silent failure)
+
+Main table (both backends): float16, float32, bfloat16, int16, uint16, int32, uint32
+No single-backend dtypes.
+
+Known PTO limitations (documented in docs/api_docs/T.tile.gather.md):
+- src_base_addr is ignored (codegen assumes 0)
+- Minimum 512 elements required (PTO backend bug, not a design constraint)
+"""
+
+import pytest
+import tilelang
+import tilelang.language as T
+import torch
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _disable_cache():
+    tilelang.disable_cache()
+    yield
+    tilelang.enable_cache()
+
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+def make_gather_baseaddr_kernel(n_src, n, dtype, base_addr):
+    @T.prim_func
+    def main(
+        A: T.Tensor((n_src,), dtype),  # type: ignore
+        B: T.Tensor((n,), "uint32"),  # type: ignore
+        C: T.Tensor((n,), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((n_src,), dtype)
+            b_ub = T.alloc_ub((n,), "uint32")
+            c_ub = T.alloc_ub((n,), dtype)
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            T.tile.gather(c_ub, a_ub, b_ub, base_addr)
+            T.copy(c_ub, C)
+
+    return main
+
+
+def golden_gather(a_cpu, b_int32, elem_size, base_addr=0):
+    # gather semantics: dst[i] = src[(base_addr + b[i]) / elem_size]  (flat indexing)
+    idx = (b_int32 + base_addr) // elem_size
+    return a_cpu[idx.long()]
+
+
+def test_gather_base_addr():
+    """Non-zero src_base_addr (ftcheck example 2).
+
+    ascendc applies base_addr; pto ignores it (documented limitation), so only
+    tested on ascendc.
+    """
+    dtype = "float32"
+    elem_size = 4
+    n_src = 1024
+    n = 512
+    base_addr = 64  # 64 bytes = 16 float32 elements
+
+    a = torch.arange(n_src, dtype=torch.float32).npu()
+    offsets_i32 = torch.arange(0, elem_size * n, elem_size, dtype=torch.int32)
+    perm = torch.randperm(n)
+    b = offsets_i32[perm].to(torch.uint32).npu()
+
+    ref = golden_gather(a.cpu(), offsets_i32[perm], elem_size, base_addr).npu()
+
+    kernel = make_gather_baseaddr_kernel(n_src, n, dtype, base_addr)
+    func = tilelang.compile(kernel, out_idx=[-1], pass_configs=PASS_CONFIGS, target="ascendc")
+
+    torch.npu.synchronize()
+    c = func(a, b)
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(c, ref, rtol=1e-2, atol=1e-2)
+
+
+def test_gather_dtype_mismatch_raises():
+    """Constraint 1: dst and src must have the same dtype."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((128,), "float32"),  # type: ignore
+        B: T.Tensor((128,), "uint32"),  # type: ignore
+        C: T.Tensor((128,), "float16"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((128,), "float32")
+            b_ub = T.alloc_ub((128,), "uint32")
+            c_ub = T.alloc_ub((128,), "float16")
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            T.tile.gather(c_ub, a_ub, b_ub, 0)
+            T.copy(c_ub, C)
+
+    with pytest.raises(RuntimeError, match="Compilation Failed"):  # noqa: B017
+        tilelang.compile(main, out_idx=[-1], pass_configs=PASS_CONFIGS, target="ascendc")
+
+
+def test_gather_offset_dtype_raises():
+    """Constraint 2: src_offset must be uint32 (enforced on ascendc)."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((128,), "float32"),  # type: ignore
+        B: T.Tensor((128,), "int32"),  # type: ignore
+        C: T.Tensor((128,), "float32"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((128,), "float32")
+            b_ub = T.alloc_ub((128,), "int32")
+            c_ub = T.alloc_ub((128,), "float32")
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            T.tile.gather(c_ub, a_ub, b_ub, 0)
+            T.copy(c_ub, C)
+
+    with pytest.raises(RuntimeError, match="Compilation Failed"):  # noqa: B017
+        tilelang.compile(main, out_idx=[-1], pass_configs=PASS_CONFIGS, target="ascendc")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-n", "8"])

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1672,14 +1672,25 @@ def gather(
 
     This intrinsic gathers elements from the source buffer based on the provided
     offsets and a base address, storing the result in the destination buffer.
+    Both ``src_base_addr`` and the values in ``src_offset`` are byte offsets;
+    the effective element index is ``(src_base_addr + src_offset[i]) /
+    elem_size``. The element count is derived from ``min(dst_size,
+    offset_size)``.
 
     Args:
         dst: The destination buffer where the gathered data will be stored.
-        src: The source buffer containing the data table.
+            Supports float16, float32, bfloat16, int16, uint16, int32, uint32
+            on both ascendc and pto backends.
+        src: The source buffer containing the data table. Must have the same
+            dtype as dst.
         src_offset: The buffer containing offsets/indices for gathering.
+            Must be uint32.
         src_base_addr: The base address offset to be added to the gather indices.
         tmp: Optional complete UB scratch storage. Its scalar dtype is
             reinterpreted by lowering and has no semantic meaning.
+
+    Returns:
+        tvm.tir.Call: A TIR intrinsic call to `tl.ascend_gather`.
     """
     if isinstance(dst, BufferRegion):
         dst_ptr, dst_extent = _handle_buffer_region(dst, "w")


### PR DESCRIPTION
## 改动内容

针对 `T.tile.gather` API 完成文档校验、测试用例补充和 docstring 更新。

### 1. Docstring 更新（修改）
- `tilelang/language/ascend_tile.py` 中 `gather` 函数的 docstring
- 在原版基础上补充，不删除原有内容：
  - 字节偏移语义说明（src_base_addr 与 src_offset 均为字节单位）
  - count 推导公式 `min(dst_size, offset_size)`
  - dst/src dtype 支持（float16/float32/bfloat16/int16/uint16/int32/uint32，两后端均支持）
  - src_offset 必须为 uint32
  - Returns 字段补全（`tvm.tir.Call`）

### 2. 测试用例（新增）
- `testing/python/language/test_tilelang_ascend_language_tile_gather_dtype_coverage.py`
- **3 个用例**（3 PASSED + 0 SKIPPED），不重复 elementwise.py 中已有的测试
- LP 分层标记：PR 合入时跑 3 个，每日 CI 跑 3 个（全 default，无 LP）

| 测试函数 | 用例数 | PR执行 | LP | 覆盖内容 |
|---------|:---:|:---:|:---:|---------|
| test_gather_base_addr | 1 | 1 | 0 | 非零 src_base_addr（base=64）× float32 × ascendc（ftcheck 示例 2） |
| test_gather_dtype_mismatch_raises | 1 | 1 | 0 | dst≠src dtype 编译失败（约束 1） |
| test_gather_offset_dtype_raises | 1 | 1 | 0 | src_offset≠uint32 编译失败（约束 2，ascendc） |
| **合计** | **3** | **3** | **0** | |

> 仓库已有 `test_gather`（elementwise.py）覆盖 2D × 7 dtype × ascendc/pto × base=0（14 用例）+ slice/larger_src/tmp 路径，不重复。1D 与 2D 走相同 codegen 路径（`math.prod` 展平），按去重规则不添加 1D 测试。

LP 标记策略（参照 mentor 的 tail_block PR + createvecindex 惯例）：
- 异常边界测试：全部默认执行（用例少，关键覆盖）
- 无 dtype/target 参数化测试（仓库已覆盖全量 dtype × target）

### 3. API 文档（新增）
- `docs/api_docs/T.tile.gather.md`：校验完成版 API 说明文档
- 相对 ftcheck 的补充：函数原型补全 tmp 可选参数、Shape 支持补充 pto ≥512 元素限制、约束条件补充 pto 忽略 base_addr 说明

## 测试结果
- **3 PASSED + 0 SKIPPED + 0 FAILED**（CI 全绿）

## 真机验证的 dtype × backend 支持矩阵

| dtype | ascendc | pto | 备注 |
|-------|:---:|:---:|------|
| float16 | ✅ | ✅ | 主表 |
| float32 | ✅ | ✅ | 主表 |
| bfloat16 | ✅ | ✅ | 主表 |
| int16 | ✅ | ✅ | 主表 |
| uint16 | ✅ | ✅ | 主表 |
| int32 | ✅ | ✅ | 主表 |
| uint32 | ✅ | ✅ | 主表 |

> 全部 7 个 dtype 两后端均支持，无单后端 dtype。现有 `test_gather`（elementwise.py）已覆盖 2D × 全量 dtype × 两后端。

## 已知限制（文档约束已写明）

| 限制 | 文档位置 | 说明 |
|------|---------|------|
| pto 忽略 src_base_addr | 约束条件后说明 | codegen 假定 base=0，非零 base_addr 仅 ascendc 生效 |
| pto N<512 静默失败 | Shape 支持 | PTO 后端 bug（非设计约束），N<512 时仅首元素正确；文档要求 pto 后端元素数 ≥ 512 |
| int8/uint8 ascendc 静默失败 | 不提（表格不列即为不支持） | 编译通过但结果错误，两后端均不正常 |

## 校验过程中发现的 bug

详细根因分析记录在 `api/bug_investigation/gather_bug.md`。

| # | Bug | 根因 | 影响范围 | 当前处理 | pto 是否受影响 |
|---|-----|------|---------|---------|:---:|
| 1 | int8/uint8 ascendc 静默失败 | static_assert SupportBytes 按 sizeof 判断，1 字节类型通过但指令语义不正确 | 不支持的 dtype（int8/uint8） | 不提（表格不列） | 否（pto 编译失败） |
| 2 | pto N<512 静默失败 | `TGather.hpp` 的 `vgather repeat=1` 未适配 `Cols < SFractalSize(512)` 的子分形 tile | pto 后端 N<512 的 gather | 文档要求 pto 元素数 ≥ 512；测试用 N=1024 规避 | 是 |

### 后续待办

| 优先级 | Bug | 待办 |
|--------|-----|------|
| 低 | int8/uint8 ascendc 静默失败 | AscendC::Gather static_assert 排除 1 字节类型 |
| 中 | pto N<512 静默失败 | 确认 `vgather` 在子分形 tile 上的确切行为（需 CCE 指令手册）；修复 `TGather.hpp` 对 `Cols < 512` 的处理 |
