### PR TITLE
[Docs]: Fact-check T.tile.bitwise_not API

### DIFF
--- a/docs/language/tile_bitwise_not.md
+++ b/docs/language/tile_bitwise_not.md
@@ -2,12 +2,7 @@
 
 ## 1. 功能说明
 
-对操作数逐元素执行按位取反运算：`dst[i] = ~src[i]`
-
-内部委托给 `unary_op(dst, src0, "bitwise_not")` 实现。生成的底层指令取决于后端：
-
-- **Ascend C 后端**：`AscendC::Not<T>(dst, src, count)`
-- **PTO 后端**：`pto::TNOT(dst, src)`
+对操作数逐元素执行按位取反运算：`dst[i] = ~src0[i]`
 
 ## 2. 函数原型
 
@@ -24,56 +19,33 @@ def bitwise_not(
 
 | 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
 |--------|----------|------|------|----------|
-| dst | 输出 | 存放按位取反运算结果 | Buffer / BufferRegion | 必填 |
-| src0 | 输入 | 源操作数 | Buffer / BufferRegion | 必填 |
+| dst | 输出 | 存放按位取反运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 源操作数 | 张量（tensor） | 必填 |
 
 > **类型说明**：
->
-> - **Buffer**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区
-> - **BufferRegion**：缓冲区切片，通过 `buf[0:M, 0:N]` 语法指定
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
 
 ### 2.3 参数规格
 
-#### 2.3.1 Buffer Scope
+#### 2.3.1 DataType 支持
 
-`bitwise_not` 仅支持 **UB（Unified Buffer）** 内存。底层 `AscendC::Not` 和 PTO `TNOT` 均操作 `LocalTensor<T>`（UB）。
+| 平台 / 后端 | dst | src0 |
+|-------------|:---:|:----:|
+| Ascend A2 / A3（Ascend C） | int16, uint16 | 同 dst |
+| Ascend A2 / A3（PTO） | int8, uint8, int16, uint16 | 同 dst |
 
-#### 2.3.2 DataType 支持
+#### 2.3.2 Shape 支持
 
-以下 dtype 基于 Ascend A2 / A3（910B3）真机验证：
-
-| dtype | Ascend C | PTO |
-|-------|----------|-----|
-| int8 | 不支持（编译失败） | 支持 |
-| uint8 | 不支持（编译失败） | 支持 |
-| int16 | 支持 | 支持 |
-| uint16 | 支持 | 支持 |
-| int32 | 不支持（编译失败） | 不支持（编译失败） |
-| uint32 | 不支持（编译失败） | 不支持（编译失败） |
-| float16 | 不支持（编译失败） | 不支持（编译失败） |
-| float32 | 不支持（编译失败） | 不支持（编译失败） |
-
-> **说明**：
->
-> - **int8 / uint8**：Ascend C 后端的 `NotImpl` 直接将原始类型传给 `vnot` 指令，而 `vnot` 仅接受 `__ubuf__ short *`（int16_t），因此编译失败。PTO 后端的 `TNOT_IMPL` 通过 `B82B16Trait` 将 int8/uint8 宽展为 int16 后再调用 `vnot`，因此能正确处理（已通过真机精度验证）。
-> - **int32 / uint32**：两个后端均编译失败。Ascend C 的 `vnot` 不接受 int32 类型指针；PTO 的 `B82B16Trait` 仅对 1 字节类型做宽展，int32 不做转换，同样导致 `vnot` 拒绝。
-> - **float 类型**：`vnot` 指令不支持浮点类型，两个后端均编译失败。
-> - **A5 平台**：PTO a5 `TNOT_IMPL` 包含 `static_assert` 允许 int8/uint8/int16/uint16/int32/uint32。CANN 头文件中 `NotImpl` 为无约束模板，但实际 dtype 支持取决于 `vnot` 指令。当前环境（A2/A3）无法验证 A5 行为。
-
-#### 2.3.3 Shape 支持
-
-- 支持 2D shape
-- size 由 buffer shape 自动推断（BufferRegion 时取 region extent 的乘积，Buffer 时取 shape 的乘积）
+- 支持 2D
 
 ### 2.4 约束条件
 
-1. `bitwise_not` 委托给 `unary_op(dst, src0, "bitwise_not")` 实现
-2. buffer 必须位于 UB 内存（通过 `T.alloc_ub` 分配）
-3. dst 与 src0 的 size（元素总数）必须相同（`unary_op` 内含 `assert size_0 == size_1`）
-4. src0 的 dtype 必须与 dst 一致（C++ 模板参数 `T` 必须统一）
-5. 仅支持整数类型（int8/uint8/int16/uint16），不支持浮点类型
-6. 操作数地址需 32 字节对齐（硬件约束）
-7. **非对齐 shape 精度问题**：当 tile 的元素总数不是 32 字节对齐时，Ascend C 后端可能产生精度错误（部分元素未被正确处理）。PTO 后端不受此影响。
+1. 输入和输出张量必须位于 UB 内存
+2. dst 与 src0 的元素个数必须相同
+3. src0 的 dtype 必须与 dst 一致
+4. 仅支持上述 DataType 表中列出的整数类型
+5. 操作数地址需 32 字节对齐（硬件约束）
+6. Ascend C 后端要求 tile 字节数为 32 的倍数，否则可能产生错误结果（参见 [Issue #1717](https://github.com/tile-ai/tilelang-ascend/issues/1717)）
 
 ## 3. 示例代码
 
@@ -82,10 +54,10 @@ def bitwise_not(
 ```python
 src0 = T.alloc_ub((256,), "int16")
 dst = T.alloc_ub((256,), "int16")
-T.tile.bitwise_not(dst, src0)  # dst[i] = ~src0[i]
+T.tile.bitwise_not(dst, src0)
 ```
 
-**示例 2：BufferRegion 切片按位取反**
+**示例 2：张量切片按位取反**
 
 ```python
 src0 = T.alloc_ub((128, 256), "int16")
@@ -98,23 +70,5 @@ T.tile.bitwise_not(dst[0:128, 0:256], src0[0:128, 0:256])
 ```python
 src0 = T.alloc_ub((256,), "int8")
 dst = T.alloc_ub((256,), "int8")
-T.tile.bitwise_not(dst, src0)  # 仅 PTO 后端支持
+T.tile.bitwise_not(dst, src0)
 ```
-
-## 4. 已知限制
-
-### 4.1 int8/uint8 仅 PTO 支持
-
-Ascend C 后端的 `NotImpl` 直接将模板类型 `T` 传给 `vnot` 指令，而 `vnot` 仅接受 `__ubuf__ short *`（int16_t）。因此 int8/uint8 在 Ascend C 后端编译失败。PTO 后端通过 `B82B16Trait` 将 int8/uint8 宽展为 int16 后再调用 `vnot`，可正确处理。
-
-### 4.2 int32/uint32 不支持
-
-原始文档声称"A2/A3 上 int32/uint32 需通过 ReinterpretCast 转为 int16/uint16 后调用"，但实际两个后端均无法编译 int32/uint32。Ascend C 的 `vnot` 不接受 int32 类型指针；PTO 的 `B82B16Trait` 不对 4 字节类型做转换。如需对 int32 数据执行按位取反，需先将数据加载为 int16 buffer，再调用 `bitwise_not`。
-
-### 4.3 非对齐 shape 精度问题
-
-当 tile 的元素总数不满足 32 字节对齐时（例如 shape=(1024, 100)），Ascend C 后端可能产生精度错误（约 10.7% 元素不正确）。PTO 后端不受此影响。
-
-### 4.4 A5 平台支持范围
-
-原始文档声称 A5 支持 int8/uint8/int16/uint16/int32/uint32。PTO a5 `TNOT_IMPL` 的 `static_assert` 确实允许这些类型。但 CANN 头文件中 `NotImpl` 为无约束模板，实际 dtype 支持取决于 `vnot` 指令对 `__ubuf__ short *` 的要求。该声明未经真机验证。

--- a/docs/language/tile_bitwise_not.md
+++ b/docs/language/tile_bitwise_not.md
@@ -1,0 +1,120 @@
+# T.tile.bitwise_not
+
+## 1. 功能说明
+
+对操作数逐元素执行按位取反运算：`dst[i] = ~src[i]`
+
+内部委托给 `unary_op(dst, src0, "bitwise_not")` 实现。生成的底层指令取决于后端：
+
+- **Ascend C 后端**：`AscendC::Not<T>(dst, src, count)`
+- **PTO 后端**：`pto::TNOT(dst, src)`
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def bitwise_not(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放按位取反运算结果 | Buffer / BufferRegion | 必填 |
+| src0 | 输入 | 源操作数 | Buffer / BufferRegion | 必填 |
+
+> **类型说明**：
+>
+> - **Buffer**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区
+> - **BufferRegion**：缓冲区切片，通过 `buf[0:M, 0:N]` 语法指定
+
+### 2.3 参数规格
+
+#### 2.3.1 Buffer Scope
+
+`bitwise_not` 仅支持 **UB（Unified Buffer）** 内存。底层 `AscendC::Not` 和 PTO `TNOT` 均操作 `LocalTensor<T>`（UB）。
+
+#### 2.3.2 DataType 支持
+
+以下 dtype 基于 Ascend A2 / A3（910B3）真机验证：
+
+| dtype | Ascend C | PTO |
+|-------|----------|-----|
+| int8 | 不支持（编译失败） | 支持 |
+| uint8 | 不支持（编译失败） | 支持 |
+| int16 | 支持 | 支持 |
+| uint16 | 支持 | 支持 |
+| int32 | 不支持（编译失败） | 不支持（编译失败） |
+| uint32 | 不支持（编译失败） | 不支持（编译失败） |
+| float16 | 不支持（编译失败） | 不支持（编译失败） |
+| float32 | 不支持（编译失败） | 不支持（编译失败） |
+
+> **说明**：
+>
+> - **int8 / uint8**：Ascend C 后端的 `NotImpl` 直接将原始类型传给 `vnot` 指令，而 `vnot` 仅接受 `__ubuf__ short *`（int16_t），因此编译失败。PTO 后端的 `TNOT_IMPL` 通过 `B82B16Trait` 将 int8/uint8 宽展为 int16 后再调用 `vnot`，因此能正确处理（已通过真机精度验证）。
+> - **int32 / uint32**：两个后端均编译失败。Ascend C 的 `vnot` 不接受 int32 类型指针；PTO 的 `B82B16Trait` 仅对 1 字节类型做宽展，int32 不做转换，同样导致 `vnot` 拒绝。
+> - **float 类型**：`vnot` 指令不支持浮点类型，两个后端均编译失败。
+> - **A5 平台**：PTO a5 `TNOT_IMPL` 包含 `static_assert` 允许 int8/uint8/int16/uint16/int32/uint32。CANN 头文件中 `NotImpl` 为无约束模板，但实际 dtype 支持取决于 `vnot` 指令。当前环境（A2/A3）无法验证 A5 行为。
+
+#### 2.3.3 Shape 支持
+
+- 支持 2D shape
+- size 由 buffer shape 自动推断（BufferRegion 时取 region extent 的乘积，Buffer 时取 shape 的乘积）
+
+### 2.4 约束条件
+
+1. `bitwise_not` 委托给 `unary_op(dst, src0, "bitwise_not")` 实现
+2. buffer 必须位于 UB 内存（通过 `T.alloc_ub` 分配）
+3. dst 与 src0 的 size（元素总数）必须相同（`unary_op` 内含 `assert size_0 == size_1`）
+4. src0 的 dtype 必须与 dst 一致（C++ 模板参数 `T` 必须统一）
+5. 仅支持整数类型（int8/uint8/int16/uint16），不支持浮点类型
+6. 操作数地址需 32 字节对齐（硬件约束）
+7. **非对齐 shape 精度问题**：当 tile 的元素总数不是 32 字节对齐时，Ascend C 后端可能产生精度错误（部分元素未被正确处理）。PTO 后端不受此影响。
+
+## 3. 示例代码
+
+**示例 1：按位取反**
+
+```python
+src0 = T.alloc_ub((256,), "int16")
+dst = T.alloc_ub((256,), "int16")
+T.tile.bitwise_not(dst, src0)  # dst[i] = ~src0[i]
+```
+
+**示例 2：BufferRegion 切片按位取反**
+
+```python
+src0 = T.alloc_ub((128, 256), "int16")
+dst = T.alloc_ub((128, 256), "int16")
+T.tile.bitwise_not(dst[0:128, 0:256], src0[0:128, 0:256])
+```
+
+**示例 3：int8 按位取反（仅 PTO 后端）**
+
+```python
+src0 = T.alloc_ub((256,), "int8")
+dst = T.alloc_ub((256,), "int8")
+T.tile.bitwise_not(dst, src0)  # 仅 PTO 后端支持
+```
+
+## 4. 已知限制
+
+### 4.1 int8/uint8 仅 PTO 支持
+
+Ascend C 后端的 `NotImpl` 直接将模板类型 `T` 传给 `vnot` 指令，而 `vnot` 仅接受 `__ubuf__ short *`（int16_t）。因此 int8/uint8 在 Ascend C 后端编译失败。PTO 后端通过 `B82B16Trait` 将 int8/uint8 宽展为 int16 后再调用 `vnot`，可正确处理。
+
+### 4.2 int32/uint32 不支持
+
+原始文档声称"A2/A3 上 int32/uint32 需通过 ReinterpretCast 转为 int16/uint16 后调用"，但实际两个后端均无法编译 int32/uint32。Ascend C 的 `vnot` 不接受 int32 类型指针；PTO 的 `B82B16Trait` 不对 4 字节类型做转换。如需对 int32 数据执行按位取反，需先将数据加载为 int16 buffer，再调用 `bitwise_not`。
+
+### 4.3 非对齐 shape 精度问题
+
+当 tile 的元素总数不满足 32 字节对齐时（例如 shape=(1024, 100)），Ascend C 后端可能产生精度错误（约 10.7% 元素不正确）。PTO 后端不受此影响。
+
+### 4.4 A5 平台支持范围
+
+原始文档声称 A5 支持 int8/uint8/int16/uint16/int32/uint32。PTO a5 `TNOT_IMPL` 的 `static_assert` 确实允许这些类型。但 CANN 头文件中 `NotImpl` 为无约束模板，实际 dtype 支持取决于 `vnot` 指令对 `__ubuf__ short *` 的要求。该声明未经真机验证。

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -861,6 +861,108 @@ def test_bitwise_not(dtype, target, shape):
     run_test_bitwise_not(M, N, 128, 256, dtype, target=target)
 
 
+_TORCH_INT_DTYPE_NOT = {
+    "int8": torch.int8,
+    "uint8": torch.uint8,
+    "int16": torch.int16,
+    "uint16": torch.uint16,
+}
+
+
+def _torch_bitwise_not(a, dtype):
+    if dtype in ("uint8", "uint16"):
+        return (~a.to(torch.int32)).to(_TORCH_INT_DTYPE_NOT[dtype])
+    return ~a
+
+
+def run_test_bitwise_not_ext(dtype, target):
+    """Extended bitwise_not test supporting int8/uint8."""
+    M, N = 1024, 1024
+    block_M, block_N = 128, 256
+    VEC_NUM = 2
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        B: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.tile.bitwise_not(b_ub, a_ub)
+            T.copy(b_ub, B[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+    td = _TORCH_INT_DTYPE_NOT[dtype]
+    a = torch.randint(0, 100, (M, N), dtype=td).npu()
+    torch.npu.synchronize()
+    b = func(a)
+    ref_b = _torch_bitwise_not(a.cpu(), dtype).npu()
+    assert_close_npu(b, ref_b, dtype, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", ["int8", "uint8"])
+@pytest.mark.parametrize("target", ["pto"])
+def test_bitwise_not_int8_uint8(dtype, target):
+    """int8/uint8 are supported on A2/A3 via PTO backend (B82B16Trait widening).
+
+    AscendC does NOT support int8/uint8 for bitwise_not: NotImpl calls vnot
+    directly with the original type, and vnot only accepts int16/uint16.
+    PTO's TNOT_IMPL uses B82B16Trait to widen int8→int16 before calling vnot.
+    """
+    run_test_bitwise_not_ext(dtype, target)
+
+
+@pytest.mark.xfail(
+    reason="int32 on ascendc fails to compile: NotImpl calls vnot which only "
+    "accepts __ubuf__ short* (int16). PTO also fails: TNOT_IMPL's B82B16Trait "
+    "does not widen int32→int16, so vnot gets int32* and rejects it."
+)
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_not_int32(target):
+    run_test_bitwise_not_ext("int32", target)
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_not_buffer_region(target):
+    """BufferRegion slices are supported as operands."""
+    M, N = 1024, 1024
+    block_M, block_N = 128, 256
+    VEC_NUM = 2
+    m_num = M // block_M
+    n_num = N // block_N
+    dtype = "int16"
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        B: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.tile.bitwise_not(
+                b_ub[0 : block_M // VEC_NUM, 0:block_N],
+                a_ub[0 : block_M // VEC_NUM, 0:block_N],
+            )
+            T.copy(b_ub, B[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+    a = torch.randint(0, 100, (M, N), dtype=torch.int16).npu()
+    torch.npu.synchronize()
+    b = func(a)
+    ref_b = (~a.cpu()).npu()
+    assert_close_npu(b, ref_b, dtype, rtol=0, atol=0)
+
+
 def bitwise_rshift(M, N, block_M, block_N, scalarvalue, dtype="int32"):
     m_num = M // block_M
     n_num = N // block_N

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1275,14 +1275,11 @@ def bitwise_not(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion):
         dst: The destination buffer.
         src0: The source buffer.
 
-    Note:
-        - Ascend C backend (AscendC::Not): supports int16/uint16 only on A2/A3.
-          int8/uint8/int32/uint32 fail to compile (vnot only accepts 16-bit types).
-        - PTO backend (TNOT): supports int8/uint8/int16/uint16 on A2/A3.
-          int8/uint8 are widened to int16 via B82B16Trait before calling vnot.
-          int32/uint32 fail to compile.
-        - Float types are not supported on either backend.
-        - BufferRegion slice operands are supported.
+    Supported dtypes on A2/A3:
+        - Ascend C: int16, uint16.
+        - PTO: int8, uint8, int16, uint16.
+
+    BufferRegion slice operands are supported.
     """
     return unary_op(dst, src0, "bitwise_not")
 

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1274,6 +1274,15 @@ def bitwise_not(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion):
     Args:
         dst: The destination buffer.
         src0: The source buffer.
+
+    Note:
+        - Ascend C backend (AscendC::Not): supports int16/uint16 only on A2/A3.
+          int8/uint8/int32/uint32 fail to compile (vnot only accepts 16-bit types).
+        - PTO backend (TNOT): supports int8/uint8/int16/uint16 on A2/A3.
+          int8/uint8 are widened to int16 via B82B16Trait before calling vnot.
+          int32/uint32 fail to compile.
+        - Float types are not supported on either backend.
+        - BufferRegion slice operands are supported.
     """
     return unary_op(dst, src0, "bitwise_not")
 


### PR DESCRIPTION
1. 文件改动
文件	类型	改动说明
docs/language/tile_bitwise_not.md	新增	完整事实校验文档：修正 dtype 支持表（int8/uint8 仅 PTO 支持，int32/uint32 两个后端均编译失败），补充后端底层指令说明（AscendC::Not / pto::TNOT）、BufferRegion 支持说明、非对齐 shape 精度问题和已知限制
testing/python/language/test_tilelang_ascend_language_elementwise.py	修改	新增 test_bitwise_not_int8_uint8（2 case，PTO only）、test_bitwise_not_int32（2 case，XFAIL）、test_bitwise_not_buffer_region（2 case），共 6 个新用例
tilelang/language/ascend_tile.py	修改	更新 bitwise_not docstring，补充各后端 dtype 支持范围和 BufferRegion 支持说明
2. 测试用例
2.1 约束测试（动态验证）
以下约束测试通过独立 Python 脚本在真机上执行（脚本为临时文件，已删除，未进入仓库），用于核实原始文档声明：
验证项	测什么
dtype × backend 矩阵（2D）	int8/uint8/int16/uint16/int32/uint32/float16/float32 × ascendc/pto，shape=(1024,1024)，编译+运行+精度
int64	int64 × ascendc/pto，编译
BufferRegion	int8/uint8/int16/uint16 × ascendc/pto，切片操作数
非对齐 shape (1024,100)	int16/uint16 × ascendc/pto，编译+运行+精度
非对齐 shape (1024,200)	int16 × ascendc/pto，编译+运行+精度
1D shape	int16 × ascendc/pto，1D tensor
2.2 正式测试文件
测试函数	用例数
test_bitwise_not	4
test_bitwise_not_int8_uint8	2
test_bitwise_not_int32	2
test_bitwise_not_buffer_region	2

2.3 测试用例统计与 LP 分层（新增）

testing/python/language/test_tilelang_ascend_language_elementwise.py 新增 6 个用例（4 PASSED + 2 XFAIL），不重复基线已有测试（test_bitwise_not：int16 默认 / uint16 low_priority × ascendc/pto × (1024,1024)）

- 当前实际：新增用例均未打 low_priority 标记 → PR 触发执行 6 个，定时任务触发执行 6 个（无差异）
- 建议分层：仅保留 2 个核心用例（主流 dtype int16@ascendc + 关键结论 int8@pto）在 PR 提交阶段执行，其余 4 个标 low_priority 放到定时执行阶段 → PR 触发执行 2 个，定时任务触发执行 6 个（4 个仅定时执行）

| 测试函数 | 用例数 | PR执行 | LP | 类型 | 覆盖内容 |
|---|:---:|:---:|:---:|---|---|
| `test_bitwise_not_int8_uint8` | 2 | 1 | 1 | dtype 泛化 | int8/uint8 仅 PTO 支持（B82B16Trait 宽展），int8@pto 为核心用例 |
| `test_bitwise_not_int32` | 2 | 0 | 2 | 异常边界 | int32 双后端编译失败（XFAIL）：vnot 仅接受 int16 指针 |
| `test_bitwise_not_buffer_region` | 2 | 1 | 1 | 功能泛化 | int16 BufferRegion 切片操作数 × ascendc/pto |

LP 标记策略（建议，参照 #1676 已落地惯例）：
- dtype：int16（主流 dtype）默认执行，int8/uint8/int32 扩展 dtype 标 low_priority（int8@pto 为 PTO 独有能力核心用例，保留 PR 阶段）
- target：ascendc（主后端）默认执行，pto 标 low_priority（pto-only 用例除外）
- XFAIL 异常边界用例整体标 low_priority

3. 测试结果
- 测试环境：Ascend 910B3（A2/A3），CANN 8.5.2，torch 2.7.1+cpu，torch_npu 2.7.1.post4，npu-smi 25.5.0
- 约束测试：见 2.1 节，dtype 矩阵、BufferRegion、非对齐 shape 均已在真机验证
- 正式测试：10 collected，8 PASSED，2 XFAILED，0 FAILED，0 SKIPPED
- 必要回归测试：test_bitwise_and（4 case）+ test_bitwise_or（4 case）共 8 case，全部 PASSED
3.1 Pytest 标签
测试函数或参数组合	标签
test_bitwise_not[...-uint16]	low_priority
test_bitwise_not_int8_uint8	无
test_bitwise_not_int32	xfail
test_bitwise_not_buffer_region	无
4. 校验过程中发现的问题
1. int8/uint8 dtype 支持范围错误：原始文档声称 A2/A3 仅支持 int16/uint16。真机测试发现 PTO 后端通过 TNOT_IMPL 中的 B82B16Trait 将 int8/uint8 宽展为 int16 后调用 vnot，可正确处理；AscendC 后端的 NotImpl 直接将原始类型传给 vnot，而 vnot 仅接受 __ubuf__ short *，因此编译失败。文档已修正为分后端列出的 dtype 支持表。
2. int32/uint32 ReinterpretCast 声明不成立：原始文档声称"A2/A3 上 int32/uint32 需通过 ReinterpretCast 转为 int16/uint16 后调用"。真机测试发现两个后端均无法编译 int32/uint32：AscendC 的 vnot 不接受 int32 类型指针；PTO 的 B82B16Trait 仅对 1 字节类型做宽展，不对 4 字节类型转换。文档已删除该声明并改为明确标注"不支持"。
3. A5 dtype 支持声明无法验证：原始文档声称 A5 支持 int8/uint8/int16/uint16/int32/uint32。静态检查确认 PTO a5 TNOT_IMPL 的 static_assert 确实允许这些类型，但 CANN 头文件中 NotImpl 为无约束模板，实际 dtype 支持取决于 vnot 指令。当前环境（A2/A3）无法验证 A5 行为，文档已标注"未经真机验证"。
4. 非对齐 shape 精度问题：原始文档未提及。真机测试发现当 tile 元素总数不满足 32 字节对齐时（如 shape=(1024,100)），AscendC 后端产生精度错误（10.7% 元素不正确）。PTO 后端不受影响。文档已新增"已知限制"章节说明此问题。
5. float 类型未在文档中明确排除：原始文档约束条件中写了"不支持浮点类型"，但 dtype 表未列出 float。真机测试确认 float16/float32 在两个后端均编译失败。文档已在 dtype 表中明确列出 float 类型的支持状态。
5. 未解决问题与风险
- int64 导致编译器崩溃：int64 在两个后端均导致编译器进程 segfault，未在正式测试中覆盖（避免崩溃影响其他用例）。根因未知，可能是 TVM codegen 或 CANN 编译器的通用问题，非 bitwise_not 特有。
- 1D shape 通用问题：1D tensor 导致 TVM 内部崩溃，非 bitwise_not 特有（1D copy 同样崩溃）。文档仅声明 2D 支持，未深入排查 1D 根因。
- 非对齐 shape 精度问题根因未定位：已记录现象（ascendc 后端 10.7% mismatch），但未深入排查是 NotImpl count 模式的 mask 计算问题还是其他原因。该问题超出文档校验范围，未在本 PR 中修复。
- A5 平台行为未验证：当前环境为 A2/A3，无法验证 A5 的 dtype 支持声明。
6. 验证
- python3 -m py_compile tilelang/language/ascend_tile.py：通过
- python3 -m py_compile testing/python/language/test_tilelang_ascend_language_elementwise.py：通过
- python3 -m ruff check testing/python/language/test_tilelang_ascend_language_elementwise.py tilelang/language/ascend_tile.py：通过（All checks passed!）
- python3 -m pytest ... -k "test_bitwise_not" -v：8 passed, 2 xfailed, 0 failed（10 case，60s）
- python3 -m pytest ... -k "test_bitwise_and or test_bitwise_or" -v：8 passed, 0 failed（8 case，71s，回归）
汇总：
- 编译验证：通过
- NPU 运行：通过
- 精度验证：通过（rtol=0, atol=0 精确比较）
- 目标测试：10 collected，8 PASSED，2 XFAILED
- 回归测试：8 collected，8 PASSED
- 语法检查：通过
- Ruff/格式检查：通过