### PR TITLE
[docs]: fact-check T.tile.bitwise_or API behavior

### DIFF
--- a/docs/language/tile_bitwise_or.md
+++ b/docs/language/tile_bitwise_or.md
@@ -1,0 +1,128 @@
+# T.tile.bitwise_or
+
+## 1. 功能说明
+
+对两个操作数逐元素执行按位或运算：`dst[i] = src0[i] | src1[i]`
+
+内部委托给 `binary_op(dst, src0, src1, "bitwise_or")` 实现。生成的底层指令取决于后端：
+
+- **Ascend C 后端**：`AscendC::Or<T>(dst, src0, src1, count)`
+- **PTO 后端**：`pto::TOR(dst, src0, src1)`
+
+> **scalar 路径不可用**：当 `src1` 为标量（`PrimExpr` / `int` / `float`）时，`binary_op` 会生成 `tl.ascend_bitwise_ors` 调用，但该算子在 C++ 层未注册（`src/op/ascend.cc` 中无 `TIR_DEFINE_TL_BUILTIN(ascend_bitwise_ors)`），编译期会报 `Operator tl.ascend_bitwise_ors is not registered`。因此 `src1` 目前仅支持 Buffer / BufferRegion / BufferLoad。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def bitwise_or(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    src1: Buffer | BufferRegion | BufferLoad | PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放按位或运算结果 | Buffer / BufferRegion | 必填 |
+| src0 | 输入 | 第一个源操作数 | Buffer / BufferRegion | 必填 |
+| src1 | 输入 | 第二个源操作数 | Buffer / BufferRegion / BufferLoad | 必填 |
+
+> **类型说明**：
+>
+> - **Buffer**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区，或其切片（BufferRegion）
+> - **BufferRegion**：缓冲区切片，通过 `buf[0:M, 0:N]` 语法指定
+> - **BufferLoad**：buffer 元素访问（如 `buf[i]`），走 `tl.ascend_bitwise_ors` 路径
+> - **PrimExpr / 标量**：函数签名中声明了 `PrimExpr`，但标量路径（`tl.ascend_bitwise_ors`）当前未注册，实际不可用。详见第 4 节约束条件。
+
+### 2.3 参数规格
+
+#### 2.3.1 Buffer Scope
+
+`bitwise_or` 仅支持 **UB（Unified Buffer）** 内存。底层 `AscendC::Or` 和 PTO `TOR` 均操作 `LocalTensor<T>`（UB）。
+
+#### 2.3.2 DataType 支持
+
+以下 dtype 基于 Ascend A2 / A3（910B3）真机验证：
+
+| dtype | Ascend C | PTO |
+|-------|----------|-----|
+| int8 | 支持 | 支持 |
+| uint8 | 支持 | 支持 |
+| int16 | 支持 | 支持 |
+| uint16 | 支持 | 支持 |
+| int32 | 编译通过但结果错误（50% 数据未处理） | 不支持（static_assert） |
+| uint32 | 编译通过但结果错误（50% 数据未处理） | 不支持（static_assert） |
+| int64 | 编译通过但结果错误（75% 数据未处理） | 不支持 |
+| float16 | 编译通过但结果无意义 | 不支持 |
+| float32 | 编译通过但结果无意义 | 不支持 |
+
+> **说明**：
+>
+> - **int8 / uint8**：Ascend C 后端的 `AscendC::Or` count 模式通过 `OrIntrinsicsImpl` 仅有 `int16_t / uint16_t` 特化，但 `vor` 指令按 int16 重解释后仍能正确处理 int8/uint8 数据（已通过真机精度验证）。PTO 后端的 `TOR` 通过 `static_assert(sizeof(T)==2 || sizeof(T)==1)` 允许 int8/uint8。
+> - **int32 / uint32**：Ascend C 后端 `OrImpl` count 模式会将 int32 数据按 int16 重解释，但 `set_vector_mask(0, count)` 中的 `count` 是 int32 元素个数，导致 mask 只覆盖一半数据，产生 50% 的错误结果。PTO 后端在编译期通过 `static_assert(sizeof(T)==2||sizeof(T)==1)` 直接拒绝。
+> - **int64**：同理，int64 按 int16 重解释后 mask 只覆盖 1/4 数据，产生 75% 的错误结果。
+> - **float 类型**：按位或对浮点数据无意义，会产生垃圾结果。
+> - **A5 平台**：CANN 头文件（dav_m300）`OrImpl` 仅有 `int16_t / uint16_t` 特化，其他类型触发 `ASCENDC_ASSERT(false)`。当前环境（A2/A3）无法验证 A5 行为。
+
+#### 2.3.3 Shape 支持
+
+- 支持 1D 和 2D
+- size 由 buffer shape 自动推断（BufferRegion 时取 region extent 的乘积，Buffer 时取 shape 的乘积）
+
+### 2.4 约束条件
+
+1. `bitwise_or` 委托给 `binary_op(dst, src0, src1, "bitwise_or")` 实现
+2. buffer 必须位于 UB 内存（通过 `T.alloc_ub` 分配）
+3. dst 与 src0 的 size（元素总数）必须相同（`binary_op` 内含 `assert size_0 == size_1`）
+4. 当 src1 为 BufferRegion 时，其 size 也必须与 dst 相同
+5. src0 和 src1 的 dtype 必须与 dst 一致（C++ 模板参数 `T` 必须统一）
+6. 仅支持整数类型（int8/uint8/int16/uint16），不支持浮点类型
+7. 操作数地址需 32 字节对齐（硬件约束）
+8. **标量 src1 不可用**：当 `src1` 为 `PrimExpr` / `int` / `float` 时，`binary_op` 生成 `tl.ascend_bitwise_ors`，但该算子未在 C++ 层注册，编译会报 `Operator tl.ascend_bitwise_ors is not registered`
+
+## 3. 示例代码
+
+**示例 1：tensor-tensor 按位或**
+
+```python
+src0 = T.alloc_ub((256,), "int16")
+src1 = T.alloc_ub((256,), "int16")
+dst = T.alloc_ub((256,), "int16")
+T.tile.bitwise_or(dst, src0, src1)
+```
+
+**示例 2：BufferRegion 切片按位或**
+
+```python
+src0 = T.alloc_ub((128, 256), "int16")
+src1 = T.alloc_ub((128, 256), "int16")
+dst = T.alloc_ub((128, 256), "int16")
+T.tile.bitwise_or(dst[0:128, 0:256], src0[0:128, 0:256], src1[0:128, 0:256])
+```
+
+**示例 3：int8 按位或**
+
+```python
+src0 = T.alloc_ub((256,), "int8")
+src1 = T.alloc_ub((256,), "int8")
+dst = T.alloc_ub((256,), "int8")
+T.tile.bitwise_or(dst, src0, src1)
+```
+
+## 4. 已知限制
+
+### 4.1 标量 src1 不可用
+
+原始文档示例中包含 `T.tile.bitwise_or(dst, src0, 0x0F)` 的 tensor-scalar 用法，但该路径在 C++ 层未注册（`src/op/ascend.cc` 中无 `TIR_DEFINE_TL_BUILTIN(ascend_bitwise_ors)`），编译期会报错。如需标量按位或，需先通过 `T.tile.fill` 将标量填入 buffer，再调用 tensor-tensor 版本。
+
+### 4.2 int32/uint32 结果错误
+
+Ascend C 后端对 int32/uint32 可编译但产生 50% 错误结果（CANN `OrImpl` count 模式的 mask 计算基于 `sizeof(T)`，将 int32 按 int16 重解释后 mask 只覆盖一半数据）。PTO 后端通过 `static_assert` 在编译期拒绝。
+
+### 4.3 A5 平台支持范围
+
+原始文档声称 A5 支持 int8/uint8/int16/uint16/int32/uint32/int64/uint64，但 CANN 头文件（dav_m300）`OrImpl` 仅有 `int16_t / uint16_t` 特化，其他类型触发 `ASCENDC_ASSERT(false)`。该声明未经真机验证且与头文件矛盾。

--- a/docs/language/tile_bitwise_or.md
+++ b/docs/language/tile_bitwise_or.md
@@ -4,13 +4,6 @@
 
 对两个操作数逐元素执行按位或运算：`dst[i] = src0[i] | src1[i]`
 
-内部委托给 `binary_op(dst, src0, src1, "bitwise_or")` 实现。生成的底层指令取决于后端：
-
-- **Ascend C 后端**：`AscendC::Or<T>(dst, src0, src1, count)`
-- **PTO 后端**：`pto::TOR(dst, src0, src1)`
-
-> **scalar 路径不可用**：当 `src1` 为标量（`PrimExpr` / `int` / `float`）时，`binary_op` 会生成 `tl.ascend_bitwise_ors` 调用，但该算子在 C++ 层未注册（`src/op/ascend.cc` 中无 `TIR_DEFINE_TL_BUILTIN(ascend_bitwise_ors)`），编译期会报 `Operator tl.ascend_bitwise_ors is not registered`。因此 `src1` 目前仅支持 Buffer / BufferRegion / BufferLoad。
-
 ## 2. 函数原型
 
 ### 2.1 函数定义
@@ -27,62 +20,35 @@ def bitwise_or(
 
 | 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
 |--------|----------|------|------|----------|
-| dst | 输出 | 存放按位或运算结果 | Buffer / BufferRegion | 必填 |
-| src0 | 输入 | 第一个源操作数 | Buffer / BufferRegion | 必填 |
-| src1 | 输入 | 第二个源操作数 | Buffer / BufferRegion / BufferLoad | 必填 |
+| dst | 输出 | 存放按位或运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 第一个源操作数 | 张量（tensor） | 必填 |
+| src1 | 输入 | 第二个源操作数 | 张量（tensor）/ 标量（scalar） | 必填 |
 
 > **类型说明**：
->
-> - **Buffer**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区，或其切片（BufferRegion）
-> - **BufferRegion**：缓冲区切片，通过 `buf[0:M, 0:N]` 语法指定
-> - **BufferLoad**：buffer 元素访问（如 `buf[i]`），走 `tl.ascend_bitwise_ors` 路径
-> - **PrimExpr / 标量**：函数签名中声明了 `PrimExpr`，但标量路径（`tl.ascend_bitwise_ors`）当前未注册，实际不可用。详见第 4 节约束条件。
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：单个元素值，可以是 buffer 元素访问（BufferLoad）或 Python 标量/表达式（PrimExpr）
 
 ### 2.3 参数规格
 
-#### 2.3.1 Buffer Scope
+#### 2.3.1 DataType 支持
 
-`bitwise_or` 仅支持 **UB（Unified Buffer）** 内存。底层 `AscendC::Or` 和 PTO `TOR` 均操作 `LocalTensor<T>`（UB）。
+| 平台 | dst | src0 | src1 |
+|------|:---:|:----:|:----:|
+| Ascend A2 / A3 | int8, uint8, int16, uint16 | 同 dst | 同 dst |
 
-#### 2.3.2 DataType 支持
-
-以下 dtype 基于 Ascend A2 / A3（910B3）真机验证：
-
-| dtype | Ascend C | PTO |
-|-------|----------|-----|
-| int8 | 支持 | 支持 |
-| uint8 | 支持 | 支持 |
-| int16 | 支持 | 支持 |
-| uint16 | 支持 | 支持 |
-| int32 | 编译通过但结果错误（50% 数据未处理） | 不支持（static_assert） |
-| uint32 | 编译通过但结果错误（50% 数据未处理） | 不支持（static_assert） |
-| int64 | 编译通过但结果错误（75% 数据未处理） | 不支持 |
-| float16 | 编译通过但结果无意义 | 不支持 |
-| float32 | 编译通过但结果无意义 | 不支持 |
-
-> **说明**：
->
-> - **int8 / uint8**：Ascend C 后端的 `AscendC::Or` count 模式通过 `OrIntrinsicsImpl` 仅有 `int16_t / uint16_t` 特化，但 `vor` 指令按 int16 重解释后仍能正确处理 int8/uint8 数据（已通过真机精度验证）。PTO 后端的 `TOR` 通过 `static_assert(sizeof(T)==2 || sizeof(T)==1)` 允许 int8/uint8。
-> - **int32 / uint32**：Ascend C 后端 `OrImpl` count 模式会将 int32 数据按 int16 重解释，但 `set_vector_mask(0, count)` 中的 `count` 是 int32 元素个数，导致 mask 只覆盖一半数据，产生 50% 的错误结果。PTO 后端在编译期通过 `static_assert(sizeof(T)==2||sizeof(T)==1)` 直接拒绝。
-> - **int64**：同理，int64 按 int16 重解释后 mask 只覆盖 1/4 数据，产生 75% 的错误结果。
-> - **float 类型**：按位或对浮点数据无意义，会产生垃圾结果。
-> - **A5 平台**：CANN 头文件（dav_m300）`OrImpl` 仅有 `int16_t / uint16_t` 特化，其他类型触发 `ASCENDC_ASSERT(false)`。当前环境（A2/A3）无法验证 A5 行为。
-
-#### 2.3.3 Shape 支持
+#### 2.3.2 Shape 支持
 
 - 支持 1D 和 2D
-- size 由 buffer shape 自动推断（BufferRegion 时取 region extent 的乘积，Buffer 时取 shape 的乘积）
 
 ### 2.4 约束条件
 
-1. `bitwise_or` 委托给 `binary_op(dst, src0, src1, "bitwise_or")` 实现
-2. buffer 必须位于 UB 内存（通过 `T.alloc_ub` 分配）
-3. dst 与 src0 的 size（元素总数）必须相同（`binary_op` 内含 `assert size_0 == size_1`）
-4. 当 src1 为 BufferRegion 时，其 size 也必须与 dst 相同
-5. src0 和 src1 的 dtype 必须与 dst 一致（C++ 模板参数 `T` 必须统一）
-6. 仅支持整数类型（int8/uint8/int16/uint16），不支持浮点类型
-7. 操作数地址需 32 字节对齐（硬件约束）
-8. **标量 src1 不可用**：当 `src1` 为 `PrimExpr` / `int` / `float` 时，`binary_op` 生成 `tl.ascend_bitwise_ors`，但该算子未在 C++ 层注册，编译会报 `Operator tl.ascend_bitwise_ors is not registered`
+1. 输入和输出张量必须位于 UB 内存
+2. dst 与 src0 的元素个数必须相同
+3. 当 src1 为切片时，其元素个数也必须与 dst 相同
+4. src0 和 src1 的 dtype 必须与 dst 一致
+5. 仅支持 int8、uint8、int16 和 uint16
+6. 操作数地址需 32 字节对齐（硬件约束）
+7. 当前 src1 仅支持张量，标量暂不可用（参见 [Issue #177](https://github.com/tile-ai/tilelang-ascend/issues/177)）
 
 ## 3. 示例代码
 
@@ -95,7 +61,7 @@ dst = T.alloc_ub((256,), "int16")
 T.tile.bitwise_or(dst, src0, src1)
 ```
 
-**示例 2：BufferRegion 切片按位或**
+**示例 2：张量切片按位或**
 
 ```python
 src0 = T.alloc_ub((128, 256), "int16")
@@ -112,17 +78,3 @@ src1 = T.alloc_ub((256,), "int8")
 dst = T.alloc_ub((256,), "int8")
 T.tile.bitwise_or(dst, src0, src1)
 ```
-
-## 4. 已知限制
-
-### 4.1 标量 src1 不可用
-
-原始文档示例中包含 `T.tile.bitwise_or(dst, src0, 0x0F)` 的 tensor-scalar 用法，但该路径在 C++ 层未注册（`src/op/ascend.cc` 中无 `TIR_DEFINE_TL_BUILTIN(ascend_bitwise_ors)`），编译期会报错。如需标量按位或，需先通过 `T.tile.fill` 将标量填入 buffer，再调用 tensor-tensor 版本。
-
-### 4.2 int32/uint32 结果错误
-
-Ascend C 后端对 int32/uint32 可编译但产生 50% 错误结果（CANN `OrImpl` count 模式的 mask 计算基于 `sizeof(T)`，将 int32 按 int16 重解释后 mask 只覆盖一半数据）。PTO 后端通过 `static_assert` 在编译期拒绝。
-
-### 4.3 A5 平台支持范围
-
-原始文档声称 A5 支持 int8/uint8/int16/uint16/int32/uint32/int64/uint64，但 CANN 头文件（dav_m300）`OrImpl` 仅有 `int16_t / uint16_t` 特化，其他类型触发 `ASCENDC_ASSERT(false)`。该声明未经真机验证且与头文件矛盾。

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -349,6 +349,206 @@ def test_bitwise_and(dtype, target, shape):
     run_test_bitwise_and(M, N, 128, 256, dtype, target=target)
 
 
+# ---- Factcheck: bitwise_or tests ----
+
+_TORCH_INT_DTYPE_OR = {
+    "int8": torch.int8,
+    "uint8": torch.uint8,
+    "int16": torch.int16,
+    "uint16": torch.uint16,
+    "int32": torch.int32,
+    "uint32": torch.uint32,
+}
+
+_BITWISE_OR_BLOCK_M = {
+    "int8": 128,
+    "uint8": 128,
+    "int16": 128,
+    "uint16": 128,
+    "int32": 64,
+    "uint32": 64,
+}
+
+
+def bitwise_or(M, N, block_M, block_N, dtype="int16"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    VEC_NUM = 2
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        B: T.Tensor((M, N), dtype),  # type: ignore
+        C: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+            T.tile.bitwise_or(c_ub, a_ub, b_ub)
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    return main
+
+
+def run_test_bitwise_or(M, N, block_M, block_N, dtype, target):
+    func = bitwise_or(M, N, block_M, block_N, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch_dtype = torch.int16 if dtype == "int16" else torch.uint16
+    a = torch.randint(0, 10, (M, N), dtype=torch_dtype).npu()
+    b = torch.randint(0, 10, (M, N), dtype=torch_dtype).npu()
+
+    torch.npu.synchronize()
+
+    c = func(a, b)
+    ref_c = a | b
+    assert_close_npu(c, ref_c, dtype, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", ["int16", pytest.param("uint16", marks=pytest.mark.low_priority)])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("shape", [(1024, 1024)])
+def test_bitwise_or(dtype, target, shape):
+    M, N = shape
+    run_test_bitwise_or(M, N, 128, 256, dtype, target=target)
+
+
+def run_test_bitwise_or_ext(dtype, target):
+    """Extended bitwise_or test supporting int8/uint8/int32/uint32."""
+    M, N = 1024, 1024
+    block_M = _BITWISE_OR_BLOCK_M[dtype]
+    block_N = 256
+    VEC_NUM = 2
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        B: T.Tensor((M, N), dtype),  # type: ignore
+        C: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+            T.tile.bitwise_or(c_ub, a_ub, b_ub)
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+    td = _TORCH_INT_DTYPE_OR[dtype]
+    a = torch.randint(0, 100, (M, N), dtype=td).npu()
+    b = torch.randint(0, 100, (M, N), dtype=td).npu()
+    torch.npu.synchronize()
+    c = func(a, b)
+    ref_c = a | b
+    assert_close_npu(c, ref_c, dtype, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", ["int8", "uint8"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_or_int8_uint8(dtype, target):
+    """int8/uint8 are supported on A2/A3 for both backends."""
+    run_test_bitwise_or_ext(dtype, target)
+
+
+@pytest.mark.xfail(
+    reason="int32 on ascendc produces 50% wrong results: CANN OrImpl count-mode "
+    "reinterprets int32 as int16 but sets mask to int32 count, processing only "
+    "half the data. PTO rejects int32 via static_assert(sizeof(T)==2||1)."
+)
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_or_int32(target):
+    run_test_bitwise_or_ext("int32", target)
+
+
+def run_test_bitwise_or_scalar(target):
+    """Scalar src1 path generates tl.ascend_bitwise_ors which is not registered."""
+    M, N = 1024, 1024
+    block_M, block_N = 128, 256
+    VEC_NUM = 2
+    m_num = M // block_M
+    n_num = N // block_N
+    dtype = "int16"
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        C: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.tile.bitwise_or(c_ub, a_ub, 0xFF)
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+
+@pytest.mark.xfail(
+    raises=Exception,
+    reason="Scalar src1 path uses tl.ascend_bitwise_ors which is not registered "
+    "in C++ (no TIR_DEFINE_TL_BUILTIN(ascend_bitwise_ors) in src/op/ascend.cc).",
+)
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_or_scalar_not_registered(target):
+    run_test_bitwise_or_scalar(target)
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_or_buffer_region(target):
+    """BufferRegion slices are supported as operands."""
+    M, N = 1024, 1024
+    block_M, block_N = 128, 256
+    VEC_NUM = 2
+    m_num = M // block_M
+    n_num = N // block_N
+    dtype = "int16"
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        B: T.Tensor((M, N), dtype),  # type: ignore
+        C: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+            T.tile.bitwise_or(
+                c_ub[0 : block_M // VEC_NUM, 0:block_N],
+                a_ub[0 : block_M // VEC_NUM, 0:block_N],
+                b_ub[0 : block_M // VEC_NUM, 0:block_N],
+            )
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+    a = torch.randint(0, 100, (M, N), dtype=torch.int16).npu()
+    b = torch.randint(0, 100, (M, N), dtype=torch.int16).npu()
+    torch.npu.synchronize()
+    c = func(a, b)
+    ref_c = a | b
+    assert_close_npu(c, ref_c, dtype, rtol=0, atol=0)
+
+
 def axpy(M, N, block_M, block_N, dtype="float"):
     m_num = M // block_M
     n_num = N // block_N

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -349,206 +349,6 @@ def test_bitwise_and(dtype, target, shape):
     run_test_bitwise_and(M, N, 128, 256, dtype, target=target)
 
 
-# ---- Factcheck: bitwise_or tests ----
-
-_TORCH_INT_DTYPE_OR = {
-    "int8": torch.int8,
-    "uint8": torch.uint8,
-    "int16": torch.int16,
-    "uint16": torch.uint16,
-    "int32": torch.int32,
-    "uint32": torch.uint32,
-}
-
-_BITWISE_OR_BLOCK_M = {
-    "int8": 128,
-    "uint8": 128,
-    "int16": 128,
-    "uint16": 128,
-    "int32": 64,
-    "uint32": 64,
-}
-
-
-def bitwise_or(M, N, block_M, block_N, dtype="int16"):
-    m_num = M // block_M
-    n_num = N // block_N
-
-    VEC_NUM = 2
-
-    @T.prim_func
-    def main(
-        A: T.Tensor((M, N), dtype),  # type: ignore
-        B: T.Tensor((M, N), dtype),  # type: ignore
-        C: T.Tensor((M, N), dtype),  # type: ignore
-    ):
-        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
-            bx = cid // n_num
-            by = cid % n_num
-
-            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
-            T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
-            T.tile.bitwise_or(c_ub, a_ub, b_ub)
-            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
-
-    return main
-
-
-def run_test_bitwise_or(M, N, block_M, block_N, dtype, target):
-    func = bitwise_or(M, N, block_M, block_N, dtype)
-    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
-
-    torch_dtype = torch.int16 if dtype == "int16" else torch.uint16
-    a = torch.randint(0, 10, (M, N), dtype=torch_dtype).npu()
-    b = torch.randint(0, 10, (M, N), dtype=torch_dtype).npu()
-
-    torch.npu.synchronize()
-
-    c = func(a, b)
-    ref_c = a | b
-    assert_close_npu(c, ref_c, dtype, rtol=0, atol=0)
-
-
-@pytest.mark.parametrize("dtype", ["int16", pytest.param("uint16", marks=pytest.mark.low_priority)])
-@pytest.mark.parametrize("target", ["ascendc", "pto"])
-@pytest.mark.parametrize("shape", [(1024, 1024)])
-def test_bitwise_or(dtype, target, shape):
-    M, N = shape
-    run_test_bitwise_or(M, N, 128, 256, dtype, target=target)
-
-
-def run_test_bitwise_or_ext(dtype, target):
-    """Extended bitwise_or test supporting int8/uint8/int32/uint32."""
-    M, N = 1024, 1024
-    block_M = _BITWISE_OR_BLOCK_M[dtype]
-    block_N = 256
-    VEC_NUM = 2
-    m_num = M // block_M
-    n_num = N // block_N
-
-    @T.prim_func
-    def main(
-        A: T.Tensor((M, N), dtype),  # type: ignore
-        B: T.Tensor((M, N), dtype),  # type: ignore
-        C: T.Tensor((M, N), dtype),  # type: ignore
-    ):
-        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
-            bx = cid // n_num
-            by = cid % n_num
-            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
-            T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
-            T.tile.bitwise_or(c_ub, a_ub, b_ub)
-            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
-
-    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
-    td = _TORCH_INT_DTYPE_OR[dtype]
-    a = torch.randint(0, 100, (M, N), dtype=td).npu()
-    b = torch.randint(0, 100, (M, N), dtype=td).npu()
-    torch.npu.synchronize()
-    c = func(a, b)
-    ref_c = a | b
-    assert_close_npu(c, ref_c, dtype, rtol=0, atol=0)
-
-
-@pytest.mark.parametrize("dtype", ["int8", "uint8"])
-@pytest.mark.parametrize("target", ["ascendc", "pto"])
-def test_bitwise_or_int8_uint8(dtype, target):
-    """int8/uint8 are supported on A2/A3 for both backends."""
-    run_test_bitwise_or_ext(dtype, target)
-
-
-@pytest.mark.xfail(
-    reason="int32 on ascendc produces 50% wrong results: CANN OrImpl count-mode "
-    "reinterprets int32 as int16 but sets mask to int32 count, processing only "
-    "half the data. PTO rejects int32 via static_assert(sizeof(T)==2||1)."
-)
-@pytest.mark.parametrize("target", ["ascendc", "pto"])
-def test_bitwise_or_int32(target):
-    run_test_bitwise_or_ext("int32", target)
-
-
-def run_test_bitwise_or_scalar(target):
-    """Scalar src1 path generates tl.ascend_bitwise_ors which is not registered."""
-    M, N = 1024, 1024
-    block_M, block_N = 128, 256
-    VEC_NUM = 2
-    m_num = M // block_M
-    n_num = N // block_N
-    dtype = "int16"
-
-    @T.prim_func
-    def main(
-        A: T.Tensor((M, N), dtype),  # type: ignore
-        C: T.Tensor((M, N), dtype),  # type: ignore
-    ):
-        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
-            bx = cid // n_num
-            by = cid % n_num
-            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
-            T.tile.bitwise_or(c_ub, a_ub, 0xFF)
-            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
-
-    tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
-
-
-@pytest.mark.xfail(
-    raises=Exception,
-    reason="Scalar src1 path uses tl.ascend_bitwise_ors which is not registered "
-    "in C++ (no TIR_DEFINE_TL_BUILTIN(ascend_bitwise_ors) in src/op/ascend.cc).",
-)
-@pytest.mark.parametrize("target", ["ascendc", "pto"])
-def test_bitwise_or_scalar_not_registered(target):
-    run_test_bitwise_or_scalar(target)
-
-
-@pytest.mark.parametrize("target", ["ascendc", "pto"])
-def test_bitwise_or_buffer_region(target):
-    """BufferRegion slices are supported as operands."""
-    M, N = 1024, 1024
-    block_M, block_N = 128, 256
-    VEC_NUM = 2
-    m_num = M // block_M
-    n_num = N // block_N
-    dtype = "int16"
-
-    @T.prim_func
-    def main(
-        A: T.Tensor((M, N), dtype),  # type: ignore
-        B: T.Tensor((M, N), dtype),  # type: ignore
-        C: T.Tensor((M, N), dtype),  # type: ignore
-    ):
-        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
-            bx = cid // n_num
-            by = cid % n_num
-            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
-            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
-            T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
-            T.tile.bitwise_or(
-                c_ub[0 : block_M // VEC_NUM, 0:block_N],
-                a_ub[0 : block_M // VEC_NUM, 0:block_N],
-                b_ub[0 : block_M // VEC_NUM, 0:block_N],
-            )
-            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
-
-    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
-    a = torch.randint(0, 100, (M, N), dtype=torch.int16).npu()
-    b = torch.randint(0, 100, (M, N), dtype=torch.int16).npu()
-    torch.npu.synchronize()
-    c = func(a, b)
-    ref_c = a | b
-    assert_close_npu(c, ref_c, dtype, rtol=0, atol=0)
-
-
 def axpy(M, N, block_M, block_N, dtype="float"):
     m_num = M // block_M
     n_num = N // block_N
@@ -3643,6 +3443,156 @@ def run_test_bitwise_or(M, N, block_M, block_N, dtype, target):
 def test_bitwise_or(dtype, target, shape):
     M, N = shape
     run_test_bitwise_or(M, N, 128, 256, dtype, target=target)
+
+
+# ---- Factcheck: extended bitwise_or tests ----
+
+_TORCH_INT_DTYPE_OR = {
+    "int8": torch.int8,
+    "uint8": torch.uint8,
+    "int16": torch.int16,
+    "uint16": torch.uint16,
+    "int32": torch.int32,
+    "uint32": torch.uint32,
+}
+
+_BITWISE_OR_BLOCK_M = {
+    "int8": 128,
+    "uint8": 128,
+    "int16": 128,
+    "uint16": 128,
+    "int32": 64,
+    "uint32": 64,
+}
+
+
+def run_test_bitwise_or_ext(dtype, target):
+    """Extended bitwise_or test supporting int8/uint8/int32/uint32."""
+    M, N = 1024, 1024
+    block_M = _BITWISE_OR_BLOCK_M[dtype]
+    block_N = 256
+    VEC_NUM = 2
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        B: T.Tensor((M, N), dtype),  # type: ignore
+        C: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+            T.tile.bitwise_or(c_ub, a_ub, b_ub)
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+    td = _TORCH_INT_DTYPE_OR[dtype]
+    a = torch.randint(0, 100, (M, N), dtype=td).npu()
+    b = torch.randint(0, 100, (M, N), dtype=td).npu()
+    torch.npu.synchronize()
+    c = func(a, b)
+    ref_c = a | b
+    assert_close_npu(c, ref_c, dtype, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", ["int8", "uint8"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_or_int8_uint8(dtype, target):
+    """int8/uint8 are supported on A2/A3 for both backends."""
+    run_test_bitwise_or_ext(dtype, target)
+
+
+@pytest.mark.xfail(
+    reason="int32 on ascendc produces 50% wrong results: CANN OrImpl count-mode "
+    "reinterprets int32 as int16 but sets mask to int32 count, processing only "
+    "half the data. PTO rejects int32 via static_assert(sizeof(T)==2||1)."
+)
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_or_int32(target):
+    run_test_bitwise_or_ext("int32", target)
+
+
+def run_test_bitwise_or_scalar(target):
+    """Scalar src1 path generates tl.ascend_bitwise_ors which is not registered."""
+    M, N = 1024, 1024
+    block_M, block_N = 128, 256
+    VEC_NUM = 2
+    m_num = M // block_M
+    n_num = N // block_N
+    dtype = "int16"
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        C: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.tile.bitwise_or(c_ub, a_ub, 0xFF)
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+
+@pytest.mark.xfail(
+    raises=Exception,
+    reason="Scalar src1 path uses tl.ascend_bitwise_ors which is not registered "
+    "in C++ (no TIR_DEFINE_TL_BUILTIN(ascend_bitwise_ors) in src/op/ascend.cc).",
+)
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_or_scalar_not_registered(target):
+    run_test_bitwise_or_scalar(target)
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_or_buffer_region(target):
+    """BufferRegion slices are supported as operands."""
+    M, N = 1024, 1024
+    block_M, block_N = 128, 256
+    VEC_NUM = 2
+    m_num = M // block_M
+    n_num = N // block_N
+    dtype = "int16"
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        B: T.Tensor((M, N), dtype),  # type: ignore
+        C: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+            T.tile.bitwise_or(
+                c_ub[0 : block_M // VEC_NUM, 0:block_N],
+                a_ub[0 : block_M // VEC_NUM, 0:block_N],
+                b_ub[0 : block_M // VEC_NUM, 0:block_N],
+            )
+            T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+    a = torch.randint(0, 100, (M, N), dtype=torch.int16).npu()
+    b = torch.randint(0, 100, (M, N), dtype=torch.int16).npu()
+    torch.npu.synchronize()
+    c = func(a, b)
+    ref_c = a | b
+    assert_close_npu(c, ref_c, dtype, rtol=0, atol=0)
 
 
 def vec_pow(M, N, block_M, block_N, dtype="float"):

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1106,15 +1106,9 @@ def bitwise_or(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, src1: Bu
     Args:
         dst: The destination buffer.
         src0: The first source buffer.
-        src1: The second source operand (Buffer, BufferRegion, or BufferLoad).
-            Note: scalar (PrimExpr/int/float) is declared in the signature but the
-            scalar path (tl.ascend_bitwise_ors) is not registered in C++, so
-            passing a scalar will raise "Operator tl.ascend_bitwise_ors is not
-            registered" at compile time.
+        src1: The second source operand. Scalar operands are currently unsupported.
 
-    Supported dtypes on A2/A3 (verified): int8, uint8, int16, uint16.
-    int32/uint32 compile on AscendC but produce 50% wrong results (CANN OrImpl
-    count-mode mask bug); PTO rejects them via static_assert(sizeof(T)==2||1).
+    Supported dtypes on A2/A3: int8, uint8, int16, uint16.
     """
     return binary_op(dst, src0, src1, "bitwise_or")
 

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1106,7 +1106,15 @@ def bitwise_or(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, src1: Bu
     Args:
         dst: The destination buffer.
         src0: The first source buffer.
-        src1: The second source operand (Buffer, BufferLoad, or Scalar).
+        src1: The second source operand (Buffer, BufferRegion, or BufferLoad).
+            Note: scalar (PrimExpr/int/float) is declared in the signature but the
+            scalar path (tl.ascend_bitwise_ors) is not registered in C++, so
+            passing a scalar will raise "Operator tl.ascend_bitwise_ors is not
+            registered" at compile time.
+
+    Supported dtypes on A2/A3 (verified): int8, uint8, int16, uint16.
+    int32/uint32 compile on AscendC but produce 50% wrong results (CANN OrImpl
+    count-mode mask bug); PTO rejects them via static_assert(sizeof(T)==2||1).
     """
     return binary_op(dst, src0, src1, "bitwise_or")
 


### PR DESCRIPTION
1. 文件改动
文件	类型	改动说明
docs/language/tile_bitwise_or.md	新增	事实校验完成版 API 文档。修正 dtype 支持表（A2/A3 实际支持 int8/uint8/int16/uint16，原文档仅声明 int16/uint16）；标注标量 src1 不可用；标注 int32/uint32 结果错误；删除原文档中 tensor-scalar 示例；修正 A5 支持声明（与 CANN dav_m300 头文件矛盾）
tilelang/language/ascend_tile.py	修改	更新 bitwise_or 函数 docstring：将 src1 类型说明从 (Buffer, BufferLoad, or Scalar) 改为 (Buffer, BufferRegion, or BufferLoad)，标注标量路径未注册，标注已验证 dtype 支持范围和 int32/uint32 限制
testing/python/language/test_tilelang_ascend_language_elementwise.py	修改	新增 10 个 test_bitwise_or* 测试用例（连同基线 test_bitwise_or 共 14 个），覆盖 int16/uint16/int8/uint8 tensor-tensor、BufferRegion 切片、int32 预期失败（XFAIL）、标量 src1 预期失败（XFAIL）
2. 测试用例
2.1 约束测试（动态验证）
验证项	测什么	结果
int16/uint16 tensor-tensor	dtype=int16/uint16, shape=(1024,1024), backend=ascendc/pto	编译通过、运行通过、精度通过（rtol=0, atol=0）
int8/uint8 tensor-tensor	dtype=int8/uint8, shape=(1024,1024), backend=ascendc/pto	编译通过、运行通过、精度通过（rtol=0, atol=0），证伪原文档"A2/A3 仅支持 int16/uint16"
BufferRegion 切片操作数	dtype=int16, BufferRegion 切片作为 dst/src0/src1, backend=ascendc/pto	编译通过、运行通过、精度通过（rtol=0, atol=0）
int32 tensor-tensor	dtype=int32, backend=ascendc	编译通过、运行通过、精度失败：50% 元素错误（32768/65536），CANN OrImpl count 模式 mask bug
int32 tensor-tensor	dtype=int32, backend=pto	编译失败：static_assert 拒绝（sizeof(T)==2 || sizeof(T)==1），Fix: TOR has invalid data type
标量 src1	src1=0xFF（int 标量）, dtype=int16, backend=ascendc/pto	编译失败：Operator tl.ascend_bitwise_ors is not registered，C++ 层未注册 TIR_DEFINE_TL_BUILTIN(ascend_bitwise_ors)
2.2 正式测试文件
测试函数	用例数	测什么
test_bitwise_or	4	int16/uint16 tensor-tensor，ascendc + pto
test_bitwise_or_int8_uint8	4	int8/uint8 tensor-tensor，ascendc + pto
test_bitwise_or_int32	2	int32 预期失败（XFAIL），ascendc + pto
test_bitwise_or_scalar_not_registered	2	标量 src1 预期失败（XFAIL），ascendc + pto
test_bitwise_or_buffer_region	2	BufferRegion 切片操作数，ascendc + pto

2.3 测试用例统计与 LP 分层（新增）

testing/python/language/test_tilelang_ascend_language_elementwise.py 新增 10 个用例（6 PASSED + 4 XFAIL），不重复基线已有测试（test_bitwise_or：int16 默认 / uint16 low_priority × ascendc/pto × (1024,1024)）

- 当前实际：新增用例均未打 low_priority 标记 → PR 触发执行 10 个，定时任务触发执行 10 个（无差异）
- 建议分层：仅保留 2 个核心用例（主流 dtype int16@ascendc + 关键结论 int8@ascendc）在 PR 提交阶段执行，其余 8 个标 low_priority 放到定时执行阶段 → PR 触发执行 2 个，定时任务触发执行 10 个（8 个仅定时执行）

| 测试函数 | 用例数 | PR执行 | LP | 类型 | 覆盖内容 |
|---|:---:|:---:|:---:|---|---|
| `test_bitwise_or_int8_uint8` | 4 | 1 | 3 | dtype 泛化 | int8/uint8 × ascendc/pto（int8@ascendc 为核心：证伪"A2/A3 仅支持 int16/uint16"） |
| `test_bitwise_or_int32` | 2 | 0 | 2 | 异常边界 | int32 预期失败（XFAIL）：ascendc 50% 精度错误 / pto static_assert 拒绝 |
| `test_bitwise_or_scalar_not_registered` | 2 | 0 | 2 | 异常边界 | 标量 src1 预期失败（XFAIL）：`tl.ascend_bitwise_ors` 未注册 |
| `test_bitwise_or_buffer_region` | 2 | 1 | 1 | 功能泛化 | int16 BufferRegion 切片操作数 × ascendc/pto |

LP 标记策略（建议，参照 #1676 已落地惯例）：
- dtype：int16（主流 dtype）默认执行，int8/uint8/int32 等扩展 dtype 标 low_priority（每函数保留 1 个核心用例 @ascendc）
- target：ascendc（主后端）默认执行，pto 标 low_priority
- XFAIL 异常边界用例整体标 low_priority（编译期快速失败/已知限制，移至每日 CI 执行）

3. 测试结果
- 测试环境：Ascend 910B3（A2/A3），CANN 8.5.2，torch 2.7.1+cpu，torch_npu 2.7.1.post4，Python 3.11.4
- 约束测试：int32 ascendc 50% 错误（32768/65536 元素不匹配）、pto static_assert 拒绝，均已通过独立脚本复现确认
- 正式测试：10 passed, 4 xfailed, 0 failed, 0 skipped（14 用例，98.22s）
- 必要回归测试：test_bitwise_and 4 passed（41.26s），确认未影响同类算子
3.1 Pytest 标签
测试函数或参数组合	标签	PR 阶段是否执行	原因
test_bitwise_or[shape0-*-uint16]	low_priority	否（PR 事件跳过，由每日定时 CI 执行）	uint16 为低优先级参数，与仓库现有 bitwise_and 测试一致
test_bitwise_or_int32	xfail	是	int32 已知失败，标注原因
test_bitwise_or_scalar_not_registered	xfail	是	标量路径未注册，标注原因
4. 校验过程中发现的问题
1. dtype 支持范围错误：原文档声明 A2/A3 仅支持 int16/uint16，A5 支持 int8/uint8/int16/uint16/int32/uint32/int64/uint64。真机测试证明 A2/A3 的 ascendc 和 pto 后端均正确支持 int8/uint8（vor 指令按 int16 重解释后结果正确）。文档已修正为 int8/uint8/int16/uint16 均支持。
2. 标量 src1 不可用：原文档示例包含 T.tile.bitwise_or(dst, src0, 0x0F) 的 tensor-scalar 用法，暗示标量路径可用。静态检查确认 src/op/ascend.cc 中无 TIR_DEFINE_TL_BUILTIN(ascend_bitwise_ors)，动态测试确认编译报 Operator tl.ascend_bitwise_ors is not registered。文档已删除标量示例，docstring 已标注限制。
3. int32/uint32 结果错误：原文档未提及 int32/uint32 的限制。真机测试发现 ascendc 后端编译通过但产生 50% 错误结果（CANN OrImpl count 模式将 int32 按 int16 重解释，mask 只覆盖一半数据），pto 后端通过 static_assert 编译期拒绝。文档和 docstring 已标注此限制。
4. A5 dtype 声明矛盾：原文档声称 A5 支持 int32/uint32/int64/uint64，但 CANN dav_m300 头文件 OrImpl 仅有 int16_t / uint16_t 特化，其他类型触发 ASCENDC_ASSERT(false)。当前环境无法验证 A5，文档已标注此矛盾。
5. 未解决问题与风险
- int32/uint32 在 ascendc 后端的 50% 错误结果为 CANN 底层 OrImpl count 模式 mask bug，与 bitwise_and 相同根因，本次仅做文档标注，未修复 CANN 实现
- 标量 src1 路径（tl.ascend_bitwise_ors）未注册，需后续在 src/op/ascend.cc 补充注册或在前端拒绝
- A5 平台 dtype 支持范围无法在当前环境（A2/A3）验证，文档中 A5 相关声明为基于头文件的静态推断
- float 类型编译通过但结果无意义，文档已标注但不阻止编译
6. 验证
- python -m pytest -k "test_bitwise_or" -v：通过，10 passed, 4 xfailed, 98.22s
- python -m pytest -k "test_bitwise_and" -v（回归）：通过，4 passed, 41.26s
- python -m pytest -k "test_bitwise_or or test_bitwise_and" -v（合并回归）：通过，14 passed, 4 xfailed, 117.24s
- python /tmp/opencode/test_int32_or.py（int32 ascendc 独立验证）：确认 50% 元素错误
- python /tmp/opencode/test_int32_or_pto.py（int32 pto 独立验证）：确认 static_assert 拒绝
- git diff --check：通过，无 whitespace 问题
- python -c "import ast; ast.parse(open('...').read())"：通过，语法正确
汇总：
- 编译验证：通过
- NPU 运行：通过
- 精度验证：通过（int8/uint8/int16/uint16）；预期失败（int32/标量）
- 目标测试：14 用例（10 passed, 4 xfailed）
- 回归测试：4 passed（bitwise_and）
- 语法检查：通过
- Ruff/格式检查：未执行（当前环境无 Ruff）