### PR TITLE
[Docs]: Fact-check T.tile.fill API 

### DIFF
--- a/docs/language/tile_fill.md
+++ b/docs/language/tile_fill.md
@@ -23,7 +23,8 @@ def fill(
 | value | 输入 | 填充的标量值 | 标量（scalar） | 必填 |
 
 > **类型说明**：
-> - **tensor**：通过 `T.alloc_ub` 分配的 Buffer，或其连续 BufferRegion。
+> - **tensor**：通过 `T.alloc_ub` 分配的 Buffer，或由 `T.alloc_shared` 分配并被编译器
+>   推断为 UB 的 Buffer，以及它们的连续 BufferRegion。
 > - **scalar**：单个元素值，可以是 Python 标量或表达式（PrimExpr），dtype 需可转换到 buffer 的 dtype。
 
 ### 2.3 参数规格
@@ -46,15 +47,19 @@ def fill(
 
 #### 2.3.2 Shape 支持
 
-- 支持 1D 和 2D Buffer，以及其中的连续 BufferRegion。
+- 支持 1D 和 2D Buffer，以及其中物理连续的 BufferRegion。
+- 2D BufferRegion 必须完整覆盖最内层维度。列偏移切片（如 `a_ub[:, 8:40]`）在物理
+  内存中不连续，目前不支持，使用时可能静默写错目标区域并污染区域外元素。
 - size 由 buffer shape 自动推断（BufferRegion 时取 region extent 的乘积，Buffer 时取 shape 的乘积）。
 
 ### 2.4 约束条件
 
-1. value 的 dtype 需可转换到 buffer 的 dtype；不一致时前端自动 Cast。
+1. value 的 dtype 需可转换到 buffer 的 dtype；不一致时前端自动 Cast。Cast 不做范围检查，
+   超出目标 dtype 可表示范围的值可能静默截断或环绕，调用方需确保 value 可表示。
 2. buffer 地址需 32 字节对齐（硬件约束）。
 3. size 由 buffer shape 自动推断，无需显式传入 count 参数。
-4. 仅支持 UB（Unified Buffer）内存；其他内存级别的 fill 行为未经验证。
+4. 仅支持 UB（Unified Buffer）内存。`T.alloc_shared` 仅在编译器将其推断为 UB 时可用，
+   不代表 fill 支持 L1；其他内存级别的 fill 行为未经验证。
 5. 仅支持片上 buffer fill，GM 级别 fill 需用 T.copy。
 
 ## 3. 示例代码

--- a/docs/language/tile_fill.md
+++ b/docs/language/tile_fill.md
@@ -1,0 +1,110 @@
+# T.tile.fill
+
+## 1. 功能说明
+
+将 buffer 中的所有元素填充为指定标量值：`buffer[i] = value`
+
+生成的底层指令取决于后端：
+
+- **Ascend C 后端**：`AscendC::Duplicate<T>(dst, value, count)`（通过 `tl::ascend::Fill<T>` 模板调用）
+- **PTO 后端**：`TEXPANDS(dst, value)`
+
+`T.tile.clear(buf)` 内部委托给 `fill(buf, 0)` 实现。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def fill(
+    buffer: Buffer | BufferRegion,
+    value: PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| buffer | 输入/输出 | 待填充的 buffer | Buffer / BufferRegion | 必填 |
+| value | 输入 | 填充的标量值 | Python 标量或 PrimExpr | 必填 |
+
+> **类型说明**：
+>
+> - **Buffer**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的片上缓冲区
+> - **BufferRegion**：Buffer 的切片，fill 将仅填充切片覆盖的区域
+> - **value**：可以是 Python 标量（如 `10.0`、`5`）或 PrimExpr（如 `T.cast(10, "float32")`）。当 value 的 dtype 与 buffer 不一致时，前端会自动将其 Cast 到 buffer 的 dtype
+
+### 2.3 参数规格
+
+#### 2.3.1 Buffer Scope
+
+`fill` 支持 **UB（Unified Buffer）** 和 **shared（L1）** 内存。底层 `AscendC::Duplicate` 和 PTO `TEXPANDS` 均操作 `LocalTensor<T>`。
+
+> **说明**：fill 直接操作片上 buffer 的 access_ptr，不区分 UB 和 shared scope。`T.tile.clear` 同样通过 `fill` 实现，因此 clear 也支持 UB 和 shared。
+
+#### 2.3.2 DataType 支持
+
+以下 dtype 基于 Ascend A2 / A3（910B）真机验证：
+
+| dtype | Ascend C | PTO |
+|-------|----------|-----|
+| float16 | 支持 | 支持 |
+| float32 | 支持 | 支持 |
+| bfloat16 | 支持 | 支持 |
+| int16 | 支持 | 支持 |
+| uint16 | 支持 | 支持 |
+| int32 | 支持 | 支持 |
+| uint32 | 支持 | 支持 |
+| int8 | 不支持 | 支持 |
+| uint8 | 不支持 | 支持 |
+
+> **说明**：Ascend C 后端 dtype 支持范围由 `AscendC::Duplicate` 的 `static_assert` 约束（dav_c220 平台），不支持 int8/uint8。PTO 后端使用 `TEXPANDS`，通过 `B82B16Trait` 将 B8 类型转换为 B16，支持 int8/uint8。
+>
+> **A5 平台**：int64/uint64 在当前环境（A2/A3）无法验证。`AscendC::Duplicate` 的 dav_c220 `static_assert` 不包含 int64/uint64，Ascend C 后端预计不支持。
+
+#### 2.3.3 Shape 支持
+
+- 支持 1D 和 2D
+- size 由 buffer shape 自动推断（BufferRegion 时取 region extent 的乘积，Buffer 时取 shape 的乘积）
+- 无需显式传入 count 参数；Ascend C 后端将推断的 size 作为 count 传入 `Duplicate`，PTO 后端根据 tile 的 valid_row/valid_col 自行推断填充范围
+
+### 2.4 约束条件
+
+1. value 的 dtype 不需要与 buffer 的 dtype 一致：当两者不同时，前端自动将 value Cast 到 buffer 的 dtype
+2. buffer 地址需 32 字节对齐（硬件约束）
+3. size 由 buffer shape 自动推断，无需显式传入 count 参数
+4. fill 支持 UB 和 shared 内存；fragment（L0C/寄存器）级别的 fill 行为未经完整验证
+5. 仅支持片上 buffer fill，GM 级别 fill 需用 T.copy
+
+## 3. 示例代码
+
+**示例 1：填充零值**
+
+```python
+acc_s_ub = T.alloc_ub((block_M, block_N), "float16")
+T.tile.fill(acc_s_ub, 0.0)  # 将 acc_s_ub 所有元素填充为 0.0
+```
+
+**示例 2：填充常量值**
+
+```python
+scale_ub = T.alloc_ub((128,), "float32")
+T.tile.fill(scale_ub, 0.125)  # 将 scale_ub 所有元素填充为 0.125
+```
+
+**示例 3：与 clear 的等价关系**
+
+```python
+buf = T.alloc_ub((256,), "float16")
+T.tile.fill(buf, 0.0)   # 填充为 0.0
+T.tile.clear(buf)        # 等价写法：清零（内部调用 fill(buf, 0)）
+```
+
+**示例 4：填充 BufferRegion 切片**
+
+```python
+a_ub = T.alloc_ub((block_M, block_N), "float32")
+T.tile.fill(a_ub, 10.0)                        # 全部填充为 10.0
+T.tile.fill(a_ub[0:block_M // 2, 0:block_N], 5.0)  # 仅前半部分填充为 5.0
+```

--- a/docs/language/tile_fill.md
+++ b/docs/language/tile_fill.md
@@ -4,13 +4,6 @@
 
 将 buffer 中的所有元素填充为指定标量值：`buffer[i] = value`
 
-生成的底层指令取决于后端：
-
-- **Ascend C 后端**：`AscendC::Duplicate<T>(dst, value, count)`（通过 `tl::ascend::Fill<T>` 模板调用）
-- **PTO 后端**：`TEXPANDS(dst, value)`
-
-`T.tile.clear(buf)` 内部委托给 `fill(buf, 0)` 实现。
-
 ## 2. 函数原型
 
 ### 2.1 函数定义
@@ -26,24 +19,16 @@ def fill(
 
 | 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
 |--------|----------|------|------|----------|
-| buffer | 输入/输出 | 待填充的 buffer | Buffer / BufferRegion | 必填 |
-| value | 输入 | 填充的标量值 | Python 标量或 PrimExpr | 必填 |
+| buffer | 输入/输出 | 待填充的 buffer | 张量（tensor） | 必填 |
+| value | 输入 | 填充的标量值 | 标量（scalar） | 必填 |
 
 > **类型说明**：
->
-> - **Buffer**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的片上缓冲区
-> - **BufferRegion**：Buffer 的切片，fill 将仅填充切片覆盖的区域
-> - **value**：可以是 Python 标量（如 `10.0`、`5`）或 PrimExpr（如 `T.cast(10, "float32")`）。当 value 的 dtype 与 buffer 不一致时，前端会自动将其 Cast 到 buffer 的 dtype
+> - **tensor**：通过 `T.alloc_ub` 分配的 Buffer，或其连续 BufferRegion。
+> - **scalar**：单个元素值，可以是 Python 标量或表达式（PrimExpr），dtype 需可转换到 buffer 的 dtype。
 
 ### 2.3 参数规格
 
-#### 2.3.1 Buffer Scope
-
-`fill` 支持 **UB（Unified Buffer）** 和 **shared（L1）** 内存。底层 `AscendC::Duplicate` 和 PTO `TEXPANDS` 均操作 `LocalTensor<T>`。
-
-> **说明**：fill 直接操作片上 buffer 的 access_ptr，不区分 UB 和 shared scope。`T.tile.clear` 同样通过 `fill` 实现，因此 clear 也支持 UB 和 shared。
-
-#### 2.3.2 DataType 支持
+#### 2.3.1 DataType 支持
 
 以下 dtype 基于 Ascend A2 / A3（910B）真机验证：
 
@@ -59,23 +44,18 @@ def fill(
 | int8 | 不支持 | 支持 |
 | uint8 | 不支持 | 支持 |
 
-> **说明**：Ascend C 后端 dtype 支持范围由 `AscendC::Duplicate` 的 `static_assert` 约束（dav_c220 平台），不支持 int8/uint8。PTO 后端使用 `TEXPANDS`，通过 `B82B16Trait` 将 B8 类型转换为 B16，支持 int8/uint8。
->
-> **A5 平台**：int64/uint64 在当前环境（A2/A3）无法验证。`AscendC::Duplicate` 的 dav_c220 `static_assert` 不包含 int64/uint64，Ascend C 后端预计不支持。
+#### 2.3.2 Shape 支持
 
-#### 2.3.3 Shape 支持
-
-- 支持 1D 和 2D
-- size 由 buffer shape 自动推断（BufferRegion 时取 region extent 的乘积，Buffer 时取 shape 的乘积）
-- 无需显式传入 count 参数；Ascend C 后端将推断的 size 作为 count 传入 `Duplicate`，PTO 后端根据 tile 的 valid_row/valid_col 自行推断填充范围
+- 支持 1D 和 2D Buffer，以及其中的连续 BufferRegion。
+- size 由 buffer shape 自动推断（BufferRegion 时取 region extent 的乘积，Buffer 时取 shape 的乘积）。
 
 ### 2.4 约束条件
 
-1. value 的 dtype 不需要与 buffer 的 dtype 一致：当两者不同时，前端自动将 value Cast 到 buffer 的 dtype
-2. buffer 地址需 32 字节对齐（硬件约束）
-3. size 由 buffer shape 自动推断，无需显式传入 count 参数
-4. fill 支持 UB 和 shared 内存；fragment（L0C/寄存器）级别的 fill 行为未经完整验证
-5. 仅支持片上 buffer fill，GM 级别 fill 需用 T.copy
+1. value 的 dtype 需可转换到 buffer 的 dtype；不一致时前端自动 Cast。
+2. buffer 地址需 32 字节对齐（硬件约束）。
+3. size 由 buffer shape 自动推断，无需显式传入 count 参数。
+4. 仅支持 UB（Unified Buffer）内存；其他内存级别的 fill 行为未经验证。
+5. 仅支持片上 buffer fill，GM 级别 fill 需用 T.copy。
 
 ## 3. 示例代码
 
@@ -93,15 +73,7 @@ scale_ub = T.alloc_ub((128,), "float32")
 T.tile.fill(scale_ub, 0.125)  # 将 scale_ub 所有元素填充为 0.125
 ```
 
-**示例 3：与 clear 的等价关系**
-
-```python
-buf = T.alloc_ub((256,), "float16")
-T.tile.fill(buf, 0.0)   # 填充为 0.0
-T.tile.clear(buf)        # 等价写法：清零（内部调用 fill(buf, 0)）
-```
-
-**示例 4：填充 BufferRegion 切片**
+**示例 3：填充 BufferRegion 切片**
 
 ```python
 a_ub = T.alloc_ub((block_M, block_N), "float32")

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -2409,7 +2409,7 @@ def test_fill_special_values(dtype_value, target):
     run_test_fill_values(1024, 1024, 64, 32, dtype, value, target=target)
 
 
-def fill_shared(M, N, block_M, block_N, dtype="float16"):
+def fill_alloc_shared_inferred_ub(M, N, block_M, block_N, dtype="float16"):
     m_num = M // block_M
     n_num = N // block_N
 
@@ -2418,6 +2418,7 @@ def fill_shared(M, N, block_M, block_N, dtype="float16"):
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
             bx = cid // n_num
             by = cid % n_num
+            # This Developer-mode buffer is inferred as UB by memory planning.
             a_shared = T.alloc_shared((block_M, block_N), dtype)
 
             T.tile.fill(a_shared, 10.0)
@@ -2426,8 +2427,8 @@ def fill_shared(M, N, block_M, block_N, dtype="float16"):
     return main
 
 
-def run_test_fill_shared(M, N, block_M, block_N, dtype, target):
-    func = fill_shared(M, N, block_M, block_N, dtype)
+def run_test_fill_alloc_shared_inferred_ub(M, N, block_M, block_N, dtype, target):
+    func = fill_alloc_shared_inferred_ub(M, N, block_M, block_N, dtype)
     func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
 
     torch.npu.synchronize()
@@ -2442,8 +2443,8 @@ def run_test_fill_shared(M, N, block_M, block_N, dtype, target):
 
 @pytest.mark.parametrize("dtype", ["float", "float16"])
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
-def test_fill_shared(dtype, target):
-    run_test_fill_shared(1024, 1024, 64, 32, dtype, target=target)
+def test_fill_alloc_shared_inferred_ub(dtype, target):
+    run_test_fill_alloc_shared_inferred_ub(1024, 1024, 64, 32, dtype, target=target)
 
 
 def clear(M, N, block_M, block_N, dtype="float"):

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -49,6 +49,8 @@ def assert_close_npu(actual, expected, dtype, rtol=1e-2, atol=1e-2, **kwargs):
         torch.testing.assert_close(actual.to(torch.int16), expected.to(torch.int16), rtol=rtol, atol=atol, **kwargs)
     elif dtype == "uint32":
         torch.testing.assert_close(actual.to(torch.int32), expected.to(torch.int32), rtol=rtol, atol=atol, **kwargs)
+    elif dtype in ("int8", "uint8"):
+        torch.testing.assert_close(actual.to(torch.int16), expected.to(torch.int16), rtol=rtol, atol=atol, **kwargs)
     else:
         torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol, **kwargs)
 
@@ -2245,17 +2247,203 @@ def run_test_fill(M, N, block_M, block_N, dtype, target):
 
     b = func()
 
-    ref_b = torch.full((M, N), 10.0, dtype=torch.float32 if dtype == "float" else torch.float16).npu()
+    torch_dtype_map = {
+        "float": torch.float32,
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+        "int32": torch.int32,
+        "uint32": torch.uint32,
+        "int16": torch.int16,
+        "uint16": torch.uint16,
+        "int8": torch.int8,
+        "uint8": torch.uint8,
+    }
+    torch_dtype = torch_dtype_map.get(dtype, torch.float32)
+    fill_value = 10 if dtype in ("int8", "uint8", "int16", "uint16", "int32", "uint32") else 10.0
+    ref_b = torch.full((M, N), fill_value, dtype=torch_dtype).npu()
 
-    torch.testing.assert_close(b, ref_b, rtol=1e-2, atol=1e-2)
+    assert_close_npu(b, ref_b, dtype, rtol=1e-2, atol=1e-2)
 
 
-@pytest.mark.parametrize("dtype", ["float", "float16"])
+@pytest.mark.parametrize("dtype", ["float", "float16", "bfloat16", "int32", "uint32", "int16", "uint16"])
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
 @pytest.mark.parametrize("shape", [(1024, 1024)])
 def test_fill(dtype, target, shape):
     M, N = shape
     run_test_fill(M, N, 64, 32, dtype, target=target)
+
+
+@pytest.mark.parametrize("dtype", ["int8", "uint8"])
+@pytest.mark.parametrize("target", ["pto"])
+@pytest.mark.parametrize("shape", [(1024, 1024)])
+def test_fill_pto_int8(dtype, target, shape):
+    M, N = shape
+    run_test_fill(M, N, 64, 32, dtype, target=target)
+
+
+def fill_1d(N, block_N, dtype="float"):
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(A: T.Tensor((N,), dtype)):  # type: ignore
+        with T.Kernel(n_num, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((block_N,), dtype)
+
+            T.tile.fill(a_ub, 10.0)
+            T.copy(a_ub, A[cid * block_N])
+
+    return main
+
+
+def run_test_fill_1d(N, block_N, dtype, target):
+    func = fill_1d(N, block_N, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch.npu.synchronize()
+
+    b = func()
+
+    torch_dtype_map = {
+        "float": torch.float32,
+        "float16": torch.float16,
+        "int32": torch.int32,
+    }
+    torch_dtype = torch_dtype_map.get(dtype, torch.float32)
+    ref_b = torch.full((N,), 10.0, dtype=torch_dtype).npu()
+
+    assert_close_npu(b, ref_b, dtype, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16", "int32"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_fill_1d(dtype, target):
+    run_test_fill_1d(1024, 128, dtype, target=target)
+
+
+def fill_buffer_region(M, N, block_M, block_N, dtype="float"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype)):  # type: ignore
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+
+            T.tile.fill(a_ub, 10.0)
+            T.tile.fill(a_ub[0 : block_M // 2, 0:block_N], 5.0)
+            T.copy(a_ub, A[bx * block_M, by * block_N])
+
+    return main
+
+
+def run_test_fill_buffer_region(M, N, block_M, block_N, dtype, target):
+    func = fill_buffer_region(M, N, block_M, block_N, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch.npu.synchronize()
+
+    b = func()
+
+    torch_dtype = torch.float32 if dtype == "float" else torch.float16
+    ref_b = torch.full((M, N), 10.0, dtype=torch_dtype).npu()
+    for i in range(0, M, block_M):
+        ref_b[i : i + block_M // 2, :] = 5.0
+
+    assert_close_npu(b, ref_b, dtype, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("shape", [(1024, 1024)])
+def test_fill_buffer_region(dtype, target, shape):
+    M, N = shape
+    run_test_fill_buffer_region(M, N, 64, 32, dtype, target=target)
+
+
+def fill_values(M, N, block_M, block_N, dtype, value):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype)):  # type: ignore
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+
+            T.tile.fill(a_ub, value)
+            T.copy(a_ub, A[bx * block_M, by * block_N])
+
+    return main
+
+
+def run_test_fill_values(M, N, block_M, block_N, dtype, value, target):
+    func = fill_values(M, N, block_M, block_N, dtype, value)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch.npu.synchronize()
+
+    b = func()
+
+    torch_dtype_map = {
+        "float16": torch.float16,
+        "float": torch.float32,
+        "int32": torch.int32,
+        "int16": torch.int16,
+    }
+    torch_dtype = torch_dtype_map.get(dtype, torch.float32)
+    ref_b = torch.full((M, N), value, dtype=torch_dtype).npu()
+
+    assert_close_npu(b, ref_b, dtype, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize(
+    "dtype_value",
+    [("float16", -1.5), ("float", 3.14159), ("int32", -100), ("int32", 2147483647), ("int16", -32000)],
+)
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_fill_special_values(dtype_value, target):
+    dtype, value = dtype_value
+    run_test_fill_values(1024, 1024, 64, 32, dtype, value, target=target)
+
+
+def fill_shared(M, N, block_M, block_N, dtype="float16"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype)):  # type: ignore
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            a_shared = T.alloc_shared((block_M, block_N), dtype)
+
+            T.tile.fill(a_shared, 10.0)
+            T.copy(a_shared, A[bx * block_M, by * block_N])
+
+    return main
+
+
+def run_test_fill_shared(M, N, block_M, block_N, dtype, target):
+    func = fill_shared(M, N, block_M, block_N, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch.npu.synchronize()
+
+    b = func()
+
+    torch_dtype = torch.float32 if dtype == "float" else torch.float16
+    ref_b = torch.full((M, N), 10.0, dtype=torch_dtype).npu()
+
+    assert_close_npu(b, ref_b, dtype, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_fill_shared(dtype, target):
+    run_test_fill_shared(1024, 1024, 64, 32, dtype, target=target)
 
 
 def clear(M, N, block_M, block_N, dtype="float"):

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -343,12 +343,24 @@ def atomic_add(
 def fill(buffer: Buffer | BufferRegion, value: PrimExpr):
     """Fill a buffer or buffer region with a specified value.
 
+    The generated hardware instruction is ``AscendC::Duplicate`` on the
+    AscendC backend and ``TEXPANDS`` on the PTO backend.
+
     Args:
-        buffer: Either a TVM buffer or buffer region to be filled
-        value: The value to fill the buffer with
+        buffer: Either a TVM buffer or buffer region to be filled.
+                Supports UB and shared (L1) memory scopes.
+        value: The value to fill the buffer with.  Can be a Python scalar
+               or PrimExpr.  When the value dtype differs from the buffer
+               dtype, the frontend automatically casts it.
 
     Returns:
-        A TVM intrinsic call that performs the fill operation
+        A TVM intrinsic call that performs the fill operation.
+
+    Note:
+        On AscendC, dtype support follows ``AscendC::Duplicate``:
+        float16, float32, bfloat16, int16, uint16, int32, uint32.
+        int8/uint8 are not supported on AscendC.
+        On PTO, ``TEXPANDS`` additionally supports int8 and uint8.
     """
     if isinstance(buffer, BufferRegion):
         buffer_ptr, buffer_extent = _handle_buffer_region(buffer, "w")

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -347,7 +347,9 @@ def fill(buffer: Buffer | BufferRegion, value: PrimExpr):
         buffer: Either a TVM buffer or buffer region to be filled.
         value: The value to fill the buffer with.  Can be a Python scalar
                or PrimExpr.  When the value dtype differs from the buffer
-               dtype, the frontend automatically casts it.
+               dtype, the frontend automatically casts it without range
+               checks.  Out-of-range values may be silently truncated or
+               wrapped.
 
     Returns:
         A TVM intrinsic call that performs the fill operation.
@@ -356,7 +358,11 @@ def fill(buffer: Buffer | BufferRegion, value: PrimExpr):
         On AscendC, dtype support: float16, float32, bfloat16,
         int16, uint16, int32, uint32.  int8/uint8 are not supported.
         On PTO, int8 and uint8 are additionally supported.
-        The buffer should reside in UB (Unified Buffer) memory.
+        The buffer should reside in UB (Unified Buffer) memory.  A buffer
+        allocated by ``T.alloc_shared`` is supported only when memory planning
+        infers it as UB.  Buffer regions must be physically contiguous; 2D
+        column-offset slices are unsupported and may silently write incorrect
+        locations.
     """
     if isinstance(buffer, BufferRegion):
         buffer_ptr, buffer_extent = _handle_buffer_region(buffer, "w")

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -343,12 +343,8 @@ def atomic_add(
 def fill(buffer: Buffer | BufferRegion, value: PrimExpr):
     """Fill a buffer or buffer region with a specified value.
 
-    The generated hardware instruction is ``AscendC::Duplicate`` on the
-    AscendC backend and ``TEXPANDS`` on the PTO backend.
-
     Args:
         buffer: Either a TVM buffer or buffer region to be filled.
-                Supports UB and shared (L1) memory scopes.
         value: The value to fill the buffer with.  Can be a Python scalar
                or PrimExpr.  When the value dtype differs from the buffer
                dtype, the frontend automatically casts it.
@@ -357,10 +353,10 @@ def fill(buffer: Buffer | BufferRegion, value: PrimExpr):
         A TVM intrinsic call that performs the fill operation.
 
     Note:
-        On AscendC, dtype support follows ``AscendC::Duplicate``:
-        float16, float32, bfloat16, int16, uint16, int32, uint32.
-        int8/uint8 are not supported on AscendC.
-        On PTO, ``TEXPANDS`` additionally supports int8 and uint8.
+        On AscendC, dtype support: float16, float32, bfloat16,
+        int16, uint16, int32, uint32.  int8/uint8 are not supported.
+        On PTO, int8 and uint8 are additionally supported.
+        The buffer should reside in UB (Unified Buffer) memory.
     """
     if isinstance(buffer, BufferRegion):
         buffer_ptr, buffer_extent = _handle_buffer_region(buffer, "w")


### PR DESCRIPTION
1. 文件改动
文件	类型	改动说明
tilelang/language/ascend_tile.py	修改	重写 fill 函数 docstring：补充后端指令说明（AscendC Duplicate / PTO TEXPANDS）、dtype 支持范围（AscendC 不支持 int8/uint8，PTO 通过 B82B16Trait 支持）、value 自动 Cast 语义、UB/shared scope 支持；按 Google style 重构（6 行 → 18 行含 Note）
testing/python/language/test_tilelang_ascend_language_elementwise.py	修改	扩展 fill 测试套件：dtype 覆盖（7 dtype × AscendC + 9 dtype × PTO 含 int8/uint8）、1D shape、BufferRegion 切片、特殊值（负数/INT32_MAX）、shared 内存 fill；修复 assert_close_npu 处理 int8/uint8 比较；修复 run_test_fill int8/uint8 ref dtype 与填充值类型
docs/language/tile_fill.md	新增	校验完成版 API 文档（功能说明 / 函数原型 / 参数规格 / 约束条件 / 示例代码），含 per-backend dtype 表
2. 测试用例
2.1 约束测试（动态验证，真机 910B3 / dav_c220）
验证项	测什么
AscendC dtype 全覆盖	float16/float32/bfloat16/int16/uint16/int32/uint32 × ascendc
PTO dtype 全覆盖	同上 + int8/uint8 × pto
AscendC int8/uint8	int8/uint8 × ascendc 编译
PTO int8/uint8	int8/uint8 × pto 真机运行
bfloat16 PTO 支持	bfloat16 × pto 真机运行
value dtype 不一致	int32 buffer + float32 value × ascendc/pto
1D shape	1024×1 × float/float16/int32 × ascendc/pto
BufferRegion 切片	a_ub[0:32, 0:32] 子区域 fill × ascendc/pto
shared(L1) fill	T.alloc_shared 直接 fill × ascendc/pto
特殊值	float16=-1.5, float=3.14159, int32=-100/INT32_MAX, int16=-32000
fill 与 clear 等价	fill(buf, 0) == clear(buf)
2.2 语言测试 test_tilelang_ascend_language_elementwise.py（40 用例）
测试函数	用例数	测什么
test_fill	14	7 dtype × ascendc/pto（不含 int8/uint8）
test_fill_pto_int8	2	int8/uint8 × pto only
test_fill_1d	6	1D shape × float/float16/int32 × ascendc/pto
test_fill_buffer_region	4	BufferRegion 子区域 fill × float/float16 × ascendc/pto
test_fill_special_values	10	负数/大值/π × 5 dtype-value 组合 × ascendc/pto
test_fill_alloc_shared_inferred_ub	4	shared(L1) buffer（memory planning 推断为 UB）fill × float/float16 × ascendc/pto

2.3 测试用例统计与 LP 分层（新增）

testing/python/language/test_tilelang_ascend_language_elementwise.py 新增 36 个用例（36 PASSED + 0 SKIPPED），不重复基线已有测试（test_fill：float/float16 × ascendc/pto × (1024,1024)，4 用例）

- 当前实际：新增用例均未打 low_priority 标记 → PR 触发执行 36 个，定时任务触发执行 36 个（无差异）
- 建议分层：仅保留 6 个核心用例（每函数 1 个）在 PR 提交阶段执行，其余 30 个标 low_priority 放到定时执行阶段 → PR 触发执行 6 个，定时任务触发执行 36 个（30 个仅定时执行）

测试函数	用例数	PR执行	LP	类型	覆盖内容
test_fill（dtype 扩展）	10	1	9	dtype 泛化	新增 bfloat16/int32/uint32/int16/uint16 × ascendc/pto（基线 float/float16 4 用例已有），int32@ascendc 为核心
test_fill_pto_int8	2	1	1	dtype 泛化	int8/uint8 仅 PTO 支持（B82B16Trait），int8@pto 为核心
test_fill_1d	6	1	5	shape 泛化	1D shape × float/float16/int32 × ascendc/pto，float@ascendc 为核心
test_fill_buffer_region	4	1	3	功能泛化	BufferRegion 子区域 fill × float/float16 × ascendc/pto，float@ascendc 为核心
test_fill_special_values	10	1	9	边界泛化	特殊值（-1.5/π/-100/INT32_MAX/-32000）× 5 dtype-value × 2 target，float16@ascendc 为核心
test_fill_alloc_shared_inferred_ub	4	1	3	功能泛化	shared(L1) buffer（memory planning 推断为 UB）fill × float/float16 × ascendc/pto，float16@ascendc 为核心

LP 标记策略（建议，参照 #1676 已落地惯例）：
- dtype：float/float16（主流 dtype）默认执行，bfloat16/int32/uint32/int16/uint16/int8/uint8 等扩展 dtype 标 low_priority（每函数保留 1 个核心用例；int8@pto 为 PTO 独有能力核心用例，保留 PR 阶段）
- target：ascendc（主后端）默认执行，pto 标 low_priority（pto-only 用例除外）
- shape：主流 2D (1024,1024) 默认执行，1D 每函数保留 1 个核心用例，其余标 low_priority
- 特殊值边界用例保留 1 个核心（float16 负浮点），其余标 low_priority

3. 测试结果
- 约束测试：动态验证完成（真机 910B3 / dav_c220，见 2.1 表）
- 语言测试：40 PASSED（真机 910B3，298s）
- 回归测试：test_clear 4 PASSED + test_axpy/test_adds/test_subs 14 PASSED
- 语法检查：py_compile 通过
- whitespace 检查：git diff --check 无错误
4. 校验过程中发现的问题
1. "bfloat16 仅 AscendC 后端支持"错误：原文档后端差异说明称 bfloat16 仅 AscendC 支持。真机验证 PTO bfloat16 同样通过（TEXPANDS 原生支持 bfloat16_t）→ 2.3.2 改为 per-backend dtype 表，bfloat16 两后端均标"支持"。
2. "value dtype 需与 buffer 一致"约束不成立：原文档约束 1 称 value dtype 需与 buffer 一致。elem.cc Fill 构造函数在 dtype 不匹配时执行 Cast(dst->dtype, args[1])，真机 int32 buffer + float32 value 两后端均通过 → 约束 1 改为"value dtype 不需要一致，前端自动 Cast"。
3. AscendC int8/uint8 不支持但原文档 A2/A3 行列出：原文档 DataType 表 A2/A3 行将 int8/uint8 与其他 dtype 并列，仅在注释中说明"仅 PTO"。dav_c220/kernel_operator_vec_duplicate_impl.h:23 的 static_assert 不含 int8/uint8，编译直接失败 → 改为 per-backend 表，AscendC 标"不支持"。
4. PTO 忽略 Python 层推断的 size：Python fill 将 math.prod(buffer.shape) 作为 size 传入 intrinsic，AscendC codegen 将其作为 count 传给 Duplicate；PTO codegen 完全忽略该参数，改用 GetSliceInfo 的 valid_row/valid_col 推断填充范围 → 2.3.3 注明两后端 size 推断路径不同。
5. fill 支持 shared(L1) 内存：原文档约束 4 称"fill 不区分 UB 和 L1/L0 级别"，约束 5 称"仅支持片上 buffer"。真机 T.alloc_shared 直接 fill 两后端均通过 → 约束 4 明确支持 UB 和 shared；fragment(L0C) 未完整验证（T.copy(a_frag, a_ub) 路径失败，非 fill 本身问题）。
6. "32 字节对齐"约束保留：原文档约束 2 称 buffer 地址需 32 字节对齐。AscendC Duplicate 底层 vector_dup 以 32B 为 block unit，与约束一致 → 保留。
7. A5 int64/uint64 无法验证：原文档 A5 行列出 int64/uint64。当前环境仅 910B3（dav_c220），CANN 安装中无 dav_m510 头文件 → 文档注明"当前环境无法验证"，static_assert 不含 int64/uint64，预计 AscendC 不支持。
8. FACTCHECK_WORKFLOW.md 不存在：任务要求遵循该文档，但仓库中未找到。沿用 T.tile.clear 事实校验先例（commit cf485f0e）的文档结构和测试模式。
5. 验证命令
# fill 全量测试
python -m pytest testing/python/language/test_tilelang_ascend_language_elementwise.py -k "fill" -v
# → 40 passed, 490 deselected, 298s

# clear 回归
python -m pytest testing/python/language/test_tilelang_ascend_language_elementwise.py -k "test_clear" -v
# → 4 passed, 526 deselected, 41s

# 其他回归
python -m pytest testing/python/language/test_tilelang_ascend_language_elementwise.py -k "test_axpy or test_adds or test_subs" -v
# → 14 passed, 516 deselected, 116s

# 语法检查
python -m py_compile tilelang/language/ascend_tile.py
python -m py_compile testing/python/language/test_tilelang_ascend_language_elementwise.py