### PR TITLE
[Fix] Correct PTO tail visibility and int32 shift test range

### DIFF
--- a/src/tl_templates/pto/common.h
+++ b/src/tl_templates/pto/common.h
@@ -1373,7 +1373,7 @@ clear_compare_tail_bits(TileUbDataND<T, Rows, Cols, RowValid, ColValid> &dst,
                         uint32_t valid_row, uint32_t logical_valid_col) {
   if ((logical_valid_col & 7U) == 0)
     return;
-  TL_PIPE_V_BARRIER();
+  pto::PtoSetWaitFlag<PIPE_V, PIPE_S>();
   uint8_t keep = static_cast<uint8_t>((1U << (logical_valid_col & 7U)) - 1U);
   uint32_t last = logical_valid_col >> 3;
   for (uint32_t r = 0; r < valid_row; ++r) {

--- a/testing/python/language/parallel/test_tilelang_ascend_language_parallel.py
+++ b/testing/python/language/parallel/test_tilelang_ascend_language_parallel.py
@@ -419,7 +419,7 @@ class TestTileLangKernels:
 
     def test_shiftright_operation(self, clear_cache, setup_random_seed):
         """Test bitwise right shift kernel"""
-        scalar_value = random.randint(1, 32)
+        scalar_value = random.randint(1, 31)
 
         def kernel_func(M, N, block_M, block_N):
             return self.unary_op_kernel_int(M, N, block_M, block_N, op_func=lambda a: a >> scalar_value, dtype="int32")


### PR DESCRIPTION
## 修改（2 行）

- #1652：Scalar 清理 compare mask 尾位前，改用已有的 `PIPE_V -> PIPE_S` 同步原语。
- #1663：int32 随机右移上限从非法的 32 改为 31。

## 验证

- 精确节点：`2 passed`
- 同卡压力：两个节点均 `32/32 passed`，无 OOM、timeout 或 device exception
- Ruff 与 clang-format 检查通过

Closes #1652
Closes #1663
