### PR TITLE
[Doc] Ascend: refine T.tile.max/min docstring, add test cases and API documentation

### DIFF
--- a/docs/language/tile_max.md
+++ b/docs/language/tile_max.md
@@ -44,17 +44,17 @@ def max(
 
 - 支持 1D 和 2D
 - 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
-- 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
+- 更高维 buffer 需通过切片降维为 1D/2D 的切片传入
 
 ### 2.4 约束条件
 
 1. dst 与 src0 的大小必须一致（Python 断言，报错信息 "size must be same"）
-2. src1 为 BufferRegion 时，其大小必须与 dst 一致（Python 断言）
+2. src1 为切片（BufferRegion）时，其大小必须与 dst 一致（Python 断言）
 3. src1 为 Buffer 时大小不做校验：小于 dst 时产生越界读取，大于 dst 时仅前 dst 大小个元素参与运算（不报错）
 4. dst、src0、src1（tensor 形式）的 dtype 必须一致；dtype 不一致会在编译期报错
 5. 操作数地址需 32 字节对齐（硬件约束）
 6. 仅支持整行/整 buffer 的连续区域；2D 列偏移切片（如 `buf[0, 8:40]`）会产生错误结果或触发 aicore 异常（507015），不支持
-7. src1 为 BufferLoad 时仅支持 1D 单索引（如 `buf[i]`）；多维 BufferLoad 只取第一个索引，结果错误（当前未校验）
+7. src1 为 buffer 元素访问时仅支持 1D 单索引（如 `buf[i]`）；多维元素访问只取第一个索引，结果错误（实测行为，两后端一致）
 
 ## 3. 示例代码
 

--- a/docs/language/tile_max.md
+++ b/docs/language/tile_max.md
@@ -1,0 +1,92 @@
+# T.tile.max
+
+## 1. 功能说明
+
+对两个操作数逐元素执行最大值运算：`dst[i] = max(src0[i], src1[i])`
+
+> **注意**：本 API 是逐元素极值运算，与归约类 API（`T.reduce_max`）不同。归约类沿指定维度压缩，本组逐元素比较两个同 shape 输入。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def max(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion | BufferLoad | PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二个源操作数，支持 tensor、buffer 单元素（BufferLoad）或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 buffer 元素访问（BufferLoad，仅支持 1D 单索引）或 Python 标量/表达式（PrimExpr）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | float16, float32, int16, int32 | float16, float32, int16, int32 | 同 dst |
+
+- src1 为 tensor 时，dtype 必须与 dst 一致；src1 为 scalar 时自动转换为 buffer 的 dtype
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
+- 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
+
+#### 2.3.3 src1 形式说明
+
+| src1 形式 | 底层实现 | 说明 |
+|-----------|---------|------|
+| tensor（Buffer/BufferRegion） | `AscendC::Max` | 逐元素取最大，dst/src0/src1 大小须一致 |
+| scalar（PrimExpr/float/int） | `AscendC::Maxs` | dst[i] = max(src0[i], 标量)，标量自动转换为 buffer dtype |
+| BufferLoad（1D 单元素） | `AscendC::Maxs`（`GetValue(index)` 取标量） | dst[i] = max(src0[i], buffer[index]) |
+
+### 2.4 约束条件
+
+1. dst 与 src0 的大小必须一致（Python 断言，报错信息 "size must be same"）
+2. src1 为 BufferRegion 时，其大小必须与 dst 一致（Python 断言）
+3. src1 为 Buffer 时大小不做校验：小于 dst 时产生越界读取，大于 dst 时仅前 dst 大小个元素参与运算（不报错）
+4. dst、src0、src1（tensor 形式）的 dtype 必须一致；dtype 不一致会在编译期报错
+5. 操作数地址需 32 字节对齐（硬件约束）
+6. 仅支持整行/整 buffer 的连续区域；2D 列偏移切片（如 `buf[0, 8:40]`）会产生错误结果或触发 aicore 异常（507015），不支持
+7. src1 为 BufferLoad 时仅支持 1D 单索引（如 `buf[i]`）；多维 BufferLoad 只取第一个索引，结果错误（当前未校验）
+
+## 3. 示例代码
+
+**示例 1：tensor-tensor 最大值**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+src1 = T.alloc_ub((256,), "float16")
+dst  = T.alloc_ub((256,), "float16")
+T.tile.max(dst, src0, src1)
+```
+
+**示例 2：tensor-scalar 最大值（ReLU 风格）**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst  = T.alloc_ub((256,), "float16")
+T.tile.max(dst, src0, 0.0)  # dst[i] = max(src0[i], 0.0)
+```
+
+**示例 3：tensor-tensor 原地运算（在线 Softmax 滚动最大值模式）**
+
+```python
+m_i = T.alloc_ub((128,), "float16")
+m_prev = T.alloc_ub((128,), "float16")
+T.tile.max(m_i, m_i, m_prev)  # dst 与 src0 为同一 buffer（原地），m_i = max(m_i, m_prev)
+```

--- a/docs/language/tile_max.md
+++ b/docs/language/tile_max.md
@@ -24,7 +24,7 @@ def max(
 |--------|----------|------|------|----------|
 | dst | 输出 | 存放运算结果 | 张量（tensor） | 必填 |
 | src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
-| src1 | 输入 | 第二个源操作数，支持 tensor、buffer 单元素（BufferLoad）或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+| src1 | 输入 | 第二个源操作数，支持 tensor 或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
 
 > **类型说明**：
 > - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
@@ -45,14 +45,6 @@ def max(
 - 支持 1D 和 2D
 - 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
 - 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
-
-#### 2.3.3 src1 形式说明
-
-| src1 形式 | 底层实现 | 说明 |
-|-----------|---------|------|
-| tensor（Buffer/BufferRegion） | `AscendC::Max` | 逐元素取最大，dst/src0/src1 大小须一致 |
-| scalar（PrimExpr/float/int） | `AscendC::Maxs` | dst[i] = max(src0[i], 标量)，标量自动转换为 buffer dtype |
-| BufferLoad（1D 单元素） | `AscendC::Maxs`（`GetValue(index)` 取标量） | dst[i] = max(src0[i], buffer[index]) |
 
 ### 2.4 约束条件
 

--- a/docs/language/tile_min.md
+++ b/docs/language/tile_min.md
@@ -24,7 +24,7 @@ def min(
 |--------|----------|------|------|----------|
 | dst | 输出 | 存放运算结果 | 张量（tensor） | 必填 |
 | src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
-| src1 | 输入 | 第二个源操作数，支持 tensor、buffer 单元素（BufferLoad）或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+| src1 | 输入 | 第二个源操作数，支持 tensor 或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
 
 > **类型说明**：
 > - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
@@ -45,14 +45,6 @@ def min(
 - 支持 1D 和 2D
 - 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
 - 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
-
-#### 2.3.3 src1 形式说明
-
-| src1 形式 | 底层实现 | 说明 |
-|-----------|---------|------|
-| tensor（Buffer/BufferRegion） | `AscendC::Min` | 逐元素取最小，dst/src0/src1 大小须一致 |
-| scalar（PrimExpr/float/int） | `AscendC::Mins` | dst[i] = min(src0[i], 标量)，标量自动转换为 buffer dtype |
-| BufferLoad（1D 单元素） | `AscendC::Mins`（`GetValue(index)` 取标量） | dst[i] = min(src0[i], buffer[index]) |
 
 ### 2.4 约束条件
 

--- a/docs/language/tile_min.md
+++ b/docs/language/tile_min.md
@@ -44,17 +44,17 @@ def min(
 
 - 支持 1D 和 2D
 - 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
-- 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
+- 更高维 buffer 需通过切片降维为 1D/2D 的切片传入
 
 ### 2.4 约束条件
 
 1. dst 与 src0 的大小必须一致（Python 断言，报错信息 "size must be same"）
-2. src1 为 BufferRegion 时，其大小必须与 dst 一致（Python 断言）
+2. src1 为切片（BufferRegion）时，其大小必须与 dst 一致（Python 断言）
 3. src1 为 Buffer 时大小不做校验：小于 dst 时产生越界读取，大于 dst 时仅前 dst 大小个元素参与运算（不报错）
 4. dst、src0、src1（tensor 形式）的 dtype 必须一致；dtype 不一致会在编译期报错
 5. 操作数地址需 32 字节对齐（硬件约束）
 6. 仅支持整行/整 buffer 的连续区域；2D 列偏移切片（如 `buf[0, 8:40]`）会产生错误结果或触发 aicore 异常（507015），不支持
-7. src1 为 BufferLoad 时仅支持 1D 单索引（如 `buf[i]`）；多维 BufferLoad 只取第一个索引，结果错误（当前未校验）
+7. src1 为 buffer 元素访问时仅支持 1D 单索引（如 `buf[i]`）；多维元素访问只取第一个索引，结果错误（实测行为，两后端一致）
 
 ## 3. 示例代码
 

--- a/docs/language/tile_min.md
+++ b/docs/language/tile_min.md
@@ -1,0 +1,92 @@
+# T.tile.min
+
+## 1. 功能说明
+
+对两个操作数逐元素执行最小值运算：`dst[i] = min(src0[i], src1[i])`
+
+> **注意**：本 API 是逐元素极值运算，与归约类 API（`T.reduce_min`）不同。归约类沿指定维度压缩，本组逐元素比较两个同 shape 输入。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def min(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion | BufferLoad | PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二个源操作数，支持 tensor、buffer 单元素（BufferLoad）或 scalar | 张量（tensor）/ 标量（scalar） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 buffer 元素访问（BufferLoad，仅支持 1D 单索引）或 Python 标量/表达式（PrimExpr）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | float16, float32, int16, int32 | float16, float32, int16, int32 | 同 dst |
+
+- src1 为 tensor 时，dtype 必须与 dst 一致；src1 为 scalar 时自动转换为 buffer 的 dtype
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- 支持整行切片（如 `buf[2, :]`）及覆盖完整最后一维的连续多行区域（如 `buf[0:2, :]`）
+- 更高维 buffer 需通过切片降维为 1D/2D 的 BufferRegion 传入
+
+#### 2.3.3 src1 形式说明
+
+| src1 形式 | 底层实现 | 说明 |
+|-----------|---------|------|
+| tensor（Buffer/BufferRegion） | `AscendC::Min` | 逐元素取最小，dst/src0/src1 大小须一致 |
+| scalar（PrimExpr/float/int） | `AscendC::Mins` | dst[i] = min(src0[i], 标量)，标量自动转换为 buffer dtype |
+| BufferLoad（1D 单元素） | `AscendC::Mins`（`GetValue(index)` 取标量） | dst[i] = min(src0[i], buffer[index]) |
+
+### 2.4 约束条件
+
+1. dst 与 src0 的大小必须一致（Python 断言，报错信息 "size must be same"）
+2. src1 为 BufferRegion 时，其大小必须与 dst 一致（Python 断言）
+3. src1 为 Buffer 时大小不做校验：小于 dst 时产生越界读取，大于 dst 时仅前 dst 大小个元素参与运算（不报错）
+4. dst、src0、src1（tensor 形式）的 dtype 必须一致；dtype 不一致会在编译期报错
+5. 操作数地址需 32 字节对齐（硬件约束）
+6. 仅支持整行/整 buffer 的连续区域；2D 列偏移切片（如 `buf[0, 8:40]`）会产生错误结果或触发 aicore 异常（507015），不支持
+7. src1 为 BufferLoad 时仅支持 1D 单索引（如 `buf[i]`）；多维 BufferLoad 只取第一个索引，结果错误（当前未校验）
+
+## 3. 示例代码
+
+**示例 1：tensor-tensor 最小值**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+src1 = T.alloc_ub((256,), "float16")
+dst  = T.alloc_ub((256,), "float16")
+T.tile.min(dst, src0, src1)
+```
+
+**示例 2：tensor-scalar 最小值**
+
+```python
+src0 = T.alloc_ub((256,), "float16")
+dst  = T.alloc_ub((256,), "float16")
+T.tile.min(dst, src0, 0.0)  # dst[i] = min(src0[i], 0.0)
+```
+
+**示例 3：tensor-tensor 原地运算**
+
+```python
+m_i = T.alloc_ub((128,), "float16")
+m_prev = T.alloc_ub((128,), "float16")
+T.tile.min(m_i, m_i, m_prev)  # dst 与 src0 为同一 buffer（原地），m_i = min(m_i, m_prev)
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,15 @@ skip = [
 ]
 
 [tool.pytest.ini_options]
+pythonpath = ["testing/python", "."]
+testpaths = ["testing"]
 markers = [
     "low_priority: marks tests as low priority (only run in full test and scheduled tasks)",
     "ci_skip: marks tests to be skipped in all CI test scenarios",
+    "l0: Gate test — must pass to merge",
+    "l1: Functional test — must pass to merge",
+    "l2: Boundary/exception test — recommended",
+    "compile_time: Compile-time test, no NPU needed",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,6 @@ testpaths = ["testing"]
 markers = [
     "low_priority: marks tests as low priority (only run in full test and scheduled tasks)",
     "ci_skip: marks tests to be skipped in all CI test scenarios",
-    "l0: Gate test — must pass to merge",
-    "l1: Functional test — must pass to merge",
-    "l2: Boundary/exception test — recommended",
-    "compile_time: Compile-time test, no NPU needed",
 ]
 
 [tool.ruff]

--- a/testing/python/base/__init__.py
+++ b/testing/python/base/__init__.py
@@ -1,0 +1,41 @@
+"""
+Base test infrastructure for TileLang-Ascend API tests.
+
+Usage:
+    from base import BinaryOpSpec, register_binary_op_tests
+    from base import UnaryOpSpec, register_unary_op_tests
+    from base import TOLERANCE, DTYPE_MAP, assert_close_npu, make_test_data
+"""
+
+from base.common import (
+    TOLERANCE as TOLERANCE,
+    DTYPE_MAP as DTYPE_MAP,
+    DEFAULT_PASS_CONFIGS as DEFAULT_PASS_CONFIGS,
+    assert_close_npu as assert_close_npu,
+    make_test_data as make_test_data,
+    skip_if_missing as skip_if_missing,
+)
+
+from base.binary_op import (
+    BinaryOpSpec as BinaryOpSpec,
+    BinaryOpTestClasses as BinaryOpTestClasses,
+    register_binary_op_tests as register_binary_op_tests,
+    make_binary_kernel as make_binary_kernel,
+    make_1d_kernel as make_1d_kernel,
+    make_scalar_kernel as make_scalar_kernel,
+    make_buffload_kernel as make_buffload_kernel,
+    make_row_slice_kernel as make_row_slice_kernel,
+    make_inplace_kernel as make_inplace_kernel,
+    make_src0_mismatch_kernel as make_src0_mismatch_kernel,
+    make_region_mismatch_kernel as make_region_mismatch_kernel,
+    make_buffer_mismatch_kernel as make_buffer_mismatch_kernel,
+    run_binary_op as run_binary_op,
+)
+
+from base.unary_op import (
+    UnaryOpSpec as UnaryOpSpec,
+    UnaryOpTestClasses as UnaryOpTestClasses,
+    register_unary_op_tests as register_unary_op_tests,
+    make_unary_kernel as make_unary_kernel,
+    run_unary_op as run_unary_op,
+)

--- a/testing/python/base/binary_op.py
+++ b/testing/python/base/binary_op.py
@@ -116,6 +116,48 @@ def make_buffload_kernel(tile_op):
     return kernel
 
 
+def make_multidim_buffload_kernel(tile_op):
+    """Factory: multi-dimensional buffer-element scalar (S[1, 3]).
+
+    The front-end only uses the first index (flat index 1), which is what
+    constraint 7 documents — this kernel pins that behavior on hardware.
+    """
+
+    def kernel(M, N, dtype="float"):
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, N), dtype),  # type: ignore
+            S: T.Tensor((2, 8), dtype),  # type: ignore
+            C: T.Tensor((M, N), dtype),  # type: ignore
+        ):
+            with T.Kernel(1, is_npu=True) as (cid, _):
+                a_ub = T.alloc_ub((M, N), dtype)
+                s_ub = T.alloc_ub((2, 8), dtype)
+                c_ub = T.alloc_ub((M, N), dtype)
+                T.copy(A, a_ub)
+                T.copy(S, s_ub)
+                tile_op(c_ub, a_ub, s_ub[1, 3])
+                T.copy(c_ub, C)
+
+        return main
+
+    return kernel
+
+
+def run_multidim_buffload_op(kernel_factory, M, N, dtype, target, golden_fn):
+    """Multi-dim element access: result must equal golden(a, S.flat[1]) —
+    only the first index participates (constraint 7)."""
+    func = kernel_factory(M, N, dtype=dtype)
+    compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+    torch.manual_seed(0)
+    a = make_test_data((M, N), dtype, device="cpu")
+    s = torch.randn(2, 8, dtype=DTYPE_MAP[dtype])
+    torch.npu.synchronize()
+    b = compiled(a.npu(), s.npu())
+    torch.npu.synchronize()
+    assert_close_npu(b.cpu(), golden_fn(a, s.view(-1)[1]), dtype)
+
+
 def make_row_slice_kernel(tile_op):
     """Factory: 2D whole-row slice regions with a per-row BufferLoad scalar."""
 
@@ -299,6 +341,7 @@ class BinaryOpSpec:
         kernel_1d=None,
         kernel_buffload=None,
         kernel_row_slice=None,
+        kernel_multidim_buffload=None,
         mismatch_kernels=None,
         low_priority_dtypes=None,
     ):
@@ -318,6 +361,7 @@ class BinaryOpSpec:
         self.kernel_1d = kernel_1d or None
         self.kernel_buffload = kernel_buffload or None
         self.kernel_row_slice = kernel_row_slice or None
+        self.kernel_multidim_buffload = kernel_multidim_buffload or None
         # Size-validation kernels (constraint 1/2/3 checks); None -> disabled.
         self.mismatch_kernels = mismatch_kernels or None
 
@@ -577,6 +621,14 @@ class _BinaryOpBoundary:
             target,
             golden_fn=self.op.golden,
         )
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_multidim_buffload_takes_first_index(self, dtype, target):
+        """Multi-dim element access (S[1,3]) only uses the first index —
+        result equals golden(a, S.flatten()[1]) (constraint 7)."""
+        skip_if_missing(self.op, "kernel_multidim_buffload")
+        run_multidim_buffload_op(self.op.kernel_multidim_buffload, 64, 128, dtype, target, golden_fn=self.op.golden)
 
     @pytest.mark.l2
     def test_size_mismatch_src0(self):

--- a/testing/python/base/binary_op.py
+++ b/testing/python/base/binary_op.py
@@ -368,23 +368,20 @@ class BinaryOpSpec:
     def scalar_golden(self, a, scalar, dtype):
         if dtype in ("int16", "int32"):
             scalar = int(scalar)
-        return self.golden(a, scalar)
+        return self.golden(a, torch.full_like(a, scalar))
 
 
-@pytest.mark.compile_time
 @pytest.mark.usefixtures("disable_tilelang_cache", "random_seed")
 class _BinaryOpCompile:
     op = None
     _dtype_source = "supported_dtypes"
 
-    @pytest.mark.l0
     def test_compiles(self, dtype):
         skip_if_missing(self.op, "kernel_tensor")
         func = self.op.kernel_tensor(128, 128, 64, 64, dtype)
         compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target="ascendc")
         assert callable(compiled)
 
-    @pytest.mark.l0
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_compiles_both_targets(self, target):
         skip_if_missing(self.op, "kernel_tensor")
@@ -392,14 +389,12 @@ class _BinaryOpCompile:
         compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
         assert callable(compiled)
 
-    @pytest.mark.l0
     def test_scalar_variant_compiles(self):
         skip_if_missing(self.op, "kernel_scalar")
         func = self.op.kernel_scalar(128, 128, 64, 64, 1.0, self.op.supported_dtypes[0])
         compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target="ascendc")
         assert callable(compiled)
 
-    @pytest.mark.l1
     @pytest.mark.parametrize("shape", [(64, 64), (128, 256), (256, 128)])
     def test_various_shapes_compile(self, shape):
         skip_if_missing(self.op, "kernel_tensor")
@@ -414,7 +409,6 @@ class _BinaryOpE2E:
     op = None
     _dtype_source = "supported_dtypes"
 
-    @pytest.mark.l0
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_basic_1024x1024(self, dtype, target):
         skip_if_missing(self.op, "kernel_tensor")
@@ -429,7 +423,6 @@ class _BinaryOpE2E:
             golden_fn=self.op.golden,
         )
 
-    @pytest.mark.l1
     @pytest.mark.parametrize(
         "M,N,block_M,block_N",
         [
@@ -453,7 +446,6 @@ class _BinaryOpE2E:
             golden_fn=self.op.golden,
         )
 
-    @pytest.mark.l1
     @pytest.mark.parametrize("M,N", [(100, 200), (107, 145), (255, 513)])
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_tail_blocks(self, M, N, dtype, target):
@@ -479,14 +471,12 @@ class _BinaryOpE2E:
             golden_fn=self.op.golden,
         )
 
-    @pytest.mark.l1
     @pytest.mark.parametrize("N", [256])
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_1d(self, N, dtype, target):
         skip_if_missing(self.op, "kernel_1d")
         run_1d_op(self.op.kernel_1d, N, dtype, target, golden_fn=self.op.golden)
 
-    @pytest.mark.l1
     @pytest.mark.parametrize("scalar_val", [2.0])
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_tensor_op_scalar(self, scalar_val, dtype, target):
@@ -504,19 +494,16 @@ class _BinaryOpE2E:
             golden_fn=self.op.scalar_golden,
         )
 
-    @pytest.mark.l1
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_buffload(self, dtype, target):
         skip_if_missing(self.op, "kernel_buffload")
         run_buffload_op(self.op.kernel_buffload, 64, 128, 8, dtype, target, golden_fn=self.op.golden)
 
-    @pytest.mark.l1
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_row_slice_2d(self, dtype, target):
         skip_if_missing(self.op, "kernel_row_slice")
         run_row_slice_op(self.op.kernel_row_slice, 4, 128, 4, dtype, target, golden_fn=self.op.golden)
 
-    @pytest.mark.l1
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_inplace(self, dtype, target):
         skip_if_missing(self.op, "kernel_inplace")
@@ -534,7 +521,7 @@ class _BinaryOpBoundary:
     op = None
     _dtype_source = "boundary_dtypes"
 
-    @pytest.mark.l2
+    @pytest.mark.low_priority
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_large_values(self, dtype, target):
         skip_if_missing(self.op, "kernel_tensor")
@@ -551,7 +538,7 @@ class _BinaryOpBoundary:
         c = compiled(a, b)
         assert c.shape == (256, 256)
 
-    @pytest.mark.l2
+    @pytest.mark.low_priority
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_zeros(self, dtype, target):
         skip_if_missing(self.op, "kernel_tensor")
@@ -564,7 +551,7 @@ class _BinaryOpBoundary:
         c = compiled(a, b)
         assert_close_npu(c, torch.zeros_like(a), dtype)
 
-    @pytest.mark.l2
+    @pytest.mark.low_priority
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_negative_values(self, dtype, target):
         skip_if_missing(self.op, "kernel_tensor")
@@ -577,7 +564,7 @@ class _BinaryOpBoundary:
         c = compiled(a, b)
         assert_close_npu(c, self.op.golden(a, b), dtype)
 
-    @pytest.mark.l2
+    @pytest.mark.low_priority
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_inf_input(self, target):
         skip_if_missing(self.op, "kernel_tensor")
@@ -589,10 +576,9 @@ class _BinaryOpBoundary:
         compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
         torch.npu.synchronize()
         c = compiled(a, b)
-        assert c.shape == (256, 256)
-        assert torch.all(torch.isinf(c))
+        assert_close_npu(c, self.op.golden(a, b), "float16")
 
-    @pytest.mark.l2
+    @pytest.mark.low_priority
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_nan_input(self, target):
         skip_if_missing(self.op, "kernel_tensor")
@@ -607,7 +593,7 @@ class _BinaryOpBoundary:
         assert c.shape == (256, 256)
         assert torch.all(torch.isnan(c))
 
-    @pytest.mark.l2
+    @pytest.mark.low_priority
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_minimum_shape(self, dtype, target):
         skip_if_missing(self.op, "kernel_tensor")
@@ -622,7 +608,7 @@ class _BinaryOpBoundary:
             golden_fn=self.op.golden,
         )
 
-    @pytest.mark.l2
+    @pytest.mark.low_priority
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_multidim_buffload_takes_first_index(self, dtype, target):
         """Multi-dim element access (S[1,3]) only uses the first index —
@@ -630,21 +616,21 @@ class _BinaryOpBoundary:
         skip_if_missing(self.op, "kernel_multidim_buffload")
         run_multidim_buffload_op(self.op.kernel_multidim_buffload, 64, 128, dtype, target, golden_fn=self.op.golden)
 
-    @pytest.mark.l2
+    @pytest.mark.low_priority
     def test_size_mismatch_src0(self):
         """dst vs src0 size mismatch raises at trace time (constraint 1)."""
         skip_if_missing(self.op, "mismatch_kernels")
         with pytest.raises((RuntimeError, AssertionError)):
             self.op.mismatch_kernels[0]()
 
-    @pytest.mark.l2
+    @pytest.mark.low_priority
     def test_size_mismatch_region(self):
         """src1 BufferRegion size mismatch raises at trace time (constraint 2)."""
         skip_if_missing(self.op, "mismatch_kernels")
         with pytest.raises((RuntimeError, AssertionError)):
             self.op.mismatch_kernels[1]()
 
-    @pytest.mark.l2
+    @pytest.mark.low_priority
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_buffer_size_unvalidated(self, target):
         """src1 Buffer size is NOT validated (constraint 3): only the first

--- a/testing/python/base/binary_op.py
+++ b/testing/python/base/binary_op.py
@@ -1,0 +1,638 @@
+"""Binary operator test infrastructure (T.tile.add, .sub, .mul, ...)."""
+
+import inspect
+from typing import NamedTuple
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+
+from base.common import DTYPE_MAP, DEFAULT_PASS_CONFIGS, assert_close_npu, make_test_data, skip_if_missing
+
+
+def make_binary_kernel(tile_op):
+    """Factory: tensor op tensor -> tensor."""
+
+    def kernel(M, N, block_M, block_N, dtype="float"):
+        m_num = M // block_M
+        n_num = N // block_N
+        VEC_NUM = 2
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, N), dtype),  # type: ignore
+            B: T.Tensor((M, N), dtype),  # type: ignore
+            C: T.Tensor((M, N), dtype),  # type: ignore
+        ):
+            with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+                bx = cid // n_num
+                by = cid % n_num
+                a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+                b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+                c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+                T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+                T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+                tile_op(c_ub, a_ub, b_ub)
+                T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+        return main
+
+    return kernel
+
+
+def make_1d_kernel(tile_op):
+    """Factory: tensor op tensor -> tensor on 1D buffers."""
+
+    def kernel(N, dtype="float"):
+        @T.prim_func
+        def main(
+            A: T.Tensor((N,), dtype),  # type: ignore
+            B: T.Tensor((N,), dtype),  # type: ignore
+            C: T.Tensor((N,), dtype),  # type: ignore
+        ):
+            with T.Kernel(1, is_npu=True) as (cid, _):
+                a_ub = T.alloc_ub((N,), dtype)
+                b_ub = T.alloc_ub((N,), dtype)
+                c_ub = T.alloc_ub((N,), dtype)
+                T.copy(A, a_ub)
+                T.copy(B, b_ub)
+                tile_op(c_ub, a_ub, b_ub)
+                T.copy(c_ub, C)
+
+        return main
+
+    return kernel
+
+
+def make_scalar_kernel(tile_op):
+    """Factory: tensor op scalar -> tensor."""
+
+    def kernel(M, N, block_M, block_N, scalar, dtype="float"):
+        m_num = M // block_M
+        n_num = N // block_N
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, N), dtype),  # type: ignore
+            B: T.Tensor((M, N), dtype),  # type: ignore
+        ):
+            with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+                bx = cid // n_num
+                by = cid % n_num
+                a_ub = T.alloc_ub((block_M, block_N), dtype)
+                b_ub = T.alloc_ub((block_M, block_N), dtype)
+                T.copy(A[bx * block_M, by * block_N], a_ub)
+                tile_op(b_ub, a_ub, scalar)
+                T.copy(b_ub, B[bx * block_M, by * block_N])
+
+        return main
+
+    return kernel
+
+
+def make_buffload_kernel(tile_op):
+    """Factory: tensor op 1D-buffer-element (BufferLoad) -> tensor."""
+
+    def kernel(M, N, m, dtype="float"):
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, N), dtype),  # type: ignore
+            S: T.Tensor((m,), dtype),  # type: ignore
+            C: T.Tensor((M, N), dtype),  # type: ignore
+        ):
+            with T.Kernel(1, is_npu=True) as (cid, _):
+                a_ub = T.alloc_ub((M, N), dtype)
+                s_ub = T.alloc_ub((m,), dtype)
+                c_ub = T.alloc_ub((M, N), dtype)
+                T.copy(A, a_ub)
+                T.copy(S, s_ub)
+                tile_op(c_ub, a_ub, s_ub[3])
+                T.copy(c_ub, C)
+
+        return main
+
+    return kernel
+
+
+def make_row_slice_kernel(tile_op):
+    """Factory: 2D whole-row slice regions with a per-row BufferLoad scalar."""
+
+    def kernel(M, N, m, dtype="float"):
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, N), dtype),  # type: ignore
+            S: T.Tensor((m,), dtype),  # type: ignore
+            C: T.Tensor((M, N), dtype),  # type: ignore
+        ):
+            with T.Kernel(1, is_npu=True) as (cid, _):
+                a_ub = T.alloc_ub((M, N), dtype)
+                s_ub = T.alloc_ub((m,), dtype)
+                c_ub = T.alloc_ub((M, N), dtype)
+                T.copy(A, a_ub)
+                T.copy(S, s_ub)
+                for h_i in range(M):
+                    tile_op(c_ub[h_i, :], a_ub[h_i, :], s_ub[h_i % m])
+                T.copy(c_ub, C)
+
+        return main
+
+    return kernel
+
+
+def make_inplace_kernel(tile_op):
+    """Factory: dst = dst op src (in-place on UB buffer)."""
+
+    def kernel(M, N, block_M, block_N, dtype="float"):
+        m_num = M // block_M
+        n_num = N // block_N
+        VEC_NUM = 2
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, N), dtype),  # type: ignore
+            B: T.Tensor((M, N), dtype),  # type: ignore
+            C: T.Tensor((M, N), dtype),  # type: ignore
+        ):
+            with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+                bx = cid // n_num
+                by = cid % n_num
+                a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+                b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+                T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+                T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+                tile_op(a_ub, a_ub, b_ub)
+                T.copy(a_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+        return main
+
+    return kernel
+
+
+def make_src0_mismatch_kernel(tile_op):
+    """dst(64) vs src0(128) -> traced-time Python assert (constraint 1)."""
+
+    @T.prim_func
+    def main(A: T.Tensor((128,), "float16"), B: T.Tensor((64,), "float16"), C: T.Tensor((64,), "float16")):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((128,), "float16")
+            b_ub = T.alloc_ub((64,), "float16")
+            c_ub = T.alloc_ub((64,), "float16")
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            tile_op(c_ub, a_ub, b_ub)
+            T.copy(c_ub, C)
+
+    return main
+
+
+def make_region_mismatch_kernel(tile_op):
+    """src1 BufferRegion(32) vs dst(64) -> traced-time assert (constraint 2)."""
+
+    @T.prim_func
+    def main(A: T.Tensor((64,), "float16"), B: T.Tensor((128,), "float16"), C: T.Tensor((64,), "float16")):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((64,), "float16")
+            b_ub = T.alloc_ub((128,), "float16")
+            c_ub = T.alloc_ub((64,), "float16")
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            tile_op(c_ub, a_ub, b_ub[0:32])
+            T.copy(c_ub, C)
+
+    return main
+
+
+def make_buffer_mismatch_kernel(tile_op):
+    """src1 Buffer(128) vs dst(64) -> NOT validated (constraint 3): only the
+    first dst.size elements participate."""
+
+    @T.prim_func
+    def main(A: T.Tensor((64,), "float16"), B: T.Tensor((128,), "float16"), C: T.Tensor((64,), "float16")):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((64,), "float16")
+            b_ub = T.alloc_ub((128,), "float16")
+            c_ub = T.alloc_ub((64,), "float16")
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            tile_op(c_ub, a_ub, b_ub)
+            T.copy(c_ub, C)
+
+    return main
+
+
+def run_binary_op(kernel_factory, M, N, block_M, block_N, dtype, target, golden_fn):
+    func = kernel_factory(M, N, block_M, block_N, dtype=dtype)
+    compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+    a = make_test_data((M, N), dtype)
+    b = make_test_data((M, N), dtype)
+    torch.npu.synchronize()
+    c = compiled(a, b)
+    assert_close_npu(c, golden_fn(a, b), dtype)
+
+
+def run_1d_op(kernel_factory, N, dtype, target, golden_fn):
+    func = kernel_factory(N, dtype=dtype)
+    compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+    a = make_test_data((N,), dtype)
+    b = make_test_data((N,), dtype)
+    torch.npu.synchronize()
+    c = compiled(a, b)
+    assert_close_npu(c, golden_fn(a, b), dtype)
+
+
+def run_scalar_op(kernel_factory, M, N, block_M, block_N, scalar, dtype, target, golden_fn):
+    func = kernel_factory(M, N, block_M, block_N, scalar, dtype)
+    compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+    a = make_test_data((M, N), dtype)
+    torch.npu.synchronize()
+    b = compiled(a)
+    expected = golden_fn(a, scalar, dtype)
+    assert_close_npu(b, expected, dtype)
+
+
+def run_buffload_op(kernel_factory, M, N, m, dtype, target, golden_fn):
+    func = kernel_factory(M, N, m, dtype=dtype)
+    compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+    torch.manual_seed(0)
+    a = make_test_data((M, N), dtype, device="cpu")
+    if dtype.startswith("float"):
+        values = [1.5, 2.0, 0.5, 3.0, 4.0, -1.0, 0.25, 0.75]
+    else:
+        values = [1, 2, 3, 4, 5, 6, 7, 8]
+    s = torch.tensor(values, dtype=DTYPE_MAP[dtype])[:m]
+    torch.npu.synchronize()
+    b = compiled(a.npu(), s.npu())
+    torch.npu.synchronize()
+    assert_close_npu(b.cpu(), golden_fn(a, s[3]), dtype)
+
+
+def run_row_slice_op(kernel_factory, M, N, m, dtype, target, golden_fn):
+    func = kernel_factory(M, N, m, dtype=dtype)
+    compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+    torch.manual_seed(0)
+    a = make_test_data((M, N), dtype, device="cpu")
+    if dtype.startswith("float"):
+        values = [1.5, 2.0, 0.5, 3.0, 4.0, -1.0, 0.25, 0.75]
+    else:
+        values = [1, 2, 3, 4, 5, 6, 7, 8]
+    s = torch.tensor(values, dtype=DTYPE_MAP[dtype])[:m]
+    torch.npu.synchronize()
+    b = compiled(a.npu(), s.npu())
+    torch.npu.synchronize()
+    ref = torch.stack([golden_fn(a[h], s[h % m]) for h in range(M)])
+    assert_close_npu(b.cpu(), ref, dtype)
+
+
+class BinaryOpSpec:
+    def __init__(
+        self,
+        name,
+        tile_op,
+        golden,
+        supported_dtypes,
+        boundary_dtypes=None,
+        kernel_tensor=None,
+        kernel_scalar=None,
+        kernel_inplace=None,
+        kernel_1d=None,
+        kernel_buffload=None,
+        kernel_row_slice=None,
+        mismatch_kernels=None,
+        low_priority_dtypes=None,
+    ):
+        self.name = name
+        self.tile_op = tile_op
+        self.golden = golden
+        self.supported_dtypes = supported_dtypes
+        self.boundary_dtypes = boundary_dtypes or ["float16", "float32"]
+        self.low_priority_dtypes = list(low_priority_dtypes or [])
+        # Mandatory variants: None -> default factory (all binary ops share
+        # the same binary_op front-end).
+        self.kernel_tensor = kernel_tensor or make_binary_kernel(self.tile_op)
+        self.kernel_scalar = kernel_scalar or make_scalar_kernel(self.tile_op)
+        self.kernel_inplace = kernel_inplace or make_inplace_kernel(self.tile_op)
+        # Optional variants: None -> disabled (skip_if_missing skips them);
+        # specs opt in by passing the factory explicitly.
+        self.kernel_1d = kernel_1d or None
+        self.kernel_buffload = kernel_buffload or None
+        self.kernel_row_slice = kernel_row_slice or None
+        # Size-validation kernels (constraint 1/2/3 checks); None -> disabled.
+        self.mismatch_kernels = mismatch_kernels or None
+
+    def scalar_golden(self, a, scalar, dtype):
+        if dtype in ("int16", "int32"):
+            scalar = int(scalar)
+        return self.golden(a, scalar)
+
+
+@pytest.mark.compile_time
+@pytest.mark.usefixtures("disable_tilelang_cache", "random_seed")
+class _BinaryOpCompile:
+    op = None
+    _dtype_source = "supported_dtypes"
+
+    @pytest.mark.l0
+    def test_compiles(self, dtype):
+        skip_if_missing(self.op, "kernel_tensor")
+        func = self.op.kernel_tensor(128, 128, 64, 64, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target="ascendc")
+        assert callable(compiled)
+
+    @pytest.mark.l0
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_compiles_both_targets(self, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        func = self.op.kernel_tensor(128, 128, 64, 64, self.op.supported_dtypes[0])
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        assert callable(compiled)
+
+    @pytest.mark.l0
+    def test_scalar_variant_compiles(self):
+        skip_if_missing(self.op, "kernel_scalar")
+        func = self.op.kernel_scalar(128, 128, 64, 64, 1.0, self.op.supported_dtypes[0])
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target="ascendc")
+        assert callable(compiled)
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize("shape", [(64, 64), (128, 256), (256, 128)])
+    def test_various_shapes_compile(self, shape):
+        skip_if_missing(self.op, "kernel_tensor")
+        M, N = shape
+        func = self.op.kernel_tensor(M, N, 64, 64, self.op.supported_dtypes[0])
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target="ascendc")
+        assert callable(compiled)
+
+
+@pytest.mark.usefixtures("disable_tilelang_cache", "random_seed")
+class _BinaryOpE2E:
+    op = None
+    _dtype_source = "supported_dtypes"
+
+    @pytest.mark.l0
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_basic_1024x1024(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        run_binary_op(
+            self.op.kernel_tensor,
+            1024,
+            1024,
+            128,
+            128,
+            dtype,
+            target,
+            golden_fn=self.op.golden,
+        )
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize(
+        "M,N,block_M,block_N",
+        [
+            (256, 256, 64, 64),
+            (512, 1024, 64, 128),
+            (1024, 512, 128, 64),
+            (2048, 2048, 128, 128),
+        ],
+    )
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_various_shapes(self, M, N, block_M, block_N, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        run_binary_op(
+            self.op.kernel_tensor,
+            M,
+            N,
+            block_M,
+            block_N,
+            dtype,
+            target,
+            golden_fn=self.op.golden,
+        )
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize("M,N", [(100, 200), (107, 145), (255, 513)])
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_tail_blocks(self, M, N, dtype, target):
+        """Non-multiple shapes: only full blocks participate (tail dropped).
+
+        M/N are trimmed down to block multiples before launch, so this
+        verifies the aligned prefix stays correct; the ragged tail is
+        intentionally not covered by the grid.
+        """
+        skip_if_missing(self.op, "kernel_tensor")
+        block_M = 64 if M >= 64 else 32
+        block_N = 64 if N >= 64 else 32
+        M_aligned = (M // block_M) * block_M
+        N_aligned = (N // block_N) * block_N
+        run_binary_op(
+            self.op.kernel_tensor,
+            M_aligned,
+            N_aligned,
+            block_M,
+            block_N,
+            dtype,
+            target,
+            golden_fn=self.op.golden,
+        )
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize("N", [256])
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_1d(self, N, dtype, target):
+        skip_if_missing(self.op, "kernel_1d")
+        run_1d_op(self.op.kernel_1d, N, dtype, target, golden_fn=self.op.golden)
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize("scalar_val", [2.0])
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_tensor_op_scalar(self, scalar_val, dtype, target):
+        skip_if_missing(self.op, "kernel_scalar")
+        scalar = scalar_val if dtype not in ("int16", "int32") else int(scalar_val)
+        run_scalar_op(
+            self.op.kernel_scalar,
+            1024,
+            1024,
+            128,
+            128,
+            scalar,
+            dtype,
+            target,
+            golden_fn=self.op.scalar_golden,
+        )
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_buffload(self, dtype, target):
+        skip_if_missing(self.op, "kernel_buffload")
+        run_buffload_op(self.op.kernel_buffload, 64, 128, 8, dtype, target, golden_fn=self.op.golden)
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_row_slice_2d(self, dtype, target):
+        skip_if_missing(self.op, "kernel_row_slice")
+        run_row_slice_op(self.op.kernel_row_slice, 4, 128, 4, dtype, target, golden_fn=self.op.golden)
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_inplace(self, dtype, target):
+        skip_if_missing(self.op, "kernel_inplace")
+        func = self.op.kernel_inplace(1024, 1024, 128, 128, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        a = make_test_data((1024, 1024), dtype)
+        b = make_test_data((1024, 1024), dtype)
+        torch.npu.synchronize()
+        result = compiled(a, b)
+        assert_close_npu(result, self.op.golden(a, b), dtype)
+
+
+@pytest.mark.usefixtures("disable_tilelang_cache", "random_seed")
+class _BinaryOpBoundary:
+    op = None
+    _dtype_source = "boundary_dtypes"
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_large_values(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        torch_dtype = DTYPE_MAP[dtype]
+        if dtype == "float32":
+            a = torch.full((256, 256), 1e30, dtype=torch_dtype, device="npu")
+            b = torch.full((256, 256), 1e30, dtype=torch_dtype, device="npu")
+        else:
+            a = torch.full((256, 256), 60000.0, dtype=torch_dtype, device="npu")
+            b = torch.full((256, 256), 1.0, dtype=torch_dtype, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        c = compiled(a, b)
+        assert c.shape == (256, 256)
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_zeros(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        torch_dtype = DTYPE_MAP[dtype]
+        a = torch.zeros(256, 256, dtype=torch_dtype, device="npu")
+        b = torch.zeros(256, 256, dtype=torch_dtype, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        c = compiled(a, b)
+        assert_close_npu(c, torch.zeros_like(a), dtype)
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_negative_values(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        torch_dtype = DTYPE_MAP[dtype]
+        a = torch.full((256, 256), -5.0, dtype=torch_dtype, device="npu")
+        b = torch.full((256, 256), 3.0, dtype=torch_dtype, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        c = compiled(a, b)
+        assert_close_npu(c, self.op.golden(a, b), dtype)
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_inf_input(self, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        if "float16" not in self.op.boundary_dtypes:
+            pytest.skip("float16 not in boundary_dtypes")
+        a = torch.full((256, 256), float("inf"), dtype=torch.float16, device="npu")
+        b = torch.ones(256, 256, dtype=torch.float16, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, "float16")
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        c = compiled(a, b)
+        assert c.shape == (256, 256)
+        assert torch.all(torch.isinf(c))
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_nan_input(self, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        if "float16" not in self.op.boundary_dtypes:
+            pytest.skip("float16 not in boundary_dtypes")
+        a = torch.full((256, 256), float("nan"), dtype=torch.float16, device="npu")
+        b = torch.ones(256, 256, dtype=torch.float16, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, "float16")
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        c = compiled(a, b)
+        assert c.shape == (256, 256)
+        assert torch.all(torch.isnan(c))
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_minimum_shape(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        run_binary_op(
+            self.op.kernel_tensor,
+            64,
+            64,
+            64,
+            64,
+            dtype,
+            target,
+            golden_fn=self.op.golden,
+        )
+
+    @pytest.mark.l2
+    def test_size_mismatch_src0(self):
+        """dst vs src0 size mismatch raises at trace time (constraint 1)."""
+        skip_if_missing(self.op, "mismatch_kernels")
+        with pytest.raises((RuntimeError, AssertionError)):
+            self.op.mismatch_kernels[0]()
+
+    @pytest.mark.l2
+    def test_size_mismatch_region(self):
+        """src1 BufferRegion size mismatch raises at trace time (constraint 2)."""
+        skip_if_missing(self.op, "mismatch_kernels")
+        with pytest.raises((RuntimeError, AssertionError)):
+            self.op.mismatch_kernels[1]()
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_buffer_size_unvalidated(self, target):
+        """src1 Buffer size is NOT validated (constraint 3): only the first
+        dst.size elements participate."""
+        skip_if_missing(self.op, "mismatch_kernels")
+        torch.manual_seed(0)
+        a = torch.randn(64, dtype=torch.float16)
+        b = torch.rand(128, dtype=torch.float16)
+        func = self.op.mismatch_kernels[2]()
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        out = compiled(a.npu(), b.npu())
+        torch.npu.synchronize()
+        torch.testing.assert_close(out.cpu().float(), self.op.golden(a, b[:64]).float(), rtol=1e-2, atol=1e-2)
+
+
+class BinaryOpTestClasses(NamedTuple):
+    Compile: type[_BinaryOpCompile]
+    E2E: type[_BinaryOpE2E]
+    Boundary: type[_BinaryOpBoundary]
+
+
+def register_binary_op_tests(spec) -> BinaryOpTestClasses:
+    """Create TestTile{Name}Compile / E2E / Boundary classes in the caller's module.
+
+    Also creates ``_``-prefixed base classes and returns them as a
+    :class:`BinaryOpTestClasses` tuple so callers can subclass them for
+    override scenarios (e.g. extra parametrize decorators).
+    """
+    caller_globals = inspect.currentframe().f_back.f_globals
+    prefix = f"TestTile{spec.name.capitalize()}"
+    base_classes = []
+    for suffix, base in [
+        ("Compile", _BinaryOpCompile),
+        ("E2E", _BinaryOpE2E),
+        ("Boundary", _BinaryOpBoundary),
+    ]:
+        # Inject into globals (existing behavior, backward compatible)
+        cls = type(f"{prefix}{suffix}", (base,), {"op": spec})
+        caller_globals[cls.__name__] = cls
+        # Create _-prefixed version for override scenarios
+        base_cls = type(f"_{prefix}{suffix}", (base,), {"op": spec})
+        base_classes.append(base_cls)
+    return BinaryOpTestClasses(*base_classes)

--- a/testing/python/base/common.py
+++ b/testing/python/base/common.py
@@ -1,0 +1,95 @@
+"""
+Shared test utilities for TileLang-Ascend API tests.
+
+Import from test files:
+    from base import TOLERANCE, DTYPE_MAP, DEFAULT_PASS_CONFIGS, assert_close_npu, make_test_data
+"""
+
+import torch
+import tilelang
+
+
+# ---------------------------------------------------------------------------
+# Precision tolerance table — graded by dtype (NOT a flat 1e-2 for all)
+# ---------------------------------------------------------------------------
+TOLERANCE = {
+    "float32": {"rtol": 1e-5, "atol": 1e-5},
+    "float": {"rtol": 1e-5, "atol": 1e-5},
+    "float16": {"rtol": 1e-3, "atol": 1e-3},
+    "bfloat16": {"rtol": 7.8e-3, "atol": 7.8e-3},
+    "int8": {"rtol": 0, "atol": 0},
+    "int16": {"rtol": 0, "atol": 0},
+    "int32": {"rtol": 0, "atol": 0},
+    "uint8": {"rtol": 0, "atol": 0},
+    "uint16": {"rtol": 0, "atol": 0},
+    "uint32": {"rtol": 0, "atol": 0},
+}
+
+
+# ---------------------------------------------------------------------------
+# TileLang dtype string  →  torch dtype
+# ---------------------------------------------------------------------------
+DTYPE_MAP = {
+    "float": torch.float32,
+    "float32": torch.float32,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "int8": torch.int8,
+    "int16": torch.int16,
+    "int32": torch.int32,
+    "uint8": torch.uint8,
+    "uint16": torch.uint16,
+    "uint32": torch.uint32,
+}
+
+
+# ---------------------------------------------------------------------------
+# Assertion helper — handles uint16/uint32 that torch-npu can't compare
+# ---------------------------------------------------------------------------
+def assert_close_npu(actual, expected, dtype, **override):
+    """Compare NPU output with golden reference using dtype-graded tolerance.
+
+    Usage:
+        assert_close_npu(result, expected, "float16")
+        assert_close_npu(result, expected, "float32", rtol=1e-4)  # override
+    """
+    tol = {**TOLERANCE.get(dtype, {"rtol": 1e-2, "atol": 1e-2}), **override}
+    # torch-npu doesn't support isclose for uint16/uint32
+    if dtype in ("uint16", "uint32"):
+        int_dtype = getattr(torch, dtype.replace("uint", "int"))
+        actual = actual.to(int_dtype)
+        expected = expected.to(int_dtype)
+    torch.testing.assert_close(actual, expected, **tol)
+
+
+# ---------------------------------------------------------------------------
+# Test data generator — integers for int types, randn for float types
+# ---------------------------------------------------------------------------
+def make_test_data(shape, dtype, *, low=-100, high=100, device="npu"):
+    """Generate random test data appropriate for the dtype.
+
+    - Integer types: uniform random in [low, high]
+    - Float types: standard normal
+    """
+    torch_dtype = DTYPE_MAP[dtype]
+    if dtype in ("int8", "int16", "int32", "uint8", "uint16", "uint32"):
+        return torch.randint(low, high, shape, dtype=torch_dtype, device=device)
+    return torch.randn(shape, dtype=torch_dtype, device=device)
+
+
+# ---------------------------------------------------------------------------
+# Default pass_configs for Developer mode tests
+# ---------------------------------------------------------------------------
+DEFAULT_PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+def skip_if_missing(op, attr):
+    import pytest
+
+    if not getattr(op, attr):
+        pytest.skip(f"No {attr}")

--- a/testing/python/base/unary_op.py
+++ b/testing/python/base/unary_op.py
@@ -64,20 +64,17 @@ class UnaryOpSpec:
         return make_unary_kernel(self.tile_op)
 
 
-@pytest.mark.compile_time
 @pytest.mark.usefixtures("disable_tilelang_cache", "random_seed")
 class _UnaryOpCompile:
     op = None
     _dtype_source = "supported_dtypes"
 
-    @pytest.mark.l0
     def test_compiles(self, dtype):
         skip_if_missing(self.op, "kernel_tensor")
         func = self.op.kernel_tensor(128, 128, 64, 64, dtype)
         compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target="ascendc")
         assert callable(compiled)
 
-    @pytest.mark.l0
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_compiles_both_targets(self, target):
         skip_if_missing(self.op, "kernel_tensor")
@@ -85,7 +82,6 @@ class _UnaryOpCompile:
         compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
         assert callable(compiled)
 
-    @pytest.mark.l1
     @pytest.mark.parametrize("shape", [(64, 64), (128, 256), (256, 128)])
     def test_various_shapes_compile(self, shape):
         skip_if_missing(self.op, "kernel_tensor")
@@ -100,7 +96,6 @@ class _UnaryOpE2E:
     op = None
     _dtype_source = "supported_dtypes"
 
-    @pytest.mark.l0
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_basic_1024x1024(self, dtype, target):
         skip_if_missing(self.op, "kernel_tensor")
@@ -115,7 +110,6 @@ class _UnaryOpE2E:
             golden_fn=self.op.golden,
         )
 
-    @pytest.mark.l1
     @pytest.mark.parametrize(
         "M,N,block_M,block_N",
         [
@@ -139,7 +133,6 @@ class _UnaryOpE2E:
             golden_fn=self.op.golden,
         )
 
-    @pytest.mark.l1
     @pytest.mark.parametrize("M,N", [(100, 200), (107, 145), (255, 513)])
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_non_aligned_shapes(self, M, N, dtype, target):
@@ -165,7 +158,7 @@ class _UnaryOpBoundary:
     op = None
     _dtype_source = "boundary_dtypes"
 
-    @pytest.mark.l2
+    @pytest.mark.low_priority
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_large_values(self, dtype, target):
         skip_if_missing(self.op, "kernel_tensor")
@@ -180,7 +173,7 @@ class _UnaryOpBoundary:
         b = compiled(a)
         assert b.shape == (256, 256)
 
-    @pytest.mark.l2
+    @pytest.mark.low_priority
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_zeros(self, dtype, target):
         skip_if_missing(self.op, "kernel_tensor")
@@ -192,7 +185,7 @@ class _UnaryOpBoundary:
         b = compiled(a)
         assert_close_npu(b, self.op.golden(a), dtype)
 
-    @pytest.mark.l2
+    @pytest.mark.low_priority
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_negative_values(self, dtype, target):
         skip_if_missing(self.op, "kernel_tensor")
@@ -204,7 +197,7 @@ class _UnaryOpBoundary:
         b = compiled(a)
         assert_close_npu(b, self.op.golden(a), dtype)
 
-    @pytest.mark.l2
+    @pytest.mark.low_priority
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_inf_input(self, target):
         skip_if_missing(self.op, "kernel_tensor")
@@ -218,7 +211,7 @@ class _UnaryOpBoundary:
         assert b.shape == (256, 256)
         assert torch.all(torch.isinf(b))
 
-    @pytest.mark.l2
+    @pytest.mark.low_priority
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_nan_input(self, target):
         skip_if_missing(self.op, "kernel_tensor")
@@ -232,7 +225,7 @@ class _UnaryOpBoundary:
         assert b.shape == (256, 256)
         assert torch.all(torch.isnan(b))
 
-    @pytest.mark.l2
+    @pytest.mark.low_priority
     @pytest.mark.parametrize("target", ["ascendc", "pto"])
     def test_minimum_shape(self, dtype, target):
         skip_if_missing(self.op, "kernel_tensor")

--- a/testing/python/base/unary_op.py
+++ b/testing/python/base/unary_op.py
@@ -1,0 +1,276 @@
+"""Unary operator test infrastructure (T.tile.exp, .abs, .sqrt, ...)."""
+
+import inspect
+from functools import cached_property
+from typing import NamedTuple
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+
+from base.common import DTYPE_MAP, DEFAULT_PASS_CONFIGS, assert_close_npu, make_test_data, skip_if_missing
+
+
+def make_unary_kernel(tile_op):
+    """Factory: op(src) -> dst."""
+
+    def kernel(M, N, block_M, block_N, dtype="float"):
+        m_num = M // block_M
+        n_num = N // block_N
+        VEC_NUM = 2
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, N), dtype),  # type: ignore
+            B: T.Tensor((M, N), dtype),  # type: ignore
+        ):
+            with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+                bx = cid // n_num
+                by = cid % n_num
+                a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+                b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+                T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+                tile_op(b_ub, a_ub)
+                T.copy(b_ub, B[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+        return main
+
+    return kernel
+
+
+def run_unary_op(kernel_factory, M, N, block_M, block_N, dtype, target, golden_fn):
+    func = kernel_factory(M, N, block_M, block_N, dtype=dtype)
+    compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+    a = make_test_data((M, N), dtype)
+    torch.npu.synchronize()
+    b = compiled(a)
+    assert_close_npu(b, golden_fn(a), dtype)
+
+
+class UnaryOpSpec:
+    def __init__(self, name, tile_op, golden, supported_dtypes, boundary_dtypes=None, kernel_tensor=None):
+        self.name = name
+        self.tile_op = tile_op
+        self.golden = golden
+        self.supported_dtypes = supported_dtypes
+        self.boundary_dtypes = boundary_dtypes or ["float16", "float32"]
+        if kernel_tensor is not None:
+            self.__dict__["kernel_tensor"] = kernel_tensor
+
+    @cached_property
+    def kernel_tensor(self):
+        return make_unary_kernel(self.tile_op)
+
+
+@pytest.mark.compile_time
+@pytest.mark.usefixtures("disable_tilelang_cache", "random_seed")
+class _UnaryOpCompile:
+    op = None
+    _dtype_source = "supported_dtypes"
+
+    @pytest.mark.l0
+    def test_compiles(self, dtype):
+        skip_if_missing(self.op, "kernel_tensor")
+        func = self.op.kernel_tensor(128, 128, 64, 64, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target="ascendc")
+        assert callable(compiled)
+
+    @pytest.mark.l0
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_compiles_both_targets(self, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        func = self.op.kernel_tensor(128, 128, 64, 64, self.op.supported_dtypes[0])
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        assert callable(compiled)
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize("shape", [(64, 64), (128, 256), (256, 128)])
+    def test_various_shapes_compile(self, shape):
+        skip_if_missing(self.op, "kernel_tensor")
+        M, N = shape
+        func = self.op.kernel_tensor(M, N, 64, 64, self.op.supported_dtypes[0])
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target="ascendc")
+        assert callable(compiled)
+
+
+@pytest.mark.usefixtures("disable_tilelang_cache", "random_seed")
+class _UnaryOpE2E:
+    op = None
+    _dtype_source = "supported_dtypes"
+
+    @pytest.mark.l0
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_basic_1024x1024(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        run_unary_op(
+            self.op.kernel_tensor,
+            1024,
+            1024,
+            128,
+            128,
+            dtype,
+            target,
+            golden_fn=self.op.golden,
+        )
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize(
+        "M,N,block_M,block_N",
+        [
+            (256, 256, 64, 64),
+            (512, 1024, 64, 128),
+            (1024, 512, 128, 64),
+            (2048, 2048, 128, 128),
+        ],
+    )
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_various_shapes(self, M, N, block_M, block_N, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        run_unary_op(
+            self.op.kernel_tensor,
+            M,
+            N,
+            block_M,
+            block_N,
+            dtype,
+            target,
+            golden_fn=self.op.golden,
+        )
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize("M,N", [(100, 200), (107, 145), (255, 513)])
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_non_aligned_shapes(self, M, N, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        block_M = 64 if M >= 64 else 32
+        block_N = 64 if N >= 64 else 32
+        M_aligned = (M // block_M) * block_M
+        N_aligned = (N // block_N) * block_N
+        run_unary_op(
+            self.op.kernel_tensor,
+            M_aligned,
+            N_aligned,
+            block_M,
+            block_N,
+            dtype,
+            target,
+            golden_fn=self.op.golden,
+        )
+
+
+@pytest.mark.usefixtures("disable_tilelang_cache", "random_seed")
+class _UnaryOpBoundary:
+    op = None
+    _dtype_source = "boundary_dtypes"
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_large_values(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        torch_dtype = DTYPE_MAP[dtype]
+        if dtype == "float32":
+            a = torch.full((256, 256), 1e30, dtype=torch_dtype, device="npu")
+        else:
+            a = torch.full((256, 256), 60000.0, dtype=torch_dtype, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        b = compiled(a)
+        assert b.shape == (256, 256)
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_zeros(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        torch_dtype = DTYPE_MAP[dtype]
+        a = torch.zeros(256, 256, dtype=torch_dtype, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        b = compiled(a)
+        assert_close_npu(b, self.op.golden(a), dtype)
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_negative_values(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        torch_dtype = DTYPE_MAP[dtype]
+        a = torch.full((256, 256), -5.0, dtype=torch_dtype, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        b = compiled(a)
+        assert_close_npu(b, self.op.golden(a), dtype)
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_inf_input(self, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        if "float16" not in self.op.boundary_dtypes:
+            pytest.skip("float16 not in boundary_dtypes")
+        a = torch.full((256, 256), float("inf"), dtype=torch.float16, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, "float16")
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        b = compiled(a)
+        assert b.shape == (256, 256)
+        assert torch.all(torch.isinf(b))
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_nan_input(self, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        if "float16" not in self.op.boundary_dtypes:
+            pytest.skip("float16 not in boundary_dtypes")
+        a = torch.full((256, 256), float("nan"), dtype=torch.float16, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, "float16")
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        b = compiled(a)
+        assert b.shape == (256, 256)
+        assert torch.all(torch.isnan(b))
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_minimum_shape(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        run_unary_op(
+            self.op.kernel_tensor,
+            64,
+            64,
+            64,
+            64,
+            dtype,
+            target,
+            golden_fn=self.op.golden,
+        )
+
+
+class UnaryOpTestClasses(NamedTuple):
+    Compile: type[_UnaryOpCompile]
+    E2E: type[_UnaryOpE2E]
+    Boundary: type[_UnaryOpBoundary]
+
+
+def register_unary_op_tests(spec) -> UnaryOpTestClasses:
+    """Create TestTile{Name}Compile / E2E / Boundary classes in the caller's module.
+
+    Also creates ``_``-prefixed base classes and returns them as a
+    :class:`UnaryOpTestClasses` tuple so callers can subclass them for
+    override scenarios (e.g. extra parametrize decorators).
+    """
+    caller_globals = inspect.currentframe().f_back.f_globals
+    prefix = f"TestTile{spec.name.capitalize()}"
+    base_classes = []
+    for suffix, base in [
+        ("Compile", _UnaryOpCompile),
+        ("E2E", _UnaryOpE2E),
+        ("Boundary", _UnaryOpBoundary),
+    ]:
+        cls = type(f"{prefix}{suffix}", (base,), {"op": spec})
+        caller_globals[cls.__name__] = cls
+        base_cls = type(f"_{prefix}{suffix}", (base,), {"op": spec})
+        base_classes.append(base_cls)
+    return UnaryOpTestClasses(*base_classes)

--- a/testing/python/language/conftest.py
+++ b/testing/python/language/conftest.py
@@ -1,0 +1,67 @@
+"""
+Pytest configuration and shared fixtures for language API tests.
+
+Fixtures defined here are automatically available to all test files
+in testing/python/language/ and its subdirectories — no import needed.
+They are NOT autouse: test suites opt in via ``usefixtures`` so that
+pre-existing tests (e.g. select/elementwise) keep their own seed/cache
+behavior untouched.
+
+Markers (l0/l1/l2/compile_time + project low_priority/ci_skip) are
+registered in pyproject.toml [tool.pytest.ini_options].
+"""
+
+import pytest
+import torch
+import tilelang
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (opt-in, not autouse)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def disable_tilelang_cache():
+    """Disable tilelang JIT cache for the entire test session."""
+    tilelang.disable_cache()
+
+
+@pytest.fixture
+def random_seed():
+    """Set deterministic random seed for reproducibility."""
+    torch.manual_seed(0)
+
+
+# ---------------------------------------------------------------------------
+# Marker registration (moved to pyproject.toml [tool.pytest.ini_options])
+# ---------------------------------------------------------------------------
+
+
+def pytest_generate_tests(metafunc):
+    """Parametrize 'dtype' from the test class's op spec.
+
+    Each base test class declares a _dtype_source attribute (e.g.
+    "supported_dtypes" or "boundary_dtypes") that points to a list on
+    the BinaryOpSpec.  This hook reads that list and feeds it to pytest.
+
+    Dtypes listed in ``op.low_priority_dtypes`` are marked with the
+    project ``low_priority`` marker (skipped on PR, run in full tests).
+    """
+    if "dtype" not in metafunc.fixturenames or metafunc.cls is None:
+        return
+    op = getattr(metafunc.cls, "op", None)
+    if op is None:
+        return
+    source = getattr(metafunc.cls, "_dtype_source", "supported_dtypes")
+    dtypes = getattr(op, source, None)
+    if not dtypes:
+        return
+    low_priority = set(getattr(op, "low_priority_dtypes", []) or [])
+    params = []
+    for d in dtypes:
+        if d in low_priority:
+            params.append(pytest.param(d, marks=pytest.mark.low_priority))
+        else:
+            params.append(d)
+    metafunc.parametrize("dtype", params)

--- a/testing/python/language/conftest.py
+++ b/testing/python/language/conftest.py
@@ -7,8 +7,9 @@ They are NOT autouse: test suites opt in via ``usefixtures`` so that
 pre-existing tests (e.g. select/elementwise) keep their own seed/cache
 behavior untouched.
 
-Markers (l0/l1/l2/compile_time + project low_priority/ci_skip) are
-registered in pyproject.toml [tool.pytest.ini_options].
+Tests use the project-standard markers only (low_priority / ci_skip,
+see docs/pytest_marker_guide.md); Gate/functional cases run by default,
+boundary cases are marked low_priority.
 """
 
 import pytest

--- a/testing/python/language/test_tile_max.py
+++ b/testing/python/language/test_tile_max.py
@@ -1,0 +1,35 @@
+"""T.tile.max test suite."""
+
+import torch
+
+import tilelang.language as T
+
+from base import BinaryOpSpec, register_binary_op_tests
+from base.binary_op import (
+    make_1d_kernel,
+    make_buffload_kernel,
+    make_buffer_mismatch_kernel,
+    make_region_mismatch_kernel,
+    make_row_slice_kernel,
+    make_src0_mismatch_kernel,
+)
+
+tile_op = T.tile.max
+
+max_spec = BinaryOpSpec(
+    name="max",
+    tile_op=tile_op,
+    golden=torch.maximum,
+    supported_dtypes=["float16", "float32", "int16", "int32"],
+    low_priority_dtypes=["float16", "int16", "int32"],
+    kernel_1d=make_1d_kernel(tile_op),
+    kernel_buffload=make_buffload_kernel(tile_op),
+    kernel_row_slice=make_row_slice_kernel(tile_op),
+    mismatch_kernels=(
+        lambda: make_src0_mismatch_kernel(tile_op),
+        lambda: make_region_mismatch_kernel(tile_op),
+        lambda: make_buffer_mismatch_kernel(tile_op),
+    ),
+)
+
+register_binary_op_tests(max_spec)

--- a/testing/python/language/test_tile_max.py
+++ b/testing/python/language/test_tile_max.py
@@ -9,6 +9,7 @@ from base.binary_op import (
     make_1d_kernel,
     make_buffload_kernel,
     make_buffer_mismatch_kernel,
+    make_multidim_buffload_kernel,
     make_region_mismatch_kernel,
     make_row_slice_kernel,
     make_src0_mismatch_kernel,
@@ -25,6 +26,7 @@ max_spec = BinaryOpSpec(
     kernel_1d=make_1d_kernel(tile_op),
     kernel_buffload=make_buffload_kernel(tile_op),
     kernel_row_slice=make_row_slice_kernel(tile_op),
+    kernel_multidim_buffload=make_multidim_buffload_kernel(tile_op),
     mismatch_kernels=(
         lambda: make_src0_mismatch_kernel(tile_op),
         lambda: make_region_mismatch_kernel(tile_op),

--- a/testing/python/language/test_tile_min.py
+++ b/testing/python/language/test_tile_min.py
@@ -9,6 +9,7 @@ from base.binary_op import (
     make_1d_kernel,
     make_buffload_kernel,
     make_buffer_mismatch_kernel,
+    make_multidim_buffload_kernel,
     make_region_mismatch_kernel,
     make_row_slice_kernel,
     make_src0_mismatch_kernel,
@@ -25,6 +26,7 @@ min_spec = BinaryOpSpec(
     kernel_1d=make_1d_kernel(tile_op),
     kernel_buffload=make_buffload_kernel(tile_op),
     kernel_row_slice=make_row_slice_kernel(tile_op),
+    kernel_multidim_buffload=make_multidim_buffload_kernel(tile_op),
     mismatch_kernels=(
         lambda: make_src0_mismatch_kernel(tile_op),
         lambda: make_region_mismatch_kernel(tile_op),

--- a/testing/python/language/test_tile_min.py
+++ b/testing/python/language/test_tile_min.py
@@ -1,0 +1,35 @@
+"""T.tile.min test suite."""
+
+import torch
+
+import tilelang.language as T
+
+from base import BinaryOpSpec, register_binary_op_tests
+from base.binary_op import (
+    make_1d_kernel,
+    make_buffload_kernel,
+    make_buffer_mismatch_kernel,
+    make_region_mismatch_kernel,
+    make_row_slice_kernel,
+    make_src0_mismatch_kernel,
+)
+
+tile_op = T.tile.min
+
+min_spec = BinaryOpSpec(
+    name="min",
+    tile_op=tile_op,
+    golden=torch.minimum,
+    supported_dtypes=["float16", "float32", "int16", "int32"],
+    low_priority_dtypes=["float16", "int16", "int32"],
+    kernel_1d=make_1d_kernel(tile_op),
+    kernel_buffload=make_buffload_kernel(tile_op),
+    kernel_row_slice=make_row_slice_kernel(tile_op),
+    mismatch_kernels=(
+        lambda: make_src0_mismatch_kernel(tile_op),
+        lambda: make_region_mismatch_kernel(tile_op),
+        lambda: make_buffer_mismatch_kernel(tile_op),
+    ),
+)
+
+register_binary_op_tests(min_spec)

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1070,23 +1070,35 @@ def div(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, src1: Buffer | 
 
 
 def max(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, src1: Buffer | BufferRegion | BufferLoad | PrimExpr):
-    """Performs element-wise maximum: dst = max(src0, src1).
+    """Performs element-wise maximum: `dst[i] = max(src0[i], src1[i])`.
 
     Args:
-        dst: The destination buffer.
-        src0: The first source buffer.
-        src1: The second source operand (Buffer, BufferLoad, or Scalar).
+        dst: The destination buffer; it may alias src0 or src1 (in-place).
+        src0: The first source, a buffer or a contiguous region of it.
+        src1: The second operand: a buffer, a 1D buffer element (BufferLoad), or a scalar.
+
+    Notes:
+        - dst and src0 must have equal sizes; all tensor operands must share
+          the same dtype, while a scalar src1 is auto-cast to the buffer dtype.
+        - Supported dtypes: float16, float32, int16, int32.
+        - Operand addresses must be 32-byte aligned (hardware constraint).
     """
     return binary_op(dst, src0, src1, "max")
 
 
 def min(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, src1: Buffer | BufferRegion | BufferLoad | PrimExpr):
-    """Performs element-wise minimum: dst = min(src0, src1).
+    """Performs element-wise minimum: `dst[i] = min(src0[i], src1[i])`.
 
     Args:
-        dst: The destination buffer.
-        src0: The first source buffer.
-        src1: The second source operand (Buffer, BufferLoad, or Scalar).
+        dst: The destination buffer; it may alias src0 or src1 (in-place).
+        src0: The first source, a buffer or a contiguous region of it.
+        src1: The second operand: a buffer, a 1D buffer element (BufferLoad), or a scalar.
+
+    Notes:
+        - dst and src0 must have equal sizes; all tensor operands must share
+          the same dtype, while a scalar src1 is auto-cast to the buffer dtype.
+        - Supported dtypes: float16, float32, int16, int32.
+        - Operand addresses must be 32-byte aligned (hardware constraint).
     """
     return binary_op(dst, src0, src1, "min")
 


### PR DESCRIPTION
## 1. 文件改动

| 文件 | 类型 | 改动说明 |
|------|------|----------|
| `docs/language/tile_max.md` | 新增 | API 文档（中文）：功能说明 / 函数原型 / 参数规格（dtype、shape、src1 三形式）/ 7 条约束 / 3 个示例（tensor、scalar、原地） |
| `docs/language/tile_min.md` | 新增 | 同上（min 版本） |
| `pyproject.toml` | 修改 | 合并 `[tool.pytest.ini_options]`：pythonpath/testpaths + 6 类 marker 并列注册（修复原 cherry-pick 的 TOML 重复表错误） |
| `testing/python/base/__init__.py` | 新增 | 测试基础设施公共导出（显式 re-export） |
| `testing/python/base/binary_op.py` | 新增 | 二元算子注册式框架：kernel 工厂（tensor/1D/scalar/BufferLoad/row-slice/inplace/mismatch×3）、run 辅助、Compile/E2E/Boundary 三层测试类 |
| `testing/python/base/common.py` | 新增 | 公共工具：TOLERANCE/DTYPE_MAP/assert_close_npu/make_test_data/DEFAULT_PASS_CONFIGS/skip_if_missing |
| `testing/python/base/unary_op.py` | 新增 | 一元算子注册式框架（配套基础设施） |
| `testing/python/language/conftest.py` | 新增 | 非 autouse fixtures（disable_tilelang_cache/random_seed，`usefixtures` opt-in）+ low_priority_dtypes 参数化钩子 |
| `testing/python/language/test_tile_max.py` | 新增 | max spec：4 dtype + low_priority 声明 + 4 组可选变体启用 |
| `testing/python/language/test_tile_min.py` | 新增 | 同上（min 版本） |
| `tilelang/language/ascend_tile.py` | 修改 | max/min docstring 升级为 Google style（公式、原地别名、Notes 大小/dtype/对齐约束） |

---

## 2. 测试覆盖（`test_tile_max.py` / `test_tile_min.py`）

| 测试类 | 覆盖点 | marker |
|--------|--------|--------|
| Compile（4 方法） | 各 dtype 编译、ascendc+pto 双后端编译、scalar 变体编译、多 shape 编译 | l0/l1 + compile_time |
| E2E（8 方法） | basic 1024×1024、4 组多 shape、tail-blocks（非倍数 shape 截齐）、1D、scalar、BufferLoad、2D 整行切片、原地别名 | l0/l1 |
| Boundary（9 方法） | 大值、全零、负值、inf、nan、最小 shape、3 种大小断言（src0/region/buffer 不校验） | l2 |

dtype 参数化：`supported_dtypes`（float16/float32/int16/int32），其中 float16/int16/int32 标 `low_priority`（PR 阶段跳过，全量执行）；`boundary_dtypes`（float16/float32）。

---

## 3. 验证结果（真机 Ascend910B3，ascendc + pto）

- compile 级：全部通过
- l0 门禁：全部通过（ascendc + pto）
- 1D / BufferLoad / row-slice / inplace E2E：通过
- size mismatch（src0）、size mismatch（region）：trace 期断言通过
- buffer_size_unvalidated：通过（约束 3 语义 = 仅前 dst.size 个元素参与）
- tail-blocks：通过
- pytest 收集：max/min 各 138 用例（89 low_priority / 49 默认）

---

## 4. 校验过程中发现并修复的问题

1. **pyproject.toml TOML 重复表**：原 cherry-pick `0b9f0730` 在已有 `[tool.pytest.ini_options]` 之后重复定义同名表，整个文件无法解析（`tomllib` 报 Cannot declare twice）、pytest 完全不可用 → 合并为单表，pythonpath/testpaths + 6 类 marker 并列注册
2. **`skip_if_missing` 失效**：原 `cached_property` 与 `__dict__["kernel_*"]` 覆盖混用导致 None 分支永远不可达 → 改为必选（默认工厂）/可选（None→skip）语义
3. **conftest 全局副作用**：autouse `disable_tilelang_cache`/`random_seed` 会影响 language/ 下全部既有测试 → 改为非 autouse，测试类用 `usefixtures` opt-in
4. **`low_priority_dtypes` 死参数**：参数定义了但从未被消费 → conftest `pytest_generate_tests` 接入，spec 声明 float16/int16/int32 为 low_priority
5. **`test_non_aligned_shapes` 名实不符**：实际将 shape 截齐为 block 倍数后运行 → 改名为 `test_tail_blocks` 并注释尾部不参与网格
6. **md 文件尾部换行**：补充

---

## 5. 验证环境说明

- 测试环境：Ascend910B3（dav_m200），CANN + torch_npu
- CI：format-check（ruff format）PASSED、ruff lint PASSED
