### PR TITLE
[Fix] Non-16-aligned D_qk scale + Autograd non-contiguous gradient (#1669)

### DIFF
--- a/examples_experiment/example_gqa_bwd/example_gqa_bwd.py
+++ b/examples_experiment/example_gqa_bwd/example_gqa_bwd.py
@@ -661,11 +661,16 @@ def ref_bwd(Q, K, V, dO, lse, is_causal=False, groups=1):
 # --- Host-side bwd pipeline: 3 sub-kernel serial launch ---
 
 
-def run_bwd(Q, K, V, dO, lse, Delta, is_causal=False, groups=1, block_M=64, block_N=64):
+def run_bwd(Q, K, V, dO, lse, Delta, is_causal=False, groups=1, block_M=64, block_N=64, dim_qk=None):
     """Host-side bwd pipeline: 3 sub-kernel serial launch.
 
     Note: block_N may be overridden by kernel auto-select
     (block_N=128 when seq_len%128==0 and dim_qk_padded<=192).
+
+    Args:
+        dim_qk: logical (unpadded) D_qk for softmax scale computation.
+            If None, inferred from Q.shape[-1] (assumes Q is already padded
+            and dim_qk == dim_qk_padded, i.e. no padding was needed).
 
     Phase 1: GEMM1 + GEMM3 -> ws_s, ws_dp (GM fp32)
     Phase 2: softmax recompute + dS -> ws_p, ws_ds, ws_p_delta, ws_ds_delta (GM fp16)
@@ -674,15 +679,16 @@ def run_bwd(Q, K, V, dO, lse, Delta, is_causal=False, groups=1, block_M=64, bloc
     Returns: dQ_fp16, dK_fp16, dV_fp16, dQ_fp32, dK_fp32, dV_fp32
     """
     batch, heads, seq_len, dim_qk_padded = Q.shape
-    dim_qk = dim_qk_padded
+    if dim_qk is None:
+        dim_qk = dim_qk_padded
     _, H_kv, _, dim_v = V.shape
 
-    # Phase 1: GEMM1 + GEMM3 -> ws_s, ws_dp
-    phase1_mod = flashattn_bwd_gemm_s_dp(batch, heads, seq_len, dim_qk, dim_v, groups, is_causal, block_M, block_N)
+    # Phase 1: GEMM1 + GEMM3 -> ws_s, ws_dp (uses dim_qk_padded for buffer shapes)
+    phase1_mod = flashattn_bwd_gemm_s_dp(batch, heads, seq_len, dim_qk_padded, dim_v, groups, is_causal, block_M, block_N)
     ws_s, ws_dp = phase1_mod(Q, K, V, dO)
     torch.npu.synchronize()
 
-    # Phase 2: softmax + dS -> ws_p, ws_ds, ws_p_delta, ws_ds_delta
+    # Phase 2: softmax + dS (uses logical dim_qk so sm_scale = 1/sqrt(dim_qk) is correct)
     phase2_mod = flashattn_bwd_softmax_ds(batch, heads, seq_len, dim_qk, dim_v, groups, is_causal, block_M, block_N)
     ws_p, ws_ds, ws_p_delta, ws_ds_delta = phase2_mod(ws_s, ws_dp, lse, Delta)
     torch.npu.synchronize()
@@ -692,7 +698,7 @@ def run_bwd(Q, K, V, dO, lse, Delta, is_causal=False, groups=1, block_M=64, bloc
     dK = torch.zeros(batch, H_kv, seq_len, dim_qk_padded, dtype=torch.float32, device=Q.device)
     dV = torch.zeros(batch, H_kv, seq_len, dim_v, dtype=torch.float32, device=Q.device)
 
-    phase3_mod = flashattn_bwd_gemm_dv_dk_dq(batch, heads, seq_len, dim_qk, dim_v, groups, is_causal, block_M, block_N)
+    phase3_mod = flashattn_bwd_gemm_dv_dk_dq(batch, heads, seq_len, dim_qk_padded, dim_v, groups, is_causal, block_M, block_N)
     phase3_mod(Q, K, dO, ws_p, ws_ds, ws_p_delta, ws_ds_delta, dQ, dK, dV)
     torch.npu.synchronize()
 
@@ -756,13 +762,20 @@ class _attention(torch.autograd.Function):
         block_M = ctx.block_M
         block_N_bwd = ctx.block_N_bwd
 
+        # Materialize non-contiguous gradient (e.g. from output.sum().backward()
+        # which produces a zero-stride view). TileLang JIT requires contiguous input.
+        if not do.is_contiguous():
+            do = do.contiguous()
+
         # Preprocess: Delta = sum(O * dO, dim=-1)
         prep_mod = flashattn_bwd_preprocess(B, H, N, D_v, blk=32)
         delta = prep_mod(o, do)
         torch.npu.synchronize()
 
         # bwd pipeline: 3 sub-kernel serial launch
-        dQ_fp16, dK_fp16, dV_fp16, _, _, _ = run_bwd(q, k, v, do, lse, delta, is_causal, groups, block_M, block_N_bwd)
+        # Pass logical D_qk so phase2 softmax scale = 1/sqrt(D_qk) is correct
+        # (not 1/sqrt(D_qk_padded) which would be wrong when D_qk is not 16-aligned).
+        dQ_fp16, dK_fp16, dV_fp16, _, _, _ = run_bwd(q, k, v, do, lse, delta, is_causal, groups, block_M, block_N_bwd, dim_qk=D_qk)
 
         # Slice to original D_qk (remove padding)
         return dQ_fp16[..., :D_qk], dK_fp16[..., :D_qk], dV_fp16, None, None

--- a/examples_experiment/example_gqa_bwd/test_gqa_bwd.py
+++ b/examples_experiment/example_gqa_bwd/test_gqa_bwd.py
@@ -653,6 +653,78 @@ def test_gqa_bwd_boundary():
     return True, []
 
 
+def test_gqa_bwd_regression():
+    """Regression tests for issue #1669.
+
+    1. D_qk=129 (non-16-aligned): verify softmax scale uses logical D_qk,
+       not padded dim_qk_padded=144.
+    2. output.sum().backward(): verify PyTorch Autograd compatibility
+       with non-contiguous gradient (zero-stride view from sum()).
+    """
+    print("\n" + "=" * 60)
+    print("[Regression] Issue #1669: non-16-aligned D_qk + Autograd compatibility")
+    print("=" * 60)
+
+    all_passed = True
+
+    # --- Regression 1: D_qk=129 (non-16-aligned) ---
+    print("\n--- Regression 1: D_qk=129 (padded to 144) ---")
+    B, H, groups, N, D_qk, D_v = 1, 4, 2, 128, 129, 128
+    H_kv = H // groups
+    torch.manual_seed(42)
+    Q_cpu = torch.randn(B, H, N, D_qk, dtype=torch.float16)
+    K_cpu = torch.randn(B, H_kv, N, D_qk, dtype=torch.float16)
+    V_cpu = torch.randn(B, H_kv, N, D_v, dtype=torch.float16)
+    dO_cpu = torch.randn(B, H, N, D_v, dtype=torch.float16)
+
+    # Use public Autograd wrapper (tests padding + scale fix end-to-end)
+    from example_gqa_bwd import attention
+
+    Q_npu = Q_cpu.to("npu").requires_grad_(True)
+    K_npu = K_cpu.to("npu").requires_grad_(True)
+    V_npu = V_cpu.to("npu").requires_grad_(True)
+    dO_npu = dO_cpu.to("npu")
+
+    output = attention(Q_npu, K_npu, V_npu, False, groups)
+    output.backward(dO_npu)
+    torch.npu.synchronize()
+
+    # Golden (CPU) — uses original D_qk=129 for scale
+    _, lse_ref = ref_fwd(Q_cpu, K_cpu, V_cpu, False, groups)
+    dQ_ref, dK_ref, dV_ref = ref_bwd(Q_cpu, K_cpu, V_cpu, dO_cpu, lse_ref, False, groups)
+
+    dQ_grad = Q_npu.grad
+    dK_grad = K_npu.grad
+    dV_grad = V_npu.grad
+
+    for name, actual, golden in [("dQ", dQ_grad, dQ_ref), ("dK", dK_grad, dK_ref), ("dV", dV_grad, dV_ref)]:
+        passed, ratio, max_abs = check_precision(actual, golden, "float16")
+        status = "[PRECISION_PASS]" if passed else "[PRECISION_FAIL]"
+        print(f"  {name}: {status} ratio={ratio:.4f} max_abs={max_abs:.3e}")
+        if not passed:
+            all_passed = False
+
+    # --- Regression 2: output.sum().backward() (non-contiguous gradient) ---
+    print("\n--- Regression 2: output.sum().backward() (zero-stride gradient) ---")
+    Q_npu2 = Q_cpu.to("npu")
+    K_npu2 = K_cpu.to("npu")
+    V_npu2 = V_cpu.to("npu")
+    Q_npu2.requires_grad_(True)
+    K_npu2.requires_grad_(True)
+    V_npu2.requires_grad_(True)
+
+    try:
+        output2 = attention(Q_npu2, K_npu2, V_npu2, False, groups)
+        output2.sum().backward()
+        torch.npu.synchronize()
+        print("  output.sum().backward(): [PASS] no contiguous error")
+    except Exception as e:
+        print(f"  output.sum().backward(): [FAIL] {type(e).__name__}: {e}")
+        all_passed = False
+
+    return all_passed, []
+
+
 # --- msprof kernel-level profiling (--level msprof) ---
 
 _MSPROF_TARGET_SCRIPT = """\
@@ -993,6 +1065,10 @@ def main():
     if args.level in ("boundary", "all", "full"):
         test_gqa_bwd_boundary()
         # Boundary failures are non-blocking
+
+    if args.level in ("all", "full"):
+        passed, _ = test_gqa_bwd_regression()
+        overall_passed = overall_passed and passed
 
     print(f"\n{'=' * 60}")
     if overall_passed:


### PR DESCRIPTION
## Summary

Fixes #1669.

### Bug 1: Non-16-aligned D_qk returns wrong gradients

`run_bwd` used padded `dim_qk_padded` (e.g. 144) for softmax scale instead of logical `D_qk` (e.g. 129), causing `sm_scale = 1/sqrt(144)` instead of `1/sqrt(129)`.

**Fix**: `run_bwd` accepts explicit `dim_qk` parameter. Phase 2 (softmax) uses logical `dim_qk` for `sm_scale`; Phase 1/3 use `dim_qk_padded` for buffer shapes. The Autograd wrapper passes `ctx.D_qk` through.

### Bug 2: PyTorch Autograd non-contiguous gradient

`output.sum().backward()` produces a zero-stride gradient view. The wrapper did not materialize it, causing `ValueError: Input tensor must be contiguous`.

**Fix**: `backward()` entry adds `if not do.is_contiguous(): do = do.contiguous()`.

## Regression Tests Added

1. **D_qk=129**: gradient comparison via public `attention` wrapper (padded to 144, scale uses 129)
2. **`output.sum().backward()`**: Autograd compatibility with zero-stride gradient

## Verification

| Test | Result |
|------|--------|
| L0 (6 cases) | 6/6 PASS |
| L1 (10 cases) | 10/10 PASS |
| L2 (3 negative) | 3 correctly rejected |
| Boundary (4) | 3 PASS + 1 WARN |
| Regression #1669 | D_qk=129 PASS + Autograd PASS |
| do_bench perf | 18423 us (no regression) |
| ruff format + check | All checks passed |

Based on #1623 (Developer-mode 3-sub-kernel rewrite).