### PR TITLE
Add gelu kernel example

### DIFF
--- a/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-compute.md
+++ b/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-compute.md
@@ -301,6 +301,12 @@ Pass 设计详见 `.agents/skills/tilelang-pass-analyzer/references/pass-designs
 | `T.tile.max(dst, src0, src1)` | dst = max(src0, src1) | buffer 或 scalar |
 | `T.tile.min(dst, src0, src1)` | dst = min(src0, src1) | buffer 或 scalar |
 
+**使用建议**
+
+- 能用连续切片加基础算术表达的公式，优先使用 `mul/add/sub`，避免引入 gather。
+- 二元向量操作的输入 dtype 应保持一致，避免一个输入是 fp16、另一个输入是 fp32。
+- 对低精度输入但要求 fp32 计算的场景，应先统一 cast 到 fp32，再执行 `mul/add/sub`。
+
 ### 4.2 单目运算
 
 | API | 功能 |
@@ -337,6 +343,14 @@ Pass 设计详见 `.agents/skills/tilelang-pass-analyzer/references/pass-designs
 
 - `silu` 执行 SiLU (Swish) 激活函数: x * sigmoid(x)
 - 支持 half、float 类型（Atlas A2/A3）
+
+**mul_add_dst 使用建议**：
+- half 模式 RoPE 的 rotate_half 可用 slice 分解 + mul + sub + mul_add_dst 实现，
+  避免 gather：
+  out1 = q1*cos - q2*s  →  mul(out1, q1, cos) + mul(tmp, q2, sin) + sub(out1, out1, tmp)
+  out2 = q2*cos + q1*s  →  mul(out2, q2, cos) + mul_add_dst(out2, q1, sin)
+- 对连续半区操作（如 half 模式 rotate_half），优先用 T.copy 切片 + 基础算术，
+  不要用 T.tile.gather。只有非连续置换（如 interleaved 偶奇交换）才用 gather。
 
 ### 4.5 逻辑运算
 
@@ -459,6 +473,40 @@ T.tile.cast(b_ub, a_ub, "CAST_RINT", 4096)
 | `T.tile.transpose(dst, src)` | 二维矩阵数据块转置（详见下方 dtype 支持说明） |
 | `T.tile.gather(dst, src, src_offset, src_base_addr)` | 按偏移收集数据 |
 | `T.tile.arith_progression(buffer, first_value, diff_value, count)` | 生成等差数列 |
+
+### 使用建议
+#### T.tile.gather(dst, src, src_offset, src_base_addr)
+
+- `mask` 表示源 tensor 的字节偏移，不是元素下标。如果 gather 的源 tensor 已经 cast 成 `float32`，即使原始输入是 `float16` / `bfloat16`，偏移也要按 `4` 字节计算。
+- 对连续切片、前后半交换这类规则操作，优先用 `T.copy` + `T.tile.mul/add/sub`，不要优先用 gather。
+- 对真正非连续的规则置换，例如偶奇交换，可以用 `T.tile.createvecindex` + `T.tile.bitwise_xor` 构造 mask，避免标量循环。
+- 偶奇交换可用 `idx xor 1`；前后半交换可用 `idx xor HalfD`。
+- gather mask 若在同一 (b,n) 组的所有 S-tile 中不变，应在 (b,n) 外层循环外生成一次并复用，避免每个 tile 重复生成
+
+#### T.tile.createvecindex(dst, first_value)
+
+- 规则 mask 优先用 `T.tile.createvecindex` 构造，再通过加减、异或、乘字节数等方式变换。
+- 避免用标量循环逐元素构造 mask。
+- 多行 gather 时要确认 mask 是每一行内的相对偏移，不要把跨行线性下标误用成每行内偏移。
+
+#### T.tile.broadcast(dst, src)
+
+- 用于 block 内多行共享同一份参数的场景，例如把 `[1, D]` 的参数扩展到 `[block_M, D]` 后参与逐元素计算。
+- `src` 和 `dst` 的 dtype 应保持一致。
+- `dst` 的 shape 通常比 `src` 多一个批量/行维度，例如 `src.shape = [1, D]`，`dst.shape = [M, D]`。
+- 如果每一行参数不同，不要用 `broadcast`；可以直接准备 `[M, D]` 形状的参数（准备`[M, D]` 形状的话可以python侧准备也可在kernel内部准备），并逐行 `T.copy`。
+- 如果为了使用 `broadcast` 导致 block 切分必须满足额外整除条件，例如 `N % block_M == 0`，需要和 host 侧 expand 参数的方案对比。小 shape 或不规则 shape 下，host expand 到 `[M, D]` 后直接读取可能更快。
+
+**T.tile.broadcast示例**
+```python
+cos_row = T.alloc_ub((1, D), "float32")
+cos_block = T.alloc_ub((block_M, D), "float32")
+
+T.copy(cos_full[s_idx, :], cos_row[0, :])
+T.tile.broadcast(cos_block, cos_row)
+
+T.tile.mul(out, x, cos_block)
+```
 
 #### T.tile.transpose 的 dtype 支持与标量回退
 

--- a/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-kernel-memory.md
+++ b/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-kernel-memory.md
@@ -67,6 +67,14 @@ with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
 - **cid**：计算任务 ID，范围 [0, block_num)
 - **vid**：Vector 单元索引（0 或 1），C、V 核配比为 1:2
 
+**使用建议**
+
+- 不要只按很小的外层维度切核。如果外层并行度不足，会导致物理核利用率低。
+- 比如当 `B*N` 小但 `S` 很大时，可以考虑 flatten 到 `[B*S*N, D]`，或者把 `S` 维也纳入切分。
+- 一个 kernel 很难同时覆盖小并行度和大并行度场景时，可以做 shape dispatch。
+- 如果外层并行度不足，不要只按小外层维度切 kernel。对于形如 [B,S,N,D] 的逐行向量计算，当 B*N 小或 S 很小时，可以 flatten 为 [B*S*N, D]，让 M 维提供并行度。必要时做 shape dispatch：大 shape 用 tiled pipeline，小 shape 用 flat kernel。
+- 尾块处理优先用 `T.ceildiv(M, block_M)` 作为 m_num，无需 host 侧 padding。手动 pad+slice 会引入额外数据拷贝开销。
+
 ### @jit 装饰器
 
 触发即时编译，将 kernel 编译为 NPU 可执行代码。
@@ -341,6 +349,16 @@ T.copy(
    必要时块 DMA 到 UB 后再做局部重排。
 
 > **设计阶段预警**：设计 4D+ 算子时，如果 `T.copy` 需要在非最内维上做切片搬运，必须在 design.md 中明确说明规避方案。不要假设 `T.copy` 支持任意维度的 strided 切片。
+
+**使用建议**
+
+- 做手动流水时，MTE2 load 阶段应尽量只放 GM→UB 的 `T.copy`。
+- 不要在 load 阶段混入 `T.tile.*` 计算，否则 timeline 上 MTE2/V 阶段会混在一起，访存计算重叠也更难调。
+- 如果 load 后需要预处理，建议先 copy 到独立 load buffer，再在 V 阶段处理。
+- 对连续半区或连续块操作，优先用多段 `T.copy`，通常比 `T.tile.gather` 更简单、更快。
+- 只有真正非连续置换才使用 T.tile.gather。连续半区交换应使用 T.copy 切片 + T.tile.mul/add/sub。规则偶奇交换可用 createvecindex + xor 1 构造 mask。mask 是源 tensor 的字节偏移；源为 float32 时乘 4。
+- 对于 [B,S,N,D] 4D 逐行算子（如 RoPE），优先保持 4D 布局按 (b,n) 外层循环 + S 维 tiling，不要 flatten 到 [M,D]。flatten 会丢失 S 维流水线机会，且需要 host 侧预展开 cos/sin 到 [M,D]。
+- 多输入算子（如 RoPE 的 query+key）可利用 vid 让两个 V 核各处理一个输入（vid=0 处理 Q，vid=1 处理 K），实现 2x 并行。而非两个 V 核处理同一输入的不同行。
 
 ---
 

--- a/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-schedule-sync.md
+++ b/.agents/skills/tilelang-custom-skill/tilelang-api-best-practices/references/api-schedule-sync.md
@@ -112,6 +112,21 @@ for k in T.Pipelined(T.ceildiv(seq_len, block_N), num_stages=2):
 - 核间流水线与核内流水线不能同时开启
 - 使用核间流水线必须开启：`"tl.ascend_auto_cv_combine": True`, `"tl.ascend_auto_cross_core_sync": True`
 
+
+
+## 2.1 小节"S 维 tiling + double-buffer 三阶段流水线"：
+### S 维 tiling + double-buffer 三阶段流水线（非 T.Pipelined 的手动实现）
+
+对于 cos/sin 只依赖 S 维的逐行算子（如 RoPE），可以用手动 set_flag/wait_flag 实现
+跨 S-tile 的 MTE2→V→MTE3 三阶段流水线，比 T.Pipelined 更灵活：
+
+1. 双缓冲分配：cos_ub[2, S_TILE, D], x_tile[2, S_TILE, D], out_tile[2, S_TILE, D]
+2. 循环外 preload tile[0]
+3. 循环内：加载 tile[i+1]（MTE2）→ 计算 tile[i]（V）→ 存储 tile[i]（MTE3）
+4. flag 同步：set_flag("mte2","v",n) / wait_flag("mte2","v",n) 控制依赖
+
+关键：gather mask / sign_mask 等常量在 (b,n) 外层循环外生成一次，所有 S-tile 复用。
+
 ---
 
 ## 3. T.Persistent

--- a/examples/cann-bench/apply_rotary_pos_emb/apply_rotary_pos_emb.py
+++ b/examples/cann-bench/apply_rotary_pos_emb/apply_rotary_pos_emb.py
@@ -1,0 +1,666 @@
+import torch
+import tilelang
+from tilelang import language as T
+
+PASS_CONFIGS_FLAT = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+}
+PASS_CONFIGS_TILE = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+_VEC_NUM = 2
+_CAST_LOW2HIGH = "CAST_NONE"
+_CAST_HIGH2LOW = "CAST_RINT"
+
+DTYPE_STR = {
+    torch.float16: "float16",
+    torch.float32: "float32",
+    torch.bfloat16: "bfloat16",
+}
+
+_flat_kernel_cache = {}
+_tile_kernel_cache = {}
+
+
+def _flat_choose_block_M(D, dtype, mode):
+    UB_LIMIT = 180000
+    need_cast = dtype in ("float16", "bfloat16")
+    if mode == "half":
+        if need_cast:
+            max_sub = max(2, UB_LIMIT // (28 * D))
+        else:
+            max_sub = max(2, UB_LIMIT // (16 * D))
+    else:
+        if need_cast:
+            max_sub = max(2, UB_LIMIT // (50 * D))
+        else:
+            max_sub = max(2, UB_LIMIT // (42 * D))
+    block_M = min(max_sub, 128) * _VEC_NUM
+    block_M = max(block_M, 4)
+    return block_M
+
+
+def _expand_cos_sin_view(cos, sin, mode):
+    """Expand (S, D/2) → (S, D) using pure view ops (expand+reshape).
+    No ACL op triggered — no .to(), .cat(), .repeat(), .stack().
+    """
+    if mode == "half":
+        cos_full = cos.unsqueeze(1).expand(-1, 2, -1).reshape(cos.shape[0], -1)
+        sin_full = sin.unsqueeze(1).expand(-1, 2, -1).reshape(sin.shape[0], -1)
+    else:
+        cos_full = cos.unsqueeze(-1).expand(-1, -1, 2).reshape(cos.shape[0], -1)
+        sin_full = sin.unsqueeze(-1).expand(-1, -1, 2).reshape(sin.shape[0], -1)
+    return cos_full, sin_full
+
+
+# ===========================================================================
+# Flat kernel — half mode (split-compute, no gather)
+# ===========================================================================
+def _make_flat_kernel_half(M, D, CS_DIM, N, layout, dtype, block_M):
+    D_HALF = D // 2
+    sub_block_M = block_M // _VEC_NUM
+    m_num = T.ceildiv(M, block_M)
+    need_cast = dtype in ("float16", "bfloat16")
+    cal_dtype = "float32" if need_cast else dtype
+    count = sub_block_M * D_HALF
+    can_preload = (2 * CS_DIM * D_HALF * 4) <= 65536
+
+    @T.prim_func
+    def main(
+        Q: T.Tensor((M, D), dtype),
+        K: T.Tensor((M, D), dtype),
+        COS: T.Tensor((CS_DIM, D_HALF), dtype),
+        SIN: T.Tensor((CS_DIM, D_HALF), dtype),
+        Q_OUT: T.Tensor((M, D), dtype),
+        K_OUT: T.Tensor((M, D), dtype),
+    ):
+        with T.Kernel(m_num, is_npu=True) as (cid, vid):
+            row_start = cid * block_M + vid * sub_block_M
+            with T.Scope("V"):
+                cos_ub = T.alloc_ub((sub_block_M, D_HALF), cal_dtype)
+                sin_ub = T.alloc_ub((sub_block_M, D_HALF), cal_dtype)
+                x_first = T.alloc_ub((sub_block_M, D_HALF), cal_dtype)
+                x_second = T.alloc_ub((sub_block_M, D_HALF), cal_dtype)
+                y_first = T.alloc_ub((sub_block_M, D_HALF), cal_dtype)
+                y_second = T.alloc_ub((sub_block_M, D_HALF), cal_dtype)
+                tmp = T.alloc_ub((sub_block_M, D_HALF), cal_dtype)
+                cos_h = T.alloc_ub((sub_block_M, D_HALF), dtype)
+                sin_h = T.alloc_ub((sub_block_M, D_HALF), dtype)
+                x_first_h = T.alloc_ub((sub_block_M, D_HALF), dtype)
+                x_second_h = T.alloc_ub((sub_block_M, D_HALF), dtype)
+                y_first_h = T.alloc_ub((sub_block_M, D_HALF), dtype)
+                y_second_h = T.alloc_ub((sub_block_M, D_HALF), dtype)
+
+                if can_preload:
+                    cos_preload = T.alloc_ub((CS_DIM, D_HALF), cal_dtype)
+                    sin_preload = T.alloc_ub((CS_DIM, D_HALF), cal_dtype)
+                    if need_cast:
+                        cos_pre_h = T.alloc_ub((CS_DIM, D_HALF), dtype)
+                        sin_pre_h = T.alloc_ub((CS_DIM, D_HALF), dtype)
+                        T.copy(COS, cos_pre_h)
+                        T.copy(SIN, sin_pre_h)
+                        T.tile.cast(cos_preload, cos_pre_h, _CAST_LOW2HIGH, CS_DIM * D_HALF)
+                        T.tile.cast(sin_preload, sin_pre_h, _CAST_LOW2HIGH, CS_DIM * D_HALF)
+                    else:
+                        T.copy(COS, cos_preload)
+                        T.copy(SIN, sin_preload)
+                    for i in T.serial(sub_block_M):
+                        row = row_start + i
+                        if layout == 0:
+                            T.copy(cos_preload[(row // N) % CS_DIM, :], cos_ub[i, :])
+                            T.copy(sin_preload[(row // N) % CS_DIM, :], sin_ub[i, :])
+                        else:
+                            T.copy(cos_preload[row % CS_DIM, :], cos_ub[i, :])
+                            T.copy(sin_preload[row % CS_DIM, :], sin_ub[i, :])
+                else:
+                    if need_cast:
+                        for i in T.serial(sub_block_M):
+                            row = row_start + i
+                            if layout == 0:
+                                T.copy(COS[(row // N) % CS_DIM, :], cos_h[i, :])
+                                T.copy(SIN[(row // N) % CS_DIM, :], sin_h[i, :])
+                            else:
+                                T.copy(COS[row % CS_DIM, :], cos_h[i, :])
+                                T.copy(SIN[row % CS_DIM, :], sin_h[i, :])
+                        T.tile.cast(cos_ub, cos_h, _CAST_LOW2HIGH, count)
+                        T.tile.cast(sin_ub, sin_h, _CAST_LOW2HIGH, count)
+                    else:
+                        for i in T.serial(sub_block_M):
+                            row = row_start + i
+                            if layout == 0:
+                                T.copy(COS[(row // N) % CS_DIM, :], cos_ub[i, :])
+                                T.copy(SIN[(row // N) % CS_DIM, :], sin_ub[i, :])
+                            else:
+                                T.copy(COS[row % CS_DIM, :], cos_ub[i, :])
+                                T.copy(SIN[row % CS_DIM, :], sin_ub[i, :])
+
+                if need_cast:
+                    T.copy(Q[row_start, 0], x_first_h)
+                    T.copy(Q[row_start, D_HALF], x_second_h)
+                    T.tile.cast(x_first, x_first_h, _CAST_LOW2HIGH, count)
+                    T.tile.cast(x_second, x_second_h, _CAST_LOW2HIGH, count)
+                    T.tile.mul(y_first, x_first, cos_ub)
+                    T.tile.mul(tmp, x_second, sin_ub)
+                    T.tile.sub(y_first, y_first, tmp)
+                    T.tile.mul(y_second, x_second, cos_ub)
+                    T.tile.mul(tmp, x_first, sin_ub)
+                    T.tile.add(y_second, y_second, tmp)
+                    T.tile.cast(y_first_h, y_first, _CAST_HIGH2LOW, count)
+                    T.tile.cast(y_second_h, y_second, _CAST_HIGH2LOW, count)
+                    T.copy(y_first_h, Q_OUT[row_start, 0])
+                    T.copy(y_second_h, Q_OUT[row_start, D_HALF])
+                    T.copy(K[row_start, 0], x_first_h)
+                    T.copy(K[row_start, D_HALF], x_second_h)
+                    T.tile.cast(x_first, x_first_h, _CAST_LOW2HIGH, count)
+                    T.tile.cast(x_second, x_second_h, _CAST_LOW2HIGH, count)
+                    T.tile.mul(y_first, x_first, cos_ub)
+                    T.tile.mul(tmp, x_second, sin_ub)
+                    T.tile.sub(y_first, y_first, tmp)
+                    T.tile.mul(y_second, x_second, cos_ub)
+                    T.tile.mul(tmp, x_first, sin_ub)
+                    T.tile.add(y_second, y_second, tmp)
+                    T.tile.cast(y_first_h, y_first, _CAST_HIGH2LOW, count)
+                    T.tile.cast(y_second_h, y_second, _CAST_HIGH2LOW, count)
+                    T.copy(y_first_h, K_OUT[row_start, 0])
+                    T.copy(y_second_h, K_OUT[row_start, D_HALF])
+                else:
+                    T.copy(Q[row_start, 0], x_first)
+                    T.copy(Q[row_start, D_HALF], x_second)
+                    T.tile.mul(y_first, x_first, cos_ub)
+                    T.tile.mul(tmp, x_second, sin_ub)
+                    T.tile.sub(y_first, y_first, tmp)
+                    T.tile.mul(y_second, x_second, cos_ub)
+                    T.tile.mul(tmp, x_first, sin_ub)
+                    T.tile.add(y_second, y_second, tmp)
+                    T.copy(y_first, Q_OUT[row_start, 0])
+                    T.copy(y_second, Q_OUT[row_start, D_HALF])
+                    T.copy(K[row_start, 0], x_first)
+                    T.copy(K[row_start, D_HALF], x_second)
+                    T.tile.mul(y_first, x_first, cos_ub)
+                    T.tile.mul(tmp, x_second, sin_ub)
+                    T.tile.sub(y_first, y_first, tmp)
+                    T.tile.mul(y_second, x_second, cos_ub)
+                    T.tile.mul(tmp, x_first, sin_ub)
+                    T.tile.add(y_second, y_second, tmp)
+                    T.copy(y_first, K_OUT[row_start, 0])
+                    T.copy(y_second, K_OUT[row_start, D_HALF])
+
+    return main
+
+
+_flat_kernel_half_jit = tilelang.jit(out_idx=[4, 5], pass_configs=PASS_CONFIGS_FLAT)(_make_flat_kernel_half)
+
+
+# ===========================================================================
+# Flat kernel — interleaved mode (pre-expanded cos/sin, gather+sin_sign)
+# ===========================================================================
+def _make_flat_kernel_interleaved(M, D, CS_DIM, N, layout, dtype, block_M):
+    """Interleaved: receives PRE-EXPANDED (CS_DIM, D) cos/sin via expand().reshape().
+    No kernel-internal expansion — just load, cast, apply sin_sign, gather+compute.
+    """
+    sub_block_M = block_M // _VEC_NUM
+    m_num = T.ceildiv(M, block_M)
+    need_cast = dtype in ("float16", "bfloat16")
+    cal_dtype = "float32" if need_cast else dtype
+    count = sub_block_M * D
+    can_preload = (2 * CS_DIM * D * 4) <= 65536
+
+    @T.prim_func
+    def main(
+        Q: T.Tensor((M, D), dtype),
+        K: T.Tensor((M, D), dtype),
+        COS: T.Tensor((CS_DIM, D), dtype),
+        SIN: T.Tensor((CS_DIM, D), dtype),
+        Q_OUT: T.Tensor((M, D), dtype),
+        K_OUT: T.Tensor((M, D), dtype),
+    ):
+        with T.Kernel(m_num, is_npu=True) as (cid, vid):
+            row_start = cid * block_M + vid * sub_block_M
+            with T.Scope("V"):
+                cos_ub = T.alloc_ub((sub_block_M, D), cal_dtype)
+                sin_ub = T.alloc_ub((sub_block_M, D), cal_dtype)
+                sin_load = T.alloc_ub((sub_block_M, D), cal_dtype)
+                x = T.alloc_ub((sub_block_M, D), cal_dtype)
+                x_rotate = T.alloc_ub((sub_block_M, D), cal_dtype)
+                out = T.alloc_ub((sub_block_M, D), cal_dtype)
+
+                # gather mask: swap pairs [1,0,3,2,...]
+                idx_i32 = T.alloc_ub((sub_block_M, D), "int32")
+                T.tile.createvecindex(idx_i32, 0)
+                idx_i16 = T.alloc_ub((sub_block_M, D), "int16")
+                T.copy(idx_i32, idx_i16)
+                ones_i16 = T.alloc_ub((sub_block_M, D), "int16")
+                T.tile.fill(ones_i16, 1)
+                mask_i16 = T.alloc_ub((sub_block_M, D), "int16")
+                T.tile.bitwise_xor(mask_i16, idx_i16, ones_i16)
+                mask_f32 = T.alloc_ub((sub_block_M, D), "float32")
+                T.copy(mask_i16, mask_f32)
+                mask_i32 = T.alloc_ub((sub_block_M, D), "int32")
+                T.copy(mask_f32, mask_i32)
+                T.tile.mul(mask_i32, mask_i32, 4)
+                gather_mask = T.alloc_ub((sub_block_M, D), "uint32")
+                T.reinterpretcast(gather_mask, mask_i32, "uint32_t")
+
+                # sin_sign: [-1,1,-1,1,...]
+                sin_sign = T.alloc_ub((D,), cal_dtype)
+                T.tile.fill(sin_sign, -1.0)
+                D_HALF = D // 2
+                for j in T.unroll(D_HALF):
+                    sin_sign[2 * j + 1] = 1.0
+                sin_sign_bc = T.alloc_ub((sub_block_M, D), cal_dtype)
+                T.tile.broadcast(sin_sign_bc, sin_sign)
+
+                cos_h = T.alloc_ub((sub_block_M, D), dtype)
+                sin_h = T.alloc_ub((sub_block_M, D), dtype)
+                x_h = T.alloc_ub((sub_block_M, D), dtype)
+                out_h = T.alloc_ub((sub_block_M, D), dtype)
+
+                # Load pre-expanded cos/sin per-row
+                if can_preload:
+                    cos_preload = T.alloc_ub((CS_DIM, D), cal_dtype)
+                    sin_preload = T.alloc_ub((CS_DIM, D), cal_dtype)
+                    if need_cast:
+                        cos_pre_h = T.alloc_ub((CS_DIM, D), dtype)
+                        sin_pre_h = T.alloc_ub((CS_DIM, D), dtype)
+                        T.copy(COS, cos_pre_h)
+                        T.copy(SIN, sin_pre_h)
+                        T.tile.cast(cos_preload, cos_pre_h, _CAST_LOW2HIGH, CS_DIM * D)
+                        T.tile.cast(sin_preload, sin_pre_h, _CAST_LOW2HIGH, CS_DIM * D)
+                    else:
+                        T.copy(COS, cos_preload)
+                        T.copy(SIN, sin_preload)
+                    for i in T.serial(sub_block_M):
+                        row = row_start + i
+                        if layout == 0:
+                            T.copy(cos_preload[(row // N) % CS_DIM, :], cos_ub[i, :])
+                            T.copy(sin_preload[(row // N) % CS_DIM, :], sin_load[i, :])
+                        else:
+                            T.copy(cos_preload[row % CS_DIM, :], cos_ub[i, :])
+                            T.copy(sin_preload[row % CS_DIM, :], sin_load[i, :])
+                else:
+                    if need_cast:
+                        for i in T.serial(sub_block_M):
+                            row = row_start + i
+                            if layout == 0:
+                                T.copy(COS[(row // N) % CS_DIM, :], cos_h[i, :])
+                                T.copy(SIN[(row // N) % CS_DIM, :], sin_h[i, :])
+                            else:
+                                T.copy(COS[row % CS_DIM, :], cos_h[i, :])
+                                T.copy(SIN[row % CS_DIM, :], sin_h[i, :])
+                        T.tile.cast(cos_ub, cos_h, _CAST_LOW2HIGH, count)
+                        T.tile.cast(sin_load, sin_h, _CAST_LOW2HIGH, count)
+                    else:
+                        for i in T.serial(sub_block_M):
+                            row = row_start + i
+                            if layout == 0:
+                                T.copy(COS[(row // N) % CS_DIM, :], cos_ub[i, :])
+                                T.copy(SIN[(row // N) % CS_DIM, :], sin_load[i, :])
+                            else:
+                                T.copy(COS[row % CS_DIM, :], cos_ub[i, :])
+                                T.copy(SIN[row % CS_DIM, :], sin_load[i, :])
+
+                # sin_ub = sin_load * sin_sign
+                T.tile.mul(sin_ub, sin_load, sin_sign_bc)
+
+                # Q: gather + mul + add
+                if need_cast:
+                    T.copy(Q[row_start, 0], x_h)
+                    T.tile.cast(x, x_h, _CAST_LOW2HIGH, count)
+                    T.tile.gather(x_rotate, x, gather_mask, 0)
+                    T.tile.mul(out, x, cos_ub)
+                    T.tile.mul(x_rotate, x_rotate, sin_ub)
+                    T.tile.add(out, out, x_rotate)
+                    T.tile.cast(out_h, out, _CAST_HIGH2LOW, count)
+                    T.copy(out_h, Q_OUT[row_start, 0])
+                    T.copy(K[row_start, 0], x_h)
+                    T.tile.cast(x, x_h, _CAST_LOW2HIGH, count)
+                    T.tile.gather(x_rotate, x, gather_mask, 0)
+                    T.tile.mul(out, x, cos_ub)
+                    T.tile.mul(x_rotate, x_rotate, sin_ub)
+                    T.tile.add(out, out, x_rotate)
+                    T.tile.cast(out_h, out, _CAST_HIGH2LOW, count)
+                    T.copy(out_h, K_OUT[row_start, 0])
+                else:
+                    T.copy(Q[row_start, 0], x)
+                    T.tile.gather(x_rotate, x, gather_mask, 0)
+                    T.tile.mul(out, x, cos_ub)
+                    T.tile.mul(x_rotate, x_rotate, sin_ub)
+                    T.tile.add(out, out, x_rotate)
+                    T.copy(out, Q_OUT[row_start, 0])
+                    T.copy(K[row_start, 0], x)
+                    T.tile.gather(x_rotate, x, gather_mask, 0)
+                    T.tile.mul(out, x, cos_ub)
+                    T.tile.mul(x_rotate, x_rotate, sin_ub)
+                    T.tile.add(out, out, x_rotate)
+                    T.copy(out, K_OUT[row_start, 0])
+
+    return main
+
+
+_flat_kernel_interleaved_jit = tilelang.jit(out_idx=[4, 5], pass_configs=PASS_CONFIGS_FLAT)(_make_flat_kernel_interleaved)
+
+
+# ===========================================================================
+# Tile kernel — receives PRE-EXPANDED (S, D) cos/sin, no internal expansion
+# ===========================================================================
+def _make_tile_kernel(B, S, N, D, layout, mode, dtype, Block_M, S_TILE, D_TILE, num_stages):
+    HalfD = D // 2
+    compute_dtype = "float32"
+    need_cast = dtype != compute_dtype
+    elem_bytes = 4
+    BN_total = B * N
+    m_num = (BN_total + Block_M - 1) // Block_M
+    s_num = (S + S_TILE - 1) // S_TILE
+    D_TILE = D
+    d_num = 1
+    tile_num = s_num * d_num
+    Dim1 = N if layout == 1 else S
+    Dim2 = S if layout == 1 else N
+
+    @T.prim_func
+    def kernel(
+        x_in_q: T.Tensor([B, Dim1, Dim2, D], dtype),
+        x_in_k: T.Tensor([B, Dim1, Dim2, D], dtype),
+        cos_full: T.Tensor([S, D], dtype),
+        sin_full: T.Tensor([S, D], dtype),
+        x_out_q: T.Tensor([B, Dim1, Dim2, D], dtype),
+        x_out_k: T.Tensor([B, Dim1, Dim2, D], dtype),
+    ):
+        with T.Kernel(m_num, is_npu=True) as (cid, vid):  # noqa: SIM117
+            with T.Scope("V"):
+                cos_ub = T.alloc_ub((2, S_TILE, D_TILE), "float32")
+                sin_ub = T.alloc_ub((2, S_TILE, D_TILE), "float32")
+                sin_load = T.alloc_ub((2, S_TILE, D_TILE), "float32")
+                cos_h = T.alloc_ub((2, S_TILE, D_TILE), dtype)
+                sin_h = T.alloc_ub((2, S_TILE, D_TILE), dtype)
+                x_tile = T.alloc_ub((2, S_TILE, D_TILE), dtype)
+                out_tile = T.alloc_ub((2, S_TILE, D_TILE), dtype)
+                x_fp32 = T.alloc_ub((S_TILE, D_TILE), "float32")
+                x_rotate = T.alloc_ub((S_TILE, D_TILE), "float32")
+                out_fp32 = T.alloc_ub((S_TILE, D_TILE), "float32")
+
+                # sin_sign
+                sin_sign = T.alloc_ub((D_TILE,), "float32")
+                if mode == "half":
+                    T.tile.fill(sin_sign, 1.0)
+                    for i in T.serial(HalfD):
+                        sin_sign[i] = -1.0
+                else:
+                    T.tile.fill(sin_sign, -1.0)
+                    for i in T.unroll(HalfD):
+                        sin_sign[2 * i + 1] = 1.0
+                sin_sign_bc = T.alloc_ub((S_TILE, D_TILE), "float32")
+                T.tile.broadcast(sin_sign_bc, sin_sign)
+
+                # gather rotate_mask
+                idx_i32 = T.alloc_ub((S_TILE, D_TILE), "int32")
+                T.tile.createvecindex(idx_i32, 0)
+                idx_i16 = T.alloc_ub((S_TILE, D_TILE), "int16")
+                T.copy(idx_i32, idx_i16)
+                half_i16 = T.alloc_ub((S_TILE, D_TILE), "int16")
+                if mode == "half":
+                    T.tile.fill(half_i16, HalfD)
+                else:
+                    T.tile.fill(half_i16, 1)
+                mask_i16 = T.alloc_ub((S_TILE, D_TILE), "int16")
+                T.tile.bitwise_xor(mask_i16, idx_i16, half_i16)
+                mask_f32 = T.alloc_ub((S_TILE, D_TILE), "float32")
+                T.copy(mask_i16, mask_f32)
+                mask_i32 = T.alloc_ub((S_TILE, D_TILE), "int32")
+                T.copy(mask_f32, mask_i32)
+                T.tile.mul(mask_i32, mask_i32, elem_bytes)
+                rotate_mask_ub = T.alloc_ub((S_TILE, D_TILE), "uint32")
+                T.reinterpretcast(rotate_mask_ub, mask_i32, "uint32_t")
+
+                for bn_local in T.serial(Block_M):
+                    bn_idx = cid * Block_M + bn_local
+                    if bn_idx < BN_total:
+                        b_idx = bn_idx // N
+                        n_idx = bn_idx % N
+
+                        T.set_flag("mte3", "mte2", 0)
+                        T.set_flag("mte3", "mte2", 1)
+                        T.wait_flag("mte3", "mte2", 0)
+
+                        s_base_0 = 0
+                        s_end_0 = T.min(S_TILE, S)
+                        T.copy(cos_full[s_base_0:s_end_0, :], cos_h[0, :, :])
+                        T.copy(sin_full[s_base_0:s_end_0, :], sin_h[0, :, :])
+                        if vid == 0:
+                            if layout == 0:
+                                T.copy(x_in_q[b_idx, s_base_0:s_end_0, n_idx, :], x_tile[0, :, :])
+                            else:
+                                T.copy(x_in_q[b_idx, n_idx, s_base_0:s_end_0, :], x_tile[0, :, :])
+                        else:
+                            if layout == 0:
+                                T.copy(x_in_k[b_idx, s_base_0:s_end_0, n_idx, :], x_tile[0, :, :])
+                            else:
+                                T.copy(x_in_k[b_idx, n_idx, s_base_0:s_end_0, :], x_tile[0, :, :])
+                        T.set_flag("mte2", "v", 0)
+
+                        for tile_id in T.serial(tile_num):
+                            cur = tile_id % 2
+                            nxt = (tile_id + 1) % 2
+                            cur_s_base = tile_id * S_TILE
+                            cur_s_end = cur_s_base + T.min(S_TILE, S - cur_s_base)
+
+                            if tile_id + 1 < tile_num:
+                                T.wait_flag("mte3", "mte2", nxt)
+                                next_s_base = (tile_id + 1) * S_TILE
+                                next_s_end = next_s_base + T.min(S_TILE, S - next_s_base)
+                                T.copy(cos_full[next_s_base:next_s_end, :], cos_h[nxt, :, :])
+                                T.copy(sin_full[next_s_base:next_s_end, :], sin_h[nxt, :, :])
+                                if vid == 0:
+                                    if layout == 0:
+                                        T.copy(x_in_q[b_idx, next_s_base:next_s_end, n_idx, :], x_tile[nxt, :, :])
+                                    else:
+                                        T.copy(x_in_q[b_idx, n_idx, next_s_base:next_s_end, :], x_tile[nxt, :, :])
+                                else:
+                                    if layout == 0:
+                                        T.copy(x_in_k[b_idx, next_s_base:next_s_end, n_idx, :], x_tile[nxt, :, :])
+                                    else:
+                                        T.copy(x_in_k[b_idx, n_idx, next_s_base:next_s_end, :], x_tile[nxt, :, :])
+                                T.set_flag("mte2", "v", nxt)
+
+                            T.wait_flag("mte2", "v", cur)
+                            # Cast cos/sin to fp32 + apply sin_sign
+                            if need_cast:
+                                T.tile.cast(cos_ub[cur, :, :], cos_h[cur, :, :], "CAST_NONE", S_TILE * D_TILE)
+                                T.tile.cast(sin_load[cur, :, :], sin_h[cur, :, :], "CAST_NONE", S_TILE * D_TILE)
+                            else:
+                                T.copy(cos_h[cur, :, :], cos_ub[cur, :, :])
+                                T.copy(sin_h[cur, :, :], sin_load[cur, :, :])
+                            T.tile.mul(sin_ub[cur, :, :], sin_load[cur, :, :], sin_sign_bc)
+
+                            if vid == 0:
+                                if need_cast:
+                                    T.tile.cast(x_fp32, x_tile[cur, :, :], "CAST_NONE", S_TILE * D_TILE)
+                                else:
+                                    T.copy(x_tile[cur, :, :], x_fp32)
+                                T.tile.gather(x_rotate, x_fp32, rotate_mask_ub, 0)
+                                T.tile.mul(out_fp32, x_fp32, cos_ub[cur, :, :])
+                                T.tile.mul_add_dst(out_fp32, x_rotate, sin_ub[cur, :, :])
+                                if need_cast:
+                                    T.tile.cast(out_tile[cur, :, :], out_fp32, "CAST_RINT", S_TILE * D_TILE)
+                                else:
+                                    T.copy(out_fp32, out_tile[cur, :, :])
+                            else:
+                                if need_cast:
+                                    T.tile.cast(x_fp32, x_tile[cur, :, :], "CAST_NONE", S_TILE * D_TILE)
+                                else:
+                                    T.copy(x_tile[cur, :, :], x_fp32)
+                                T.tile.gather(x_rotate, x_fp32, rotate_mask_ub, 0)
+                                T.tile.mul(out_fp32, x_fp32, cos_ub[cur, :, :])
+                                T.tile.mul_add_dst(out_fp32, x_rotate, sin_ub[cur, :, :])
+                                if need_cast:
+                                    T.tile.cast(out_tile[cur, :, :], out_fp32, "CAST_RINT", S_TILE * D_TILE)
+                                else:
+                                    T.copy(out_fp32, out_tile[cur, :, :])
+                            T.set_flag("v", "mte3", cur)
+
+                            T.wait_flag("v", "mte3", cur)
+                            if vid == 0:
+                                if layout == 0:
+                                    T.copy(out_tile[cur, :, :], x_out_q[b_idx, cur_s_base:cur_s_end, n_idx, :])
+                                else:
+                                    T.copy(out_tile[cur, :, :], x_out_q[b_idx, n_idx, cur_s_base:cur_s_end, :])
+                            else:
+                                if layout == 0:
+                                    T.copy(out_tile[cur, :, :], x_out_k[b_idx, cur_s_base:cur_s_end, n_idx, :])
+                                else:
+                                    T.copy(out_tile[cur, :, :], x_out_k[b_idx, n_idx, cur_s_base:cur_s_end, :])
+                            T.set_flag("mte3", "mte2", cur)
+
+                        T.wait_flag("mte3", "mte2", 0)
+                        T.wait_flag("mte3", "mte2", 1)
+
+    return kernel
+
+
+_tile_kernel_jit = tilelang.jit(pass_configs=PASS_CONFIGS_TILE)(_make_tile_kernel)
+
+
+# ===========================================================================
+# Python entry
+# ===========================================================================
+def apply_rotary_pos_emb_flat(query, key, cos, sin, layout=0, rotaryMode="half"):
+    if layout == 0:
+        B, S, N, D = query.shape
+    else:
+        B, N, S, D = query.shape
+    M = B * S * N if layout == 0 else B * N * S
+    tl_dtype = DTYPE_STR[query.dtype]
+
+    q_2d = query.reshape(M, D)
+    k_2d = key.reshape(M, D)
+
+    if rotaryMode == "half":
+        # half: pass raw (CS_DIM, D_HALF) — kernel does split-compute
+        if cos.dim() == 3:
+            cos_2d = cos.reshape(-1, cos.shape[-1])
+            sin_2d = sin.reshape(-1, sin.shape[-1])
+            cs_dim = B * S
+        else:
+            cos_2d = cos
+            sin_2d = sin
+            cs_dim = S
+    else:
+        # interleaved: pre-expand (CS_DIM, D_HALF) → (CS_DIM, D) via expand().reshape()
+        if cos.dim() == 3:
+            cos_raw = cos.reshape(-1, cos.shape[-1])
+            sin_raw = sin.reshape(-1, sin.shape[-1])
+        else:
+            cos_raw = cos
+            sin_raw = sin
+        cos_2d, sin_2d = _expand_cos_sin_view(cos_raw, sin_raw, rotaryMode)
+        cs_dim = cos_2d.shape[0]
+
+    block_M = _flat_choose_block_M(D, tl_dtype, rotaryMode)
+    cache_key = (M, D, cs_dim, N, layout, block_M, tl_dtype, rotaryMode)
+    if cache_key not in _flat_kernel_cache:
+        if rotaryMode == "half":
+            _flat_kernel_cache[cache_key] = _flat_kernel_half_jit(M, D, cs_dim, N, layout, tl_dtype, block_M)
+        else:
+            _flat_kernel_cache[cache_key] = _flat_kernel_interleaved_jit(M, D, cs_dim, N, layout, tl_dtype, block_M)
+    kernel = _flat_kernel_cache[cache_key]
+
+    q_out_2d, k_out_2d = kernel(q_2d, k_2d, cos_2d, sin_2d)
+    q_out = q_out_2d.reshape(query.shape)
+    k_out = k_out_2d.reshape(key.shape)
+    return q_out, k_out
+
+
+def apply_rotary_pos_emb_tl(query, key, cos, sin, layout=0, rotaryMode="half"):
+    if layout == 0:
+        B, S, N, D = query.shape
+    else:
+        B, N, S, D = query.shape
+
+    dtype_str = DTYPE_STR[query.dtype]
+    BN_total = B * N
+    M_total = B * N * S
+
+    use_flat = (BN_total < 20) or (S <= 31) or (M_total <= 50000)
+
+    if use_flat:
+        return apply_rotary_pos_emb_flat(query, key, cos, sin, layout, rotaryMode)
+
+    # tile kernel — pre-expand cos/sin via expand().reshape() (pure view, no ACL op)
+    if cos.dim() == 3:
+        cos_raw = cos.reshape(-1, cos.shape[-1])
+        sin_raw = sin.reshape(-1, sin.shape[-1])
+    else:
+        cos_raw = cos
+        sin_raw = sin
+    cos_full, sin_full = _expand_cos_sin_view(cos_raw, sin_raw, rotaryMode)
+
+    UB_LIMIT = 180224
+    ds = 4 if dtype_str == "float32" else 2
+    s_tile_max = (UB_LIMIT - 8 * D) // (D * (72 + 2 * ds))
+    S_TILE = min(max(s_tile_max, 1), S)
+
+    if BN_total < 20:
+        Block_M = 1
+    else:
+        Block_M = min(BN_total, max(3, BN_total // 20))
+    num_stages = 2
+    D_TILE = D
+
+    tile_cache_key = (B, S, N, D, layout, rotaryMode, dtype_str, Block_M, S_TILE, D_TILE, num_stages)
+    if tile_cache_key not in _tile_kernel_cache:
+        _tile_kernel_cache[tile_cache_key] = _tile_kernel_jit(
+            B,
+            S,
+            N,
+            D,
+            layout,
+            rotaryMode,
+            dtype_str,
+            Block_M,
+            S_TILE,
+            D_TILE,
+            num_stages,
+        )
+    kernel = _tile_kernel_cache[tile_cache_key]
+
+    q_out = torch.empty_like(query)
+    k_out = torch.empty_like(key)
+    kernel(query, key, cos_full, sin_full, q_out, k_out)
+    return q_out, k_out
+
+
+def apply_rotary_pos_emb(query, key, cos, sin, layout=0, rotaryMode="half"):
+    if layout not in (0, 1):
+        raise ValueError("layout must be 0 ([B,S,N,D]) or 1 ([B,N,S,D])")
+    if rotaryMode not in ("half", "interleaved"):
+        raise ValueError("rotaryMode must be 'half' or 'interleaved'")
+    if query.dtype not in DTYPE_STR:
+        raise ValueError(f"unsupported dtype: {query.dtype}")
+    if key.dtype != query.dtype or cos.dtype != query.dtype or sin.dtype != query.dtype:
+        raise ValueError("query, key, cos and sin must have the same dtype")
+    if query.shape != key.shape:
+        raise ValueError("query and key must have the same shape")
+    if query.dim() != 4:
+        raise ValueError("query and key must be 4D tensors")
+    if query.shape[-1] % 2 != 0:
+        raise ValueError("head_dim must be even")
+    if cos.shape != sin.shape:
+        raise ValueError("cos and sin must have the same shape")
+    S = query.shape[1] if layout == 0 else query.shape[2]
+    D = query.shape[-1]
+    if cos.dim() == 2:
+        if cos.shape != (S, D // 2):
+            raise ValueError("2D cos/sin shape must be (seq_len, head_dim / 2)")
+    elif cos.dim() == 3:
+        if cos.shape != (query.shape[0], S, D // 2):
+            raise ValueError("3D cos/sin shape must be (batch_size, seq_len, head_dim / 2)")
+    else:
+        raise ValueError("cos and sin must be 2D or 3D tensors")
+    return apply_rotary_pos_emb_tl(query, key, cos, sin, layout, rotaryMode)
+
+
+__all__ = ["apply_rotary_pos_emb"]

--- a/examples/cann-bench/apply_rotary_pos_emb/test_apply_rotary_pos_emb.py
+++ b/examples/cann-bench/apply_rotary_pos_emb/test_apply_rotary_pos_emb.py
@@ -1,0 +1,452 @@
+"""ApplyRotaryPosEmb tests mirroring cann-bench cases.csv.
+
+Levels:
+  - l0: small smoke cases
+  - l1: 20 functional cases copied from cann-bench/tasks/level2/apply_rotary_pos_emb/cases.csv
+  - l2: argument rejection checks
+  - boundary: special values from cases.csv
+"""
+
+import argparse
+import math
+import os
+import sys
+
+import tilelang
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from apply_rotary_pos_emb import apply_rotary_pos_emb  # noqa: E402
+
+
+COVERAGE_CATEGORY = "FusedComposite"
+COVERAGE_MANIFEST = {}
+COVERAGE_NA = {}
+
+
+DTYPE_MAP = {
+    "float16": torch.float16,
+    "float32": torch.float32,
+    "bfloat16": torch.bfloat16,
+}
+
+
+PRECISION_THRESHOLDS = {
+    "float16": (1.0e-2, 1.0e-1),
+    "float32": (5.0e-3, 5.0e-2),
+    "bfloat16": (1.0e-2, 1.0e-1),
+}
+
+
+def _sf(v):
+    if isinstance(v, str):
+        return {"inf": float("inf"), "-inf": float("-inf"), "nan": float("nan")}[v]
+    return v
+
+
+def make_input(shape, dtype_str, value_range, seed):
+    torch_dtype = DTYPE_MAP[dtype_str]
+    lo, hi = _sf(value_range[0]), _sf(value_range[1])
+    generator = torch.Generator().manual_seed(seed)
+
+    if isinstance(lo, float) and isinstance(hi, float) and math.isnan(lo) and math.isnan(hi):
+        return torch.full(shape, float("nan"), dtype=torch_dtype).npu()
+
+    if isinstance(lo, float) and (math.isinf(lo) or math.isinf(hi)):
+        base = (torch.rand(shape, dtype=torch.float32, generator=generator) * 2.0 - 1.0).to(torch_dtype)
+        flat = base.view(-1)
+        if flat.numel() > 0:
+            flat[0] = float("inf")
+        if flat.numel() > 1:
+            flat[1] = float("-inf")
+        return base.npu()
+
+    if lo == hi:
+        return torch.full(shape, float(lo), dtype=torch_dtype).npu()
+
+    return (torch.rand(shape, dtype=torch.float32, generator=generator) * (hi - lo) + lo).to(torch_dtype).npu()
+
+
+def rotate_half(x, mode):
+    if mode == "interleaved":
+        x1 = x[..., ::2]
+        x2 = x[..., 1::2]
+        return torch.stack((-x2, x1), dim=-1).flatten(-2)
+    half_dim = x.shape[-1] // 2
+    return torch.cat((-x[..., half_dim:], x[..., :half_dim]), dim=-1)
+
+
+def golden_apply_rotary_pos_emb(query, key, cos, sin, layout=0, rotaryMode="half"):
+    input_dtype = query.dtype
+    compute_dtype = torch.float32 if input_dtype in (torch.float16, torch.bfloat16) else input_dtype
+    query = query.to(compute_dtype)
+    key = key.to(compute_dtype)
+    cos = cos.to(compute_dtype)
+    sin = sin.to(compute_dtype)
+
+    def apply_one(x):
+        cos_work = cos
+        sin_work = sin
+        if cos_work.dim() == 2:
+            cos_work = cos_work.unsqueeze(0).unsqueeze(2)
+            sin_work = sin_work.unsqueeze(0).unsqueeze(2)
+        elif cos_work.dim() == 3:
+            cos_work = cos_work.unsqueeze(2)
+            sin_work = sin_work.unsqueeze(2)
+
+        if layout == 1:
+            cos_work = cos_work.transpose(1, 2)
+            sin_work = sin_work.transpose(1, 2)
+
+        if rotaryMode == "interleaved":
+            cos_work = cos_work.unsqueeze(-1).expand(*cos_work.shape, 2).reshape(*cos_work.shape[:-1], -1)
+            sin_work = sin_work.unsqueeze(-1).expand(*sin_work.shape, 2).reshape(*sin_work.shape[:-1], -1)
+        else:
+            cos_work = cos_work.repeat(1, 1, 1, 2)
+            sin_work = sin_work.repeat(1, 1, 1, 2)
+
+        return x * cos_work + rotate_half(x, rotaryMode) * sin_work
+
+    q_out = apply_one(query)
+    k_out = apply_one(key)
+    if input_dtype in (torch.float16, torch.bfloat16):
+        q_out = q_out.to(input_dtype)
+        k_out = k_out.to(input_dtype)
+    return q_out, k_out
+
+
+def check_precision(actual, golden, dtype_str):
+    threshold, mare_threshold = PRECISION_THRESHOLDS[dtype_str]
+    actual = actual.detach().cpu()
+    golden = golden.detach().cpu()
+
+    if not torch.equal(torch.isnan(actual), torch.isnan(golden)):
+        return False, float("inf"), float("inf"), "NaN position mismatch"
+    if not torch.equal(torch.isinf(actual), torch.isinf(golden)):
+        return False, float("inf"), float("inf"), "Inf position mismatch"
+
+    mask = torch.isfinite(actual) & torch.isfinite(golden)
+    if mask.sum().item() == 0:
+        return True, 0.0, 0.0, ""
+
+    a = actual[mask].float()
+    g = golden[mask].float()
+    abs_err = (a - g).abs()
+    rel_err = abs_err / (g.abs() + 1.0e-7)
+    mere = rel_err.mean().item()
+    mare = rel_err.max().item()
+    max_abs = abs_err.max().item()
+    passed = mere <= threshold and mare <= mare_threshold
+    return passed, mere, mare, f"max_abs={max_abs:.6e}"
+
+
+def run_case(case_id, input_shapes, dtype_str, layout, rotary_mode, value_ranges, note=""):
+    query = make_input(tuple(input_shapes[0]), dtype_str, value_ranges[0], 1000 + case_id * 4)
+    key = make_input(tuple(input_shapes[1]), dtype_str, value_ranges[1], 1001 + case_id * 4)
+    cos = make_input(tuple(input_shapes[2]), dtype_str, value_ranges[2], 1002 + case_id * 4)
+    sin = make_input(tuple(input_shapes[3]), dtype_str, value_ranges[3], 1003 + case_id * 4)
+
+    q_out, k_out = apply_rotary_pos_emb(query, key, cos, sin, layout=layout, rotaryMode=rotary_mode)
+    q_golden, k_golden = golden_apply_rotary_pos_emb(query.cpu(), key.cpu(), cos.cpu(), sin.cpu(), layout, rotary_mode)
+
+    q_ok, q_mere, q_mare, q_extra = check_precision(q_out, q_golden, dtype_str)
+    k_ok, k_mere, k_mare, k_extra = check_precision(k_out, k_golden, dtype_str)
+    passed = q_ok and k_ok
+    tag = "PASS" if passed else "FAIL"
+    print(
+        f"[PRECISION_{tag}] case_{case_id:02d} dtype={dtype_str} layout={layout} mode={rotary_mode} "
+        f"q(MERE={q_mere:.6e}, MARE={q_mare:.6e}, {q_extra}) "
+        f"k(MERE={k_mere:.6e}, MARE={k_mare:.6e}, {k_extra}) {note}"
+    )
+    return passed
+
+
+L1_CASES = [
+    (
+        1,
+        [[16, 512, 16, 128], [16, 512, 16, 128], [512, 64], [512, 64]],
+        "float16",
+        0,
+        "half",
+        [[-1, 1], [-1, 1], [-1, 1], [-1, 1]],
+        "M-float16-16M-aligned-layout0-half",
+    ),
+    (
+        2,
+        [[7, 1021, 31, 64], [7, 1021, 31, 64], [1021, 32], [1021, 32]],
+        "float32",
+        0,
+        "half",
+        [[-2, 2], [-2, 2], [-1, 1], [-1, 1]],
+        "L-float32-14M-prime-layout0-half",
+    ),
+    (
+        3,
+        [[31, 251, 7, 128], [31, 251, 7, 128], [251, 64], [251, 64]],
+        "bfloat16",
+        0,
+        "half",
+        [[-3, 3], [-3, 3], [-1, 1], [-1, 1]],
+        "M-bfloat16-7M-prime-layout0-half",
+    ),
+    (
+        4,
+        [[15, 16, 511, 128], [15, 16, 511, 128], [511, 64], [511, 64]],
+        "float16",
+        1,
+        "half",
+        [[-10, 10], [-10, 10], [-1, 1], [-1, 1]],
+        "M-float16-15M-prime-layout1-half",
+    ),
+    (
+        5,
+        [[8, 2048, 16, 128], [8, 2048, 16, 128], [2048, 64], [2048, 64]],
+        "float32",
+        0,
+        "interleaved",
+        [[-100, 100], [-100, 100], [-1, 1], [-1, 1]],
+        "L-float32-33M-aligned-layout0-interleaved",
+    ),
+    (
+        6,
+        [[17, 15, 1021, 64], [17, 15, 1021, 64], [1021, 32], [1021, 32]],
+        "bfloat16",
+        1,
+        "interleaved",
+        [[-1000, 1000], [-1000, 1000], [-1, 1], [-1, 1]],
+        "M-bfloat16-16M-prime-layout1-interleaved",
+    ),
+    (
+        7,
+        [[13, 511, 13, 128], [13, 511, 13, 128], [511, 64], [511, 64]],
+        "float16",
+        0,
+        "half",
+        [[-0.1, 0.1], [-0.1, 0.1], [-1, 1], [-1, 1]],
+        "M-float16-10M-small-range",
+    ),
+    (
+        8,
+        [[7, 1009, 7, 128], [7, 1009, 7, 128], [1009, 64], [1009, 64]],
+        "float32",
+        0,
+        "half",
+        [[-1, 2], [-1, 2], [-1, 1], [-1, 1]],
+        "M-float32-7M-asymmetric",
+    ),
+    (
+        9,
+        [[257, 17, 17, 128], [257, 17, 17, 128], [17, 64], [17, 64]],
+        "bfloat16",
+        1,
+        "half",
+        [[-5, 10], [-5, 10], [-1, 1], [-1, 1]],
+        "M-bfloat16-9M-layout1-half",
+    ),
+    (
+        10,
+        [[11, 503, 11, 128], [11, 503, 11, 128], [503, 64], [503, 64]],
+        "float16",
+        0,
+        "interleaved",
+        [[-50, 100], [-50, 100], [-1, 1], [-1, 1]],
+        "M-float16-8M-interleaved",
+    ),
+    (
+        11,
+        [[19, 1023, 19, 64], [19, 1023, 19, 64], [1023, 32], [1023, 32]],
+        "float32",
+        0,
+        "half",
+        [[-65504, 65504], [-65504, 65504], [-1, 1], [-1, 1]],
+        "L-float32-24M-boundary",
+    ),
+    (
+        12,
+        [[4001, 3, 3, 64], [4001, 3, 3, 64], [3, 32], [3, 32]],
+        "bfloat16",
+        1,
+        "interleaved",
+        [[-88, 88], [-88, 88], [-1, 1], [-1, 1]],
+        "S-bfloat16-2M-layout1-interleaved",
+    ),
+    (
+        13,
+        [[1, 500001, 1, 64], [1, 500001, 1, 64], [500001, 32], [500001, 32]],
+        "float16",
+        0,
+        "half",
+        [["-inf", "inf"], ["-inf", "inf"], [-1, 1], [-1, 1]],
+        "M-float16-32M-inf",
+    ),
+    (
+        14,
+        [[3, 13, 17, 128], [3, 13, 17, 128], [13, 64], [13, 64]],
+        "float32",
+        0,
+        "half",
+        [["nan", "nan"], ["nan", "nan"], ["nan", "nan"], ["nan", "nan"]],
+        "S-float32-85K-nan",
+    ),
+    (
+        15,
+        [[509, 4, 4, 128], [509, 4, 4, 128], [4, 64], [4, 64]],
+        "bfloat16",
+        1,
+        "half",
+        [[0, 0], [0, 0], [0, 0], [0, 0]],
+        "S-bfloat16-360K-zero",
+    ),
+    (
+        16,
+        [[16, 61, 16, 128], [16, 61, 16, 128], [61, 64], [61, 64]],
+        "float16",
+        0,
+        "half",
+        [[-0.5, 0.5], [-0.5, 0.5], [-1, 1], [-1, 1]],
+        "M-float16-2M-small-range",
+    ),
+    (
+        17,
+        [[1023, 31, 31, 64], [1023, 31, 31, 64], [31, 32], [31, 32]],
+        "float32",
+        1,
+        "interleaved",
+        [[-1, 3], [-1, 3], [-1, 1], [-1, 1]],
+        "L-float32-60M-layout1-interleaved",
+    ),
+    (
+        18,
+        [[8, 255, 8, 128], [8, 255, 8, 128], [255, 64], [255, 64]],
+        "bfloat16",
+        0,
+        "half",
+        [[-1000, 1000], [-1000, 1000], [-1, 1], [-1, 1]],
+        "L-bfloat16-2M-large-range",
+    ),
+    (
+        19,
+        [[127, 4, 4, 128], [127, 4, 4, 128], [4, 64], [4, 64]],
+        "float16",
+        1,
+        "half",
+        [[-0.2, 0.2], [-0.2, 0.2], [-1, 1], [-1, 1]],
+        "S-float16-260K-layout1-half",
+    ),
+    (
+        20,
+        [[7, 2047, 7, 128], [7, 2047, 7, 128], [2047, 64], [2047, 64]],
+        "float32",
+        0,
+        "interleaved",
+        [[-3, 6], [-3, 6], [-1, 1], [-1, 1]],
+        "M-float32-12M-interleaved",
+    ),
+]
+
+
+def test_apply_rotary_pos_emb_l0():
+    smoke_cases = [
+        (
+            101,
+            [[2, 8, 2, 64], [2, 8, 2, 64], [8, 32], [8, 32]],
+            "float16",
+            0,
+            "half",
+            [[-1, 1], [-1, 1], [-1, 1], [-1, 1]],
+            "l0-layout0-half",
+        ),
+        (
+            102,
+            [[2, 2, 8, 64], [2, 2, 8, 64], [8, 32], [8, 32]],
+            "float32",
+            1,
+            "interleaved",
+            [[-1, 1], [-1, 1], [-1, 1], [-1, 1]],
+            "l0-layout1-interleaved",
+        ),
+        (
+            103,
+            [[1, 16, 1, 128], [1, 16, 1, 128], [16, 64], [16, 64]],
+            "bfloat16",
+            0,
+            "half",
+            [[-1, 1], [-1, 1], [-1, 1], [-1, 1]],
+            "l0-bfloat16-half",
+        ),
+    ]
+    ok = True
+    for case in smoke_cases:
+        try:
+            ok &= run_case(*case)
+        except Exception as e:
+            print(f"[PRECISION_FAIL] case_{case[0]:02d}: {e}")
+            ok = False
+    return ok
+
+
+def test_apply_rotary_pos_emb_l1():
+    ok = True
+    for case in L1_CASES:
+        try:
+            ok &= run_case(*case)
+        except Exception as e:
+            print(f"[PRECISION_FAIL] case_{case[0]:02d}: {e}")
+            ok = False
+    return ok
+
+
+def test_apply_rotary_pos_emb_l2():
+    def _expect_reject(desc, fn):
+        try:
+            fn()
+            print(f"[BOUNDARY_WARN] {desc}: silently accepted")
+        except (AssertionError, ValueError, RuntimeError, KeyError):
+            print(f"[BOUNDARY_PASS] {desc}: correctly rejected")
+
+    q = torch.randn(1, 4, 1, 64, dtype=torch.float32).npu()
+    k = torch.randn(1, 4, 1, 64, dtype=torch.float32).npu()
+    c = torch.randn(4, 32, dtype=torch.float32).npu()
+    s = torch.randn(4, 32, dtype=torch.float32).npu()
+    _expect_reject("invalid_layout", lambda: apply_rotary_pos_emb(q, k, c, s, layout=2, rotaryMode="half"))
+    _expect_reject("invalid_mode", lambda: apply_rotary_pos_emb(q, k, c, s, layout=0, rotaryMode="bad"))
+    _expect_reject("odd_head_dim", lambda: apply_rotary_pos_emb(q[..., :63], k[..., :63], c, s, layout=0, rotaryMode="half"))
+
+
+def test_apply_rotary_pos_emb_boundary():
+    ok = True
+    for case in [L1_CASES[i - 1] for i in (13, 14, 15)]:
+        try:
+            ok &= run_case(*case)
+        except Exception as e:
+            print(f"[BOUNDARY_FAIL] case_{case[0]:02d}: {e}")
+            ok = False
+    return ok
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--level", default="l0", choices=["l0", "l1", "l2", "boundary", "all"])
+    args = parser.parse_args()
+
+    tilelang.disable_cache()
+    torch.manual_seed(0)
+
+    blocking_ok = True
+    if args.level in ("l0", "all"):
+        blocking_ok &= test_apply_rotary_pos_emb_l0()
+    if args.level in ("l1", "all"):
+        blocking_ok &= test_apply_rotary_pos_emb_l1()
+    if args.level in ("l2", "all"):
+        test_apply_rotary_pos_emb_l2()
+    if args.level in ("boundary", "all"):
+        blocking_ok &= test_apply_rotary_pos_emb_boundary()
+
+    if blocking_ok:
+        print("Test Passed!")
+        sys.exit(0)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cann-bench/gelu/gelu.py
+++ b/examples/cann-bench/gelu/gelu.py
@@ -1,0 +1,650 @@
+
+import tilelang
+import tilelang.language as T
+import torch
+
+RSQRT_2 = 0.7071067811865476
+SQRT_8_PI = 1.5957691216057307
+COEFF_044715 = 0.044715
+COEFF_044715_SQRT_8_PI = COEFF_044715 * SQRT_8_PI
+
+ERF_P = 0.3275911
+ERF_A1 = 0.254829592
+ERF_A2 = -0.284496736
+ERF_A3 = 1.421413741
+ERF_A4 = -1.453152027
+ERF_A5 = 1.061405429
+
+_CAST_LOW2HIGH = "CAST_NONE"
+_CAST_HIGH2LOW = "CAST_RINT"
+
+BLOCK_N = 8192
+VEC_NUM = 2
+_KERNEL_CACHE = {}
+
+TORCH_DTYPE_MAP = {
+    "float16": torch.float16,
+    "float32": torch.float32,
+    "bfloat16": torch.bfloat16,
+}
+TORCH_TO_STR = {
+    torch.float16: "float16",
+    torch.float32: "float32",
+    torch.bfloat16: "bfloat16",
+}
+
+PRECISION_THRESHOLDS = {
+    "float16": 2 ** (-10),
+    "float32": 2 ** (-13),
+    "bfloat16": 2 ** (-7),
+}
+
+pipe_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+@tilelang.jit(out_idx=[-1], pass_configs=pipe_configs)
+def _gelu_tanh_kernel(N, block_N, dtype="float32"):
+    tile_elem = block_N // VEC_NUM
+    total_tiles = (N + block_N - 1) // block_N
+    tiles_per_block = max(2, min(8, (total_tiles + 23) // 24))
+    num_blocks = (total_tiles + tiles_per_block - 1) // tiles_per_block
+
+    @T.prim_func
+    def main(X: T.Tensor((N,), dtype), Y: T.Tensor((N,), dtype)):
+        with T.Kernel(num_blocks, is_npu=True) as (cid, vid):
+            x_ub = T.alloc_ub((2, tile_elem), dtype)
+            y_ub = T.alloc_ub((2, tile_elem), dtype)
+            t0 = T.alloc_ub((tile_elem,), dtype)
+            base = cid * tiles_per_block * block_N + vid * tile_elem
+
+            with T.Scope("V"):
+                T.set_flag("mte3", "mte2", 0)
+                T.set_flag("mte3", "mte2", 1)
+                T.wait_flag("mte3", "mte2", 0)
+                T.copy(X[base], x_ub[0, :])
+                T.set_flag("mte2", "v", 0)
+
+                for tile in T.unroll(0, tiles_per_block - 1):
+                    cur = tile % 2
+                    nxt = (tile + 1) % 2
+                    cur_off = base + tile * block_N
+                    next_off = base + (tile + 1) * block_N
+
+                    T.wait_flag("mte3", "mte2", nxt)
+                    T.copy(X[next_off], x_ub[nxt, :])
+                    T.set_flag("mte2", "v", nxt)
+
+                    T.wait_flag("mte2", "v", cur)
+                    T.tile.mul(y_ub[cur, :], x_ub[cur, :], x_ub[cur, :])
+                    T.tile.mul(t0, x_ub[cur, :], y_ub[cur, :])
+                    T.tile.mul(t0, t0, COEFF_044715_SQRT_8_PI)
+                    T.tile.axpy(t0, x_ub[cur, :], SQRT_8_PI)
+                    T.tile.sigmoid(y_ub[cur, :], t0)
+                    T.tile.mul(y_ub[cur, :], x_ub[cur, :], y_ub[cur, :])
+                    T.set_flag("v", "mte3", cur)
+
+                    T.wait_flag("v", "mte3", cur)
+                    T.copy(y_ub[cur, :], Y[cur_off])
+                    T.set_flag("mte3", "mte2", cur)
+
+                last_stage = (tiles_per_block - 1) % 2
+                last_off = base + (tiles_per_block - 1) * block_N
+                T.wait_flag("mte2", "v", last_stage)
+                T.tile.mul(y_ub[last_stage, :], x_ub[last_stage, :], x_ub[last_stage, :])
+                T.tile.mul(t0, x_ub[last_stage, :], y_ub[last_stage, :])
+                T.tile.mul(t0, t0, COEFF_044715_SQRT_8_PI)
+                T.tile.axpy(t0, x_ub[last_stage, :], SQRT_8_PI)
+                T.tile.sigmoid(y_ub[last_stage, :], t0)
+                T.tile.mul(y_ub[last_stage, :], x_ub[last_stage, :], y_ub[last_stage, :])
+                T.set_flag("v", "mte3", last_stage)
+
+                T.wait_flag("v", "mte3", last_stage)
+                T.copy(y_ub[last_stage, :], Y[last_off])
+                T.set_flag("mte3", "mte2", last_stage)
+
+                T.wait_flag("mte3", "mte2", 0)
+                T.wait_flag("mte3", "mte2", 1)
+    return main
+
+
+@tilelang.jit(out_idx=[-1], pass_configs=pipe_configs)
+def _gelu_tanh_cast_kernel(N, block_N, in_dtype="float16", cal_dtype="float32"):
+    tile_elem = block_N // VEC_NUM
+    total_tiles = (N + block_N - 1) // block_N
+    tiles_per_block = max(2, min(8, (total_tiles + 23) // 24))
+    num_blocks = (total_tiles + tiles_per_block - 1) // tiles_per_block
+
+    @T.prim_func
+    def main(X: T.Tensor((N,), in_dtype), Y: T.Tensor((N,), in_dtype)):
+        with T.Kernel(num_blocks, is_npu=True) as (cid, vid):
+            x_ub = T.alloc_ub((2, tile_elem), cal_dtype)
+            y_ub = T.alloc_ub((2, tile_elem), cal_dtype)
+            t0 = T.alloc_ub((tile_elem,), cal_dtype)
+            x_h = T.alloc_ub((2, tile_elem), in_dtype)
+            y_h = T.alloc_ub((2, tile_elem), in_dtype)
+            base = cid * tiles_per_block * block_N + vid * tile_elem
+
+            with T.Scope("V"):
+                T.set_flag("mte3", "mte2", 0)
+                T.set_flag("mte3", "mte2", 1)
+                T.wait_flag("mte3", "mte2", 0)
+                T.copy(X[base], x_h[0, :])
+                T.set_flag("mte2", "v", 0)
+
+                for tile in T.unroll(0, tiles_per_block - 1):
+                    cur = tile % 2
+                    nxt = (tile + 1) % 2
+                    cur_off = base + tile * block_N
+                    next_off = base + (tile + 1) * block_N
+
+                    T.wait_flag("mte3", "mte2", nxt)
+                    T.copy(X[next_off], x_h[nxt, :])
+                    T.set_flag("mte2", "v", nxt)
+
+                    T.wait_flag("mte2", "v", cur)
+                    T.tile.cast(x_ub[cur, :], x_h[cur, :], _CAST_LOW2HIGH, tile_elem)
+                    T.tile.mul(y_ub[cur, :], x_ub[cur, :], x_ub[cur, :])
+                    T.tile.mul(t0, x_ub[cur, :], y_ub[cur, :])
+                    T.tile.mul(t0, t0, COEFF_044715_SQRT_8_PI)
+                    T.tile.axpy(t0, x_ub[cur, :], SQRT_8_PI)
+                    T.tile.sigmoid(y_ub[cur, :], t0)
+                    T.tile.mul(y_ub[cur, :], x_ub[cur, :], y_ub[cur, :])
+                    T.tile.cast(y_h[cur, :], y_ub[cur, :], _CAST_HIGH2LOW, tile_elem)
+                    T.set_flag("v", "mte3", cur)
+
+                    T.wait_flag("v", "mte3", cur)
+                    T.copy(y_h[cur, :], Y[cur_off])
+                    T.set_flag("mte3", "mte2", cur)
+
+                last_stage = (tiles_per_block - 1) % 2
+                last_off = base + (tiles_per_block - 1) * block_N
+                T.wait_flag("mte2", "v", last_stage)
+                T.tile.cast(x_ub[last_stage, :], x_h[last_stage, :], _CAST_LOW2HIGH, tile_elem)
+                T.tile.mul(y_ub[last_stage, :], x_ub[last_stage, :], x_ub[last_stage, :])
+                T.tile.mul(t0, x_ub[last_stage, :], y_ub[last_stage, :])
+                T.tile.mul(t0, t0, COEFF_044715_SQRT_8_PI)
+                T.tile.axpy(t0, x_ub[last_stage, :], SQRT_8_PI)
+                T.tile.sigmoid(y_ub[last_stage, :], t0)
+                T.tile.mul(y_ub[last_stage, :], x_ub[last_stage, :], y_ub[last_stage, :])
+                T.tile.cast(y_h[last_stage, :], y_ub[last_stage, :], _CAST_HIGH2LOW, tile_elem)
+                T.set_flag("v", "mte3", last_stage)
+
+                T.wait_flag("v", "mte3", last_stage)
+                T.copy(y_h[last_stage, :], Y[last_off])
+                T.set_flag("mte3", "mte2", last_stage)
+
+                T.wait_flag("mte3", "mte2", 0)
+                T.wait_flag("mte3", "mte2", 1)
+    return main
+
+
+@tilelang.jit(out_idx=[-1], pass_configs=pipe_configs)
+def _gelu_exact_hw_kernel(N, block_N, in_dtype="float16", cal_dtype="float32"):
+    tile_elem = block_N // VEC_NUM
+    total_tiles = (N + block_N - 1) // block_N
+    tiles_per_block = max(2, min(8, (total_tiles + 23) // 24))
+    num_blocks = (total_tiles + tiles_per_block - 1) // tiles_per_block
+
+    @T.prim_func
+    def main(X: T.Tensor((N,), in_dtype), Y: T.Tensor((N,), in_dtype)):
+        with T.Kernel(num_blocks, is_npu=True) as (cid, vid):
+            x_ub = T.alloc_ub((2, tile_elem), cal_dtype)
+            y_ub = T.alloc_ub((2, tile_elem), cal_dtype)
+            t0 = T.alloc_ub((tile_elem,), cal_dtype)
+            z_ub = T.alloc_ub((tile_elem,), cal_dtype)
+            x_h = T.alloc_ub((2, tile_elem), in_dtype)
+            y_h = T.alloc_ub((2, tile_elem), in_dtype)
+            base = cid * tiles_per_block * block_N + vid * tile_elem
+
+            with T.Scope("V"):
+                T.set_flag("mte3", "mte2", 0)
+                T.set_flag("mte3", "mte2", 1)
+                T.wait_flag("mte3", "mte2", 0)
+                T.copy(X[base], x_h[0, :])
+                T.set_flag("mte2", "v", 0)
+
+                for tile in T.unroll(0, tiles_per_block - 1):
+                    cur = tile % 2
+                    nxt = (tile + 1) % 2
+                    cur_off = base + tile * block_N
+                    next_off = base + (tile + 1) * block_N
+
+                    T.wait_flag("mte3", "mte2", nxt)
+                    T.copy(X[next_off], x_h[nxt, :])
+                    T.set_flag("mte2", "v", nxt)
+
+                    T.wait_flag("mte2", "v", cur)
+                    T.tile.cast(x_ub[cur, :], x_h[cur, :], _CAST_LOW2HIGH, tile_elem)
+                    T.tile.mul(z_ub, x_ub[cur, :], RSQRT_2)
+                    T.tile.erf(t0, z_ub)
+                    T.tile.add(t0, t0, 1.0)
+                    T.tile.mul(y_ub[cur, :], x_ub[cur, :], t0)
+                    T.tile.mul(y_ub[cur, :], y_ub[cur, :], 0.5)
+                    T.tile.cast(y_h[cur, :], y_ub[cur, :], _CAST_HIGH2LOW, tile_elem)
+                    T.set_flag("v", "mte3", cur)
+
+                    T.wait_flag("v", "mte3", cur)
+                    T.copy(y_h[cur, :], Y[cur_off])
+                    T.set_flag("mte3", "mte2", cur)
+
+                last_stage = (tiles_per_block - 1) % 2
+                last_off = base + (tiles_per_block - 1) * block_N
+                T.wait_flag("mte2", "v", last_stage)
+                T.tile.cast(x_ub[last_stage, :], x_h[last_stage, :], _CAST_LOW2HIGH, tile_elem)
+                T.tile.mul(z_ub, x_ub[last_stage, :], RSQRT_2)
+                T.tile.erf(t0, z_ub)
+                T.tile.add(t0, t0, 1.0)
+                T.tile.mul(y_ub[last_stage, :], x_ub[last_stage, :], t0)
+                T.tile.mul(y_ub[last_stage, :], y_ub[last_stage, :], 0.5)
+                T.tile.cast(y_h[last_stage, :], y_ub[last_stage, :], _CAST_HIGH2LOW, tile_elem)
+                T.set_flag("v", "mte3", last_stage)
+
+                T.wait_flag("v", "mte3", last_stage)
+                T.copy(y_h[last_stage, :], Y[last_off])
+                T.set_flag("mte3", "mte2", last_stage)
+
+                T.wait_flag("mte3", "mte2", 0)
+                T.wait_flag("mte3", "mte2", 1)
+    return main
+
+
+@tilelang.jit(out_idx=[-1], pass_configs=pipe_configs)
+def _gelu_exact_as_kernel(N, block_N, dtype="float32"):
+    tile_elem = block_N // VEC_NUM
+    total_tiles = (N + block_N - 1) // block_N
+    tiles_per_block = max(2, min(8, (total_tiles + 23) // 24))
+    num_blocks = (total_tiles + tiles_per_block - 1) // tiles_per_block
+
+    @T.prim_func
+    def main(X: T.Tensor((N,), dtype), Y: T.Tensor((N,), dtype)):
+        with T.Kernel(num_blocks, is_npu=True) as (cid, vid):
+            x_ub = T.alloc_ub((2, tile_elem), dtype)
+            y_ub = T.alloc_ub((2, tile_elem), dtype)
+            t0 = T.alloc_ub((tile_elem,), dtype)
+            t1 = T.alloc_ub((tile_elem,), dtype)
+            t2 = T.alloc_ub((tile_elem,), dtype)
+            z_ub = T.alloc_ub((tile_elem,), dtype)
+            h0 = T.alloc_ub((tile_elem,), dtype)
+            h1 = T.alloc_ub((tile_elem,), dtype)
+            ones = T.alloc_ub((tile_elem,), dtype)
+            base = cid * tiles_per_block * block_N + vid * tile_elem
+
+            with T.Scope("V"):
+                T.tile.fill(ones, 1.0)
+
+                T.set_flag("mte3", "mte2", 0)
+                T.set_flag("mte3", "mte2", 1)
+                T.wait_flag("mte3", "mte2", 0)
+                T.copy(X[base], x_ub[0, :])
+                T.set_flag("mte2", "v", 0)
+
+                for tile in T.unroll(0, tiles_per_block - 1):
+                    cur = tile % 2
+                    nxt = (tile + 1) % 2
+                    cur_off = base + tile * block_N
+                    next_off = base + (tile + 1) * block_N
+
+                    T.wait_flag("mte3", "mte2", nxt)
+                    T.copy(X[next_off], x_ub[nxt, :])
+                    T.set_flag("mte2", "v", nxt)
+
+                    T.wait_flag("mte2", "v", cur)
+                    T.tile.mul(z_ub, x_ub[cur, :], RSQRT_2)
+                    T.tile.mul(t0, z_ub, z_ub)
+                    T.tile.abs(t1, z_ub)
+                    T.tile.mul(t0, t0, -1.0)
+                    T.tile.exp(t0, t0)
+                    T.tile.mul(t2, t1, ERF_P)
+                    T.tile.add(t2, t2, 1.0)
+                    T.tile.div(t2, ones, t2)
+                    T.tile.fill(h0, ERF_A5)
+                    T.tile.fill(h1, ERF_A4)
+                    T.tile.mul_add_dst(h1, t2, h0)
+                    T.tile.fill(h0, ERF_A3)
+                    T.tile.mul_add_dst(h0, t2, h1)
+                    T.tile.fill(h1, ERF_A2)
+                    T.tile.mul_add_dst(h1, t2, h0)
+                    T.tile.fill(h0, ERF_A1)
+                    T.tile.mul_add_dst(h0, t2, h1)
+                    T.tile.mul(t1, h0, t2)
+                    T.tile.mul(t1, t1, t0)
+                    T.tile.sub(y_ub[cur, :], ones, t1)
+                    T.tile.mul(t0, y_ub[cur, :], -1.0)
+                    T.tile.compare(t1, z_ub, 0.0, "GE")
+                    T.tile.select(y_ub[cur, :], t1, y_ub[cur, :], t0, "VSEL_TENSOR_TENSOR_MODE")
+                    T.tile.add(y_ub[cur, :], y_ub[cur, :], 1.0)
+                    T.tile.mul(y_ub[cur, :], y_ub[cur, :], 0.5)
+                    T.tile.mul(y_ub[cur, :], x_ub[cur, :], y_ub[cur, :])
+                    T.set_flag("v", "mte3", cur)
+
+                    T.wait_flag("v", "mte3", cur)
+                    T.copy(y_ub[cur, :], Y[cur_off])
+                    T.set_flag("mte3", "mte2", cur)
+
+                last_stage = (tiles_per_block - 1) % 2
+                last_off = base + (tiles_per_block - 1) * block_N
+                T.wait_flag("mte2", "v", last_stage)
+                T.tile.mul(z_ub, x_ub[last_stage, :], RSQRT_2)
+                T.tile.mul(t0, z_ub, z_ub)
+                T.tile.abs(t1, z_ub)
+                T.tile.mul(t0, t0, -1.0)
+                T.tile.exp(t0, t0)
+                T.tile.mul(t2, t1, ERF_P)
+                T.tile.add(t2, t2, 1.0)
+                T.tile.div(t2, ones, t2)
+                T.tile.fill(h0, ERF_A5)
+                T.tile.fill(h1, ERF_A4)
+                T.tile.mul_add_dst(h1, t2, h0)
+                T.tile.fill(h0, ERF_A3)
+                T.tile.mul_add_dst(h0, t2, h1)
+                T.tile.fill(h1, ERF_A2)
+                T.tile.mul_add_dst(h1, t2, h0)
+                T.tile.fill(h0, ERF_A1)
+                T.tile.mul_add_dst(h0, t2, h1)
+                T.tile.mul(t1, h0, t2)
+                T.tile.mul(t1, t1, t0)
+                T.tile.sub(y_ub[last_stage, :], ones, t1)
+                T.tile.mul(t0, y_ub[last_stage, :], -1.0)
+                T.tile.compare(t1, z_ub, 0.0, "GE")
+                T.tile.select(y_ub[last_stage, :], t1, y_ub[last_stage, :], t0, "VSEL_TENSOR_TENSOR_MODE")
+                T.tile.add(y_ub[last_stage, :], y_ub[last_stage, :], 1.0)
+                T.tile.mul(y_ub[last_stage, :], y_ub[last_stage, :], 0.5)
+                T.tile.mul(y_ub[last_stage, :], x_ub[last_stage, :], y_ub[last_stage, :])
+                T.set_flag("v", "mte3", last_stage)
+
+                T.wait_flag("v", "mte3", last_stage)
+                T.copy(y_ub[last_stage, :], Y[last_off])
+                T.set_flag("mte3", "mte2", last_stage)
+
+                T.wait_flag("mte3", "mte2", 0)
+                T.wait_flag("mte3", "mte2", 1)
+    return main
+
+
+@tilelang.jit(out_idx=[-1], pass_configs=pipe_configs)
+def _gelu_exact_as_cast_kernel(N, block_N, in_dtype="bfloat16", cal_dtype="float32"):
+    tile_elem = block_N // VEC_NUM
+    total_tiles = (N + block_N - 1) // block_N
+    tiles_per_block = max(2, min(8, (total_tiles + 23) // 24))
+    num_blocks = (total_tiles + tiles_per_block - 1) // tiles_per_block
+
+    @T.prim_func
+    def main(X: T.Tensor((N,), in_dtype), Y: T.Tensor((N,), in_dtype)):
+        with T.Kernel(num_blocks, is_npu=True) as (cid, vid):
+            x_ub = T.alloc_ub((2, tile_elem), cal_dtype)
+            y_ub = T.alloc_ub((2, tile_elem), cal_dtype)
+            x_h = T.alloc_ub((2, tile_elem), in_dtype)
+            y_h = T.alloc_ub((2, tile_elem), in_dtype)
+            t0 = T.alloc_ub((tile_elem,), cal_dtype)
+            t1 = T.alloc_ub((tile_elem,), cal_dtype)
+            t2 = T.alloc_ub((tile_elem,), cal_dtype)
+            z_ub = T.alloc_ub((tile_elem,), cal_dtype)
+            h0 = T.alloc_ub((tile_elem,), cal_dtype)
+            h1 = T.alloc_ub((tile_elem,), cal_dtype)
+            ones = T.alloc_ub((tile_elem,), cal_dtype)
+            base = cid * tiles_per_block * block_N + vid * tile_elem
+
+            with T.Scope("V"):
+                T.tile.fill(ones, 1.0)
+
+                T.set_flag("mte3", "mte2", 0)
+                T.set_flag("mte3", "mte2", 1)
+                T.wait_flag("mte3", "mte2", 0)
+                T.copy(X[base], x_h[0, :])
+                T.set_flag("mte2", "v", 0)
+
+                for tile in T.unroll(0, tiles_per_block - 1):
+                    cur = tile % 2
+                    nxt = (tile + 1) % 2
+                    cur_off = base + tile * block_N
+                    next_off = base + (tile + 1) * block_N
+
+                    T.wait_flag("mte3", "mte2", nxt)
+                    T.copy(X[next_off], x_h[nxt, :])
+                    T.set_flag("mte2", "v", nxt)
+
+                    T.wait_flag("mte2", "v", cur)
+                    T.tile.cast(x_ub[cur, :], x_h[cur, :], _CAST_LOW2HIGH, tile_elem)
+                    T.tile.mul(z_ub, x_ub[cur, :], RSQRT_2)
+                    T.tile.mul(t0, z_ub, z_ub)
+                    T.tile.abs(t1, z_ub)
+                    T.tile.mul(t0, t0, -1.0)
+                    T.tile.exp(t0, t0)
+                    T.tile.mul(t2, t1, ERF_P)
+                    T.tile.add(t2, t2, 1.0)
+                    T.tile.div(t2, ones, t2)
+                    T.tile.fill(h0, ERF_A5)
+                    T.tile.fill(h1, ERF_A4)
+                    T.tile.mul_add_dst(h1, t2, h0)
+                    T.tile.fill(h0, ERF_A3)
+                    T.tile.mul_add_dst(h0, t2, h1)
+                    T.tile.fill(h1, ERF_A2)
+                    T.tile.mul_add_dst(h1, t2, h0)
+                    T.tile.fill(h0, ERF_A1)
+                    T.tile.mul_add_dst(h0, t2, h1)
+                    T.tile.mul(t1, h0, t2)
+                    T.tile.mul(t1, t1, t0)
+                    T.tile.sub(y_ub[cur, :], ones, t1)
+                    T.tile.mul(t0, y_ub[cur, :], -1.0)
+                    T.tile.compare(t1, z_ub, 0.0, "GE")
+                    T.tile.select(y_ub[cur, :], t1, y_ub[cur, :], t0, "VSEL_TENSOR_TENSOR_MODE")
+                    T.tile.add(y_ub[cur, :], y_ub[cur, :], 1.0)
+                    T.tile.mul(y_ub[cur, :], y_ub[cur, :], 0.5)
+                    T.tile.mul(y_ub[cur, :], x_ub[cur, :], y_ub[cur, :])
+                    T.tile.cast(y_h[cur, :], y_ub[cur, :], _CAST_HIGH2LOW, tile_elem)
+                    T.set_flag("v", "mte3", cur)
+
+                    T.wait_flag("v", "mte3", cur)
+                    T.copy(y_h[cur, :], Y[cur_off])
+                    T.set_flag("mte3", "mte2", cur)
+
+                last_stage = (tiles_per_block - 1) % 2
+                last_off = base + (tiles_per_block - 1) * block_N
+                T.wait_flag("mte2", "v", last_stage)
+                T.tile.cast(x_ub[last_stage, :], x_h[last_stage, :], _CAST_LOW2HIGH, tile_elem)
+                T.tile.mul(z_ub, x_ub[last_stage, :], RSQRT_2)
+                T.tile.mul(t0, z_ub, z_ub)
+                T.tile.abs(t1, z_ub)
+                T.tile.mul(t0, t0, -1.0)
+                T.tile.exp(t0, t0)
+                T.tile.mul(t2, t1, ERF_P)
+                T.tile.add(t2, t2, 1.0)
+                T.tile.div(t2, ones, t2)
+                T.tile.fill(h0, ERF_A5)
+                T.tile.fill(h1, ERF_A4)
+                T.tile.mul_add_dst(h1, t2, h0)
+                T.tile.fill(h0, ERF_A3)
+                T.tile.mul_add_dst(h0, t2, h1)
+                T.tile.fill(h1, ERF_A2)
+                T.tile.mul_add_dst(h1, t2, h0)
+                T.tile.fill(h0, ERF_A1)
+                T.tile.mul_add_dst(h0, t2, h1)
+                T.tile.mul(t1, h0, t2)
+                T.tile.mul(t1, t1, t0)
+                T.tile.sub(y_ub[last_stage, :], ones, t1)
+                T.tile.mul(t0, y_ub[last_stage, :], -1.0)
+                T.tile.compare(t1, z_ub, 0.0, "GE")
+                T.tile.select(y_ub[last_stage, :], t1, y_ub[last_stage, :], t0, "VSEL_TENSOR_TENSOR_MODE")
+                T.tile.add(y_ub[last_stage, :], y_ub[last_stage, :], 1.0)
+                T.tile.mul(y_ub[last_stage, :], y_ub[last_stage, :], 0.5)
+                T.tile.mul(y_ub[last_stage, :], x_ub[last_stage, :], y_ub[last_stage, :])
+                T.tile.cast(y_h[last_stage, :], y_ub[last_stage, :], _CAST_HIGH2LOW, tile_elem)
+                T.set_flag("v", "mte3", last_stage)
+
+                T.wait_flag("v", "mte3", last_stage)
+                T.copy(y_h[last_stage, :], Y[last_off])
+                T.set_flag("mte3", "mte2", last_stage)
+
+                T.wait_flag("mte3", "mte2", 0)
+                T.wait_flag("mte3", "mte2", 1)
+    return main
+
+
+def compute_mere_mare(actual, golden):
+    actual = actual.float()
+    golden = golden.float()
+    diff = (actual - golden).abs()
+    denom = golden.abs() + 1e-7
+    relative_err = diff / denom
+    mere = relative_err.mean().item()
+    mare = relative_err.max().item()
+    return mere, mare
+
+def check_precision(actual, golden, threshold):
+    mere, mare = compute_mere_mare(actual, golden)
+    passed = (mere < threshold) and (mare < 10 * threshold)
+    return passed, mere, mare
+
+def gen_input(shape, dtype_str, value_range):
+    torch_dtype = TORCH_DTYPE_MAP[dtype_str]
+    low, high = value_range
+    x = torch.empty(shape, dtype=torch.float32).uniform_(low, high).to(torch_dtype)
+    return x
+
+
+def run_gelu_kernel(x, approximate="none", block_N=BLOCK_N):
+    if not x.is_npu:
+        x = x.npu()
+    orig_dtype = x.dtype
+    N = x.numel()
+    x_flat = x.contiguous().view(-1)
+
+    if orig_dtype == torch.float16:
+        if approximate == "tanh":
+            cache_key = (N, block_N, "fp16_cast_tanh")
+            if cache_key not in _KERNEL_CACHE:
+                _KERNEL_CACHE[cache_key] = _gelu_tanh_cast_kernel(N, block_N, in_dtype="float16", cal_dtype="float32")
+        else:
+            cache_key = (N, block_N, "fp16_tanh")
+            if cache_key not in _KERNEL_CACHE:
+                _KERNEL_CACHE[cache_key] = _gelu_tanh_kernel(N, block_N, dtype="float16")
+    elif orig_dtype == torch.bfloat16:
+        if approximate == "tanh":
+            cache_key = (N, block_N, "bf16_cast_tanh")
+            if cache_key not in _KERNEL_CACHE:
+                _KERNEL_CACHE[cache_key] = _gelu_tanh_cast_kernel(N, block_N, in_dtype="bfloat16", cal_dtype="float32")
+        else:
+            cache_key = (N, block_N, "bf16_exact_as_cast")
+            if cache_key not in _KERNEL_CACHE:
+                _KERNEL_CACHE[cache_key] = _gelu_exact_as_cast_kernel(N, 4096, in_dtype="bfloat16", cal_dtype="float32")
+    else:
+        if approximate == "tanh":
+            cache_key = (N, block_N, "fp32_tanh")
+            if cache_key not in _KERNEL_CACHE:
+                _KERNEL_CACHE[cache_key] = _gelu_tanh_kernel(N, block_N, dtype="float32")
+        else:
+            cache_key = (N, block_N, "fp32_exact_as")
+            if cache_key not in _KERNEL_CACHE:
+                _KERNEL_CACHE[cache_key] = _gelu_exact_as_kernel(N, block_N, dtype="float32")
+
+    kernel = _KERNEL_CACHE[cache_key]
+    y_flat = kernel(x_flat)
+    y = y_flat.view(x.shape)
+    return y
+
+
+def gelu(x, approximate="none"):
+    return run_gelu_kernel(x, approximate=approximate)
+
+
+__all__ = ["gelu"]
+
+
+# ---------------------------------------------------------------------------
+# Test harness
+# ---------------------------------------------------------------------------
+RTOL_MAP = {"float16": 1e-3, "bfloat16": 8e-3, "float32": 1e-4}
+ATOL_MAP = {"float16": 1e-3, "bfloat16": 8e-3, "float32": 1e-5}
+
+
+def run_gelu(case_id, shape, dtype_str, approximate, value_range):
+    torch_dtype = TORCH_DTYPE_MAP[dtype_str]
+    lo, hi = value_range
+    x = torch.empty(shape, dtype=torch.float32).uniform_(lo, hi).to(torch_dtype).npu()
+
+    y = gelu(x, approximate=approximate)
+    ref = torch.nn.functional.gelu(x, approximate=approximate)
+
+    rtol = RTOL_MAP.get(dtype_str, 1e-2)
+    atol = ATOL_MAP.get(dtype_str, 1e-2)
+    y_c = y.cpu().float()
+    ref_c = ref.cpu().float()
+    torch.testing.assert_close(y_c, ref_c, rtol=rtol, atol=atol)
+
+    print(
+        f"Case {case_id}: PASSED  "
+        f"(shape={shape}, dtype={dtype_str}, approximate={approximate})"
+    )
+
+
+if __name__ == "__main__":
+    torch.manual_seed(42)
+
+    # (case_id, shape, dtype, approximate, value_range)
+    test_cases = [
+        (1, [1024], "float32", "none", [-3, 3]),
+        (2, [1024], "float32", "tanh", [-3, 3]),
+        (3, [1024], "float16", "none", [-3, 3]),
+        (4, [1024], "float16", "tanh", [-3, 3]),
+        (5, [1024], "bfloat16", "none", [-3, 3]),
+        (6, [1024], "bfloat16", "tanh", [-3, 3]),
+        (7, [1024, 1024], "float32", "none", [-5, 5]),
+        (8, [1024, 1024], "float32", "tanh", [-5, 5]),
+        (9, [1024, 1024], "float16", "none", [-5, 5]),
+        (10, [1024, 1024], "float16", "tanh", [-5, 5]),
+        (11, [1024, 1024], "bfloat16", "none", [-5, 5]),
+        (12, [1024, 1024], "bfloat16", "tanh", [-5, 5]),
+        (13, [2048, 2048], "float32", "none", [-10, 10]),
+        (14, [2048, 2048], "float32", "tanh", [-10, 10]),
+        (15, [2048, 2048], "float16", "none", [-10, 10]),
+        (16, [2048, 2048], "float16", "tanh", [-10, 10]),
+        (17, [2048, 2048], "bfloat16", "none", [-10, 10]),
+        (18, [2048, 2048], "bfloat16", "tanh", [-10, 10]),
+        (19, [363, 367, 373], "float32", "none", [-3, 3]),
+        (20, [363, 367, 373], "float32", "tanh", [-3, 3]),
+        (21, [363, 367, 373], "float16", "none", [-3, 3]),
+        (22, [363, 367, 373], "float16", "tanh", [-3, 3]),
+        (23, [363, 367, 373], "bfloat16", "none", [-3, 3]),
+        (24, [363, 367, 373], "bfloat16", "tanh", [-3, 3]),
+        (25, [4096, 4096], "float32", "none", [-1, 1]),
+        (26, [4096, 4096], "float16", "tanh", [-1, 1]),
+        (27, [4096, 4096], "bfloat16", "none", [-1, 1]),
+        (28, [8192], "float32", "none", [-6, 6]),
+        (29, [8192], "float16", "tanh", [-6, 6]),
+        (30, [8192], "bfloat16", "none", [-6, 6]),
+        (31, [1], "float32", "none", [-3, 3]),
+        (32, [1], "float16", "tanh", [-3, 3]),
+        (33, [1], "bfloat16", "none", [-3, 3]),
+        (34, [1000003], "float32", "none", [-3, 3]),
+        (35, [1000003], "float16", "tanh", [-3, 3]),
+        (36, [1000003], "bfloat16", "none", [-3, 3]),
+        (37, [3, 7, 13, 4001], "float32", "none", [-3, 3]),
+        (38, [3, 7, 13, 4001], "float16", "tanh", [-3, 3]),
+        (39, [3, 7, 13, 4001], "bfloat16", "none", [-3, 3]),
+        (40, [512, 2049], "bfloat16", "tanh", [-0.5, 0.5]),
+        (41, [255, 8193], "float16", "none", [-1, 3]),
+        (42, [4097, 511], "float32", "tanh", [-1000, 1000]),
+    ]
+
+    print("=" * 70)
+    print("Gelu TileLang-Ascend 测试 (torch.nn.functional.gelu 语义)")
+    print(f"共 {len(test_cases)} 个测试用例")
+    print("=" * 70)
+
+    passed = 0
+    failed = 0
+    for case_id, shape, dtype, approximate, value_range in test_cases:
+        try:
+            run_gelu(case_id, shape, dtype, approximate, value_range)
+            passed += 1
+        except Exception as e:
+            print(f"Case {case_id}: FAILED - {e}")
+            failed += 1
+
+    print("=" * 70)
+    print(f"测试完成: {passed} passed, {failed} failed")
+    if failed == 0:
+        print("Test Passed!")


### PR DESCRIPTION

新增examples gelu算子，基线对比加速比为 0.5x，但是目前v核已经满载，以下为精度与性能对比测试报告

# 算子评测报告

**评测代号**: cann_final_eval_20260818_173034
**评测时间**: 2026-08-18T17:30:34.600750
**设备**: npu:0
**框架版本**: V0.4.0
**评测集版本**: tasks-v0.4.0

## 概览

| 指标 | 数值 |
|------|------|
| 评测算子数 | 1 |
| 总用例数 | 20 |
| 通过用例数 | 20 |
| 失败用例数 | 0 |
| 通过率 | 100.00% |
| 综合得分 | 63.95 |

## 算子详情

### Gelu（level1/gelu）

| 指标 | 数值 |
|------|------|
| 用例数 | 20 |
| 通过数 | 20 |
| 失败数 | 0 |
| 通过率 | 100.00% |
| 平均加速比 | 0.50x |
| 编译/运行得分 | 20.00 |
| 精度得分 | 30.00 |
| 性能得分 | 13.95 |
| 得分 | 63.95 |

| 用例ID | 状态 | 耗时(μs) | 加速比 | 精度误差 |
|--------|------|----------|--------|----------|
| level1/gelu_1 | ✅ | 8.62 | 0.79x | 0.000977 |
| level1/gelu_2 | ✅ | 79.62 | 0.22x | 0.000000 |
| level1/gelu_3 | ✅ | 315.66 | 0.20x | 0.000000 |
| level1/gelu_4 | ✅ | 395.58 | 0.70x | 0.000000 |
| level1/gelu_5 | ✅ | 422.20 | 0.84x | 0.000000 |
| level1/gelu_6 | ✅ | 12.50 | 0.57x | 0.000000 |
| level1/gelu_7 | ✅ | 8.58 | 0.83x | 0.001953 |
| level1/gelu_8 | ✅ | 12.88 | 0.54x | 0.000000 |
| level1/gelu_9 | ✅ | 923.90 | 0.19x | 0.000015 |
| level1/gelu_10 | ✅ | 12.52 | 0.55x | 0.000000 |
| level1/gelu_11 | ✅ | 30.96 | 0.23x | 0.000000 |
| level1/gelu_12 | ✅ | 12.66 | 0.54x | 0.000000 |
| level1/gelu_13 | ✅ | 178.80 | 0.24x | 0.000000 |
| level1/gelu_14 | ✅ | 23.72 | 0.58x | 0.000000 |
| level1/gelu_15 | ✅ | 30.40 | 0.21x | 0.000000 |
| level1/gelu_16 | ✅ | 48.30 | 0.22x | 0.000000 |
| level1/gelu_17 | ✅ | 16.64 | 0.64x | 0.000000 |
| level1/gelu_18 | ✅ | 40.94 | 0.25x | 0.000000 |
| level1/gelu_19 | ✅ | 16.68 | 0.65x | 0.000000 |
| level1/gelu_20 | ✅ | 177.70 | 1.10x | 0.000000 |

<img width="1568" height="652" alt="image" src="https://github.com/user-attachments/assets/3d2480d4-9eb0-4fdb-bfde-53cf1258d7bb" />
