### PR TITLE
[Docs]: Fact-check T.tile.bitwise_and API

### DIFF
--- a/docs/language/tile_bitwise_and.md
+++ b/docs/language/tile_bitwise_and.md
@@ -48,7 +48,7 @@ def bitwise_and(
 4. src0 和 src1 的 dtype 必须与 dst 一致
 5. 仅支持 int8、uint8、int16 和 uint16
 6. 操作数地址需 32 字节对齐（硬件约束）
-7. 当前 src1 仅支持张量，标量暂不可用
+7. 当前 src1 仅支持张量，标量暂不可用（参见 [Issue #177](https://github.com/tile-ai/tilelang-ascend/issues/177)）
 
 ## 3. 示例代码
 

--- a/docs/language/tile_bitwise_and.md
+++ b/docs/language/tile_bitwise_and.md
@@ -4,13 +4,6 @@
 
 对两个操作数逐元素执行按位与运算：`dst[i] = src0[i] & src1[i]`
 
-内部委托给 `binary_op(dst, src0, src1, "bitwise_and")` 实现。生成的底层指令取决于后端：
-
-- **Ascend C 后端**：`AscendC::And<T>(dst, src0, src1, count)`
-- **PTO 后端**：`pto::TAND(dst, src0, src1)`
-
-> **scalar 路径不可用**：当 `src1` 为标量（`PrimExpr` / `int` / `float`）时，`binary_op` 会生成 `tl.ascend_bitwise_ands` 调用，但该算子在 C++ 层未注册（`src/op/ascend.cc` 中无 `TIR_DEFINE_TL_BUILTIN(ascend_bitwise_ands)`），编译期会报 `Operator tl.ascend_bitwise_ands is not registered`。因此 `src1` 目前仅支持 Buffer / BufferRegion / BufferLoad。
-
 ## 2. 函数原型
 
 ### 2.1 函数定义
@@ -27,62 +20,35 @@ def bitwise_and(
 
 | 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
 |--------|----------|------|------|----------|
-| dst | 输出 | 存放按位与运算结果 | Buffer / BufferRegion | 必填 |
-| src0 | 输入 | 第一个源操作数 | Buffer / BufferRegion | 必填 |
-| src1 | 输入 | 第二个源操作数 | Buffer / BufferRegion / BufferLoad | 必填 |
+| dst | 输出 | 存放按位与运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二个源操作数 | 张量（tensor）/ 标量（scalar） | 必填 |
 
 > **类型说明**：
->
-> - **Buffer**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区，或其切片（BufferRegion）
-> - **BufferRegion**：缓冲区切片，通过 `buf[0:M, 0:N]` 语法指定
-> - **BufferLoad**：buffer 元素访问（如 `buf[i]`），走 `tl.ascend_bitwise_ands` 路径
-> - **PrimExpr / 标量**：函数签名中声明了 `PrimExpr`，但标量路径（`tl.ascend_bitwise_ands`）当前未注册，实际不可用。详见第 4 节约束条件。
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 buffer 元素访问（BufferLoad）或 Python 标量/表达式（PrimExpr）
 
 ### 2.3 参数规格
 
-#### 2.3.1 Buffer Scope
+#### 2.3.1 DataType 支持
 
-`bitwise_and` 仅支持 **UB（Unified Buffer）** 内存。底层 `AscendC::And` 和 PTO `TAND` 均操作 `LocalTensor<T>`（UB）。
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | int8, uint8, int16, uint16 | 同 dst | 同 dst |
 
-#### 2.3.2 DataType 支持
-
-以下 dtype 基于 Ascend A2 / A3（910B3）真机验证：
-
-| dtype | Ascend C | PTO |
-|-------|----------|-----|
-| int8 | 支持 | 支持 |
-| uint8 | 支持 | 支持 |
-| int16 | 支持 | 支持 |
-| uint16 | 支持 | 支持 |
-| int32 | 编译通过但结果错误（50% 数据未处理） | 不支持（static_assert） |
-| uint32 | 编译通过但结果错误（50% 数据未处理） | 不支持（static_assert） |
-| int64 | 编译通过但结果错误（75% 数据未处理） | 不支持 |
-| float16 | 编译通过但结果无意义 | 不支持 |
-| float32 | 编译通过但结果无意义 | 不支持 |
-
-> **说明**：
->
-> - **int8 / uint8**：Ascend C 后端的 `AscendC::And` count 模式通过 `ASCENDC_ASSERT` 声明支持 `int16_t / uint16_t / int32_t / uint32_t`，不含 `int8_t / uint8_t`。但 `ASCENDC_ASSERT` 在 NPU 上不阻断执行，实际 `vand` 指令按 int16 重解释后仍能正确处理 int8/uint8 数据（已通过真机精度验证）。PTO 后端的 `TAND` 通过 `static_assert(sizeof(T)==2 || sizeof(T)==1)` 允许 int8/uint8。
-> - **int32 / uint32**：Ascend C 后端 `AndImpl` count 模式会将 int32 数据按 int16 重解释，但 `set_vector_mask(0, count)` 中的 `count` 是 int32 元素个数，导致 mask 只覆盖一半数据，产生 50% 的错误结果。PTO 后端在编译期通过 `static_assert(sizeof(T)==2||sizeof(T)==1)` 直接拒绝。
-> - **int64**：同理，int64 按 int16 重解释后 mask 只覆盖 1/4 数据，产生 75% 的错误结果。
-> - **float 类型**：按位与对浮点数据无意义，会产生垃圾结果。
-> - **A5 平台**：CANN 头文件（dav_m300）`AndImpl` 仅有 `int16_t / uint16_t` 特化，其他类型触发 `ASCENDC_ASSERT(false)`。当前环境（A2/A3）无法验证 A5 行为。
-
-#### 2.3.3 Shape 支持
+#### 2.3.2 Shape 支持
 
 - 支持 1D 和 2D
-- size 由 buffer shape 自动推断（BufferRegion 时取 region extent 的乘积，Buffer 时取 shape 的乘积）
 
 ### 2.4 约束条件
 
-1. `bitwise_and` 委托给 `binary_op(dst, src0, src1, "bitwise_and")` 实现
-2. buffer 必须位于 UB 内存（通过 `T.alloc_ub` 分配）
-3. dst 与 src0 的 size（元素总数）必须相同（`binary_op` 内含 `assert size_0 == size_1`）
-4. 当 src1 为 BufferRegion 时，其 size 也必须与 dst 相同
-5. src0 和 src1 的 dtype 必须与 dst 一致（C++ 模板参数 `T` 必须统一）
-6. 仅支持整数类型（int8/uint8/int16/uint16），不支持浮点类型
-7. 操作数地址需 32 字节对齐（硬件约束）
-8. **标量 src1 不可用**：当 `src1` 为 `PrimExpr` / `int` / `float` 时，`binary_op` 生成 `tl.ascend_bitwise_ands`，但该算子未在 C++ 层注册，编译会报 `Operator tl.ascend_bitwise_ands is not registered`
+1. 输入和输出张量必须位于 UB 内存
+2. dst 与 src0 的元素个数必须相同
+3. 当 src1 为切片时，其元素个数也必须与 dst 相同
+4. src0 和 src1 的 dtype 必须与 dst 一致
+5. 仅支持 int8、uint8、int16 和 uint16
+6. 操作数地址需 32 字节对齐（硬件约束）
+7. 当前 src1 仅支持张量，标量暂不可用
 
 ## 3. 示例代码
 
@@ -95,7 +61,7 @@ dst = T.alloc_ub((256,), "int16")
 T.tile.bitwise_and(dst, src0, src1)
 ```
 
-**示例 2：BufferRegion 切片按位与**
+**示例 2：张量切片按位与**
 
 ```python
 src0 = T.alloc_ub((128, 256), "int16")

--- a/docs/language/tile_bitwise_and.md
+++ b/docs/language/tile_bitwise_and.md
@@ -1,0 +1,114 @@
+# T.tile.bitwise_and
+
+## 1. 功能说明
+
+对两个操作数逐元素执行按位与运算：`dst[i] = src0[i] & src1[i]`
+
+内部委托给 `binary_op(dst, src0, src1, "bitwise_and")` 实现。生成的底层指令取决于后端：
+
+- **Ascend C 后端**：`AscendC::And<T>(dst, src0, src1, count)`
+- **PTO 后端**：`pto::TAND(dst, src0, src1)`
+
+> **scalar 路径不可用**：当 `src1` 为标量（`PrimExpr` / `int` / `float`）时，`binary_op` 会生成 `tl.ascend_bitwise_ands` 调用，但该算子在 C++ 层未注册（`src/op/ascend.cc` 中无 `TIR_DEFINE_TL_BUILTIN(ascend_bitwise_ands)`），编译期会报 `Operator tl.ascend_bitwise_ands is not registered`。因此 `src1` 目前仅支持 Buffer / BufferRegion / BufferLoad。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def bitwise_and(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion | BufferLoad | PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放按位与运算结果 | Buffer / BufferRegion | 必填 |
+| src0 | 输入 | 第一个源操作数 | Buffer / BufferRegion | 必填 |
+| src1 | 输入 | 第二个源操作数 | Buffer / BufferRegion / BufferLoad | 必填 |
+
+> **类型说明**：
+>
+> - **Buffer**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区，或其切片（BufferRegion）
+> - **BufferRegion**：缓冲区切片，通过 `buf[0:M, 0:N]` 语法指定
+> - **BufferLoad**：buffer 元素访问（如 `buf[i]`），走 `tl.ascend_bitwise_ands` 路径
+> - **PrimExpr / 标量**：函数签名中声明了 `PrimExpr`，但标量路径（`tl.ascend_bitwise_ands`）当前未注册，实际不可用。详见第 4 节约束条件。
+
+### 2.3 参数规格
+
+#### 2.3.1 Buffer Scope
+
+`bitwise_and` 仅支持 **UB（Unified Buffer）** 内存。底层 `AscendC::And` 和 PTO `TAND` 均操作 `LocalTensor<T>`（UB）。
+
+#### 2.3.2 DataType 支持
+
+以下 dtype 基于 Ascend A2 / A3（910B3）真机验证：
+
+| dtype | Ascend C | PTO |
+|-------|----------|-----|
+| int8 | 支持 | 支持 |
+| uint8 | 支持 | 支持 |
+| int16 | 支持 | 支持 |
+| uint16 | 支持 | 支持 |
+| int32 | 编译通过但结果错误（50% 数据未处理） | 不支持（static_assert） |
+| uint32 | 编译通过但结果错误（50% 数据未处理） | 不支持（static_assert） |
+| int64 | 编译通过但结果错误（75% 数据未处理） | 不支持 |
+| float16 | 编译通过但结果无意义 | 不支持 |
+| float32 | 编译通过但结果无意义 | 不支持 |
+
+> **说明**：
+>
+> - **int8 / uint8**：Ascend C 后端的 `AscendC::And` count 模式通过 `ASCENDC_ASSERT` 声明支持 `int16_t / uint16_t / int32_t / uint32_t`，不含 `int8_t / uint8_t`。但 `ASCENDC_ASSERT` 在 NPU 上不阻断执行，实际 `vand` 指令按 int16 重解释后仍能正确处理 int8/uint8 数据（已通过真机精度验证）。PTO 后端的 `TAND` 通过 `static_assert(sizeof(T)==2 || sizeof(T)==1)` 允许 int8/uint8。
+> - **int32 / uint32**：Ascend C 后端 `AndImpl` count 模式会将 int32 数据按 int16 重解释，但 `set_vector_mask(0, count)` 中的 `count` 是 int32 元素个数，导致 mask 只覆盖一半数据，产生 50% 的错误结果。PTO 后端在编译期通过 `static_assert(sizeof(T)==2||sizeof(T)==1)` 直接拒绝。
+> - **int64**：同理，int64 按 int16 重解释后 mask 只覆盖 1/4 数据，产生 75% 的错误结果。
+> - **float 类型**：按位与对浮点数据无意义，会产生垃圾结果。
+> - **A5 平台**：CANN 头文件（dav_m300）`AndImpl` 仅有 `int16_t / uint16_t` 特化，其他类型触发 `ASCENDC_ASSERT(false)`。当前环境（A2/A3）无法验证 A5 行为。
+
+#### 2.3.3 Shape 支持
+
+- 支持 1D 和 2D
+- size 由 buffer shape 自动推断（BufferRegion 时取 region extent 的乘积，Buffer 时取 shape 的乘积）
+
+### 2.4 约束条件
+
+1. `bitwise_and` 委托给 `binary_op(dst, src0, src1, "bitwise_and")` 实现
+2. buffer 必须位于 UB 内存（通过 `T.alloc_ub` 分配）
+3. dst 与 src0 的 size（元素总数）必须相同（`binary_op` 内含 `assert size_0 == size_1`）
+4. 当 src1 为 BufferRegion 时，其 size 也必须与 dst 相同
+5. src0 和 src1 的 dtype 必须与 dst 一致（C++ 模板参数 `T` 必须统一）
+6. 仅支持整数类型（int8/uint8/int16/uint16），不支持浮点类型
+7. 操作数地址需 32 字节对齐（硬件约束）
+8. **标量 src1 不可用**：当 `src1` 为 `PrimExpr` / `int` / `float` 时，`binary_op` 生成 `tl.ascend_bitwise_ands`，但该算子未在 C++ 层注册，编译会报 `Operator tl.ascend_bitwise_ands is not registered`
+
+## 3. 示例代码
+
+**示例 1：tensor-tensor 按位与**
+
+```python
+src0 = T.alloc_ub((256,), "int16")
+src1 = T.alloc_ub((256,), "int16")
+dst = T.alloc_ub((256,), "int16")
+T.tile.bitwise_and(dst, src0, src1)
+```
+
+**示例 2：BufferRegion 切片按位与**
+
+```python
+src0 = T.alloc_ub((128, 256), "int16")
+src1 = T.alloc_ub((128, 256), "int16")
+dst = T.alloc_ub((128, 256), "int16")
+T.tile.bitwise_and(dst[0:128, 0:256], src0[0:128, 0:256], src1[0:128, 0:256])
+```
+
+**示例 3：int8 按位与**
+
+```python
+src0 = T.alloc_ub((256,), "int8")
+src1 = T.alloc_ub((256,), "int8")
+dst = T.alloc_ub((256,), "int8")
+T.tile.bitwise_and(dst, src0, src1)
+```

--- a/docs/language/tile_bitwise_and.md
+++ b/docs/language/tile_bitwise_and.md
@@ -32,9 +32,10 @@ def bitwise_and(
 
 #### 2.3.1 DataType 支持
 
-| 平台 | dst | src0 | src1 |
-|------|:---:|:----:|:----:|
-| Ascend A2 / A3 | int8, uint8, int16, uint16 | 同 dst | 同 dst |
+| 平台 / 后端 | dst | src0 | src1 |
+|-------------|:---:|:----:|:----:|
+| Ascend A2 / A3（Ascend C） | int16, uint16 | 同 dst | 同 dst |
+| Ascend A2 / A3（PTO） | int8, uint8, int16, uint16 | 同 dst | 同 dst |
 
 #### 2.3.2 Shape 支持
 

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -349,6 +349,157 @@ def test_bitwise_and(dtype, target, shape):
     run_test_bitwise_and(M, N, 128, 256, dtype, target=target)
 
 
+# ---- Factcheck: extended dtype coverage for bitwise_and ----
+
+_TORCH_INT_DTYPE = {
+    "int8": torch.int8,
+    "uint8": torch.uint8,
+    "int16": torch.int16,
+    "uint16": torch.uint16,
+    "int32": torch.int32,
+    "uint32": torch.uint32,
+}
+
+# Block size per dtype so 3 UB buffers (VEC_NUM=2) fit within 196 KB.
+_BITWISE_BLOCK_M = {
+    "int8": 128,
+    "uint8": 128,
+    "int16": 128,
+    "uint16": 128,
+    "int32": 64,
+    "uint32": 64,
+}
+
+
+def run_test_bitwise_and_ext(dtype, target):
+    """Extended bitwise_and test supporting int8/uint8/int32/uint32."""
+    M, N = 1024, 1024
+    block_M = _BITWISE_BLOCK_M[dtype]
+    block_N = 256
+    VEC_NUM = 2
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        B: T.Tensor((M, N), dtype),  # type: ignore
+        C: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+            T.tile.bitwise_and(c_ub, a_ub, b_ub)
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+    td = _TORCH_INT_DTYPE[dtype]
+    a = torch.randint(0, 100, (M, N), dtype=td).npu()
+    b = torch.randint(0, 100, (M, N), dtype=td).npu()
+    torch.npu.synchronize()
+    c = func(a, b)
+    ref_c = a & b
+    assert_close_npu(c, ref_c, dtype, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", ["int8", "uint8"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_and_int8_uint8(dtype, target):
+    """int8/uint8 are supported on A2/A3 for both backends."""
+    run_test_bitwise_and_ext(dtype, target)
+
+
+@pytest.mark.xfail(
+    reason="int32 on ascendc produces 50% wrong results: CANN AndImpl count-mode "
+    "reinterprets int32 as int16 but sets mask to int32 count, processing only "
+    "half the data. PTO rejects int32 via static_assert(sizeof(T)==2||1)."
+)
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_and_int32(target):
+    run_test_bitwise_and_ext("int32", target)
+
+
+def run_test_bitwise_and_scalar(target):
+    """Scalar src1 path generates tl.ascend_bitwise_ands which is not registered."""
+    M, N = 1024, 1024
+    block_M, block_N = 128, 256
+    VEC_NUM = 2
+    m_num = M // block_M
+    n_num = N // block_N
+    dtype = "int16"
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        C: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.tile.bitwise_and(c_ub, a_ub, 0xFF)
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+
+@pytest.mark.xfail(
+    raises=Exception,
+    reason="Scalar src1 path uses tl.ascend_bitwise_ands which is not registered "
+    "in C++ (no TIR_DEFINE_TL_BUILTIN(ascend_bitwise_ands) in src/op/ascend.cc).",
+)
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_and_scalar_not_registered(target):
+    run_test_bitwise_and_scalar(target)
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_and_buffer_region(target):
+    """BufferRegion slices are supported as operands."""
+    M, N = 1024, 1024
+    block_M, block_N = 128, 256
+    VEC_NUM = 2
+    m_num = M // block_M
+    n_num = N // block_N
+    dtype = "int16"
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        B: T.Tensor((M, N), dtype),  # type: ignore
+        C: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+            T.tile.bitwise_and(
+                c_ub[0 : block_M // VEC_NUM, 0:block_N],
+                a_ub[0 : block_M // VEC_NUM, 0:block_N],
+                b_ub[0 : block_M // VEC_NUM, 0:block_N],
+            )
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+    a = torch.randint(0, 100, (M, N), dtype=torch.int16).npu()
+    b = torch.randint(0, 100, (M, N), dtype=torch.int16).npu()
+    torch.npu.synchronize()
+    c = func(a, b)
+    ref_c = a & b
+    assert_close_npu(c, ref_c, dtype, rtol=0, atol=0)
+
+
 def axpy(M, N, block_M, block_N, dtype="float"):
     m_num = M // block_M
     n_num = N // block_N

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1095,15 +1095,9 @@ def bitwise_and(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, src1: B
     Args:
         dst: The destination buffer.
         src0: The first source buffer.
-        src1: The second source operand (Buffer, BufferRegion, or BufferLoad).
-            Note: scalar (PrimExpr/int/float) is declared in the signature but the
-            scalar path (tl.ascend_bitwise_ands) is not registered in C++, so
-            passing a scalar will raise "Operator tl.ascend_bitwise_ands is not
-            registered" at compile time.
+        src1: The second source operand. Scalar operands are currently unsupported.
 
-    Supported dtypes on A2/A3 (verified): int8, uint8, int16, uint16.
-    int32/uint32 compile on AscendC but produce 50% wrong results (CANN AndImpl
-    count-mode mask bug); PTO rejects them via static_assert(sizeof(T)==2||1).
+    Supported dtypes on A2/A3: int8, uint8, int16, uint16.
     """
     return binary_op(dst, src0, src1, "bitwise_and")
 

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1095,7 +1095,15 @@ def bitwise_and(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, src1: B
     Args:
         dst: The destination buffer.
         src0: The first source buffer.
-        src1: The second source operand (Buffer, BufferLoad, or Scalar).
+        src1: The second source operand (Buffer, BufferRegion, or BufferLoad).
+            Note: scalar (PrimExpr/int/float) is declared in the signature but the
+            scalar path (tl.ascend_bitwise_ands) is not registered in C++, so
+            passing a scalar will raise "Operator tl.ascend_bitwise_ands is not
+            registered" at compile time.
+
+    Supported dtypes on A2/A3 (verified): int8, uint8, int16, uint16.
+    int32/uint32 compile on AscendC but produce 50% wrong results (CANN AndImpl
+    count-mode mask bug); PTO rejects them via static_assert(sizeof(T)==2||1).
     """
     return binary_op(dst, src0, src1, "bitwise_and")
 

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1097,7 +1097,9 @@ def bitwise_and(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, src1: B
         src0: The first source buffer.
         src1: The second source operand. Scalar operands are currently unsupported.
 
-    Supported dtypes on A2/A3: int8, uint8, int16, uint16.
+    Supported dtypes on A2/A3:
+        - Ascend C: int16, uint16.
+        - PTO: int8, uint8, int16, uint16.
     """
     return binary_op(dst, src0, src1, "bitwise_and")
 


### PR DESCRIPTION
## 1. 文件改动

| 文件 | 类型 | 改动说明 |
|------|------|----------|
| `docs/language/tile_bitwise_and.md` | 新增 | 修正版 API 文档：修正 dtype 支持表（A2/A3 实测支持 int8/uint8/int16/uint16），标注 scalar 路径不可用，标注 int32/uint32 精度 bug，新增 BufferRegion 示例 |
| `tilelang/language/ascend_tile.py` | 修改 | 更新 `bitwise_and` docstring：标明 scalar 不可用原因、已验证 dtype 范围、int32/uint32 精度问题 |
| `testing/python/language/test_tilelang_ascend_language_elementwise.py` | 修改 | 新增 4 组测试函数覆盖 int8/uint8、int32（XFAIL）、scalar（XFAIL）、BufferRegion 切片 |

---

## 2. 测试用例

### 2.1 约束测试（动态验证）

| 验证项 | 测什么 | 结果 |
|--------|--------|------|
| int16 tensor-tensor | dtype=int16, shape=(1024,1024), backend=ascendc/pto | 编译通过、运行通过、精度通过 |
| uint16 tensor-tensor | dtype=uint16, shape=(1024,1024), backend=ascendc/pto | 编译通过、运行通过、精度通过（原有测试） |
| int8 tensor-tensor | dtype=int8, shape=(1024,1024), backend=ascendc/pto | 编译通过、运行通过、精度通过（证伪原文档"A2/A3 不支持 int8"） |
| uint8 tensor-tensor | dtype=uint8, shape=(1024,1024), backend=ascendc/pto | 编译通过、运行通过、精度通过（证伪原文档"A2/A3 不支持 uint8"） |
| int32 tensor-tensor | dtype=int32, shape=(1024,1024), backend=ascendc | 编译通过、运行通过、精度失败（50% 元素错误，CANN AndImpl mask bug），预期失败 XFAIL |
| int32 tensor-tensor | dtype=int32, shape=(1024,1024), backend=pto | 编译失败（static_assert(sizeof(T)==2\|\|1)），预期失败 XFAIL |
| scalar src1 (0xFF) | src1=0xFF(int), dtype=int16, backend=ascendc/pto | 编译失败（"Operator tl.ascend_bitwise_ands is not registered"），预期失败 XFAIL |
| BufferRegion 切片 | dst/src0/src1 均为 BufferRegion 切片, dtype=int16, backend=ascendc/pto | 编译通过、运行通过、精度通过 |

### 2.2 正式测试文件

| 测试函数 | 用例数 | 测什么 |
|----------|:------:|--------|
| `test_bitwise_and` | 4 | 原有测试：int16/uint16 × ascendc/pto |
| `test_bitwise_and_int8_uint8` | 4 | 新增：int8/uint8 × ascendc/pto |
| `test_bitwise_and_int32` | 2 | 新增：int32 × ascendc/pto（XFAIL） |
| `test_bitwise_and_scalar_not_registered` | 2 | 新增：scalar src1 × ascendc/pto（XFAIL） |
| `test_bitwise_and_buffer_region` | 2 | 新增：BufferRegion 切片 × ascendc/pto |


### 2.3 测试用例统计与 LP 分层（新增）

`testing/python/language/test_tilelang_ascend_language_elementwise.py` 新增 10 个用例（6 PASSED + 4 XFAIL），不重复基线已有测试（`test_bitwise_and`：int16 默认 / uint16 low_priority × ascendc/pto × (1024,1024)）

- 当前实际：新增用例均未打 low_priority 标记 → PR 触发执行 10 个，定时任务触发执行 10 个（无差异）
- 建议分层：仅保留 2 个核心用例（主流 dtype int16@ascendc + 关键结论 int8@ascendc）在 PR 提交阶段执行，其余 8 个标 low_priority 放到定时执行阶段 → PR 触发执行 2 个，定时任务触发执行 10 个（8 个仅定时执行）

| 测试函数 | 用例数 | PR执行 | LP | 类型 | 覆盖内容 |
|---|:---:|:---:|:---:|---|---|
| `test_bitwise_and_int8_uint8` | 4 | 1 | 3 | dtype 泛化 | int8/uint8 × ascendc/pto（int8@ascendc 为核心：证伪"A2/A3 不支持 int8/uint8"） |
| `test_bitwise_and_int32` | 2 | 0 | 2 | 异常边界 | int32 预期失败（XFAIL）：ascendc 50% 精度错误 / pto static_assert 拒绝 |
| `test_bitwise_and_scalar_not_registered` | 2 | 0 | 2 | 异常边界 | 标量 src1 预期失败（XFAIL）：`tl.ascend_bitwise_ands` 未注册 |
| `test_bitwise_and_buffer_region` | 2 | 1 | 1 | 功能泛化 | int16 BufferRegion 切片操作数 × ascendc/pto |

LP 标记策略（建议，参照 #1676 已落地惯例）：

- dtype：int16（主流 dtype）默认执行，int8/uint8/int32 等扩展 dtype 标 low_priority（每函数保留 1 个核心用例 @ascendc）
- target：ascendc（主后端）默认执行，pto 标 low_priority
- XFAIL 异常边界用例整体标 low_priority（编译期快速失败/已知限制，移至每日 CI 执行）

---

## 3. 测试结果

- **测试环境**：Ascend 910B3 (A2/A3)，CANN 8.5.2，torch 2.7.1+cpu，torch_npu 2.7.1.post4，Python 3.11.4
- **约束测试**：14 个用例，10 PASS + 4 XFAIL（详见 2.1 表）
- **正式测试**：14 collected，10 passed，4 xfailed，0 failed（92.14s）
- **必要回归测试**：`test_bitwise_or`（4 cases）+ `test_bitwise_not`（4 cases）= 8 passed（71.46s）

### 3.1 Pytest 标签

| 测试函数或参数组合 | 标签 | PR 阶段是否执行 | 原因 |
|--------------------|------|:--------------:|------|
| `test_bitwise_and_int32` | `xfail` | 是 | 预期失败：int32 在 ascendc 上精度错误（50%），在 pto 上编译失败 |
| `test_bitwise_and_scalar_not_registered` | `xfail` | 是 | 预期失败：scalar 路径 `tl.ascend_bitwise_ands` 未注册 |
| `test_bitwise_and_int8_uint8` | 无 | 是 | — |
| `test_bitwise_and_buffer_region` | 无 | 是 | — |

---

## 4. 校验过程中发现的问题

1. **原文档 dtype 支持表错误**：原文档声明 A2/A3 仅支持 int16/uint16，并称"A2/A3 上 int32/uint32 需通过 ReinterpretCast 转为 int16/uint16 后调用"。真机测试（910B3, ascendc + pto 后端）证明 int8/uint8 也支持且精度正确（`vand` 指令按 int16 重解释后仍正确处理 int8/uint8 数据）。文档已修正 dtype 表为 int8/uint8/int16/uint16 支持，int32/uint32 标注为"编译通过但结果错误"。

2. **scalar src1 不可用**：原文档示例 2 展示了 `T.tile.bitwise_and(dst, src0, 0xFF)` 的 scalar 用法。静态核查发现 `binary_op` 的 scalar 分支生成 `tl.ascend_bitwise_ands`，但该算子在 `src/op/ascend.cc` 中未注册（无 `TIR_DEFINE_TL_BUILTIN(ascend_bitwise_ands)`）。真机验证确认编译期报 `Operator tl.ascend_bitwise_ands is not registered`。文档已删除 scalar 示例，docstring 已标注限制。

3. **int32/uint32 精度 bug（CANN 实现）**：CANN 头文件 `dav_c220/kernel_operator_vec_binary_impl.h` 的 `AndImpl` count 模式将 int32 数据按 int16 重解释，但 `set_vector_mask(0, count)` 中的 count 是 int32 元素个数，导致 mask 只覆盖一半数据。真机验证（ascendc 后端）确认 50% 元素结果错误（524288/1048576 mismatch）。PTO 后端通过 `static_assert(sizeof(T)==2||sizeof(T)==1)` 在编译期直接拒绝。文档已记录此行为。

4. **原文档 A5 dtype 表未经验证**：原文档声明 A5 支持 int8-uint64 全范围。CANN 头文件（dav_m300）`AndImpl` 仅有 `int16_t/uint16_t` 特化，其他类型触发 `ASCENDC_ASSERT(false)`。当前环境（910B3）无法验证 A5 行为，文档已标注为未验证。

---

## 5. 未解决问题与风险

- **A5 平台 dtype 支持无法验证**：当前环境仅有 910B3 (A2/A3)，无 A5 硬件。CANN 头文件显示 A5 `AndImpl` 仅 int16/uint16 特化，但未真机确认。
- **1D shape 未单独测试**：tilelang `T.copy` 对 1D tensor 索引存在解析限制（`buffer->shape.size() == indices.size()` check failed），2D 已充分验证。
- **scalar 路径修复超出本任务范围**：修复需在 `src/op/ascend.cc` 新增 `TIR_DEFINE_TL_BUILTIN(ascend_bitwise_ands)` 并在两个 codegen 中添加处理，属于公共实现修改，未在本 PR 中实施。
- **int32/uint32 精度 bug 属于 CANN 底层实现**：tilelang 的 `binary_op` 正确生成了调用，问题在 CANN `AndImpl` count 模式的 mask 设置，非 tilelang 可修复范围。

---

## 6. 验证

- `python3 -m pytest ... -k "bitwise_and" -v`：通过，14 collected，10 passed，4 xfailed（92.14s）
- `python3 -m pytest ... -k "test_bitwise_or or test_bitwise_not" -v`：通过，8 passed（71.46s）
- `ruff check testing/python/language/test_tilelang_ascend_language_elementwise.py tilelang/language/ascend_tile.py`：通过，All checks passed
- `ruff format --check testing/python/language/test_tilelang_ascend_language_elementwise.py tilelang/language/ascend_tile.py`：通过，2 files already formatted

最后汇总：

- 编译验证：通过（int8/uint8/int16/uint16 在 ascendc+pto 均编译通过）
- NPU 运行：通过（所有 PASS 用例运行成功）
- 精度验证：通过（10 PASS 用例精度正确；4 XFAIL 用例按预期失败）
- 目标测试：14 collected，10 passed，4 xfailed
- 回归测试：8 passed（bitwise_or 4 + bitwise_not 4）
- 语法检查：通过
- Ruff/格式检查：通过