### PR TITLE
[Doc]: Make T.tile.clamp effective on PTO and fact-check docs

### DIFF
--- a/docs/api_docs/T.tile.atomic_add.md
+++ b/docs/api_docs/T.tile.atomic_add.md
@@ -1,0 +1,71 @@
+# T.tile.atomic_add
+
+## 1. 功能说明
+
+将本地 tensor（UB/L0C/L1）的数据原子累加到 GM 目标 tensor：`dst[GM][i] += src[local][i]`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def atomic_add(
+    dst: Buffer | BufferRegion | BufferLoad,
+    src: Buffer | BufferRegion | BufferLoad,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | GM 上的目标区域，累加结果写回此处 | 张量（tensor，scope 必须为 global） | 必填 |
+| src | 输入 | 本地 tensor，其数据将被原子累加到 dst | 张量（tensor，scope 必须为 local） | 必填 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared`、`T.alloc_L0C`、`T.alloc_L1` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **global scope**：通过 `T.alloc_gm` 或外部传入的 GM buffer
+> - **local scope**：UB、L0C、L1 等非 GM 内存区域
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src |
+|------|:---:|:---:|
+| Ascend A2 / A3 | float16, float32, int16, int32, bfloat16 | float16, float32, int16, int32, bfloat16 |
+
+> int8 仅 pto 后端支持。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+### 2.4 约束条件
+
+1. dst 的 buffer scope 必须为 `global`（GM），否则抛出 `ValueError`
+2. src 的 buffer scope 必须为 local（UB/L0C/L1 等），不能为 `global`，否则抛出 `ValueError`
+3. dst 与 src 的 dtype 必须相同（所有路径）
+4. 仅支持 local（VECOUT/L0C/L1）→ GM 方向的 DMA 搬运附带原子累加（硬件约束）
+5. 累加前 GM 需清零：DMA 原子累加不会自动清零，开发者需在调用前确保 dst GM 已清零
+6. 完成后自动关闭原子操作：tilelang 在原子累加完成后自动调用 `disable_dma_atomic`，开发者无需手动关闭
+
+## 3. 示例代码
+
+**示例 1：UB → GM 原子累加**
+
+```python
+C_gm = T.alloc_gm((256,), "float32")
+src_ub = T.alloc_ub((256,), "float32")
+T.tile.fill(src_ub, 1.0)
+T.tile.atomic_add(C_gm, src_ub)
+```
+
+**示例 2：L0C → GM 原子累加（GEMM split-K 场景）**
+
+```python
+C_gm = T.alloc_gm((block_M, block_N), "float32")
+C_L0 = T.alloc_L0C((block_M, block_N), "float32")
+T.gemm_v0(A_L1, B_L1, C_L0, init=True)
+T.tile.atomic_add(C_gm[by * block_M, bx * block_N], C_L0)
+```

--- a/docs/language/tile_clamp.md
+++ b/docs/language/tile_clamp.md
@@ -1,0 +1,105 @@
+# T.tile.clamp
+
+## 1. 功能说明
+
+将源 buffer 中的元素钳位到闭区间 `[min_scalar, max_scalar]`，并写入目标 buffer：
+`out[i] = min(max(buffer[i], min_scalar), max_scalar)`。
+
+小于下界的元素替换为 `min_scalar`，大于上界的元素替换为 `max_scalar`，区间内的元素保持不变。
+支持输入和输出使用同一个 buffer 的原地计算。
+
+> **注意区分**：`T.clamp` 是标量级运算，用于 `T.Parallel` 循环内的逐元素表达式；
+> `T.tile.clamp` 是 buffer 级 intrinsic，对 Unified Buffer 中的一段连续区域执行计算。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def clamp(
+    out: Buffer | BufferRegion,
+    buffer: Buffer | BufferRegion,
+    min_scalar: PrimExpr,
+    max_scalar: PrimExpr,
+    count: PrimExpr,
+    *,
+    tmp: Buffer | BufferRegion | None = None,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| out | 输出 | 存放钳位结果的 UB buffer，可与 `buffer` 相同 | 张量（tensor） | 必填 |
+| buffer | 输入 | 源 UB buffer | 张量（tensor） | 必填 |
+| min_scalar | 输入 | 闭区间下界，可转换为 `buffer` 的 dtype | 标量表达式（PrimExpr） | 必填 |
+| max_scalar | 输入 | 闭区间上界，可转换为 `buffer` 的 dtype | 标量表达式（PrimExpr） | 必填 |
+| count | 输入 | 从所选区域起始位置开始参与计算的元素个数 | 整数表达式（PrimExpr） | 必填 |
+| tmp | 输入/输出 | PTO 路径可选的显式 UB 临时空间，仅能以关键字参数传入 | 张量（tensor）或 `None` | 可选，默认 `None` |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub` 分配的 Buffer，或其连续 BufferRegion。
+> - **PrimExpr**：TileLang 编译期可表示的标量或整数表达式。
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 / 后端 | out | buffer | min_scalar / max_scalar |
+|-------------|:---:|:------:|:-----------------------:|
+| Ascend A2 / A3，AscendC | float16, float32, int16, int32 | float16, float32, int16, int32 | 可转换为 buffer dtype 的标量 |
+| Ascend A2 / A3，PTO | float16, float32, int16, int32 | float16, float32, int16, int32 | 可转换为 buffer dtype 的标量 |
+
+`out` 与 `buffer` 的 dtype 必须相同。
+
+#### 2.3.2 Shape 支持
+
+- 支持一维、二维 Buffer，以及其中的连续 BufferRegion。
+- `out` 与 `buffer` 的 shape 和元素总数必须相同。
+
+#### 2.3.3 count 与临时空间说明
+
+- AscendC 按 `count` 处理所选区域的前缀元素，未处理的后缀保持不变。
+- PTO 当前要求 `count` 等于所选 tile 的完整元素数，不支持 partial count。
+- AscendC 使用基础 `Maxs` 和 `Mins` 指令组合，不需要临时空间。
+- PTO 使用临时 tile 保存下界。`tmp=None` 时框架自动申请与所选源区域字节数相同的空间；
+  显式传入 `tmp` 时，其 dtype 不参与计算，后端按 `buffer.dtype` 重新解释存储。
+
+### 2.4 约束条件
+
+1. `out` 与 `buffer` 必须具有相同的 dtype、shape 和可访问元素数。
+2. `min_scalar` 必须小于或等于 `max_scalar`。
+3. `count` 不得超过源区域或目标区域可访问的元素数；PTO 还要求 `count` 等于完整 tile 元素数。
+4. 操作数位于 Unified Buffer，起始地址需满足 32 字节对齐要求（硬件约束）。
+5. `out` 可以与 `buffer` 完全相同以执行原地计算；其他部分重叠方式不属于支持范围。
+6. PTO 显式 `tmp` 必须是一维、静态、连续、固定宽度标量 dtype 的 `shared.ub` Buffer，
+   或起始字节地址满足 32 字节对齐的 BufferRegion，容量不得小于所选源区域的字节数。
+7. `tmp` 不得与 `out` 或 `buffer` 重叠。当前前端校验 `tmp` 的布局和起始地址，
+   但不校验调用者提供的显式临时空间容量是否充足。
+
+## 3. 示例代码
+
+**示例 1：AscendC partial count**
+
+```python
+src = T.alloc_ub((64,), "float16")
+dst = T.alloc_ub((64,), "float16")
+T.tile.clamp(dst, src, 0.0, 6.0, 17)  # 只钳位前 17 个元素
+```
+
+**示例 2：PTO 完整 tile 与自动临时空间**
+
+```python
+values = T.alloc_ub((4, 16), "float32")
+T.tile.clamp(values, values, -1.0, 1.0, 64)  # 原地计算，框架自动申请 PTO 临时空间
+```
+
+**示例 3：BufferRegion 与显式临时空间**
+
+```python
+src = T.alloc_ub((2, 64), "int16")
+dst = T.alloc_ub((2, 64), "int16")
+workspace = T.alloc_ub((64,), "int16")
+T.tile.clamp(dst[1, :], src[0, :], -8, 7, 64, tmp=workspace)
+```

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -3385,18 +3385,35 @@ void CodeGenTileLangAscendPto::BinaryVecClampMaxMinOpsCodegen(
 
 void CodeGenTileLangAscendPto::BinaryVecClampOpsCodegen(
     const CallNode *op, const std::string &op_name) {
+  ICHECK_EQ(op->args.size(), 7U);
   ShapeInfo src_shape_info = GetSliceInfo(op->args[2].as<CallNode>());
   ShapeInfo dst_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
+  ShapeInfo tmp_shape_info = GetSliceInfo(op->args[3].as<CallNode>());
 
   auto scalar_min = PrintExpr(op->args[op->args.size() - 3]);
   auto scalar_max = PrintExpr(op->args[op->args.size() - 2]);
 
   std::string src_name = ResolveUbSliceName(src_shape_info);
   std::string dst_name = ResolveUbSliceName(dst_shape_info);
+  std::string min_name = GetTempVarName("clamp_min");
+
+  // A2/A3 PTO provides TMINS but not TMAXS. Materialize the lower bound in
+  // the typed workspace and use the supported tile-tile TMAX instead.
+  ShapeInfo min_shape_info = dst_shape_info;
+  min_shape_info.first_addr = tmp_shape_info.first_addr;
+  min_shape_info.offset = tmp_shape_info.offset;
+  min_shape_info.ub_name = tmp_shape_info.ub_name;
+  CreateUbVariableND(min_name, min_shape_info);
 
   this->PrintIndent();
-  this->stream << "TMAXS(" << dst_name << ", " << src_name << ", " << scalar_min
+  this->stream << "TEXPANDS(" << min_name << ", " << scalar_min << ");\n";
+  this->PrintIndent();
+  this->stream << "TL_PIPE_V_BARRIER();\n";
+  this->PrintIndent();
+  this->stream << "TMAX(" << dst_name << ", " << src_name << ", " << min_name
                << ");\n";
+  this->PrintIndent();
+  this->stream << "TL_PIPE_V_BARRIER();\n";
   this->PrintIndent();
   this->stream << "TMINS(" << dst_name << ", " << dst_name << ", " << scalar_max
                << ");\n";

--- a/src/transform/allocate_tmp_buffer.cc
+++ b/src/transform/allocate_tmp_buffer.cc
@@ -547,8 +547,11 @@ WorkspaceSpec GetPTOWorkspaceSpec(const CallNode *call,
     return RequireWorkspace(GetAccessPtrDtype(call->args[2]),
                             EstimatePTOWorkspaceBytes(call, alloc_buffers));
   }
-  if (call->op.same_as(tl::ascend_clamp()) ||
-      call->op.same_as(tl::ascend_clamp_max()) ||
+  if (call->op.same_as(tl::ascend_clamp())) {
+    return RequireWorkspace(GetAccessPtrDtype(call->args[2]),
+                            GetAccessPtrBytes(call->args[2]));
+  }
+  if (call->op.same_as(tl::ascend_clamp_max()) ||
       call->op.same_as(tl::ascend_clamp_min()) ||
       call->op.same_as(tl::ascend_sigmoid()) ||
       call->op.same_as(tl::ascend_pow()) ||

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -1489,113 +1489,141 @@ def test_cast_scale(dtype, target, shape):
     run_test_cast_scale(M, N, 16, 16, "CAST_RINT", 4096, 1.0, target)
 
 
-def clamp(M, N, block_M, block_N, max_val, min_val, dtype="float16"):
-    m_num = M // block_M
-    n_num = N // block_N
-    num_blocks = m_num * n_num
+_TILE_CLAMP_INPUT_PATTERN = [-20, -3, -2, -1, 0, 1, 2, 3, 4, 20]
+_TILE_CLAMP_TORCH_DTYPES = {
+    "float": torch.float32,
+    "float16": torch.float16,
+    "int16": torch.int16,
+    "int32": torch.int32,
+}
 
-    VEC_NUM = 2
 
+def _tile_clamp_numel(shape):
+    result = 1
+    for extent in shape:
+        result *= extent
+    return result
+
+
+def _tile_clamp_input(shape, dtype):
+    numel = _tile_clamp_numel(shape)
+    repeat = (numel + len(_TILE_CLAMP_INPUT_PATTERN) - 1) // len(
+        _TILE_CLAMP_INPUT_PATTERN
+    )
+    return (
+        torch.tensor(_TILE_CLAMP_INPUT_PATTERN, dtype=_TILE_CLAMP_TORCH_DTYPES[dtype])
+        .repeat(repeat)[:numel]
+        .reshape(shape)
+    )
+
+
+def tile_clamp_kernel(shape, dtype, count, inplace=False):
     @T.prim_func
     def main(
-        input: T.Tensor((M, N), dtype),  # type: ignore
-        output: T.Tensor((M, N), dtype),  # type: ignore
+        A: T.Tensor(shape, dtype),  # type: ignore
+        B: T.Tensor(shape, dtype),  # type: ignore
     ):
-        with T.Kernel(num_blocks, is_npu=True) as (cid, vid):
-            bx = cid // n_num
-            by = cid % n_num
-
-            block_size = block_M * block_N // VEC_NUM
-            in_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-            out_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-
-            T.copy(input[bx * block_M + vid * block_M // VEC_NUM, by * block_N], in_ub)
-
-            T.tile.clamp(out_ub, in_ub, min_val, max_val, block_size)
-
-            T.copy(out_ub, output[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+        with T.Kernel(1, is_npu=True) as (_, vid):
+            src_ub = T.alloc_ub(shape, dtype)
+            dst_ub = src_ub if inplace else T.alloc_ub(shape, dtype)
+            if vid == 0:
+                T.copy(A, src_ub)
+                if not inplace:
+                    T.tile.fill(dst_ub, -99)
+                T.tile.clamp(dst_ub, src_ub, -2, 3, count)
+                T.copy(dst_ub, B)
 
     return main
 
 
-def run_test_clamp(M, N, max_val, min_val, thresh, dtype, target, block_M=64, block_N=64):
-    if min_val > max_val:
-        max_val, min_val = min_val, max_val
+def run_test_tile_clamp(shape, dtype, target, count=None, inplace=False):
+    numel = _tile_clamp_numel(shape)
+    if count is None:
+        count = numel
+    kernel = tilelang.compile(
+        tile_clamp_kernel(shape, dtype, count, inplace),
+        out_idx=[-1],
+        pass_configs=pass_configs,
+        target=target,
+    )
 
-    func = clamp(M, N, block_M, block_N, max_val, min_val, dtype)
-    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
-
-    a = (torch.rand(M, N) - 0.5) * 2 * thresh
-    a = a.half().npu() if dtype == "float16" else a.float().npu()
-
-    b = func(a)
-    ref_b = torch.clamp(a, min_val, max_val)
-
-    torch.testing.assert_close(b, ref_b, rtol=1e-2, atol=1e-2)
+    input_host = _tile_clamp_input(shape, dtype)
+    expected_host = torch.full_like(input_host, -99)
+    expected_host.reshape(-1)[:count] = torch.clamp(
+        input_host.reshape(-1)[:count], -2, 3
+    )
+    output = kernel(input_host.npu())
+    torch.npu.synchronize()
+    torch.testing.assert_close(output, expected_host.npu(), rtol=0, atol=0)
 
 
-@pytest.mark.parametrize("dtype", ["float", "float16"])
+@pytest.mark.parametrize(
+    ("dtype", "target"),
+    [
+        ("float", "ascendc"),
+        ("float16", "ascendc"),
+        ("int16", "ascendc"),
+        ("int32", "ascendc"),
+        ("float", "pto"),
+        ("float16", "pto"),
+        ("int16", "pto"),
+        ("int32", "pto"),
+    ],
+)
+def test_tile_clamp_full_tile(dtype, target):
+    run_test_tile_clamp((4, 16), dtype, target)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16", "int16", "int32"])
+@pytest.mark.parametrize("count", [17, 32])
+def test_tile_clamp_ascendc_partial_count(dtype, count):
+    run_test_tile_clamp((64,), dtype, "ascendc", count=count)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "target"),
+    [
+        ("float16", "ascendc"),
+        ("float16", "pto"),
+        ("int32", "pto"),
+    ],
+)
+def test_tile_clamp_inplace(dtype, target):
+    run_test_tile_clamp((64,), dtype, target, inplace=True)
+
+
+def tile_clamp_region_kernel(dtype):
+    @T.prim_func
+    def main(
+        A: T.Tensor((2, 64), dtype),  # type: ignore
+        B: T.Tensor((2, 64), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (_, vid):
+            src_ub = T.alloc_ub((2, 64), dtype)
+            dst_ub = T.alloc_ub((2, 64), dtype)
+            if vid == 0:
+                T.copy(A, src_ub)
+                T.tile.fill(dst_ub, -99)
+                T.tile.clamp(dst_ub[1, :], src_ub[0, :], -2, 3, 64)
+                T.copy(dst_ub, B)
+
+    return main
+
+
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
-def test_clamp(dtype, target):
-    M, N = 1024, 1024
-    thresh = 10000
-    max_val = random.uniform(-thresh, thresh)
-    min_val = random.uniform(-thresh, thresh)
-    run_test_clamp(M, N, max_val, min_val, thresh, dtype, target, block_M=64, block_N=64)
-
-
-def clamp_slice(M, N, block_M, block_N, max_val, min_val, dtype="float16"):
-    m_num = M // block_M
-    n_num = N // block_N
-    num_blocks = m_num * n_num
-
-    VEC_NUM = 2
-
-    @T.prim_func
-    def main(
-        input: T.Tensor((M, N), dtype),  # type: ignore
-        output: T.Tensor((M, N), dtype),  # type: ignore
-    ):
-        with T.Kernel(num_blocks, is_npu=True) as (cid, vid):
-            bx = cid // n_num
-            by = cid % n_num
-
-            block_size = block_M * block_N // VEC_NUM
-            in_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-            out_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-            T.copy(input[bx * block_M + vid * block_M // VEC_NUM, by * block_N], in_ub)
-            for i in range(block_M // VEC_NUM):
-                T.tile.clamp(out_ub[i, :], in_ub[i, :], min_val, max_val, block_size)
-
-            T.copy(out_ub, output[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
-
-    return main
-
-
-def run_test_clamp_slice(M, N, max_val, min_val, thresh, dtype, target, block_M=64, block_N=64):
-    if min_val > max_val:
-        max_val, min_val = min_val, max_val
-
-    func = clamp_slice(M, N, block_M, block_N, max_val, min_val, dtype)
-    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
-
-    a = (torch.rand(M, N) - 0.5) * 2 * thresh
-    a = a.half().npu() if dtype == "float16" else a.float().npu()
-
-    b = func(a)
-    ref_b = torch.clamp(a, min_val, max_val)
-
-    torch.testing.assert_close(b, ref_b, rtol=1e-2, atol=1e-2)
-
-
-@pytest.mark.parametrize("dtype", ["float", "float16"])
-@pytest.mark.parametrize("target", ["ascendc"])
-def test_clamp_slice(dtype, target):
-    M, N = 1024, 1024
-    thresh = 10000
-    max_val = random.uniform(-thresh, thresh)
-    min_val = random.uniform(-thresh, thresh)
-    run_test_clamp_slice(M, N, max_val, min_val, thresh, dtype, target, block_M=64, block_N=64)
+def test_tile_clamp_buffer_region(target):
+    kernel = tilelang.compile(
+        tile_clamp_region_kernel("float16"),
+        out_idx=[-1],
+        pass_configs=pass_configs,
+        target=target,
+    )
+    input_host = _tile_clamp_input((2, 64), "float16")
+    expected_host = torch.full_like(input_host, -99)
+    expected_host[1, :] = torch.clamp(input_host[0, :], -2, 3)
+    output = kernel(input_host.npu())
+    torch.npu.synchronize()
+    torch.testing.assert_close(output, expected_host.npu(), rtol=0, atol=0)
 
 
 def compare(M, N, block_M, block_N, mode, dtype="float", out_dtype="uint8"):

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -1507,14 +1507,8 @@ def _tile_clamp_numel(shape):
 
 def _tile_clamp_input(shape, dtype):
     numel = _tile_clamp_numel(shape)
-    repeat = (numel + len(_TILE_CLAMP_INPUT_PATTERN) - 1) // len(
-        _TILE_CLAMP_INPUT_PATTERN
-    )
-    return (
-        torch.tensor(_TILE_CLAMP_INPUT_PATTERN, dtype=_TILE_CLAMP_TORCH_DTYPES[dtype])
-        .repeat(repeat)[:numel]
-        .reshape(shape)
-    )
+    repeat = (numel + len(_TILE_CLAMP_INPUT_PATTERN) - 1) // len(_TILE_CLAMP_INPUT_PATTERN)
+    return torch.tensor(_TILE_CLAMP_INPUT_PATTERN, dtype=_TILE_CLAMP_TORCH_DTYPES[dtype]).repeat(repeat)[:numel].reshape(shape)
 
 
 def tile_clamp_kernel(shape, dtype, count, inplace=False):
@@ -1549,9 +1543,7 @@ def run_test_tile_clamp(shape, dtype, target, count=None, inplace=False):
 
     input_host = _tile_clamp_input(shape, dtype)
     expected_host = torch.full_like(input_host, -99)
-    expected_host.reshape(-1)[:count] = torch.clamp(
-        input_host.reshape(-1)[:count], -2, 3
-    )
+    expected_host.reshape(-1)[:count] = torch.clamp(input_host.reshape(-1)[:count], -2, 3)
     output = kernel(input_host.npu())
     torch.npu.synchronize()
     torch.testing.assert_close(output, expected_host.npu(), rtol=0, atol=0)

--- a/testing/python/language/test_tilelang_ascend_language_explicit_tmp.py
+++ b/testing/python/language/test_tilelang_ascend_language_explicit_tmp.py
@@ -370,6 +370,7 @@ def test_every_workspace_api_has_the_target_specific_lowered_layout(model, expli
     pto_workspace_ops = {
         "tl.ascend_reduce",
         "tl.ascend_bitwise_xor",
+        "tl.ascend_clamp",
         "tl.ascend_merge_sort",
         "tl.ascend_select",
         "tl.ascend_sort",
@@ -757,7 +758,6 @@ def test_pto_zero_workspace_apis_elide_an_explicit_empty_arena():
                 T.tile.pow(dst_ub, src_ub, src_ub, tmp=arena_ub)
                 T.tile.clamp_max(dst_ub, src_ub, 1.0, 64, tmp=arena_ub)
                 T.tile.clamp_min(dst_ub, src_ub, -1.0, 64, tmp=arena_ub)
-                T.tile.clamp(dst_ub, src_ub, -1.0, 1.0, 64, tmp=arena_ub)
                 T.tile.round(dst_ub, src_ub, 64, tmp=arena_ub)
                 T.tile.gather_mask(dst_ub, src_ub, "P0101", tmp=arena_ub)
 
@@ -767,7 +767,6 @@ def test_pto_zero_workspace_apis_elide_an_explicit_empty_arena():
         "tl.ascend_pow",
         "tl.ascend_clamp_max",
         "tl.ascend_clamp_min",
-        "tl.ascend_clamp",
         "tl.ascend_round",
         "tl.ascend_gather_mask",
     }
@@ -1143,6 +1142,46 @@ def test_ascendc_zero_workspace_codegen_uses_basic_intrinsics():
     assert "tl::ascend::Broadcast" in source
     assert "tmp_ub" not in source
     assert "PopStackBuffer" not in source
+
+
+@pytest.mark.parametrize(
+    ("dtype", "count", "expected_bytes"),
+    [
+        ("float16", 64, 128),
+        ("float32", 64, 256),
+        ("int16", 64, 128),
+        ("int32", 64, 256),
+    ],
+)
+def test_pto_clamp_workspace_matches_source(dtype, count, expected_bytes):
+    src = _ub_buffer("src", (count,), dtype)
+    dst = _ub_buffer("dst", (count,), dtype)
+    call = ascend_tile.clamp(dst, src, -1, 1, count)
+
+    func, _, workspace = _lower_single_workspace(call, 3, [src, dst], model="pto")
+
+    assert workspace is not None
+    assert workspace.args[0].dtype == dtype
+    assert _workspace_bytes(workspace) == expected_bytes
+    assert _allocated_buffer_names(func).count("tmp_ub") == 1
+
+
+def test_pto_clamp_codegen_uses_supported_tile_max():
+    @T.prim_func
+    def main():
+        with T.Kernel(1, is_npu=True) as (_, vid):
+            src_ub = T.alloc_ub((64,), "float16")
+            dst_ub = T.alloc_ub((64,), "float16")
+            if vid == 0:
+                T.tile.clamp(dst_ub, src_ub, -1.0, 1.0, 64)
+
+    source = tilelang.lower(main, target="pto").kernel_source
+
+    assert "TEXPANDS(clamp_min" in source
+    assert "TMAX(dst_ub, src_ub, clamp_min" in source
+    assert "TMINS(dst_ub, dst_ub" in source
+    assert "TMAXS(" not in source
+    assert "tmp_ub" in source
 
 
 def test_ascendc_experimental_reduce_codegen_uses_source_dtype_workspace():

--- a/testing/python/language/test_tilelang_ascend_language_tile_atomic_add_dtype_coverage.py
+++ b/testing/python/language/test_tilelang_ascend_language_tile_atomic_add_dtype_coverage.py
@@ -1,0 +1,172 @@
+"""
+T.tile.atomic_add dtype coverage tests.
+
+Existing coverage in test_tilelang_ascend_language_tile_atomic_add.py:
+- float32/float16 x ascendc/pto (1D UB->GM)
+- float32 x ascendc/pto (2D UB->GM)
+- float16 x ascendc/pto (2D L0C->GM via GEMM)
+
+This file supplements with:
+1. int32 dtype coverage (1D UB->GM, ascendc + pto) — discovered support beyond ftcheck
+2. Scope violation tests (dst=UB, src=GM must raise)
+3. Dtype mismatch test (dst float32, src float16 must raise)
+4. Unsupported dtype compilation errors (uint16/uint32 x pto, int8 x ascendc)
+
+Test suite follows the simplification principle for direct-intrinsic APIs
+(mentor z00520135 review on PR4): since atomic_add has no type-specific
+processing logic, only representative dtypes are tested.
+"""
+
+import pytest
+import tilelang
+import tilelang.language as T
+import torch
+
+tilelang.disable_cache()
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+}
+
+VEC_NUM = 2
+
+
+def _torch_dtype(dtype):
+    mapping = {
+        "float16": torch.float16,
+        "float32": torch.float32,
+        "int16": torch.int16,
+        "int32": torch.int32,
+        "int8": torch.int8,
+    }
+    return mapping[dtype]
+
+
+def _fill_value(dtype):
+    if dtype in ("int16", "int32", "int8"):
+        return 1
+    return 1.0
+
+
+def _make_ub_to_gm_1d(dtype, tile_n=32, num_blocks=4):
+    @T.prim_func
+    def main(C: T.Tensor((tile_n,), dtype)):  # type: ignore
+        with T.Kernel(num_blocks, is_npu=True) as (cid, vid):
+            src_ub = T.alloc_ub((tile_n,), dtype)
+            T.tile.fill(src_ub, _fill_value(dtype))
+            T.tile.atomic_add(C[0], src_ub)
+
+    return main
+
+
+def _run_and_check(program, shape, dtype, num_blocks, target):
+    kernel = tilelang.compile(program, pass_configs=PASS_CONFIGS, target=target)
+    torch_dtype = _torch_dtype(dtype)
+    out = torch.zeros(shape, dtype=torch_dtype, device="npu")
+    torch.npu.synchronize()
+    kernel(out)
+    torch.npu.synchronize()
+    expected = torch.full(shape, num_blocks * VEC_NUM, dtype=torch_dtype, device="npu")
+    torch.testing.assert_close(out, expected, rtol=1e-5, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Functional tests: int32 dtype (default — core integer type, discovered support)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="tile atomic_add correctness requires an Ascend NPU runtime",
+)
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_atomic_add_int32_1d(target):
+    num_blocks = 4
+    tile_n = 32
+    program = _make_ub_to_gm_1d("int32", tile_n=tile_n, num_blocks=num_blocks)
+    _run_and_check(program, (tile_n,), "int32", num_blocks, target)
+
+
+# ---------------------------------------------------------------------------
+# Exception boundary: scope violations (default — no LP)
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_add_dst_scope_violation_raises():
+    """dst must be GM scope; using UB should raise during TIR construction."""
+
+    with pytest.raises(RuntimeError, match="DiagnosticError"):
+
+        @T.prim_func
+        def main(C: T.Tensor((32,), "float32")):  # type: ignore
+            with T.Kernel(1, is_npu=True) as (cid, _):
+                dst_ub = T.alloc_ub((32,), "float32")
+                src_ub = T.alloc_ub((32,), "float32")
+                T.tile.fill(src_ub, 1.0)
+                T.tile.atomic_add(dst_ub[0], src_ub)
+
+
+def test_atomic_add_src_scope_violation_raises():
+    """src must be local scope; using GM should raise during TIR construction."""
+
+    with pytest.raises(RuntimeError, match="DiagnosticError"):
+
+        @T.prim_func
+        def main(
+            C: T.Tensor((32,), "float32"),  # type: ignore
+            D: T.Tensor((32,), "float32"),  # type: ignore
+        ):
+            with T.Kernel(1, is_npu=True) as (cid, _):
+                T.tile.atomic_add(C[0], D[0])
+
+
+# ---------------------------------------------------------------------------
+# Exception boundary: dtype mismatch (default — no LP)
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_add_dtype_mismatch_raises():
+    """dst and src dtype must match; mismatch should raise at compile time."""
+
+    @T.prim_func
+    def main(C: T.Tensor((32,), "float32")):  # type: ignore
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            src_ub = T.alloc_ub((32,), "float16")
+            T.tile.fill(src_ub, 1.0)
+            T.tile.atomic_add(C[0], src_ub)
+
+    with pytest.raises(RuntimeError, match="dtype to match"):  # noqa: B017
+        tilelang.compile(main, pass_configs=PASS_CONFIGS, target="ascendc")
+
+
+# ---------------------------------------------------------------------------
+# Exception boundary: unsupported dtype (default — no LP)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "dtype,target",
+    [
+        ("uint16", "pto"),
+        ("uint32", "pto"),
+        ("int8", "ascendc"),
+    ],
+)
+def test_atomic_add_unsupported_dtype_raises(dtype, target):
+    """uint16/uint32 x pto and int8 x ascendc should fail at compile time."""
+
+    @T.prim_func
+    def main(C: T.Tensor((32,), dtype)):  # type: ignore
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            src_ub = T.alloc_ub((32,), dtype)
+            T.tile.fill(src_ub, 1)
+            T.tile.atomic_add(C[0], src_ub)
+
+    with pytest.raises(RuntimeError, match="Compilation Failed"):  # noqa: B017
+        tilelang.compile(main, pass_configs=PASS_CONFIGS, target=target)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-n", "8"])

--- a/testing/python/language/test_tilelang_ascend_language_tile_atomic_add_dtype_coverage.py
+++ b/testing/python/language/test_tilelang_ascend_language_tile_atomic_add_dtype_coverage.py
@@ -81,7 +81,13 @@ def _run_and_check(program, shape, dtype, num_blocks, target):
     not (hasattr(torch, "npu") and torch.npu.is_available()),
     reason="tile atomic_add correctness requires an Ascend NPU runtime",
 )
-@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param("ascendc", marks=pytest.mark.low_priority, id="int32-ascendc"),
+        pytest.param("pto", id="int32-pto"),
+    ],
+)
 def test_atomic_add_int32_1d(target):
     num_blocks = 4
     tile_n = 32
@@ -150,7 +156,7 @@ def test_atomic_add_dtype_mismatch_raises():
     "dtype,target",
     [
         ("uint16", "pto"),
-        ("uint32", "pto"),
+        pytest.param("uint32", "pto", marks=pytest.mark.low_priority, id="uint32-pto"),
         ("int8", "ascendc"),
     ],
 )

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -320,6 +320,16 @@ def atomic_add(
 
     V1 intentionally models Ascend DMA atomic add only: the destination must be
     GM, and the source must be a local tensor region that can be copied out.
+
+    Args:
+        dst: GM destination tensor (Buffer/BufferRegion/BufferLoad). Scope must be
+            ``global``. Supports float16, float32, int16, int32, bfloat16.
+        src: Local source tensor (Buffer/BufferRegion/BufferLoad). Scope must be
+            local (UB/L0C/L1). dtype must match dst for UB->GM; L0C->GM allows
+            dtype mismatch (e.g. L0C float -> GM half).
+
+    Returns:
+        tvm.tir.Call: A TIR intrinsic call to ``tl.ascend_atomic_add``.
     """
     dst_scope = _atomic_add_scope(dst, "dst")
     src_scope = _atomic_add_scope(src, "src")

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -2236,20 +2236,33 @@ def clamp(
     *,
     tmp: Buffer | BufferRegion | None = None,
 ):  # noqa: F821
-    """
-    Clip tensor elements to [min_scalar, max_scalar] range, replace out-of-bounds values with boundary values
+    """Clamp UB elements to the inclusive ``[min_scalar, max_scalar]`` range.
+
+    ``out`` and ``buffer`` may be one- or two-dimensional UB buffers or
+    contiguous buffer regions and may be the same object for an in-place
+    operation. They must have matching shapes and dtypes. AscendC and PTO
+    support float16, float32, int16, and int32. AscendC applies the operation
+    to the first ``count`` elements; PTO currently requires ``count`` to equal
+    the selected tile extent.
 
     Args:
-        out: The destination buffer where the result will be stored.
-        buffer: The first source operand buffer.
-        min_scalar: The min scalar value
-        max_scalar: The max scalar value
-        count: The size of tensor out
-        tmp: Optional complete UB scratch storage. Its scalar dtype is
-            reinterpreted by lowering and has no semantic meaning.
+        out: Destination UB buffer or contiguous buffer region.
+        buffer: Source UB buffer or contiguous buffer region.
+        min_scalar: Inclusive lower bound, convertible to ``buffer.dtype``.
+        max_scalar: Inclusive upper bound, convertible to ``buffer.dtype``.
+            This must be greater than or equal to ``min_scalar``.
+        count: Number of leading elements to clamp. This must not exceed the
+            number of accessible source or destination elements.
+        tmp: Optional explicit UB scratch storage for PTO. It must be a
+            one-dimensional, static, contiguous fixed-width scalar buffer in
+            ``shared.ub``, or an equivalent 32-byte-aligned buffer region, with
+            at least as many bytes as the selected source region. Its dtype is
+            ignored and lowering reinterprets the storage as ``buffer.dtype``.
+            When omitted, lowering allocates the required space. AscendC needs
+            no workspace and elides this operand.
 
     Returns:
-        A TVM intrinsic call that performs the clamp operation.
+        tvm.tir.Call: Intrinsic call for the selected Ascend backend.
     """
     if isinstance(out, BufferRegion):
         out_ptr, _ = _handle_buffer_region(out, "w")


### PR DESCRIPTION
## 1. 文件改动

| 文件 | 类型 | 改动说明 |
|------|------|----------|
| `src/target/codegen_ascend_pto.cc` | 修改 | 修复 PTO `T.tile.clamp` lower-bound 操作无效的问题：删除 A2/A3 PTO 不支持的标量 `TMAXS`，改为通过类型化临时 tile 执行 `TEXPANDS` → `TMAX` → `TMINS`，并在相关指令间插入 vector pipeline barrier |
| `src/transform/allocate_tmp_buffer.cc` | 修改 | 将 PTO `ascend_clamp` 从 zero-workspace 算子改为需要 workspace；临时空间 dtype 与源 buffer 一致，容量等于所选源区域的字节数；`clamp_min`/`clamp_max` 仍保持 zero-workspace |
| `testing/python/language/test_tilelang_ascend_language_elementwise.py` | 修改 | 重写原有随机 clamp 测试，新增确定性边界数据；覆盖 4 种 dtype × 2 backend、AscendC partial count、原地计算和 BufferRegion；删除旧 `clamp_slice` 中将 2048 作为 64 元素切片 count 的越界风险 |
| `testing/python/language/test_tilelang_ascend_language_tile_atomic_add_dtype_coverage.py` | 新增 | atomic_add dtype 覆盖补充：int32 1D UB→GM（ascendc/pto）、dst/src scope 违规、dtype 不匹配、不支持 dtype 编译报错，共 8 用例（2 个标 low_priority） |
| `testing/python/language/test_tilelang_ascend_language_explicit_tmp.py` | 修改 | 更新 PTO workspace 算子清单，新增 4 种 dtype 的 workspace 大小/类型测试，以及 `TEXPANDS`/`TMAX`/`TMINS` 静态 codegen 回归测试 |
| `tilelang/language/ascend_tile.py` | 修改 | 重写 `T.tile.clamp` docstring：补充真实签名、1D/2D 连续区域、4 种 dtype、原地计算、backend-specific count 行为和 PTO workspace 契约；补充 `T.tile.atomic_add` docstring 的返回值说明 |
| `docs/language/tile_clamp.md` | 新增 | 新增校验后的 API 文档，包含功能说明、函数原型、参数规格、dtype/shape 支持、count 与 workspace 差异、约束条件和示例代码 |

---

## 2. 测试用例

### 2.1 约束测试（动态验证，真机 dav_m200/A2 / Ascend 910B3）

| 验证项 | 测什么 | 结果 |
|--------|--------|:----:|
| PTO 原实现语义 | float16/float32/int16/int32 的上下界钳位 | 编译成功但 lower-bound 无效，结果基本保持输入不变 |
| PTO 指令支持 | 检查 CANN 8.5.2 A2/A3 PTO 的 `TMAXS`、`TMAX`、`TMINS` | `TMAXS` 不可用；tile-to-tile `TMAX` 与 `TMINS` 可用 |
| dtype 支持 | float16、float32、int16、int32 × ascendc/pto | 两个 backend 的完整 tile 均通过 |
| 边界值语义 | 小于下界、等于下界、区间内、等于上界、大于上界 | 与 `torch.clamp` 一致 |
| AscendC partial count | count=17/32，预初始化未处理后缀 | 仅前 `count` 个元素发生变化，后缀保持不变 |
| PTO partial count | count 小于 tile extent | 当前不支持；PTO 要求 count 等于完整 tile 元素数 |
| 原地计算 | `out` 与 `buffer` 使用同一个 UB buffer | ascendc/pto 均通过 |
| BufferRegion | 不同行的连续 64 元素区域作为 src/dst | ascendc/pto 均通过 |
| 3D Buffer | 三维 UB buffer | 两个 backend 均不能可靠处理完整区域，因此文档限制为 1D/2D |
| PTO 自动 workspace | `tmp=None` 时检查生成代码和真机结果 | 自动申请源 dtype、源区域字节数大小的临时空间 |
| PTO 显式 workspace lowering | 检查 float16/float32/int16/int32 的 dtype 和字节数 | 64 元素分别为 128/256/128/256 字节 |
| AscendC workspace | 检查基础 `Maxs`/`Mins` lowering | 不需要临时空间 |

### 2.2 语言测试 `test_tilelang_ascend_language_elementwise.py`（21 用例）

| 测试函数 | 用例数 | 测什么 |
|----------|:---:|--------|
| `test_tile_clamp_full_tile` | 8 | float16/float32/int16/int32 × ascendc/pto，完整 2D tile |
| `test_tile_clamp_ascendc_partial_count` | 8 | 4 种 dtype × count(17/32)，验证未处理后缀保持不变 |
| `test_tile_clamp_inplace` | 3 | ascendc/pto 原地计算，包括 float16 与 int32 |
| `test_tile_clamp_buffer_region` | 2 | 连续 BufferRegion × ascendc/pto |

### 2.3 静态 workspace/codegen 测试（5 个新增参数化用例）

| 测试函数 | 用例数 | 测什么 |
|----------|:---:|--------|
| `test_pto_clamp_workspace_matches_source` | 4 | 4 种 dtype 的 workspace dtype、容量和自动 `tmp_ub` 分配 |
| `test_pto_clamp_codegen_uses_supported_tile_max` | 1 | 生成 `TEXPANDS`/`TMAX`/`TMINS`，且不再出现 `TMAXS` |


### 2.4 测试用例统计与 LP 分层

**clamp（`test_tilelang_ascend_language_elementwise.py`，21 用例）**

- 当前实际：均未打 low_priority 标记 → PR 触发执行 21 个，定时任务触发执行 21 个（无差异）
- 建议分层：仅保留 5 个核心用例（完整 tile 2 个 + partial count/原地/BufferRegion 各 1 个）在 PR 提交阶段执行，其余 16 个标 low_priority 放到定时执行阶段 → PR 触发执行 5 个，定时任务触发执行 21 个

| 测试函数 | 用例数 | PR执行 | LP | 类型 | 覆盖内容 |
|---|:---:|:---:|:---:|---|---|
| `test_tile_clamp_full_tile` | 8 | 2 | 6 | 核心功能 | 4 dtype × 2 backend 完整 2D tile，float32/float16@ascendc 为核心 |
| `test_tile_clamp_ascendc_partial_count` | 8 | 1 | 7 | 功能泛化 | partial count=17/32 × 4 dtype，float@ascendc 为核心 |
| `test_tile_clamp_inplace` | 3 | 1 | 2 | 功能泛化 | 原地计算：float16@ascendc 为核心 |
| `test_tile_clamp_buffer_region` | 2 | 1 | 1 | 功能泛化 | 连续 BufferRegion × ascendc/pto，ascendc 为核心 |

**atomic_add（`test_tilelang_ascend_language_tile_atomic_add_dtype_coverage.py`，新增文件，8 用例）**

LP 分层标记（已落地）：PR 触发执行 6 个，定时任务触发执行 8 个（2 个标 low_priority 仅定时执行）

| 测试函数 | 用例数 | PR执行 | LP | 类型 | 覆盖内容 |
|---|:---:|:---:|:---:|---|---|
| `test_atomic_add_int32_1d` | 2 | 1 | 1 | dtype 泛化 | int32 1D UB→GM（超出原 factcheck 的支持发现）：pto 默认执行，ascendc 标 low_priority |
| `test_atomic_add_dst_scope_violation_raises` | 1 | 1 | 0 | 异常边界 | dst=UB 触发 DiagnosticError |
| `test_atomic_add_src_scope_violation_raises` | 1 | 1 | 0 | 异常边界 | src=GM 触发 DiagnosticError |
| `test_atomic_add_dtype_mismatch_raises` | 1 | 1 | 0 | 异常边界 | dst/src dtype 不一致编译报错 |
| `test_atomic_add_unsupported_dtype_raises` | 3 | 2 | 1 | 异常边界 | uint16@pto、int8@ascendc 编译失败；uint32@pto 标 low_priority |

**静态 workspace/codegen 测试（`test_tilelang_ascend_language_explicit_tmp.py`，5 用例）**

`test_pto_clamp_workspace_matches_source`（4）+ `test_pto_clamp_codegen_uses_supported_tile_max`（1）均为编译期静态断言，不占 NPU，默认在 PR 阶段执行。

LP 标记策略（建议，参照 #1676 已落地惯例）：

- dtype：float32/float16（主流 dtype）默认执行，int16/int32 等扩展 dtype 标 low_priority（每函数保留 1 个核心用例）
- target：ascendc（主后端）默认执行，pto 标 low_priority
- 静态 codegen 断言与异常边界（scope 违规/dtype 不匹配，TIR 构造期快速失败）保留 PR 阶段执行
- 不支持 dtype 的编译失败用例标 low_priority（每类保留 1 个核心用例）

---

## 3. 测试结果

- **PTO 修复后探索性测试**：20 个受支持场景全部通过
- **语言测试**：21 PASSED，505 deselected，1 warning
- **完整 explicit-tmp 静态测试**：73 PASSED，1 warning
- **聚焦 workspace/codegen 静态测试**：10 PASSED，63 deselected
- **远程构建**：成功
- **Python 语法检查**：通过
- **clang-format dry-run**：通过
- **git diff --check**：通过
- **ruff / yapf / codespell**：CANNLab 环境中不可用，未执行

### 3.1 pytest 标签

本次新增的 21 个动态 clamp 用例与 5 个静态 workspace/codegen 用例未添加 `low_priority` 标签（建议按 2.4 节 LP 分层补标：clamp 保留 5 个核心用例 PR 执行，其余 16 个标 low_priority）；atomic_add 新增 8 个用例中 2 个已标 low_priority（int32@ascendc、uint32@pto）。

| 测试类型 | 用例数 | PR 执行 | low_priority |
|----------|:---:|:---:|:---:|
| 完整 tile | 8 | 8（建议 2） | 0（建议 6） |
| AscendC partial count | 8 | 8（建议 1） | 0（建议 7） |
| 原地计算 | 3 | 3（建议 1） | 0（建议 2） |
| BufferRegion | 2 | 2（建议 1） | 0（建议 1） |
| PTO workspace/codegen 静态 | 5 | 5 | 0 |
| atomic_add 功能/异常边界 | 8 | 6 | 2（已打标） |

---

## 4. 校验过程中发现的问题

1. **PTO clamp 原实现实际无效**：旧 lowering 生成 `TMAXS(dst, src, min)` 和 `TMINS(dst, dst, max)`。CANN 8.5.2 的 A2/A3 PTO 没有实现标量 `TMAXS`，导致 kernel 可以完成编译，但 lower-bound 操作没有生效，最终结果通常保持为原输入。

2. **仅验证构建成功无法发现问题**：旧 PTO kernel 能完成编译，必须在真机执行并与 `torch.clamp` 比较才能识别数值语义错误。

3. **PTO 需要临时 tile 实现下界钳位**：修复后先用 `TEXPANDS` 将下界广播到与源相同 dtype 的临时 tile，再使用支持的 tile-to-tile `TMAX`，最后执行 `TMINS`。这避免了依赖未实现的 `TMAXS`。

4. **PTO workspace 元数据与真实实现不符**：原先 `ascend_clamp` 被归类为 zero-workspace 算子。新实现需要保存广播后的下界，因此 PTO workspace 调整为与所选源区域字节数相同；AscendC 仍使用基础 `Maxs`/`Mins`，无需 workspace。

5. **PTO 当前不支持 partial count**：PTO codegen 基于完整 tile 执行运算，未按 `count` 截断。文档明确要求 PTO 的 `count` 等于所选 tile 的完整元素数；AscendC 则支持处理前缀元素。

6. **旧 BufferRegion 测试存在 count 越界风险**：原 `clamp_slice` 测试对每个 64 元素行切片传入整个 block 的 `count=2048`，可能造成越界访问，不能作为可靠的切片支持证据。该测试已替换为 count 与区域大小一致的确定性用例。

7. **支持范围应限制为 1D/2D 连续区域**：探索性 3D 用例中两个 backend 都未可靠处理完整区域，因此文档只声明经过验证的一维、二维 Buffer 和连续 BufferRegion。

8. **原地计算可用**：仓库已有实际原地调用，但缺少专门回归测试。本次在 ascendc/pto 真机验证后加入永久测试，文档明确允许 `out` 与 `buffer` 完全相同。

9. **4 种 dtype 均可用**：float16、float32、int16、int32 在 ascendc/pto 完整 tile 场景均通过真机数值验证，文档据此补全支持表。

---

## 5. 提交信息

- `700d1791 [Fix]: Make PTO tile clamp effective on A2/A3 🤖`
- `f0e8facc [Docs]: Fact-check T.tile.clamp API 🤖`

分支：

- Base：`tile-ai/tilelang-ascend:ascendc_pto`
- Head：`zhangfei-machao/tilelang-ascend:docs/clamp-factcheck`

---

## 6. 验证命令

```bash
cmake --build /mnt/workspace/gitCode/tilelang-ascend/build -j2

pytest testing/python/language/test_tilelang_ascend_language_elementwise.py \
  -k tile_clamp -vv -s

pytest testing/python/language/test_tilelang_ascend_language_explicit_tmp.py \
  -vv -s

clang-format --dry-run --Werror \
  src/target/codegen_ascend_pto.cc \
  src/transform/allocate_tmp_buffer.cc

git diff --check upstream/ascendc_pto...HEAD
```