### PR TITLE
[Docs]: Fact-check T.tile.bitwise_lshift API 🤖

### DIFF
--- a/docs/language/tile_bitwise_lshift.md
+++ b/docs/language/tile_bitwise_lshift.md
@@ -2,14 +2,9 @@
 
 ## 1. 功能说明
 
-对 buffer 中每个元素执行标量左移运算：`dst[i] = src0[i] << scalarValue`
+将源张量中的每个元素左移指定的标量位数：`dst[i] = src0[i] << scalarValue`
 
-底层委托给 `tir.call_intrin("tl.ascend_bitwise_lshift", ...)` 实现。生成的底层指令取决于后端：
-
-- **Ascend C 后端**：`AscendC::ShiftLeft<T>(dst, src, scalarValue, count)`
-- **PTO 后端**：`TSHLS(dst, src, scalar)`
-
-> **移位语义说明**：无论有符号还是无符号类型，左移均为**逻辑左移**——高位丢弃，低位补 0。底层 `vshls` / `vshl` 指令不区分符号类型，符号位不会被特殊保留。
+> **移位语义说明**：Ascend A2 / A3（910B3）实测有符号与无符号类型均表现为逻辑左移，即高位丢弃、低位补 0。该结果与 Ascend C 文档对有符号类型的描述存在差异，正在 [Issue #1718](https://github.com/tile-ai/tilelang-ascend/issues/1718) 中跟踪。
 
 ## 2. 函数原型
 
@@ -27,58 +22,34 @@ def bitwise_lshift(
 
 | 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
 |--------|----------|------|------|----------|
-| dst | 输出 | 存放左移运算结果 | Buffer / BufferRegion | 必填 |
-| src0 | 输入 | 源操作数 | Buffer / BufferRegion | 必填 |
-| scalarValue | 输入 | 位移位数（标量） | PrimExpr / Python 标量 | 必填 |
+| dst | 输出 | 存放左移运算结果 | 张量（tensor） | 必填 |
+| src0 | 输入 | 源操作数 | 张量（tensor） | 必填 |
+| scalarValue | 输入 | 位移位数 | 标量（scalar） | 必填 |
 
 > **类型说明**：
->
-> - **Buffer**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区
-> - **BufferRegion**：缓冲区切片，通过 `buf[0:M, 0:N]` 语法指定
-> - **scalarValue**：Python 标量或 PrimExpr，表示位移位数。codegen 会在 scalarValue 的 dtype 与 src0 不一致时自动插入类型转换（如 `int16(scalarValue)`），因此 Python 层面不强制要求 scalarValue 的 dtype 与 dst 一致。
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+> - **scalar**：Python 标量或 PrimExpr
 
 ### 2.3 参数规格
 
-#### 2.3.1 Buffer Scope
+#### 2.3.1 DataType 支持
 
-`bitwise_lshift` 仅支持 **UB（Unified Buffer）** 内存。底层 `AscendC::ShiftLeft` 和 PTO `TSHLS` 均操作 `LocalTensor<T>`（UB）。
+| 平台 | dst | src0 | scalarValue |
+|------|:---:|:----:|:-----------:|
+| Ascend A2 / A3 | int16, uint16, int32, uint32 | 同 dst | 标量 |
 
-#### 2.3.2 DataType 支持
-
-以下 dtype 基于 Ascend A2 / A3（910B3）真机验证：
-
-| dtype | Ascend C | PTO |
-|-------|----------|-----|
-| int8 | 不支持（编译失败） | 不支持（编译失败） |
-| uint8 | 不支持（编译失败） | 不支持（编译失败） |
-| int16 | 支持 | 支持 |
-| uint16 | 支持 | 支持 |
-| int32 | 支持 | 支持 |
-| uint32 | 支持 | 支持 |
-| int64 | 不支持（编译失败） | 不支持（编译失败） |
-| uint64 | 不支持（编译失败） | 不支持（编译失败） |
-| float16 | 不支持（编译失败） | 不支持（编译失败） |
-| float32 | 不支持（编译失败） | 不支持（编译失败） |
-
-> **说明**：
->
-> - **Ascend C 后端**：`ShiftLeftImpl` 仅有 `int16_t`、`uint16_t`、`int32_t`、`uint32_t` 的特化版本。其余类型命中通用模板，触发 `ASCENDC_ASSERT(false, ...)` 编译失败。
-> - **PTO 后端（A2/A3）**：`TShiftCheck` 的 `static_assert` 仅允许 `int32_t`、`int`、`int16_t`、`uint32_t`、`uint16_t`、`unsigned int`。其余类型触发编译失败。
-> - **A5 平台**：PTO a5 `TSHLS_IMPL` 的 `static_assert` 允许 `int8_t`、`uint8_t`、`int16_t`、`uint16_t`、`int32_t`、`uint32_t`。但 **不包含 `int64_t` / `uint64_t`**。当前环境（A2/A3）无法验证 A5 行为。
-
-#### 2.3.3 Shape 支持
+#### 2.3.2 Shape 支持
 
 - 支持 1D 和 2D
-- size 由 buffer shape 自动推断（BufferRegion 时取 region extent 的乘积，Buffer 时取 shape 的乘积）
 
 ### 2.4 约束条件
 
-1. `bitwise_lshift` 委托给 `tir.call_intrin("tl.ascend_bitwise_lshift", ...)` 实现
-2. buffer 必须位于 UB 内存（通过 `T.alloc_ub` 分配）
-3. dst 与 src0 的 size（元素总数）必须相同（源码内含 `assert size_0 == size_2`）
-4. src0 的 dtype 必须与 dst 一致（C++ 模板参数 `T` 必须统一）
-5. 仅支持整数类型（int16/uint16/int32/uint32），不支持浮点类型
-6. scalarValue 为标量（PrimExpr），不支持 tensor-tensor 位移；其 dtype 不要求与 dst 一致（codegen 自动转换）
+1. 输入和输出张量必须位于 UB 内存
+2. dst 与 src0 的元素个数必须相同
+3. src0 的 dtype 必须与 dst 一致
+4. 仅支持 int16、uint16、int32 和 uint32
+5. scalarValue 当前仅支持标量；张量位移量暂未开放（参见 [Issue #1719](https://github.com/tile-ai/tilelang-ascend/issues/1719)）
+6. scalarValue 的 dtype 无需与 dst 一致
 7. 操作数地址需 32 字节对齐（硬件约束）
 
 ## 3. 示例代码
@@ -88,7 +59,7 @@ def bitwise_lshift(
 ```python
 src0 = T.alloc_ub((64, 256), "int16")
 dst = T.alloc_ub((64, 256), "int16")
-T.tile.bitwise_lshift(dst, src0, 2)  # dst[i] = src0[i] << 2
+T.tile.bitwise_lshift(dst, src0, 2)
 ```
 
 **示例 2：1D 标量左移**
@@ -96,10 +67,10 @@ T.tile.bitwise_lshift(dst, src0, 2)  # dst[i] = src0[i] << 2
 ```python
 src0 = T.alloc_ub((1024,), "int32")
 dst = T.alloc_ub((1024,), "int32")
-T.tile.bitwise_lshift(dst, src0, 4)  # dst[i] = src0[i] << 4
+T.tile.bitwise_lshift(dst, src0, 4)
 ```
 
-**示例 3：BufferRegion 切片左移**
+**示例 3：张量切片左移**
 
 ```python
 src0 = T.alloc_ub((64, 256), "int32")
@@ -107,21 +78,3 @@ dst = T.alloc_ub((64, 256), "int32")
 for i in range(64):
     T.tile.bitwise_lshift(dst[i, :], src0[i, :], 1)
 ```
-
-## 4. 已知限制
-
-### 4.1 非对齐 shape 精度问题
-
-当 tile 的元素总数不满足 32 字节对齐时（例如 shape=(1024, 100)），Ascend C 后端产生精度错误（约 3.8%~10.7% 元素不正确）。PTO 后端不受此影响。
-
-### 4.2 int8 / uint8 / int64 / uint64 不支持
-
-原始文档声称 A5 支持 int64 / uint64。经核查，PTO a5 `TSHLS_IMPL` 的 `static_assert` 仅允许 int8/uint8/int16/uint16/int32/uint32，**不包含 int64 / uint64**。A2/A3 的 PTO `TShiftCheck` 和 Ascend C `ShiftLeftImpl` 均不支持 int8/uint8/int64/uint64。
-
-### 4.3 移位语义
-
-原始文档声称"有符号类型执行算术左移（次高位丢弃，低位补 0）"。经真机验证，左移为**逻辑左移**：无论有符号或无符号类型，高位丢弃、低位补 0，符号位不被特殊保留。底层 `vshls` / `vshl` 指令不区分符号类型。
-
-### 4.4 A5 平台支持范围
-
-原始文档声称 A5 支持 int8/uint8/int16/uint16/int32/uint32/int64/uint64。经核查 PTO a5 `static_assert`，实际允许 int8/uint8/int16/uint16/int32/uint32，**不包含 int64/uint64**。该声明未经真机验证。

--- a/docs/language/tile_bitwise_lshift.md
+++ b/docs/language/tile_bitwise_lshift.md
@@ -1,0 +1,127 @@
+# T.tile.bitwise_lshift
+
+## 1. 功能说明
+
+对 buffer 中每个元素执行标量左移运算：`dst[i] = src0[i] << scalarValue`
+
+底层委托给 `tir.call_intrin("tl.ascend_bitwise_lshift", ...)` 实现。生成的底层指令取决于后端：
+
+- **Ascend C 后端**：`AscendC::ShiftLeft<T>(dst, src, scalarValue, count)`
+- **PTO 后端**：`TSHLS(dst, src, scalar)`
+
+> **移位语义说明**：无论有符号还是无符号类型，左移均为**逻辑左移**——高位丢弃，低位补 0。底层 `vshls` / `vshl` 指令不区分符号类型，符号位不会被特殊保留。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def bitwise_lshift(
+    dst: Buffer | BufferRegion,
+    src0: Buffer | BufferRegion,
+    scalarValue: PrimExpr,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放左移运算结果 | Buffer / BufferRegion | 必填 |
+| src0 | 输入 | 源操作数 | Buffer / BufferRegion | 必填 |
+| scalarValue | 输入 | 位移位数（标量） | PrimExpr / Python 标量 | 必填 |
+
+> **类型说明**：
+>
+> - **Buffer**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区
+> - **BufferRegion**：缓冲区切片，通过 `buf[0:M, 0:N]` 语法指定
+> - **scalarValue**：Python 标量或 PrimExpr，表示位移位数。codegen 会在 scalarValue 的 dtype 与 src0 不一致时自动插入类型转换（如 `int16(scalarValue)`），因此 Python 层面不强制要求 scalarValue 的 dtype 与 dst 一致。
+
+### 2.3 参数规格
+
+#### 2.3.1 Buffer Scope
+
+`bitwise_lshift` 仅支持 **UB（Unified Buffer）** 内存。底层 `AscendC::ShiftLeft` 和 PTO `TSHLS` 均操作 `LocalTensor<T>`（UB）。
+
+#### 2.3.2 DataType 支持
+
+以下 dtype 基于 Ascend A2 / A3（910B3）真机验证：
+
+| dtype | Ascend C | PTO |
+|-------|----------|-----|
+| int8 | 不支持（编译失败） | 不支持（编译失败） |
+| uint8 | 不支持（编译失败） | 不支持（编译失败） |
+| int16 | 支持 | 支持 |
+| uint16 | 支持 | 支持 |
+| int32 | 支持 | 支持 |
+| uint32 | 支持 | 支持 |
+| int64 | 不支持（编译失败） | 不支持（编译失败） |
+| uint64 | 不支持（编译失败） | 不支持（编译失败） |
+| float16 | 不支持（编译失败） | 不支持（编译失败） |
+| float32 | 不支持（编译失败） | 不支持（编译失败） |
+
+> **说明**：
+>
+> - **Ascend C 后端**：`ShiftLeftImpl` 仅有 `int16_t`、`uint16_t`、`int32_t`、`uint32_t` 的特化版本。其余类型命中通用模板，触发 `ASCENDC_ASSERT(false, ...)` 编译失败。
+> - **PTO 后端（A2/A3）**：`TShiftCheck` 的 `static_assert` 仅允许 `int32_t`、`int`、`int16_t`、`uint32_t`、`uint16_t`、`unsigned int`。其余类型触发编译失败。
+> - **A5 平台**：PTO a5 `TSHLS_IMPL` 的 `static_assert` 允许 `int8_t`、`uint8_t`、`int16_t`、`uint16_t`、`int32_t`、`uint32_t`。但 **不包含 `int64_t` / `uint64_t`**。当前环境（A2/A3）无法验证 A5 行为。
+
+#### 2.3.3 Shape 支持
+
+- 支持 1D 和 2D
+- size 由 buffer shape 自动推断（BufferRegion 时取 region extent 的乘积，Buffer 时取 shape 的乘积）
+
+### 2.4 约束条件
+
+1. `bitwise_lshift` 委托给 `tir.call_intrin("tl.ascend_bitwise_lshift", ...)` 实现
+2. buffer 必须位于 UB 内存（通过 `T.alloc_ub` 分配）
+3. dst 与 src0 的 size（元素总数）必须相同（源码内含 `assert size_0 == size_2`）
+4. src0 的 dtype 必须与 dst 一致（C++ 模板参数 `T` 必须统一）
+5. 仅支持整数类型（int16/uint16/int32/uint32），不支持浮点类型
+6. scalarValue 为标量（PrimExpr），不支持 tensor-tensor 位移；其 dtype 不要求与 dst 一致（codegen 自动转换）
+7. 操作数地址需 32 字节对齐（硬件约束）
+
+## 3. 示例代码
+
+**示例 1：标量左移（2D）**
+
+```python
+src0 = T.alloc_ub((64, 256), "int16")
+dst = T.alloc_ub((64, 256), "int16")
+T.tile.bitwise_lshift(dst, src0, 2)  # dst[i] = src0[i] << 2
+```
+
+**示例 2：1D 标量左移**
+
+```python
+src0 = T.alloc_ub((1024,), "int32")
+dst = T.alloc_ub((1024,), "int32")
+T.tile.bitwise_lshift(dst, src0, 4)  # dst[i] = src0[i] << 4
+```
+
+**示例 3：BufferRegion 切片左移**
+
+```python
+src0 = T.alloc_ub((64, 256), "int32")
+dst = T.alloc_ub((64, 256), "int32")
+for i in range(64):
+    T.tile.bitwise_lshift(dst[i, :], src0[i, :], 1)
+```
+
+## 4. 已知限制
+
+### 4.1 非对齐 shape 精度问题
+
+当 tile 的元素总数不满足 32 字节对齐时（例如 shape=(1024, 100)），Ascend C 后端产生精度错误（约 3.8%~10.7% 元素不正确）。PTO 后端不受此影响。
+
+### 4.2 int8 / uint8 / int64 / uint64 不支持
+
+原始文档声称 A5 支持 int64 / uint64。经核查，PTO a5 `TSHLS_IMPL` 的 `static_assert` 仅允许 int8/uint8/int16/uint16/int32/uint32，**不包含 int64 / uint64**。A2/A3 的 PTO `TShiftCheck` 和 Ascend C `ShiftLeftImpl` 均不支持 int8/uint8/int64/uint64。
+
+### 4.3 移位语义
+
+原始文档声称"有符号类型执行算术左移（次高位丢弃，低位补 0）"。经真机验证，左移为**逻辑左移**：无论有符号或无符号类型，高位丢弃、低位补 0，符号位不被特殊保留。底层 `vshls` / `vshl` 指令不区分符号类型。
+
+### 4.4 A5 平台支持范围
+
+原始文档声称 A5 支持 int8/uint8/int16/uint16/int32/uint32/int64/uint64。经核查 PTO a5 `static_assert`，实际允许 int8/uint8/int16/uint16/int32/uint32，**不包含 int64/uint64**。该声明未经真机验证。

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -1016,8 +1016,7 @@ def test_bitwise_lshift_int8_xfail(dtype, target):
 
 
 @pytest.mark.xfail(
-    reason="float16/float32 are not supported: bitwise shift is integer-only. "
-    "Both AscendC and PTO lack float specializations."
+    reason="float16/float32 are not supported: bitwise shift is integer-only. Both AscendC and PTO lack float specializations."
 )
 @pytest.mark.parametrize("dtype", ["float16", "float32"])
 @pytest.mark.parametrize("target", ["ascendc", "pto"])

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -807,6 +807,224 @@ def test_bitwise_lshift_slice(dtype, target, shape):
     run_test_bitwise_lshift_slice(M, N, 128, 256, scalarvalue=scalarvalue, dtype=dtype, target=target)
 
 
+# ---------------------------------------------------------------------------
+# Factcheck tests for T.tile.bitwise_lshift
+# ---------------------------------------------------------------------------
+
+_TORCH_INT_DTYPE_LSHIFT = {
+    "int16": torch.int16,
+    "uint16": torch.uint16,
+    "int32": torch.int32,
+    "uint32": torch.uint32,
+}
+
+
+def _lshift_ref(a_cpu, scalarvalue, dtype):
+    """Compute reference left shift on CPU, handling dtype overflow correctly."""
+    if dtype == "uint16":
+        return torch.bitwise_left_shift(a_cpu.to(torch.int32), scalarvalue).to(torch.uint16)
+    elif dtype == "uint32":
+        return torch.bitwise_left_shift(a_cpu.to(torch.int32), scalarvalue).to(torch.uint32)
+    return torch.bitwise_left_shift(a_cpu, scalarvalue)
+
+
+def run_test_bitwise_lshift_signed_semantics(dtype, target, scalarvalue):
+    """Verify that left shift on signed types is logical (not sign-preserving).
+
+    The original doc claims signed types use 'arithmetic left shift' preserving
+    the sign bit. The actual vshls/vshl instruction is a standard logical
+    left shift — sign bit is NOT preserved.
+    """
+    M, N = 1024, 1024
+    block_M, block_N = 128, 256
+    VEC_NUM = 2
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        B: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.tile.bitwise_lshift(b_ub, a_ub, scalarvalue)
+            T.copy(b_ub, B[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+    td = _TORCH_INT_DTYPE_LSHIFT[dtype]
+    if "int" in dtype and "int8" not in dtype:
+        low = -100
+        high = 100
+    else:
+        low = 1
+        high = 100
+    a = torch.randint(low=low, high=high, size=(M, N), dtype=td).npu()
+    torch.npu.synchronize()
+    b = func(a)
+    ref_b = _lshift_ref(a.cpu(), scalarvalue, dtype).npu()
+    assert_close_npu(b, ref_b, dtype, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("scalarvalue", [1, 2, 4])
+@pytest.mark.parametrize("dtype", ["int16", "int32"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_lshift_signed_semantics(dtype, target, scalarvalue):
+    run_test_bitwise_lshift_signed_semantics(dtype, target, scalarvalue)
+
+
+def run_test_bitwise_lshift_1d(dtype, target, scalarvalue):
+    """Test 1D buffer shape support."""
+    N = 1024
+    block_N = 1024
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),  # type: ignore
+        B: T.Tensor((N,), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((block_N,), dtype)
+            b_ub = T.alloc_ub((block_N,), dtype)
+            T.copy(A[0:], a_ub)
+            T.tile.bitwise_lshift(b_ub, a_ub, scalarvalue)
+            T.copy(b_ub, B[0:])
+
+    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+    td = _TORCH_INT_DTYPE_LSHIFT[dtype]
+    a = torch.randint(1, 100, size=(N,), dtype=td).npu()
+    torch.npu.synchronize()
+    b = func(a)
+    ref_b = _lshift_ref(a.cpu(), scalarvalue, dtype).npu()
+    assert_close_npu(b, ref_b, dtype, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("scalarvalue", [1, 4, 8])
+@pytest.mark.parametrize("dtype", ["int16", "uint16", "int32", "uint32"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_lshift_1d(dtype, target, scalarvalue):
+    run_test_bitwise_lshift_1d(dtype, target, scalarvalue)
+
+
+def run_test_bitwise_lshift_boundary(dtype, target, scalarvalue):
+    """Test boundary shift values: 0, max-bit-width, and over-width."""
+    M, N = 1024, 1024
+    block_M, block_N = 128, 256
+    VEC_NUM = 2
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        B: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.tile.bitwise_lshift(b_ub, a_ub, scalarvalue)
+            T.copy(b_ub, B[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+    td = _TORCH_INT_DTYPE_LSHIFT[dtype]
+    a = torch.randint(1, 100, size=(M, N), dtype=td).npu()
+    torch.npu.synchronize()
+    b = func(a)
+    ref_b = _lshift_ref(a.cpu(), scalarvalue, dtype).npu()
+    assert_close_npu(b, ref_b, dtype, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("scalarvalue", [0, 1, 15, 16])
+@pytest.mark.parametrize("dtype", ["int16", "uint16"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_lshift_boundary_int16(dtype, target, scalarvalue):
+    run_test_bitwise_lshift_boundary(dtype, target, scalarvalue)
+
+
+@pytest.mark.parametrize("scalarvalue", [0, 1, 31, 32])
+@pytest.mark.parametrize("dtype", ["int32", "uint32"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_lshift_boundary_int32(dtype, target, scalarvalue):
+    run_test_bitwise_lshift_boundary(dtype, target, scalarvalue)
+
+
+def run_test_bitwise_lshift_non_aligned(dtype, target, scalarvalue):
+    """Test non-32-byte-aligned shapes for precision issues."""
+    M, N = 1024, 100
+    block_M, block_N = 128, 100
+    VEC_NUM = 2
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        B: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+            T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+            T.tile.bitwise_lshift(b_ub, a_ub, scalarvalue)
+            T.copy(b_ub, B[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+    td = _TORCH_INT_DTYPE_LSHIFT[dtype]
+    a = torch.randint(1, 100, size=(M, N), dtype=td).npu()
+    torch.npu.synchronize()
+    b = func(a)
+    ref_b = _lshift_ref(a.cpu(), scalarvalue, dtype).npu()
+    assert_close_npu(b, ref_b, dtype, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("scalarvalue", [1, 4])
+@pytest.mark.parametrize("dtype", ["int16", "uint16", "int32", "uint32"])
+@pytest.mark.parametrize("target", ["pto"])
+def test_bitwise_lshift_non_aligned(dtype, target, scalarvalue):
+    run_test_bitwise_lshift_non_aligned(dtype, target, scalarvalue)
+
+
+@pytest.mark.xfail(
+    reason="Ascend C backend produces precision errors when tile element count "
+    "is not 32-byte aligned (e.g. shape=(1024,100)). PTO backend is unaffected."
+)
+@pytest.mark.parametrize("scalarvalue", [1, 4])
+@pytest.mark.parametrize("dtype", ["int16", "uint16", "int32", "uint32"])
+@pytest.mark.parametrize("target", ["ascendc"])
+def test_bitwise_lshift_non_aligned_ascendc_xfail(dtype, target, scalarvalue):
+    run_test_bitwise_lshift_non_aligned(dtype, target, scalarvalue)
+
+
+@pytest.mark.xfail(
+    reason="int8/uint8 are not supported on A2/A3 for bitwise_lshift: "
+    "AscendC ShiftLeftImpl has no int8/uint8 specialization (ASCENDC_ASSERT false), "
+    "PTO TShiftCheck static_assert only allows int16/uint16/int32/uint32."
+)
+@pytest.mark.parametrize("dtype", ["int8", "uint8"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_lshift_int8_xfail(dtype, target):
+    run_test_bitwise_lshift_boundary(dtype, target, 1)
+
+
+@pytest.mark.xfail(
+    reason="float16/float32 are not supported: bitwise shift is integer-only. "
+    "Both AscendC and PTO lack float specializations."
+)
+@pytest.mark.parametrize("dtype", ["float16", "float32"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_bitwise_lshift_float_xfail(dtype, target):
+    run_test_bitwise_lshift_boundary(dtype, target, 1)
+
+
 def bitwise_not(M, N, block_M, block_N, dtype="int16"):
     m_num = M // block_M
     n_num = N // block_N

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1398,10 +1398,21 @@ def mul_add_dst(
 def bitwise_lshift(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, scalarValue: PrimExpr):  # noqa: F821
     """Performs element-wise bitwise left shift: dst = src0 << scalarValue.
 
+    The shift is a **logical** left shift for both signed and unsigned types:
+    high bits are discarded and low bits are filled with 0. The sign bit is
+    NOT preserved.
+
+    Supported dtypes (A2/A3):
+      - Ascend C: int16, uint16, int32, uint32
+      - PTO:      int16, uint16, int32, uint32
+
+    int8/uint8/int64/uint64/float are not supported and fail at compile time.
+
     Args:
-        dst: The destination buffer.
-        src0: The source buffer.
-        scalarValue: The number of bits to shift (scalar).
+        dst: The destination buffer (UB).
+        src0: The source buffer (UB), must have the same size and dtype as dst.
+        scalarValue: The number of bits to shift (scalar). The codegen
+            automatically casts scalarValue to src0's dtype if they differ.
     """
     if isinstance(dst, BufferRegion):
         dst_ptr, dst_extent = _handle_buffer_region(dst, "w")

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1398,21 +1398,15 @@ def mul_add_dst(
 def bitwise_lshift(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion, scalarValue: PrimExpr):  # noqa: F821
     """Performs element-wise bitwise left shift: dst = src0 << scalarValue.
 
-    The shift is a **logical** left shift for both signed and unsigned types:
-    high bits are discarded and low bits are filled with 0. The sign bit is
-    NOT preserved.
+    The API currently accepts a scalar shift amount. Tensor shift amounts are
+    not yet supported.
 
-    Supported dtypes (A2/A3):
-      - Ascend C: int16, uint16, int32, uint32
-      - PTO:      int16, uint16, int32, uint32
-
-    int8/uint8/int64/uint64/float are not supported and fail at compile time.
+    Supported dtypes on A2/A3: int16, uint16, int32, uint32.
 
     Args:
         dst: The destination buffer (UB).
         src0: The source buffer (UB), must have the same size and dtype as dst.
-        scalarValue: The number of bits to shift (scalar). The codegen
-            automatically casts scalarValue to src0's dtype if they differ.
+        scalarValue: The number of bits to shift (scalar).
     """
     if isinstance(dst, BufferRegion):
         dst_ptr, dst_extent = _handle_buffer_region(dst, "w")


### PR DESCRIPTION
1. 文件改动
文件	类型	改动说明
docs/language/tile_bitwise_lshift.md	新增	校验后完整 API 文档（127 行），修正移位语义、dtype 支持表、scalarValue 类型转换说明、非对齐精度限制
tilelang/language/ascend_tile.py	修改	bitwise_lshift docstring 扩充：明确逻辑左移语义、A2/A3 支持 dtype、codegen 自动类型转换、UB scope 约束
testing/python/language/test_tilelang_ascend_language_elementwise.py	修改	新增 8 个测试函数共 92 个参数化用例，覆盖有符号语义、1D shape、边界值、非对齐、int8/uint8/float 反例
2. 测试用例
2.1 约束测试（动态验证）
验证项	测什么
移位语义（有符号）	int16/int32 × ascendc/pto × shift 1/2/4，输入含负值，对比 torch.bitwise_left_shift
1D shape	4 dtypes × 2 backends × shift 1/4/8，shape=(1024,)
边界值 int16/uint16	shift 0/1/15/16 × 2 dtypes × 2 backends
边界值 int32/uint32	shift 0/1/31/32 × 2 dtypes × 2 backends
非对齐 shape（PTO）	shape=(1024,100)，4 dtypes × shift 1/4，PTO backend
非对齐 shape（Ascend C）	同上，Ascend C backend
int8/uint8 反例	int8/uint8 × 2 backends，shift 1
float 反例	float16/float32 × 2 backends，shift 1
2.2 正式测试文件
测试函数
test_bitwise_lshift_signed_semantics
test_bitwise_lshift_1d
test_bitwise_lshift_boundary_int16
test_bitwise_lshift_boundary_int32
test_bitwise_lshift_non_aligned
test_bitwise_lshift_non_aligned_ascendc_xfail
test_bitwise_lshift_int8_xfail
test_bitwise_lshift_float_xfail

2.3 测试用例统计与 LP 分层（新增）

testing/python/language/test_tilelang_ascend_language_elementwise.py 新增 92 个用例（76 PASSED + 16 XFAIL），不重复基线已有测试（test_bitwise_lshift / test_bitwise_lshift_slice：int16/int32 默认 + uint16/uint32 low_priority，lshift 基线 pto 亦标 low_priority）

- 当前实际：新增用例均未打 low_priority 标记 → PR 触发执行 92 个，定时任务触发执行 92 个（无差异）
- 建议分层：仅保留 4 个核心用例（每函数 1 个：主流 dtype int16/int32 × 主后端 ascendc）在 PR 提交阶段执行，其余 88 个标 low_priority 放到定时执行阶段 → PR 触发执行 4 个，定时任务触发执行 92 个（88 个仅定时执行）

| 测试函数 | 用例数 | PR执行 | LP | 类型 | 覆盖内容 |
|---|:---:|:---:|:---:|---|---|
| `test_bitwise_lshift_signed_semantics` | 12 | 1 | 11 | 核心语义 | 左移为逻辑移位（证伪"算术左移"）：int16/int32 × ascendc/pto × shift 1/2/4，int16@ascendc 为核心 |
| `test_bitwise_lshift_1d` | 24 | 1 | 23 | shape 泛化 | 1D buffer：4 dtype × shift 1/4/8 × ascendc/pto，int16@ascendc 为核心 |
| `test_bitwise_lshift_boundary_int16` | 16 | 1 | 15 | 边界泛化 | shift 0/1/15/16 × int16/uint16 × ascendc/pto，int16@ascendc 为核心 |
| `test_bitwise_lshift_boundary_int32` | 16 | 1 | 15 | 边界泛化 | shift 0/1/31/32 × int32/uint32 × ascendc/pto，int32@ascendc 为核心 |
| `test_bitwise_lshift_non_aligned` | 8 | 0 | 8 | shape 泛化 | 非对齐 (1024,100)：4 dtype × shift 1/4 × pto |
| `test_bitwise_lshift_non_aligned_ascendc_xfail` | 8 | 0 | 8 | 异常边界 | 非对齐 AscendC 精度错误（XFAIL） |
| `test_bitwise_lshift_int8_xfail` | 4 | 0 | 4 | 异常边界 | int8/uint8 编译失败（XFAIL） |
| `test_bitwise_lshift_float_xfail` | 4 | 0 | 4 | 异常边界 | float16/float32 编译失败（XFAIL） |

LP 标记策略（建议，参照 #1676 已落地惯例）：
- dtype：int16/int32（基线默认执行 dtype）每函数保留 1 个 @ascendc 核心用例，uint16/uint32 及其余组合标 low_priority
- target：ascendc（主后端）默认执行，pto 标 low_priority
- shape：主流 2D (1024,1024) 默认执行，1D 每函数保留 1 个核心用例，非对齐 shape 整体标 low_priority
- XFAIL 异常边界用例整体标 low_priority

3. 测试结果
- 测试环境：Ascend A2/A3（910B3）、CANN 8.5.2、Python 3.11.4、torch 2.7.1+cpu、torch_npu 2.7.1.post4
- 约束测试：76 passed, 16 xfailed（详见 2.1）
- 正式测试：76 passed, 16 xfailed, 0 failed, 0 skipped（92 用例）
- 必要回归测试：原始 test_bitwise_lshift[ascendc-int16/uint16] 2 passed；test_bitwise_not[ascendc-int16/uint16] 2 passed
3.1 Pytest 标签
本次新增测试暂未打 low_priority 标记，建议按 2.3 节 LP 分层补标（XFAIL 用例已用 @pytest.mark.xfail 标记）。
4. 校验过程中发现的问题
1. 移位语义描述错误：原文档声称"有符号类型执行算术左移（次高位丢弃，低位补 0）"，暗示符号位被保留。真机测试（int16/int32 × ascendc/pto × 含负值输入，12 个用例）证明左移为逻辑左移——高位丢弃、低位补 0，符号位不保留。底层 vshls/vshl 指令不区分符号类型。文档和 docstring 均已修正。
2. A5 平台 int64/uint64 声明错误：原文档声称 A5 支持 int64/uint64。静态核查 PTO a5 TSHLS_IMPL（3rdparty/pto-isa/include/pto/npu/a5/TShlS.hpp:50-53）的 static_assert 仅允许 int8/uint8/int16/uint16/int32/uint32，不包含 int64/uint64。文档已修正。A5 行为未经真机验证。
3. scalarValue dtype 约束过严：原文档约束"scalarValue 的数据类型需与 dst 元素类型一致"。静态核查 codegen（src/target/codegen_ascend.cc:1563-1566、src/target/codegen_ascend_pto.cc:2614-2616）发现 codegen 在 scalarValue dtype 与 src0 不一致时自动插入类型转换（如 int16(scalarValue)）。文档已澄清为"不强制要求一致，codegen 自动转换"。
4. Ascend C 非对齐 shape 精度问题：当 tile 元素总数不满足 32 字节对齐时（如 shape=(1024,100)），Ascend C 后端产生精度错误（3.8%~10.7% 元素不正确）。PTO 后端不受影响。已标记为 xfail 并在文档"已知限制"章节记录。
5. int8/uint8 不支持：原文档未明确 int8/uint8 在 A2/A3 上的状态。静态核查 Ascend C ShiftLeftImpl 仅有 int16/uint16/int32/uint32 特化（kernel_operator_vec_binary_scalar_impl.h:1168-1173），通用模板触发 ASCENDC_ASSERT(false)；PTO TShiftCheck（TBitwiseSOp.hpp:24-27）static_assert 不允许 int8/uint8。真机编译失败验证通过（4 xfail）。
5. 未解决问题与风险
- A5 平台 dtype 支持基于 static_assert 静态分析，未经真机验证（当前环境为 A2/A3）
- Ascend C 非对齐 shape 精度问题根因未修复，仅以 xfail 和文档约束规避
- A5 PTO static_assert 允许 int8/uint8，但 A2/A3 不允许；A5 的 int8/uint8 运行时行为未知
- Ruff 工具在当前环境不可用，未执行 lint 检查
6. 验证
- cmake -B build -S . -DCMAKE_BUILD_TYPE=Release && cmake --build build -j2：通过，增量编译无错误
- python3 -m pytest -k "bitwise_lshift_signed_semantics" -vv -s：通过，12 passed
- python3 -m pytest -k "bitwise_lshift_1d" -vv -s：通过，24 passed
- python3 -m pytest -k "bitwise_lshift_boundary" -vv -s：通过，32 passed
- python3 -m pytest -k "bitwise_lshift_non_aligned" -vv -s：PTO 8 passed，AscendC 8 xfailed
- python3 -m pytest -k "bitwise_lshift_int8_xfail or bitwise_lshift_float_xfail" -vv -s：8 xfailed
- python3 -m pytest -k "test_bitwise_lshift and ascendc and int16"：通过，2 passed（回归）
- python3 -m pytest -k "test_bitwise_not and ascendc and int16"：通过，2 passed（回归）
- python3 -c "import ast; ast.parse(open('tilelang/language/ascend_tile.py').read())"：通过
- python3 -c "import ast; ast.parse(open('testing/python/language/...elementwise.py').read())"：通过
- git diff --check：通过
汇总：
- 编译验证：通过
- NPU 运行：通过
- 精度验证：通过（76 passed），预期失败 16 xfailed
- 目标测试：92 用例，76 passed, 16 xfailed
- 回归测试：4 用例，4 passed
- 语法检查：通过
- Ruff/格式检查：未执行（工具不可用）