### PR TITLE
Fix KeyError in disk cache reload

### DIFF
--- a/tilelang/jit/adapter/cython/cython_wrapper.pyx
+++ b/tilelang/jit/adapter/cython/cython_wrapper.pyx
@@ -96,7 +96,7 @@ cdef class CythonKernelWrapper:
         sym_val_by_name = {}
         for key, (ref_tensor_idx, ref_shape_idx) in self.dynamic_symbolic_map.items():
             val = int(inputs[ref_tensor_idx].shape[ref_shape_idx])
-            sym_val_by_name[key] = val
+            sym_val_by_name[str(key)] = val
 
         # Prepare input and output tensors
         for i in range(len(self.params)):
@@ -113,9 +113,9 @@ cdef class CythonKernelWrapper:
                     elif isinstance(s, tir.PrimExpr):
                         vmap = {}
                         for v in tir.analysis.undefined_vars(s):
-                            if v not in sym_val_by_name:
+                            if str(v) not in sym_val_by_name:
                                 raise KeyError(f"Unfounded symbolic var: {str(v)}")
-                            vmap[v] = tir.IntImm(v.dtype, sym_val_by_name[v])
+                            vmap[v] = tir.IntImm(v.dtype, sym_val_by_name[str(v)])
                         ss = stmt_functor.substitute(s, vmap)
                         ss = analyzer.simplify(ss)
                         if isinstance(ss, tir.IntImm):


### PR DESCRIPTION
# [Fix] 修复磁盘缓存加载时 Symbolic Var 查找失败导致 KeyError

## 问题现象

使用动态 shape（`T.symbolic`）的 kernel，第一次编译运行正常，但**从磁盘缓存加载复用时报错**：

```
KeyError: 'Unfounded symbolic var: grid_tile'
```

### 复现方式

```python
import tilelang
import tilelang.language as T

@tilelang.jit(out_idx=[1])
def kernel():
    grid_tile = T.symbolic("grid_tile")  # 动态维度

    @T.prim_func
    def main(
        x: T.Tensor([grid_tile, 256], "float"),
        y: T.Tensor([grid_tile, 256], "float"),
    ):
        ...
    return main

# 第一次运行：缓存为空，完整编译 → 通过
# 第二次运行（新进程）：缓存已有 → 从磁盘加载 → KeyError
```

用两个子进程模拟即可复现：
- **Run 1（fresh compile）**：缓存目录为空，从源码完整编译 → ✅ 通过
- **Run 2（disk cache reload）**：缓存目录已有上次编译产物，从磁盘加载 → ❌ 报错

---

## 根因分析

### 核心矛盾：`tir.Var` 的身份 vs 名字

TVM 的 `tir.Var`（符号变量）是一个 C++ 对象的 Python 包装。它的 **hash 和字典查找基于对象内存地址，而非变量名**：

```python
from tvm import tir

v1 = tir.Var("grid_tile", "int32")
v2 = tir.Var("grid_tile", "int32")  # 同名，不同对象

hash(v1) != hash(v2)       # True —— hash 不同
v1 in {v2: 42}             # False —— 字典查不到
```

就像两个同名同姓的人，身份证号不同，在按身份证号查的系统中互相不匹配。

### 两条代码路径的差异

kernel 创建有两条路径，`tir.Var` 对象来源不同：

**路径 A — Fresh Compile（缓存未命中）**：

```
prim_func → artifact.params → param_shapes 中的 tir.Var（对象 X）
prim_func → dynamic_symbolic_map 的 key        （对象 X）
                                        ↑ 同一对象，hash 一致 → 查找成功 ✅
```

**路径 B — Disk Cache Reload（缓存命中）**：

```
prim_func → dynamic_symbolic_map 的 key              （对象 X，原始）
params.pkl → cloudpickle 反序列化 → param_shapes 中的 tir.Var（对象 Y，新建）
                                        ↑ 不同对象，hash 不同 → 查找失败 ❌
```

磁盘缓存通过 `cloudpickle` 序列化/反序列化 `params.pkl`，这个过程会**重建 `tir.Var` 对象**——名字相同但内存地址不同。而 `dynamic_symbolic_map` 的 key 来自 `prim_func`（原始对象），`param_shapes` 中的 `tir.Var` 来自反序列化（新建对象），两者 hash 不匹配，字典查找失败。

### 数据流图示

```
┌───────────────────────────────────────────────────────────────┐
│                    Fresh Compile 路径                          │
│                                                               │
│   prim_func ──┬──► dynamic_symbolic_map key (tir.Var 对象 X) │
│               │                                               │
│               └──► params ──► param_shapes (tir.Var 对象 X)  │
│                                                               │
│   forward(): sym_val_by_name[对象 X] ← 查找用对象 X ✅ 匹配   │
└───────────────────────────────────────────────────────────────┘

┌───────────────────────────────────────────────────────────────┐
│                   Disk Cache Reload 路径                      │
│                                                               │
│   prim_func ────────► dynamic_symbolic_map key (tir.Var 对象 X)│
│                                                               │
│   params.pkl ─cloudpickle──► params ──► param_shapes          │
│                                       (tir.Var 对象 Y)        │
│                                                               │
│   forward(): sym_val_by_name[对象 X] ← 查找用对象 Y ❌ 不匹配 │
│   → KeyError: 'Unfounded symbolic var: grid_tile'            │
└───────────────────────────────────────────────────────────────┘
```

### 问题引入历史

本 bug 由 commit `3855c76a`（2025-12-08）引入。该 commit 在添加 workspace 自动分配功能时重写了 shape 解析逻辑，丢失了原有的 `str()` 字符串比较保护。后续 commit `8881ea76`（2026-01-12）进一步重构为支持复杂表达式 shape，沿用了对象查找方式，bug 一直存在。

| commit | 作者 | 时间 | 说明 |
|--------|------|------|------|
| `611cc484` (PR #213) | alex_xiao | 2025-03-19 | 引入磁盘缓存，**同时带了 `str()` 保护** |
| `3855c76a` | zyh5913 | 2025-12-08 | 添加 workspace 功能，**丢失 `str()` 保护** ❌ |
| `8881ea76` | Itz-ix35 | 2026-01-12 | 支持复杂表达式 shape，沿用对象查找，bug 依旧 |

---

## 解决方案

将 `sym_val_by_name` 字典的 key 从 `tir.Var` **对象**改为 `str(var)` **变量名字符串**。

### 修改文件

`tilelang/jit/adapter/cython/cython_wrapper.pyx`，`forward()` 方法，共 3 处。

### 修改内容

```diff
  sym_val_by_name = {}
  for key, (ref_tensor_idx, ref_shape_idx) in self.dynamic_symbolic_map.items():
      val = int(inputs[ref_tensor_idx].shape[ref_shape_idx])
-     sym_val_by_name[key] = val
+     sym_val_by_name[str(key)] = val          # 点1：存值时用 str(key)

  for v in tir.analysis.undefined_vars(s):
-     if v not in sym_val_by_name:
+     if str(v) not in sym_val_by_name:        # 点2：查找时用 str(v)
          raise KeyError(f"Unfounded symbolic var: {str(v)}")
-     vmap[v] = tir.IntImm(v.dtype, sym_val_by_name[v])
+     vmap[v] = tir.IntImm(v.dtype, sym_val_by_name[str(v)])  # 点3：取值时用 str(v)
```

---

## 为什么这么改

### 为什么用 `str()` 而不是对象比较？

`tir.Var` 对象在跨进程（序列化/反序列化）后身份会变化，但**变量名（`str(var)`）是稳定的**。用变量名字符串作 key，不受对象身份变化影响。

### 为什么有 3 个修改点？

`8881ea76` 引入的复杂表达式支持（如 `grid_tile // 2` 作为 shape）需要经过 IR 替换链：

```
sym_val_by_name[存入] → undefined_vars[查找] → sym_val_by_name[取出] → vmap[替换]
```

中间字典 `sym_val_by_name` 有 3 个接触点（存入、查找、取出），都必须用 `str()` 保护。否则任何一个点用对象查找都会失败。

### 为什么 `vmap` 仍用 `tir.Var` 对象作 key？

```python
vmap[v] = tir.IntImm(v.dtype, sym_val_by_name[str(v)])
```

`vmap` 传给 `stmt_functor.substitute(s, vmap)`，这个函数在 IR 内部遍历表达式树，用 `tir.Var` 对象匹配并替换。这里必须用 `param_shapes` 中的实际 `tir.Var` 对象（即表达式 `s` 中出现的那些变量），否则替换不会生效。

所以完整的逻辑是：
1. **`sym_val_by_name`** —— 用 `str()` 字符串作 key，解决跨序列化查找问题
2. **`vmap`** —— 用 `tir.Var` 对象作 key，供 IR 替换使用

两者各司其职，互不冲突。

### 与主仓的一致性

主仓（tilelang）从 PR #213 起就用 `str(s) == str(key)` 字符串比较，本修复与其原理完全一致：

| 维度 | 主仓 | 本修复 |
|------|------|--------|
| 相等判断原理 | `str()` 字符串比较 | `str()` 字符串比较 |
| 实现形式 | 遍历 + `str(s) == str(key)` | 字典 + `str(key)` 预转换 |
| 保护点数量 | 1 个（无 IR 替换链） | 3 个（有 IR 替换链） |

实现形式略有不同是因为 tilelang-ascend 的 `8881ea76` 引入了主仓没有的复杂表达式 shape 支持，需要 IR 替换链，因此保护点多 2 个。

### 为什么不直接照搬主仓代码？

主仓的 shape 解析逻辑不经过 IR substitute，直接从 tensor 读 shape 值，仅支持单个 `tir.Var` 作为 shape。tilelang-ascend 的 `8881ea76` 扩展了复杂表达式（如 `grid_tile // 2`）支持能力，如果照搬主仓会丢失这个功能。本修复在保留该能力的基础上加回 `str()` 保护。

---

## 测试报告

### 测试矩阵

| 测试项 | 用例数 | 结果 | 耗时 |
|--------|--------|------|------|
| `ott_test.py` 复现脚本（fresh + cache reload） | 2 | ✅ 全通过 | ~30s |
| `test_tilelang_ascend_language_gm_to_ub.py` | 95 | ✅ 全通过 | 10m35s |
| `test_tilelang_ascend_language_gm_to_l1.py` | 49 | ✅ 全通过 | 6m02s |
| `test_tilelang_ascend_language_copy_runtime_extent.py` | 2* | ✅ 全通过 | 32s |
| `test_tilelang_ascend_language_alloc_codegen.py` | 10 | ✅ 全通过 | 15s |
| `test_ascend_compile_flags.py`（cache reload 回归） | 18 | ✅ 全通过 | 32s |
| `example_cache_reload.py`（双 symbolic fresh + reload） | 2 | ✅ 全通过 | ~30s |

**总计 178 个用例全部通过，0 个与本次修复相关的失败。**

\* `copy_runtime_extent` 中 2 个 `test_atomic_add_runtime_inner_extent` 用例因 `T.tile.atomic_add` codegen 的独立 bug 跳过，与本次修复无关。

### 关键测试说明

**`ott_test.py` 复现脚本**：通过子进程模拟两次运行同一 kernel，第一次 fresh compile、第二次 disk cache reload，验证两条路径都能正确解析动态 shape。

**`gm_to_ub.py` / `gm_to_l1.py`**：覆盖 GM↔UB、GM→L1 copy 的动态 shape 场景（`T.symbolic("M")`、`T.symbolic("N")`、`T.symbolic("split")`、`T.symbolic("K")` 等），是动态 shape 的核心测试。

**`alloc_codegen.py`**：覆盖复杂表达式 shape（`batch + 1`、`batch * 2 + 1`、`batch + seq`），验证 `8881ea76` 引入的能力不受影响。

**`test_ascend_compile_flags.py`**：验证 `from_database` 磁盘恢复路径参数传递完整性。

---

## 已知残留风险

### 同名 Symbolic 碰撞

`str()` 比较依赖变量名唯一性。如果用户创建两个同名但不同对象的 symbolic var，`str()` 会误匹配：

```python
n1 = T.symbolic("n")
n2 = T.symbolic("n")  # 同名不同对象，语义独立

@T.prim_func
def main(
    x: T.Tensor([n1, 256], "float"),
    y: T.Tensor([n2, 256], "float"),  # 与 x 语义无关
):
    ...
```

此场景下 `str(n1) == str(n2) == "n"`，后者会覆盖前者。

**评估**：主仓从 PR #213 起同样存在此风险，未做防护。实际使用中创建同名但语义不同的 symbolic var 属于用户错误，无合理用例，当前不处理。

---

## 改动范围

仅 1 个文件，3 行改动：

```
tilelang/jit/adapter/cython/cython_wrapper.pyx | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```
