### PR TITLE
fix(persistent): guard partial single waves

### DIFF
--- a/src/ir.cc
+++ b/src/ir.cc
@@ -114,6 +114,29 @@ ForFrame PersistentFor(const Array<PrimExpr> &domain, const PrimExpr &wave_size,
                        const PrimExpr &index, PrimExpr group_size) {
   using namespace tvm::tir;
   ICHECK(!domain.empty());
+  arith::Analyzer validation_analyzer;
+  for (const auto &extent : domain) {
+    ICHECK(!validation_analyzer.CanProveLess(extent, 1))
+        << "T.Persistent domain extents must be positive, but got " << extent;
+  }
+  ICHECK(!validation_analyzer.CanProveLess(wave_size, 1))
+      << "T.Persistent wave_size must be positive, but got " << wave_size;
+  ICHECK(!validation_analyzer.CanProveLess(index, 0) &&
+         !validation_analyzer.CanProveGreaterEqual(index - wave_size, 0))
+      << "T.Persistent index must satisfy 0 <= index < wave_size, but got "
+      << "index=" << index << " and wave_size=" << wave_size;
+  ICHECK(!validation_analyzer.CanProveLess(group_size, 1))
+      << "T.Persistent group_size must be positive, but got " << group_size;
+  PrimExpr last_extent = domain[domain.size() - 1];
+  PrimExpr effective_group_size = min(group_size, last_extent);
+  PrimExpr group_remainder =
+      validation_analyzer.Simplify(truncmod(last_extent, effective_group_size));
+  if (const int64_t *remainder = as_const_int(group_remainder)) {
+    ICHECK_EQ(*remainder, 0)
+        << "T.Persistent last domain extent must be divisible by "
+        << "min(group_size, domain[-1]), but got domain[-1]=" << last_extent
+        << " and group_size=" << group_size;
+  }
   ObjectPtr<ForFrameNode> n = make_object<ForFrameNode>();
   n->vars.reserve(domain.size());
   n->doms.reserve(domain.size());
@@ -147,7 +170,8 @@ ForFrame PersistentFor(const Array<PrimExpr> &domain, const PrimExpr &wave_size,
     ICHECK_EQ(vars.size(), doms.size());
     Map<String, ObjectRef> anno;
     Array<PrimExpr> idxs(grouped_domain.size(), PrimExpr());
-    PrimExpr rem = loop_var * wave_size + index;
+    PrimExpr global_index = loop_var * wave_size + index;
+    PrimExpr rem = global_index;
 
     for (int i = grouped_domain.size() - 1; i >= 1; --i) {
       idxs.Set(i, truncmod(rem, grouped_domain[i]));
@@ -156,7 +180,7 @@ ForFrame PersistentFor(const Array<PrimExpr> &domain, const PrimExpr &wave_size,
     idxs.Set(0, rem);
 
     auto out_if = tvm::tir::IfThenElse(
-        domain_size <= (loop_var * wave_size + index),
+        domain_size <= global_index,
         tvm::tir::Evaluate(
             tvm::tir::Call(DataType::Handle(), tvm::tl::loop_break(), {})),
         Stmt());
@@ -165,6 +189,13 @@ ForFrame PersistentFor(const Array<PrimExpr> &domain, const PrimExpr &wave_size,
     Stmt new_body = body;
     if (analyzer.CanProveGreaterEqual(waves, 2)) {
       new_body = SeqStmt({out_if, body});
+    } else if (!analyzer.CanProveEqual(domain_size, wave_size)) {
+      // A unit loop can be removed during lowering, so a loop_break guard
+      // would become an invalid top-level C++ break. Predicate the tile body
+      // for partial first waves and symbolic wave counts instead. Under
+      // Persistent's 0 <= index < wave_size contract, no guard is needed when
+      // the domain is provably exactly one full wave.
+      new_body = tvm::tir::IfThenElse(global_index < domain_size, body, Stmt());
     }
     Stmt outer =
         For(loop_var, 0, waves, ForKind::kSerial, new_body, NullOpt, anno);

--- a/testing/python/language/test_tilelang_ascend_language_persistent.py
+++ b/testing/python/language/test_tilelang_ascend_language_persistent.py
@@ -1,0 +1,148 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+
+import pytest
+import tilelang
+import tilelang.language as T
+import tvm
+from tvm import tir
+
+
+WAVE_SIZE = 20
+
+
+def _persistent_kernel(rows, cols=2):
+    @T.prim_func
+    def main(O: T.Tensor((rows, cols), "int32")):
+        with T.Kernel(WAVE_SIZE, is_npu=True) as (cid, _):
+            for row, col in T.Persistent([rows, cols], WAVE_SIZE, cid):
+                O[row, col] = row * cols + col
+
+    return main
+
+
+def _persistent_loop(func):
+    loops = []
+
+    def collect(node):
+        if isinstance(node, tir.For):
+            loops.append(node)
+
+    tir.stmt_functor.post_order_visit(func.body, collect)
+    assert len(loops) == 1
+    return loops[0]
+
+
+def _loop_break_calls(stmt):
+    calls = []
+
+    def collect(node):
+        if isinstance(node, tir.Call) and getattr(node.op, "name", None) == "tl.loop_break":
+            calls.append(node)
+
+    tir.stmt_functor.post_order_visit(stmt, collect)
+    return calls
+
+
+def _block_index(func):
+    indices = []
+
+    def collect(node):
+        if (
+            isinstance(node, tir.AttrStmt)
+            and node.attr_key == "thread_extent"
+            and isinstance(node.node, tir.IterVar)
+            and node.node.thread_tag == "blockIdx.x"
+        ):
+            indices.append(node.node.var)
+
+    tir.stmt_functor.post_order_visit(func.body, collect)
+    assert len(indices) == 1
+    return indices[0]
+
+
+def _global_index(func, loop):
+    return loop.loop_var * WAVE_SIZE + _block_index(func)
+
+
+def _assert_break_guard_precedes_tile_body(func, loop, domain_size):
+    assert isinstance(loop.body, tir.SeqStmt)
+    assert len(loop.body.seq) >= 2
+    guard = loop.body.seq[0]
+    assert isinstance(guard, tir.IfThenElse)
+    assert len(_loop_break_calls(guard)) == 1
+    expected_condition = tir.LE(domain_size, _global_index(func, loop))
+    assert tvm.ir.structural_equal(guard.condition, expected_condition)
+    for stmt in loop.body.seq[1:]:
+        assert not _loop_break_calls(stmt)
+
+
+def _assert_tile_body_is_predicated(func, loop, domain_size):
+    assert isinstance(loop.body, tir.IfThenElse)
+    assert not _loop_break_calls(loop.body)
+    expected_condition = tir.LT(_global_index(func, loop), domain_size)
+    assert tvm.ir.structural_equal(loop.body.condition, expected_condition)
+    assert loop.body.else_case is None
+
+
+@pytest.mark.parametrize(
+    "rows,expected_waves,guard_kind",
+    [
+        (4, 1, "predicate"),  # 8 tiles: partial first wave (issue #1551).
+        (10, 1, "none"),  # 20 tiles: exactly one full wave keeps the fast path.
+        (11, 2, "break"),  # 22 tiles: partial final wave.
+        (20, 2, "break"),  # 40 tiles: preserve the existing multi-wave guard.
+    ],
+)
+def test_persistent_guard_for_static_domains(rows, expected_waves, guard_kind):
+    func = _persistent_kernel(rows)
+    loop = _persistent_loop(func)
+
+    assert isinstance(loop.extent, tir.IntImm)
+    assert loop.extent.value == expected_waves
+    if guard_kind == "break":
+        _assert_break_guard_precedes_tile_body(func, loop, rows * 2)
+    elif guard_kind == "predicate":
+        _assert_tile_body_is_predicated(func, loop, rows * 2)
+    else:
+        assert guard_kind == "none"
+        assert not _loop_break_calls(loop)
+        assert not isinstance(loop.body, tir.IfThenElse)
+
+
+def test_persistent_guard_for_dynamic_domain():
+    rows = T.symbolic("rows")
+    func = _persistent_kernel(rows)
+    loop = _persistent_loop(func)
+
+    _assert_tile_body_is_predicated(func, loop, rows * 2)
+
+
+@pytest.mark.parametrize(
+    "domain,wave_size,index,group_size,error_match",
+    [
+        ([0, 2], WAVE_SIZE, 0, 8, "domain extents must be positive"),
+        ([4, 2], 0, 0, 8, "wave_size must be positive"),
+        ([4, 2], WAVE_SIZE, -1, 8, "index must satisfy"),
+        ([4, 2], WAVE_SIZE, WAVE_SIZE, 8, "index must satisfy"),
+        ([4, 2], WAVE_SIZE, 0, 0, "group_size must be positive"),
+        ([4, 3], WAVE_SIZE, 0, 2, "last domain extent must be divisible"),
+    ],
+)
+def test_persistent_rejects_invalid_static_arguments(domain, wave_size, index, group_size, error_match):
+    with pytest.raises(tvm.TVMError, match=error_match):
+        T.Persistent(domain, wave_size, index, group_size)
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_partial_single_wave_guard_reaches_codegen(target):
+    artifact = tilelang.lower(_persistent_kernel(4), target=target)
+
+    assert "break;" not in artifact.kernel_source
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_multi_wave_break_guard_reaches_codegen(target):
+    artifact = tilelang.lower(_persistent_kernel(11), target=target)
+
+    assert artifact.kernel_source.count("break;") == 1

--- a/tilelang/language/persistent.py
+++ b/tilelang/language/persistent.py
@@ -2,28 +2,30 @@
 # Licensed under the MIT License.
 """The language interface for tl programs."""
 
-from typing import List
+from __future__ import annotations
+
 from tvm import tir
 from tilelang import _ffi_api
 
 
 def Persistent(
-    domain: list[tir.PrimExpr],
-    wave_size: tir.PrimExpr,
-    index: tir.PrimExpr,
-    group_size: tir.PrimExpr | None = 8,
+    domain: list[tir.PrimExpr | int],
+    wave_size: tir.PrimExpr | int,
+    index: tir.PrimExpr | int,
+    group_size: tir.PrimExpr | int = 8,
 ):
     """Tools to construct persistent for loop.
 
     Parameters
     ----------
-    domain : List[tir.PrimExpr]
-        The list of dominators.
-    wave_size : int
-        The wave size.
-    index : int
-        The tile index in one wave.
-    group_size : tir.PrimExpr
-        The group size.
+    domain : list[tir.PrimExpr or int]
+        Positive extent of each iteration-domain dimension.
+    wave_size : tir.PrimExpr or int
+        Positive number of workers in one wave.
+    index : tir.PrimExpr or int
+        Worker index in one wave. Must satisfy ``0 <= index < wave_size``.
+    group_size : tir.PrimExpr or int
+        Positive grouping factor for the last domain dimension. The last
+        extent must be divisible by ``min(group_size, domain[-1])``.
     """
     return _ffi_api.Persistent(domain, wave_size, index, group_size)


### PR DESCRIPTION
Fixes #1551。

## 问题说明

`examples/gemm/example_gemm_intrinsic_persistent.py` 在以下参数下出现精度错误：

```text
M=512
N=512
K=512
```

issue #1551 报告的结果为：

- 进程退出码为 `1`，触发 `AssertionError`；
- 不匹配元素为 `228317 / 262144`，约占 `87.1%`；
- 最大绝对误差为 `149.625`，位置为 `(374, 260)`；
- 最大相对误差为 `inf`，位置为 `(59, 497)`。

对比测试中，以下较大 shape 可以通过：

```text
M=1024, N=1024, K=1024
M=2048, N=1024, K=1024
M=1024, N=1024, K=2048
M=2048, N=1024, K=2048
```

## 复现方式

进入 GEMM 示例目录并执行：

```bash
cd examples/gemm
python example_gemm_intrinsic_persistent.py --m 512 --n 512 --k 512
```

修复前，该命令会因输出结果与参考结果不一致而触发 `AssertionError`。

## 原因分析

该示例使用以下 `T.Persistent` 调度参数：

```python
core_num = 20
block_M = 128
block_N = 256

with T.Kernel(core_num, is_npu=True) as (cid, _):
    for bx, by in T.Persistent(
        [T.ceildiv(M, block_M), T.ceildiv(N, block_N)],
        core_num,
        cid,
    ):
        ...
```

当 `M=N=512` 时：

```text
m_tiles = ceildiv(512, 128) = 4
n_tiles = ceildiv(512, 256) = 2
domain_size = 4 * 2 = 8
wave_size = core_num = 20
waves = ceildiv(8, 20) = 1
```

因此，本次计算只有 `8` 个有效 tile，但 kernel 启动了 `20` 个 worker。

`T.Persistent` 中每个 worker 对应的全局 tile 编号为：

```text
global_index = loop_var * wave_size + index
```

在本例中只有一个 wave，因此 `loop_var=0`，且 `index=cid`：

```text
global_index = cid
```

合法的 worker 为：

```text
cid = 0, 1, ..., 7
```

`cid >= 8` 的 worker 没有对应的有效 tile，必须在进入 tile body 前跳过执行。

修复前，`PersistentFor` 只在能够证明 `waves >= 2` 时插入包含 `tl.loop_break` 的越界 guard：

```cpp
if (analyzer.CanProveGreaterEqual(waves, 2)) {
  new_body = SeqStmt({out_if, body});
}
```

对于本例：

```text
waves = 1
```

因此不会生成 guard。`cid >= 8` 的 worker 仍会进入 tile body，并通过 grouped mapping 得到超出 `domain=[4,2]` 范围的坐标。

在默认 `group_size=8` 下，实际使用：

```text
group_size = min(8, domain[-1]) = 2
```

对于 `domain=[4,2]`，坐标映射为：

```text
bx = (global_index / 2) % 4
by = (global_index / 8) * 2 + global_index % 2
```

其中 `/` 表示整数除法。

映射结果如下：

| `global_index` | `bx` | `by` | 状态 |
|---:|---:|---:|---|
| 0～7 | 0～3 | 0～1 | 合法 |
| 8～15 | 0～3 | 2～3 | `by` 越界 |
| 16～19 | 0～1 | 4～5 | `by` 越界 |

这些 worker 随后会执行包含以下形式的内存访问：

```python
T.copy(B[0, by * block_N], B_L1[0, :, :])
...
T.copy(C_L0, C[bx * block_M, by * block_N])
```

当 `by >= 2` 时，`by * block_N >= 512`，超出了当前矩阵 N 维的有效范围，导致非法 tile 对应的 B 读取和 C 写入，最终产生 issue #1551 中报告的精度错误。

## 解决方案

本 PR 在 `PersistentFor` 中显式构造：

```cpp
PrimExpr global_index = loop_var * wave_size + index;
```

并根据 `waves` 与 `domain_size` 的静态分析结果采用不同的 guard。

### 1. 可以证明存在多个 wave

保留原有的循环内 `break` guard：

```cpp
if (analyzer.CanProveGreaterEqual(waves, 2)) {
  new_body = SeqStmt({out_if, body});
}
```

其中 `out_if` 判断：

```text
domain_size <= global_index
```

对应逻辑为：

```cpp
if (global_index >= domain_size) {
  break;
}
```

该路径继续用于多 wave 调度，包括最后一个 wave 未满的情况。

### 2. 无法证明存在多个 wave，且无法证明恰好为一个完整 wave

使用正向 predicate 包住整个 tile body：

```cpp
else if (!analyzer.CanProveEqual(domain_size, wave_size)) {
  new_body =
      tvm::tir::IfThenElse(global_index < domain_size, body, Stmt());
}
```

对应逻辑为：

```cpp
if (global_index < domain_size) {
  // tile body
}
```

该路径覆盖：

- `domain_size < wave_size` 的未满单 wave；
- 编译期无法确定 `domain_size` 和 `waves` 的动态 domain。

对于 issue #1551 中的 `domain_size=8`、`wave_size=20`，生成代码包含：

```cpp
if (cid < 8) {
  // tile body
}
```

因此 `cid >= 8` 的 worker 不再执行 tile 内存访问。

### 3. 可以证明恰好为一个完整 wave

当：

```text
domain_size == wave_size
```

并满足：

```text
0 <= index < wave_size
```

时，当前 wave 中的所有 worker 都对应有效 tile，因此不插入额外 guard，保留原有路径。

## 为什么未满单 wave 不使用 `break`

如果单 wave 路径使用：

```cpp
if (global_index >= domain_size) {
  break;
}
```

其外围循环的 extent 为 `1`。该循环可能在 lowering 阶段被消除，使 `break` 失去所属循环，最终生成位于函数体中的无效 C++：

```cpp
if (cid >= 8) {
  break;
}
```

因此，未满单 wave 和 symbolic wave count 使用：

```text
global_index < domain_size
```

作为正向 predicate，而多 wave 路径继续使用循环内 `break`。

## 修改内容

### `src/ir.cc`

- 增加 `global_index`；
- 保留多 wave 的 `break` guard；
- 为未满单 wave 和动态 domain 使用 `global_index < domain_size` predicate；
- 保留恰好一个完整 wave 时的无 guard 路径。

### `tilelang/language/persistent.py`

更新 `T.Persistent` 的参数类型和调用约束：

```text
domain 中各维 extent 必须为正数
wave_size > 0
0 <= index < wave_size
group_size > 0
domain[-1] 必须能够被 min(group_size, domain[-1]) 整除
```

### `testing/python/language/test_tilelang_ascend_language_persistent.py`

新增回归测试，覆盖以下情况：

| `domain` | `domain_size` | `waves` | 预期 guard |
|---|---:|---:|---|
| `[4,2]` | 8 | 1 | `global_index < domain_size` predicate |
| `[10,2]` | 20 | 1 | 无 guard |
| `[11,2]` | 22 | 2 | 循环内 `break` |
| `[20,2]` | 40 | 2 | 保留循环内 `break` |
| `[rows,2]` | 动态 | 动态 | `global_index < domain_size` predicate |

测试同时检查：

- TIR 中 guard 的结构与条件；
- 未满单 wave 中不存在 `tl.loop_break`；
- 多 wave 的 guard 位于 tile body 之前；
- AscendC 和 PTO codegen 中，未满单 wave 不生成顶层 `break;`；
- AscendC 和 PTO codegen 中，多 wave 保留一个循环内 `break;`。

## 验证结果

执行专项测试：

```bash
pytest -q testing/python/language/test_tilelang_ascend_language_persistent.py
```

结果：

```text
9 passed
```

同时确认：

- issue #1551 对应的 `512×512×512` shape 生成 `if (cid < 8)`；
- 未满单 wave 的生成代码中不存在无效的顶层 `break;`；
- 多 wave 路径继续生成循环内 `break;`；
- AscendC 和 PTO 两个 target 均包含对应的 codegen 回归测试。
