### PR TITLE
docs: add alloc API documentation

### DIFF
--- a/docs/api_docs/T.alloc_fragment.md
+++ b/docs/api_docs/T.alloc_fragment.md
@@ -1,0 +1,81 @@
+# T.alloc_fragment
+
+## 1. 功能说明
+
+分配 fragment 层级存储，在 Ascend 平台由 `InferAllocScope` pass 根据在 GEMM 中的位置自动推断为 L0A（`wmma.matrix_a`）/ L0B（`wmma.matrix_b`）/ L0C（`wmma.accumulator`）；未在 GEMM 中使用时默认映射到 L0C。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def alloc_fragment(
+    shape: tuple,
+    dtype: str,
+    scope: str = "local.fragment",
+) -> Buffer
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| shape | 输入 | buffer 的形状 | 整数元组 | 必填 |
+| dtype | 输入 | buffer 的数据类型（如 `"float16"`、`"float32"`、`"int32"`） | 字符串 | 必填 |
+| scope | 输入 | 内存作用域，通常使用默认值由编译器自动推断 | 字符串 | 可选（默认 `"local.fragment"`） |
+
+> **返回值说明**：
+> - 返回 `T.Buffer` 对象，可用于 `T.copy`、计算原语等操作
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dtype |
+|------|:-----:|
+| Ascend A2 / A3 | float16, bfloat16, float32, int32 |
+
+> alloc_fragment 通常用作 GEMM 累加器。
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D（GEMM 场景下须为 2D 矩阵分形）
+
+#### 2.3.3 Ascend 平台内存层级映射
+
+`InferAllocScope` pass 在编译期根据 buffer 在 GEMM 中的位置推断最终硬件 scope：
+
+| GEMM 位置 | 推断 scope | Ascend 硬件映射 |
+|----------|-----------|----------------|
+| position 0（左矩阵 A） | `wmma.matrix_a` | L0A |
+| position 1（右矩阵 B） | `wmma.matrix_b` | L0B |
+| position 2（累加器 C） | `wmma.accumulator` | L0C |
+| 未在 GEMM 中使用 | `wmma.accumulator` | L0C |
+
+### 2.4 约束条件
+
+1. 必须在 `T.Kernel` 作用域内调用
+2. GEMM 场景下 shape 须为 2D 矩阵分形
+
+## 3. 示例代码
+
+**示例 1：分配 GEMM 累加器**
+
+```python
+block_M, block_N = 128, 128
+accum_dtype = "float32"
+
+C_L0 = T.alloc_fragment((block_M, block_N), accum_dtype)
+```
+
+**示例 2：GEMM 完整分配**
+
+```python
+block_M, block_K, block_N = 128, 128, 128
+dtype = "float16"
+accum_dtype = "float32"
+
+A_L1 = T.alloc_shared((block_M, block_K), dtype)
+B_L1 = T.alloc_shared((block_K, block_N), dtype)
+C_L0 = T.alloc_fragment((block_M, block_N), accum_dtype)
+```

--- a/docs/api_docs/T.alloc_shared.md
+++ b/docs/api_docs/T.alloc_shared.md
@@ -1,0 +1,78 @@
+# T.alloc_shared
+
+## 1. 功能说明
+
+分配 shared 层级存储，在 Ascend 平台由 `InferAllocScope` pass 根据使用场景自动推断为 L1 Buffer（`shared.l1`）或 Unified Buffer（`shared.ub`）。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def alloc_shared(
+    shape: tuple,
+    dtype: str,
+    scope: str = "shared",
+) -> Buffer
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| shape | 输入 | buffer 的形状 | 整数元组 | 必填 |
+| dtype | 输入 | buffer 的数据类型（如 `"float16"`、`"float32"`、`"int32"`） | 字符串 | 必填 |
+| scope | 输入 | 内存作用域，通常使用默认值由编译器自动推断 | 字符串 | 可选（默认 `"shared"`） |
+
+> **返回值说明**：
+> - 返回 `T.Buffer` 对象，可用于 `T.copy`、计算原语等操作
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dtype |
+|------|:-----:|
+| Ascend A2 / A3 | float16, float32, bfloat16, int8, int16, int32, uint8, uint16, uint32 |
+
+> 仅 ascendc 支持：int64, uint64
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+
+#### 2.3.3 Ascend 平台内存层级映射
+
+`InferAllocScope` pass 在编译期根据 buffer 的实际使用场景推断最终硬件 scope：
+
+| 使用场景 | 推断 scope | Ascend 硬件映射 |
+|---------|-----------|----------------|
+| 仅 Cube 计算路径 | `shared.l1` | L1 Buffer |
+| 仅 Vector 计算路径 | `shared.ub` | Unified Buffer（UB） |
+| 混合使用（Cube + Vector） | `shared.l1` | L1 Buffer |
+
+### 2.4 约束条件
+
+1. 必须在 `T.Kernel` 作用域内调用
+
+## 3. 示例代码
+
+**示例 1：GEMM 中分配 L1 缓冲**
+
+```python
+block_M, block_K, block_N = 128, 128, 128
+dtype = "float16"
+
+A_L1 = T.alloc_shared((block_M, block_K), dtype)
+B_L1 = T.alloc_shared((block_K, block_N), dtype)
+```
+
+**示例 2：Vector 计算中分配 UB 缓冲**
+
+```python
+block_M, block_N = 128, 128
+dtype = "float16"
+
+a_ub = T.alloc_shared((block_M, block_N), dtype)
+b_ub = T.alloc_shared((block_M, block_N), dtype)
+```

--- a/docs/api_docs/T.alloc_var.md
+++ b/docs/api_docs/T.alloc_var.md
@@ -1,0 +1,85 @@
+# T.alloc_var
+
+## 1. 功能说明
+
+分配单元素标量变量（内部 shape 固定为 `[1]`），用于条件标志位、循环计数器、临时标量等场景。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+`alloc_var` 支持多种调用形式，统一签名如下：
+
+```python
+def alloc_var(
+    dtype: str,
+    *args,
+    scope: str = "local.var",
+    init: PrimExpr | int | float | None = None,
+) -> Buffer
+```
+
+> **多签名说明**：`alloc_var` 的第二个位置参数根据类型自动区分 `init` 和 `scope`，详见 [2.3.3 alloc_var 调用方式](#233-alloc_var-调用方式)。
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dtype | 输入 | 变量的数据类型（如 `"int32"`、`"bool"`、`"float32"`） | 字符串 | 必填 |
+| init | 输入 | 初始值，支持常量、表达式或其他 `alloc_var` 变量；为 `None` 时不初始化 | 整数 / 浮点数 / PrimExpr | 可选（默认 `None`） |
+| scope | 输入 | 内存作用域 | 字符串 | 可选（默认 `"local.var"`） |
+
+> **返回值说明**：
+> - 返回单元素 `T.Buffer` 对象（shape 为 `[1]`），通过索引 `[0]` 或直接赋值访问
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dtype |
+|------|:-----:|
+| Ascend A2 / A3 | int32, bool, float32, float16, bfloat16, int8, int16, int64, uint32, uint64 |
+
+> 仅 ascendc 支持：uint8, uint16
+> pto 后端所有 dtype 均精度验证失败。
+
+#### 2.3.2 Shape 支持
+
+- 固定单元素（内部 shape 为 `[1]`，用户无需指定 shape）
+
+#### 2.3.3 alloc_var 调用方式
+
+`alloc_var` 的第二个位置参数根据类型自动区分 `init` 和 `scope`：
+
+| 调用方式 | 含义 |
+|---------|------|
+| `T.alloc_var("int32")` | 无初始值 |
+| `T.alloc_var("int32", 1)` | init=1 |
+| `T.alloc_var("int32", "local.var")` | scope="local.var" |
+| `T.alloc_var("int32", 1, "local.var")` | init=1, scope="local.var" |
+| `T.alloc_var("int32", init=1)` | init=1（关键字参数） |
+| `T.alloc_var("int32", "local.var", init=1)` | init=1, scope="local.var" |
+
+### 2.4 约束条件
+
+1. 必须在 `T.Kernel` 作用域内调用
+2. `init` 不可重复指定（位置参数和关键字参数不能同时提供 init）
+3. `scope` 必须为字符串类型
+4. 最多接受 3 个位置参数（dtype、init、scope）
+
+## 3. 示例代码
+
+**示例 1：分配标量变量**
+
+```python
+flag = T.alloc_var("bool", init=False)
+counter = T.alloc_var("int32", init=0)
+value = T.alloc_var("float32", init=0.0)
+```
+
+**示例 2：变量间初始化**
+
+```python
+a = T.alloc_var("int32", init=1)
+b = T.alloc_var("int32", init=a)
+```


### PR DESCRIPTION
为 alloc_shared / alloc_fragment/ alloc_var 三个内存分配新增API文档

- docs/api_docs/T.alloc_shared.md
- docs/api_docs/T.alloc_fragment.md
- docs/api_docs/T.alloc_var.md

验证来源：ascendc+pto真机，仓库test_alloc_var ascendc+pto passed