### PR TITLE
[Docs]: Fact-check T.tile.clear API 

### DIFF
--- a/docs/language/tile_clear.md
+++ b/docs/language/tile_clear.md
@@ -4,18 +4,13 @@
 
 将 buffer 中的所有元素清零：`buffer[i] = 0`
 
-内部委托给 `fill(buffer, 0)` 实现。生成的底层指令取决于后端：
-
-- **Ascend C 后端**：`AscendC::Duplicate<T>(dst, 0, count)`
-- **PTO 后端**：`TEXPANDS(dst, 0)`
-
 ## 2. 函数原型
 
 ### 2.1 函数定义
 
 ```python
 def clear(
-    buffer: Buffer | tir.Var,
+    buffer: Buffer | BufferRegion,
 )
 ```
 
@@ -23,20 +18,14 @@ def clear(
 
 | 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
 |--------|----------|------|------|---------|
-| buffer | 输入/输出 | 待清零的 buffer | Buffer / BufferRegion / tir.Var | 必填 |
+| buffer | 输入/输出 | 待清零的 buffer | 张量（tensor） | 必填 |
 
 > **类型说明**：
->
-> - **Buffer**：通过 `T.alloc_ub` 分配的 UB 缓冲区。`fill` 也接受 `BufferRegion`（切片），因此传入 `BufferRegion` 同样可用，但函数签名中的类型标注为 `Buffer | tir.Var`。
-> - **tir.Var**：当传入 tir.Var 时，`clear` 会通过 `T.has_let_value` / `T.get_let_value` 解析为 BufferRegion 再调用 `fill`。
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
 
 ### 2.3 参数规格
 
-#### 2.3.1 Buffer Scope
-
-`clear` 仅支持 **UB（Unified Buffer）** 内存。底层 `AscendC::Duplicate` 和 PTO `TEXPANDS` 均操作 `LocalTensor<T>`（UB）。
-
-#### 2.3.2 DataType 支持
+#### 2.3.1 DataType 支持
 
 以下 dtype 基于 Ascend A2 / A3（910B）真机验证：
 
@@ -52,22 +41,15 @@ def clear(
 | int8 | 不支持 | 支持 |
 | uint8 | 不支持 | 支持 |
 
-> **说明**：Ascend C 后端 dtype 支持范围由 `AscendC::Duplicate` 的 `static_assert` 约束，不支持 int8/uint8。PTO 后端使用 `TEXPANDS`，支持 int8/uint8。
->
-> **A5 平台**：int64/uint64 在当前环境（A2/A3）无法验证。`IsDuplicateSupported_v` 不包含 int64/uint64，Ascend C 后端预计不支持。
-
-#### 2.3.3 Shape 支持
+#### 2.3.2 Shape 支持
 
 - 支持 1D 和 2D
-- size 由 buffer shape 自动推断（BufferRegion 时取 region extent 的乘积，Buffer 时取 shape 的乘积）
 
 ### 2.4 约束条件
 
-1. `clear` 委托给 `fill(buffer, 0)` 实现
-2. buffer 必须位于 UB 内存（通过 `T.alloc_ub` 分配）
-3. buffer 地址需 32 字节对齐（硬件约束）
-4. size 由 buffer shape 自动推断，无需显式传入 count 参数
-5. 当传入 tir.Var 时，需确保该变量已通过 `T.has_let_value` 绑定到有效的 BufferRegion
+1. buffer 必须位于 UB 内存（通过 `T.alloc_ub` 分配）
+2. buffer 地址需 32 字节对齐（硬件约束）
+3. size 由 buffer shape 自动推断，无需显式传入 count 参数
 
 ## 3. 示例代码
 

--- a/docs/language/tile_clear.md
+++ b/docs/language/tile_clear.md
@@ -1,0 +1,88 @@
+# T.tile.clear
+
+## 1. 功能说明
+
+将 buffer 中的所有元素清零：`buffer[i] = 0`
+
+内部委托给 `fill(buffer, 0)` 实现。生成的底层指令取决于后端：
+
+- **Ascend C 后端**：`AscendC::Duplicate<T>(dst, 0, count)`
+- **PTO 后端**：`TEXPANDS(dst, 0)`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def clear(
+    buffer: Buffer | tir.Var,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|---------|
+| buffer | 输入/输出 | 待清零的 buffer | Buffer / BufferRegion / tir.Var | 必填 |
+
+> **类型说明**：
+>
+> - **Buffer**：通过 `T.alloc_ub` 分配的 UB 缓冲区。`fill` 也接受 `BufferRegion`（切片），因此传入 `BufferRegion` 同样可用，但函数签名中的类型标注为 `Buffer | tir.Var`。
+> - **tir.Var**：当传入 tir.Var 时，`clear` 会通过 `T.has_let_value` / `T.get_let_value` 解析为 BufferRegion 再调用 `fill`。
+
+### 2.3 参数规格
+
+#### 2.3.1 Buffer Scope
+
+`clear` 仅支持 **UB（Unified Buffer）** 内存。底层 `AscendC::Duplicate` 和 PTO `TEXPANDS` 均操作 `LocalTensor<T>`（UB）。
+
+#### 2.3.2 DataType 支持
+
+以下 dtype 基于 Ascend A2 / A3（910B）真机验证：
+
+| dtype | Ascend C | PTO |
+|-------|----------|-----|
+| float16 | 支持 | 支持 |
+| float32 | 支持 | 支持 |
+| bfloat16 | 支持 | 支持 |
+| int16 | 支持 | 支持 |
+| uint16 | 支持 | 支持 |
+| int32 | 支持 | 支持 |
+| uint32 | 支持 | 支持 |
+| int8 | 不支持 | 支持 |
+| uint8 | 不支持 | 支持 |
+
+> **说明**：Ascend C 后端 dtype 支持范围由 `AscendC::Duplicate` 的 `static_assert` 约束，不支持 int8/uint8。PTO 后端使用 `TEXPANDS`，支持 int8/uint8。
+>
+> **A5 平台**：int64/uint64 在当前环境（A2/A3）无法验证。`IsDuplicateSupported_v` 不包含 int64/uint64，Ascend C 后端预计不支持。
+
+#### 2.3.3 Shape 支持
+
+- 支持 1D 和 2D
+- size 由 buffer shape 自动推断（BufferRegion 时取 region extent 的乘积，Buffer 时取 shape 的乘积）
+
+### 2.4 约束条件
+
+1. `clear` 委托给 `fill(buffer, 0)` 实现
+2. buffer 必须位于 UB 内存（通过 `T.alloc_ub` 分配）
+3. buffer 地址需 32 字节对齐（硬件约束）
+4. size 由 buffer shape 自动推断，无需显式传入 count 参数
+5. 当传入 tir.Var 时，需确保该变量已通过 `T.has_let_value` 绑定到有效的 BufferRegion
+
+## 3. 示例代码
+
+**示例 1：清零 UB 缓冲区**
+
+```python
+a_ub = T.alloc_ub((block_M, block_N), "float16")
+T.tile.fill(a_ub, 10.0)
+T.tile.clear(a_ub)  # 将 a_ub 所有元素清零
+```
+
+**示例 2：清零 BufferRegion 切片**
+
+```python
+a_ub = T.alloc_ub((block_M, block_N), "float32")
+T.tile.fill(a_ub, 10.0)
+T.tile.clear(a_ub[0:block_M, 0:block_N])  # 清零指定区域
+```

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -2284,7 +2284,108 @@ def run_test_clear(M, N, block_M, block_N, dtype, target):
 
     b = func()
 
-    ref_b = torch.zeros((M, N), dtype=torch.float32 if dtype == "float" else torch.float16).npu()
+    torch_dtype_map = {
+        "float": torch.float32,
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+        "int32": torch.int32,
+        "uint32": torch.uint32,
+        "int16": torch.int16,
+        "uint16": torch.uint16,
+        "int8": torch.int8,
+        "uint8": torch.uint8,
+    }
+    torch_dtype = torch_dtype_map.get(dtype, torch.float32)
+    ref_b = torch.zeros((M, N), dtype=torch_dtype).npu()
+
+    assert_close_npu(b, ref_b, dtype, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16", "bfloat16", "int32", "int16", "uint16"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("shape", [(1024, 1024)])
+def test_clear(dtype, target, shape):
+    M, N = shape
+    run_test_clear(M, N, 64, 32, dtype, target=target)
+
+
+@pytest.mark.parametrize("dtype", ["int8", "uint8"])
+@pytest.mark.parametrize("target", ["pto"])
+@pytest.mark.parametrize("shape", [(1024, 1024)])
+def test_clear_pto_int8(dtype, target, shape):
+    M, N = shape
+    run_test_clear(M, N, 64, 32, dtype, target=target)
+
+
+def clear_1d(N, block_N, dtype="float"):
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(A: T.Tensor((N,), dtype)):  # type: ignore
+        with T.Kernel(n_num, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((block_N,), dtype)
+
+            T.tile.fill(a_ub, 10.0)
+            T.tile.clear(a_ub)
+            T.copy(a_ub, A[cid * block_N])
+
+    return main
+
+
+def run_test_clear_1d(N, block_N, dtype, target):
+    func = clear_1d(N, block_N, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch.npu.synchronize()
+
+    b = func()
+
+    torch_dtype_map = {
+        "float": torch.float32,
+        "float16": torch.float16,
+        "int32": torch.int32,
+        "int8": torch.int8,
+    }
+    torch_dtype = torch_dtype_map.get(dtype, torch.float32)
+    ref_b = torch.zeros((N,), dtype=torch_dtype).npu()
+
+    torch.testing.assert_close(b, ref_b, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16", "int32"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_clear_1d(dtype, target):
+    run_test_clear_1d(1024, 128, dtype, target=target)
+
+
+def clear_buffer_region(M, N, block_M, block_N, dtype="float"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype)):  # type: ignore
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+
+            T.tile.fill(a_ub, 10.0)
+            T.tile.clear(a_ub[0:block_M, 0:block_N])
+            T.copy(a_ub, A[bx * block_M, by * block_N])
+
+    return main
+
+
+def run_test_clear_buffer_region(M, N, block_M, block_N, dtype, target):
+    func = clear_buffer_region(M, N, block_M, block_N, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch.npu.synchronize()
+
+    b = func()
+
+    torch_dtype = torch.float32 if dtype == "float" else torch.float16
+    ref_b = torch.zeros((M, N), dtype=torch_dtype).npu()
 
     torch.testing.assert_close(b, ref_b, rtol=1e-2, atol=1e-2)
 
@@ -2292,9 +2393,9 @@ def run_test_clear(M, N, block_M, block_N, dtype, target):
 @pytest.mark.parametrize("dtype", ["float", "float16"])
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
 @pytest.mark.parametrize("shape", [(1024, 1024)])
-def test_clear(dtype, target, shape):
+def test_clear_buffer_region(dtype, target, shape):
     M, N = shape
-    run_test_clear(M, N, 64, 32, dtype, target=target)
+    run_test_clear_buffer_region(M, N, 64, 32, dtype, target=target)
 
 
 def gather(M, N, block_M, block_N, dtype="int32"):

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -367,29 +367,14 @@ def fill(buffer: Buffer | BufferRegion, value: PrimExpr):
     )
 
 
-def clear(buffer: Buffer | tir.Var):
+def clear(buffer: Buffer | BufferRegion):
     """Clear a buffer or buffer region by filling with zeros.
 
-    Delegates to ``fill(buffer, 0)``.  The generated hardware instruction is
-    ``AscendC::Duplicate`` on the AscendC backend and ``TEXPANDS`` on the PTO
-    backend.
-
     Args:
-        buffer: The buffer, buffer region, or variable to be cleared.
-                If a BufferRegion is passed, it is forwarded to ``fill`` which
-                accepts BufferRegion.  If a tir.Var is provided, it will be
-                resolved automatically via ``T.has_let_value`` /
-                ``T.get_let_value``.
+        buffer: The buffer or buffer region to be cleared.
 
     Returns:
         A TVM intrinsic call that fills the buffer with zeros.
-
-    Note:
-        On AscendC, dtype support follows ``AscendC::Duplicate``:
-        float16, float32, bfloat16, int16, uint16, int32, uint32.
-        int8/uint8 are not supported on AscendC.
-        On PTO, ``TEXPANDS`` additionally supports int8 and uint8.
-        The buffer must reside in UB (Unified Buffer) memory.
     """
     if isinstance(buffer, tir.Var) and T.has_let_value(buffer):
         buffer_region = T.get_let_value(buffer)

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -370,12 +370,26 @@ def fill(buffer: Buffer | BufferRegion, value: PrimExpr):
 def clear(buffer: Buffer | tir.Var):
     """Clear a buffer or buffer region by filling with zeros.
 
+    Delegates to ``fill(buffer, 0)``.  The generated hardware instruction is
+    ``AscendC::Duplicate`` on the AscendC backend and ``TEXPANDS`` on the PTO
+    backend.
+
     Args:
         buffer: The buffer, buffer region, or variable to be cleared.
-                If a tir.Var is provided, it will be resolved automatically.
+                If a BufferRegion is passed, it is forwarded to ``fill`` which
+                accepts BufferRegion.  If a tir.Var is provided, it will be
+                resolved automatically via ``T.has_let_value`` /
+                ``T.get_let_value``.
 
     Returns:
         A TVM intrinsic call that fills the buffer with zeros.
+
+    Note:
+        On AscendC, dtype support follows ``AscendC::Duplicate``:
+        float16, float32, bfloat16, int16, uint16, int32, uint32.
+        int8/uint8 are not supported on AscendC.
+        On PTO, ``TEXPANDS`` additionally supports int8 and uint8.
+        The buffer must reside in UB (Unified Buffer) memory.
     """
     if isinstance(buffer, tir.Var) and T.has_let_value(buffer):
         buffer_region = T.get_let_value(buffer)


### PR DESCRIPTION
1. 文件改动
文件	类型
tilelang/language/ascend_tile.py	修改
testing/python/language/test_tilelang_ascend_language_elementwise.py	修改
docs/language/tile_clear.md	新增
2. 测试用例
2.1 约束测试（动态验证，真机 Ascend910B3 / dav_c220）
验证项	测什么
AscendC dtype 覆盖	float / float16 / bfloat16 / int32 / int16 / uint16 × (1024,1024)
PTO dtype 覆盖	同上 6 种 + int8 / uint8
int8/uint8 AscendC	AscendC::Duplicate static_assert
int8/uint8 PTO	TEXPANDS
bfloat16 PTO	原 doc 称"仅 AscendC 支持"
1D shape	float / float16 / int32 × ascendc / pto
BufferRegion 切片	a_ub[0:block_M, 0:block_N] × float / float16 × 2 target
L0C clear（AscendC float32）	T.alloc_L0C + T.tile.clear + T.copy
L0C clear（PTO）	同上
32 字节对齐	通用 UB 硬件约束
A5 int64/uint64	IsDuplicateSupported_v 不含 int64/uint64
"不生成独立的底层指令"	fill 生成 AscendC::Duplicate / PTO TEXPANDS
2.2 语言测试 test_tilelang_ascend_language_elementwise.py（24 用例）
测试函数
test_clear
test_clear_pto_int8
test_clear_1d
test_clear_buffer_region

2.3 测试用例统计与 LP 分层（新增）

testing/python/language/test_tilelang_ascend_language_elementwise.py 新增 20 个用例（20 PASSED + 0 SKIPPED），不重复基线已有测试（test_clear：float/float16 × ascendc/pto × (1024,1024)，4 用例）

- 当前实际：新增用例均未打 low_priority 标记 → PR 触发执行 20 个，定时任务触发执行 20 个（无差异）
- 建议分层：仅保留 4 个核心用例（每函数 1 个）在 PR 提交阶段执行，其余 16 个标 low_priority 放到定时执行阶段 → PR 触发执行 4 个，定时任务触发执行 20 个（16 个仅定时执行）

测试函数	用例数	PR执行	LP	类型	覆盖内容
test_clear（dtype 扩展）	8	1	7	dtype 泛化	新增 bfloat16/int32/int16/uint16 × ascendc/pto（基线 float/float16 4 用例已有），int32@ascendc 为核心
test_clear_pto_int8	2	1	1	dtype 泛化	int8/uint8 仅 PTO 支持（TEXPANDS），int8@pto 为核心
test_clear_1d	6	1	5	shape 泛化	1D shape × float/float16/int32 × ascendc/pto，float@ascendc 为核心
test_clear_buffer_region	4	1	3	功能泛化	BufferRegion 切片 × float/float16 × ascendc/pto，float@ascendc 为核心

LP 标记策略（建议，参照 #1676 已落地惯例）：
- dtype：float（主流 dtype）默认执行，bfloat16/int32/int16/uint16/int8/uint8 等扩展 dtype 标 low_priority（每函数保留 1 个核心用例；int8@pto 为 PTO 独有能力核心用例，保留 PR 阶段）
- target：ascendc（主后端）默认执行，pto 标 low_priority（pto-only 用例除外）
- shape：主流 2D (1024,1024) 默认执行，1D 每函数保留 1 个核心用例，其余标 low_priority

3. 测试结果
- 约束测试：动态验证完成（真机 Ascend910B3，见 2.1 表）
- 语言测试：24 PASSED（真机 Ascend910B3，单次运行 156.87s）
- 回归测试：test_fill 4 PASSED、test_dynamic_fill 6 PASSED
- 语法检查：py_compile 通过（ascend_tile.py、测试文件）
- git diff --check：通过
4. 校验过程中发现的问题
1. "不生成独立的底层指令"描述错误：原文档功能说明称 clear 不生成独立底层指令。实际 clear 委托 fill(buffer, 0)，fill 在 AscendC 后端生成 AscendC::Duplicate<T>(dst, 0, count)，在 PTO 后端生成 TEXPANDS(dst, 0)，均为真实硬件指令 → 功能说明改为"委托 fill(buffer, 0) 实现，生成 Duplicate / TEXPANDS"。
2. 函数签名类型标注不准确：原文档写 Buffer | BufferRegion | tir.Var，实际源码签名为 Buffer | tir.Var。BufferRegion 通过 fill 间接支持（fill 接受 BufferRegion），但不在 clear 的类型标注中 → 签名改为 Buffer | tir.Var，参数说明注明 BufferRegion 经 fill 可用。
3. bfloat16 后端支持范围错误：原文档称"A2/A3 平台上 bfloat16 仅 Ascend C 后端支持"。真机验证 PTO TEXPANDS 同样支持 bfloat16 → dtype 表改为两后端均支持。
4. int8/uint8 后端支持确认：原文档列 int8/uint8 为 A2/A3 支持，后端差异说明称"int8/uint8 仅 PTO 后端支持"。真机验证：AscendC Duplicate static_assert 拒绝 int8/uint8，PTO TEXPANDS 通过 → dtype 表按后端分列，AscendC 不支持、PTO 支持。
5. "fill 支持所有常见 dtype"描述不准确：原文档称"fill 的底层指令（Duplicate / TEXPANDS）支持所有常见 dtype"。IsDuplicateSupported_v 仅含 7 种（int16/uint16/half/bfloat16/int32/uint32/float），不含 int8/uint8/int64/uint64 → 删除该泛称，改为按后端分列实际支持的 dtype。
6. A5 int64/uint64 无法验证：原文档列 A5 额外支持 int64/uint64。当前环境为 910B3（A2/A3），IsDuplicateSupported_v 不含 int64/uint64 → 文档标注"当前环境无法验证，Ascend C 后端预计不支持"。
7. L0C 清零示例不严谨：原文档示例 2 展示 T.alloc_L0C + T.tile.clear。AscendC float32 可编译但 L0C 非 UB 内存（Fill 签名为 LocalTensor<T> 即 UB）；float16 的 copy_l0c_to_gm 在 A2 不支持；PTO TEXPANDS 拒绝 TileType::Acc → 示例改为 BufferRegion 切片。
8. uint16/uint32 精度比较修复：原 run_test_clear 用 torch.testing.assert_close 直接比较，torch-npu 不支持 uint16 isclose → 改用 assert_close_npu（转 int16/int32 比较），与文件中其他整数测试一致。
5. 验证命令
# 目标测试
pytest testing/python/language/test_tilelang_ascend_language_elementwise.py::test_clear \
       testing/python/language/test_tilelang_ascend_language_elementwise.py::test_clear_pto_int8 \
       testing/python/language/test_tilelang_ascend_language_elementwise.py::test_clear_1d \
       testing/python/language/test_tilelang_ascend_language_elementwise.py::test_clear_buffer_region \
       -vv -s

# 回归
pytest testing/python/language/test_tilelang_ascend_language_elementwise.py::test_fill -vv -s
pytest testing/python/language/test_tilelang_ascend_language_dynamic_fill.py -vv -s

# 语法
python -m py_compile tilelang/language/ascend_tile.py
python -m py_compile testing/python/language/test_tilelang_ascend_language_elementwise.py
git diff --check