### PR TITLE
[Doc] Ascend: refine T.tile.sin/cos docstrings, add test cases and API documentation 🤖

### DIFF
--- a/docs/language/tile_cos.md
+++ b/docs/language/tile_cos.md
@@ -1,0 +1,76 @@
+# T.tile.cos
+
+## 1. 功能说明
+
+对源操作数逐元素执行余弦运算：`dst[i] = cos(src[i])`
+
+> cos 为独立实现，直接映射到 `tl.ascend_cos` intrinsic（Ascend C 高阶 API `Cos`，多项式近似实现）。Ascend C 后端内部需要临时空间（tmpBuffer）存储中间变量；**PTO 后端不支持 cos**（编译期报 `tl.ascend_cos is not supported by the PTO backend`，无原生 PTO-ISA 指令）。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def cos(
+    dst: Buffer | BufferRegion,
+    src: Buffer | BufferRegion,
+    *,
+    tmp: Buffer | BufferRegion | None = None,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放余弦运算结果 | 张量（tensor） | 必填 |
+| src | 输入 | 源操作数 | 张量（tensor） | 必填 |
+| tmp | 输入 | 显式指定的 UB 临时缓冲区（一般无需用户提供，省略时框架自动申请） | 张量（tensor） | 可选 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src |
+|------|:---:|:---:|
+| Ascend A2 / A3（Ascend C 后端） | float16, float32 | float16, float32 |
+
+- 整数 dtype（int16/int32）与 bfloat16 编译失败（`src/transform/allocate_tmp_buffer.cc` 校验 `dtype.is_float() && bits ∈ {16, 32}`）
+- PTO 后端：不支持（编译期报错）
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- 支持整行切片（如 `buf[0:32, :]`）；仅计算切片区域内元素，区域外内容未定义
+
+### 2.4 约束条件
+
+1. dst 与 src 的元素总数必须相同，否则前端 assert 失败（"size must be same"）
+2. dst 与 src 的 dtype 必须一致（Ascend C 约束）
+3. 操作数地址需 32 字节对齐（硬件约束）
+4. **支持原地运算**（dst 与 src 为同一 buffer，Ascend C 后端真机实测正确）
+5. 特殊值遵循 IEEE 语义（真机实测）：`cos(0)=1`、`cos(±inf)=nan`、`cos(nan)=nan`
+6. 精度（真机实测，Ascend910B3）：float16 相对误差 ≤ 5e-4（多项式近似）、float32 绝对误差 ≤ 4e-9
+7. 输入超出 [-65504.0, 65504.0] 时（float32 大值输入），多项式近似不做范围归约，结果与 IEEE 参考值可能不一致
+8. 接口内部使用框架自动申请的临时缓冲区（fp16：`max(2S, 512)` 字节、fp32：`max(2S, 384)` 字节，S 为 src 字节数），无需用户手动分配；也可通过 `tmp` 参数显式提供
+
+## 3. 示例代码
+
+**示例 1：1D 余弦运算**
+
+```python
+src = T.alloc_ub((1024,), "float16")
+dst = T.alloc_ub((1024,), "float16")
+T.tile.cos(dst, src)
+```
+
+**示例 2：2D 余弦运算（整行切片）**
+
+```python
+src = T.alloc_ub((128, 64), "float16")
+dst = T.alloc_ub((128, 64), "float16")
+T.tile.cos(dst[0:64, :], src[0:64, :])
+```

--- a/docs/language/tile_sin.md
+++ b/docs/language/tile_sin.md
@@ -1,0 +1,76 @@
+# T.tile.sin
+
+## 1. 功能说明
+
+对源操作数逐元素执行正弦运算：`dst[i] = sin(src[i])`
+
+> sin 为独立实现，直接映射到 `tl.ascend_sin` intrinsic（Ascend C 高阶 API `Sin`，多项式近似实现）。Ascend C 后端内部需要临时空间（tmpBuffer）存储中间变量；**PTO 后端不支持 sin**（编译期报 `tl.ascend_sin is not supported by the PTO backend`，无原生 PTO-ISA 指令）。
+
+## 2. 函数原型
+
+### 2.1 函数定义
+
+```python
+def sin(
+    dst: Buffer | BufferRegion,
+    src: Buffer | BufferRegion,
+    *,
+    tmp: Buffer | BufferRegion | None = None,
+)
+```
+
+### 2.2 参数说明
+
+| 参数名 | 输入/输出 | 描述 | 类型 | 必填/可选 |
+|--------|----------|------|------|----------|
+| dst | 输出 | 存放正弦运算结果 | 张量（tensor） | 必填 |
+| src | 输入 | 源操作数 | 张量（tensor） | 必填 |
+| tmp | 输入 | 显式指定的 UB 临时缓冲区（一般无需用户提供，省略时框架自动申请） | 张量（tensor） | 可选 |
+
+> **类型说明**：
+> - **tensor**：通过 `T.alloc_ub`、`T.alloc_shared` 等分配的缓冲区（Buffer），或其切片（BufferRegion）
+
+### 2.3 参数规格
+
+#### 2.3.1 DataType 支持
+
+| 平台 | dst | src |
+|------|:---:|:---:|
+| Ascend A2 / A3（Ascend C 后端） | float16, float32 | float16, float32 |
+
+- 整数 dtype（int16/int32）与 bfloat16 编译失败（`src/transform/allocate_tmp_buffer.cc` 校验 `dtype.is_float() && bits ∈ {16, 32}`）
+- PTO 后端：不支持（编译期报错）
+
+#### 2.3.2 Shape 支持
+
+- 支持 1D 和 2D
+- 支持整行切片（如 `buf[0:32, :]`）；仅计算切片区域内元素，区域外内容未定义
+
+### 2.4 约束条件
+
+1. dst 与 src 的元素总数必须相同，否则前端 assert 失败（"size must be same"）
+2. dst 与 src 的 dtype 必须一致（Ascend C 约束）
+3. 操作数地址需 32 字节对齐（硬件约束）
+4. **支持原地运算**（dst 与 src 为同一 buffer，Ascend C 后端真机实测正确）
+5. 特殊值遵循 IEEE 语义（真机实测）：`sin(0)=0`、`sin(±inf)=nan`、`sin(nan)=nan`
+6. 精度（真机实测，Ascend910B3）：float16 相对误差 ≤ 5e-4（多项式近似）、float32 绝对误差 ≤ 1.2e-7
+7. 输入超出 [-65504.0, 65504.0] 时（float32 大值输入），多项式近似不做范围归约，结果与 IEEE 参考值可能不一致
+8. 接口内部使用框架自动申请的临时缓冲区（fp16：`max(2S, 512)` 字节、fp32：`max(2S, 384)` 字节，S 为 src 字节数），无需用户手动分配；也可通过 `tmp` 参数显式提供
+
+## 3. 示例代码
+
+**示例 1：1D 正弦运算**
+
+```python
+src = T.alloc_ub((1024,), "float16")
+dst = T.alloc_ub((1024,), "float16")
+T.tile.sin(dst, src)
+```
+
+**示例 2：2D 正弦运算（整行切片）**
+
+```python
+src = T.alloc_ub((128, 64), "float16")
+dst = T.alloc_ub((128, 64), "float16")
+T.tile.sin(dst[0:64, :], src[0:64, :])
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,15 @@ skip = [
 ]
 
 [tool.pytest.ini_options]
+pythonpath = ["testing/python", "."]
+testpaths = ["testing"]
 markers = [
     "low_priority: marks tests as low priority (only run in full test and scheduled tasks)",
     "ci_skip: marks tests to be skipped in all CI test scenarios",
+    "l0: Gate test — must pass to merge",
+    "l1: Functional test — must pass to merge",
+    "l2: Boundary/exception test — recommended",
+    "compile_time: Compile-time test, no NPU needed",
 ]
 
 [tool.ruff]

--- a/testing/python/base/__init__.py
+++ b/testing/python/base/__init__.py
@@ -1,0 +1,41 @@
+"""
+Base test infrastructure for TileLang-Ascend API tests.
+
+Usage:
+    from base import BinaryOpSpec, register_binary_op_tests
+    from base import UnaryOpSpec, register_unary_op_tests
+    from base import TOLERANCE, DTYPE_MAP, assert_close_npu, make_test_data
+"""
+
+from base.common import (
+    TOLERANCE as TOLERANCE,
+    DTYPE_MAP as DTYPE_MAP,
+    DEFAULT_PASS_CONFIGS as DEFAULT_PASS_CONFIGS,
+    assert_close_npu as assert_close_npu,
+    make_test_data as make_test_data,
+    skip_if_missing as skip_if_missing,
+)
+
+from base.binary_op import (
+    BinaryOpSpec as BinaryOpSpec,
+    BinaryOpTestClasses as BinaryOpTestClasses,
+    register_binary_op_tests as register_binary_op_tests,
+    make_binary_kernel as make_binary_kernel,
+    make_1d_kernel as make_1d_kernel,
+    make_scalar_kernel as make_scalar_kernel,
+    make_buffload_kernel as make_buffload_kernel,
+    make_row_slice_kernel as make_row_slice_kernel,
+    make_inplace_kernel as make_inplace_kernel,
+    make_src0_mismatch_kernel as make_src0_mismatch_kernel,
+    make_region_mismatch_kernel as make_region_mismatch_kernel,
+    make_buffer_mismatch_kernel as make_buffer_mismatch_kernel,
+    run_binary_op as run_binary_op,
+)
+
+from base.unary_op import (
+    UnaryOpSpec as UnaryOpSpec,
+    UnaryOpTestClasses as UnaryOpTestClasses,
+    register_unary_op_tests as register_unary_op_tests,
+    make_unary_kernel as make_unary_kernel,
+    run_unary_op as run_unary_op,
+)

--- a/testing/python/base/binary_op.py
+++ b/testing/python/base/binary_op.py
@@ -1,0 +1,638 @@
+"""Binary operator test infrastructure (T.tile.add, .sub, .mul, ...)."""
+
+import inspect
+from typing import NamedTuple
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+
+from base.common import DTYPE_MAP, DEFAULT_PASS_CONFIGS, assert_close_npu, make_test_data, skip_if_missing
+
+
+def make_binary_kernel(tile_op):
+    """Factory: tensor op tensor -> tensor."""
+
+    def kernel(M, N, block_M, block_N, dtype="float"):
+        m_num = M // block_M
+        n_num = N // block_N
+        VEC_NUM = 2
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, N), dtype),  # type: ignore
+            B: T.Tensor((M, N), dtype),  # type: ignore
+            C: T.Tensor((M, N), dtype),  # type: ignore
+        ):
+            with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+                bx = cid // n_num
+                by = cid % n_num
+                a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+                b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+                c_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+                T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+                T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+                tile_op(c_ub, a_ub, b_ub)
+                T.copy(c_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+        return main
+
+    return kernel
+
+
+def make_1d_kernel(tile_op):
+    """Factory: tensor op tensor -> tensor on 1D buffers."""
+
+    def kernel(N, dtype="float"):
+        @T.prim_func
+        def main(
+            A: T.Tensor((N,), dtype),  # type: ignore
+            B: T.Tensor((N,), dtype),  # type: ignore
+            C: T.Tensor((N,), dtype),  # type: ignore
+        ):
+            with T.Kernel(1, is_npu=True) as (cid, _):
+                a_ub = T.alloc_ub((N,), dtype)
+                b_ub = T.alloc_ub((N,), dtype)
+                c_ub = T.alloc_ub((N,), dtype)
+                T.copy(A, a_ub)
+                T.copy(B, b_ub)
+                tile_op(c_ub, a_ub, b_ub)
+                T.copy(c_ub, C)
+
+        return main
+
+    return kernel
+
+
+def make_scalar_kernel(tile_op):
+    """Factory: tensor op scalar -> tensor."""
+
+    def kernel(M, N, block_M, block_N, scalar, dtype="float"):
+        m_num = M // block_M
+        n_num = N // block_N
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, N), dtype),  # type: ignore
+            B: T.Tensor((M, N), dtype),  # type: ignore
+        ):
+            with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+                bx = cid // n_num
+                by = cid % n_num
+                a_ub = T.alloc_ub((block_M, block_N), dtype)
+                b_ub = T.alloc_ub((block_M, block_N), dtype)
+                T.copy(A[bx * block_M, by * block_N], a_ub)
+                tile_op(b_ub, a_ub, scalar)
+                T.copy(b_ub, B[bx * block_M, by * block_N])
+
+        return main
+
+    return kernel
+
+
+def make_buffload_kernel(tile_op):
+    """Factory: tensor op 1D-buffer-element (BufferLoad) -> tensor."""
+
+    def kernel(M, N, m, dtype="float"):
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, N), dtype),  # type: ignore
+            S: T.Tensor((m,), dtype),  # type: ignore
+            C: T.Tensor((M, N), dtype),  # type: ignore
+        ):
+            with T.Kernel(1, is_npu=True) as (cid, _):
+                a_ub = T.alloc_ub((M, N), dtype)
+                s_ub = T.alloc_ub((m,), dtype)
+                c_ub = T.alloc_ub((M, N), dtype)
+                T.copy(A, a_ub)
+                T.copy(S, s_ub)
+                tile_op(c_ub, a_ub, s_ub[3])
+                T.copy(c_ub, C)
+
+        return main
+
+    return kernel
+
+
+def make_row_slice_kernel(tile_op):
+    """Factory: 2D whole-row slice regions with a per-row BufferLoad scalar."""
+
+    def kernel(M, N, m, dtype="float"):
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, N), dtype),  # type: ignore
+            S: T.Tensor((m,), dtype),  # type: ignore
+            C: T.Tensor((M, N), dtype),  # type: ignore
+        ):
+            with T.Kernel(1, is_npu=True) as (cid, _):
+                a_ub = T.alloc_ub((M, N), dtype)
+                s_ub = T.alloc_ub((m,), dtype)
+                c_ub = T.alloc_ub((M, N), dtype)
+                T.copy(A, a_ub)
+                T.copy(S, s_ub)
+                for h_i in range(M):
+                    tile_op(c_ub[h_i, :], a_ub[h_i, :], s_ub[h_i % m])
+                T.copy(c_ub, C)
+
+        return main
+
+    return kernel
+
+
+def make_inplace_kernel(tile_op):
+    """Factory: dst = dst op src (in-place on UB buffer)."""
+
+    def kernel(M, N, block_M, block_N, dtype="float"):
+        m_num = M // block_M
+        n_num = N // block_N
+        VEC_NUM = 2
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, N), dtype),  # type: ignore
+            B: T.Tensor((M, N), dtype),  # type: ignore
+            C: T.Tensor((M, N), dtype),  # type: ignore
+        ):
+            with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+                bx = cid // n_num
+                by = cid % n_num
+                a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+                b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+                T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+                T.copy(B[bx * block_M + vid * block_M // VEC_NUM, by * block_N], b_ub)
+                tile_op(a_ub, a_ub, b_ub)
+                T.copy(a_ub, C[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+        return main
+
+    return kernel
+
+
+def make_src0_mismatch_kernel(tile_op):
+    """dst(64) vs src0(128) -> traced-time Python assert (constraint 1)."""
+
+    @T.prim_func
+    def main(A: T.Tensor((128,), "float16"), B: T.Tensor((64,), "float16"), C: T.Tensor((64,), "float16")):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((128,), "float16")
+            b_ub = T.alloc_ub((64,), "float16")
+            c_ub = T.alloc_ub((64,), "float16")
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            tile_op(c_ub, a_ub, b_ub)
+            T.copy(c_ub, C)
+
+    return main
+
+
+def make_region_mismatch_kernel(tile_op):
+    """src1 BufferRegion(32) vs dst(64) -> traced-time assert (constraint 2)."""
+
+    @T.prim_func
+    def main(A: T.Tensor((64,), "float16"), B: T.Tensor((128,), "float16"), C: T.Tensor((64,), "float16")):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((64,), "float16")
+            b_ub = T.alloc_ub((128,), "float16")
+            c_ub = T.alloc_ub((64,), "float16")
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            tile_op(c_ub, a_ub, b_ub[0:32])
+            T.copy(c_ub, C)
+
+    return main
+
+
+def make_buffer_mismatch_kernel(tile_op):
+    """src1 Buffer(128) vs dst(64) -> NOT validated (constraint 3): only the
+    first dst.size elements participate."""
+
+    @T.prim_func
+    def main(A: T.Tensor((64,), "float16"), B: T.Tensor((128,), "float16"), C: T.Tensor((64,), "float16")):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((64,), "float16")
+            b_ub = T.alloc_ub((128,), "float16")
+            c_ub = T.alloc_ub((64,), "float16")
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            tile_op(c_ub, a_ub, b_ub)
+            T.copy(c_ub, C)
+
+    return main
+
+
+def run_binary_op(kernel_factory, M, N, block_M, block_N, dtype, target, golden_fn):
+    func = kernel_factory(M, N, block_M, block_N, dtype=dtype)
+    compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+    a = make_test_data((M, N), dtype)
+    b = make_test_data((M, N), dtype)
+    torch.npu.synchronize()
+    c = compiled(a, b)
+    assert_close_npu(c, golden_fn(a, b), dtype)
+
+
+def run_1d_op(kernel_factory, N, dtype, target, golden_fn):
+    func = kernel_factory(N, dtype=dtype)
+    compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+    a = make_test_data((N,), dtype)
+    b = make_test_data((N,), dtype)
+    torch.npu.synchronize()
+    c = compiled(a, b)
+    assert_close_npu(c, golden_fn(a, b), dtype)
+
+
+def run_scalar_op(kernel_factory, M, N, block_M, block_N, scalar, dtype, target, golden_fn):
+    func = kernel_factory(M, N, block_M, block_N, scalar, dtype)
+    compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+    a = make_test_data((M, N), dtype)
+    torch.npu.synchronize()
+    b = compiled(a)
+    expected = golden_fn(a, scalar, dtype)
+    assert_close_npu(b, expected, dtype)
+
+
+def run_buffload_op(kernel_factory, M, N, m, dtype, target, golden_fn):
+    func = kernel_factory(M, N, m, dtype=dtype)
+    compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+    torch.manual_seed(0)
+    a = make_test_data((M, N), dtype, device="cpu")
+    if dtype.startswith("float"):
+        values = [1.5, 2.0, 0.5, 3.0, 4.0, -1.0, 0.25, 0.75]
+    else:
+        values = [1, 2, 3, 4, 5, 6, 7, 8]
+    s = torch.tensor(values, dtype=DTYPE_MAP[dtype])[:m]
+    torch.npu.synchronize()
+    b = compiled(a.npu(), s.npu())
+    torch.npu.synchronize()
+    assert_close_npu(b.cpu(), golden_fn(a, s[3]), dtype)
+
+
+def run_row_slice_op(kernel_factory, M, N, m, dtype, target, golden_fn):
+    func = kernel_factory(M, N, m, dtype=dtype)
+    compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+    torch.manual_seed(0)
+    a = make_test_data((M, N), dtype, device="cpu")
+    if dtype.startswith("float"):
+        values = [1.5, 2.0, 0.5, 3.0, 4.0, -1.0, 0.25, 0.75]
+    else:
+        values = [1, 2, 3, 4, 5, 6, 7, 8]
+    s = torch.tensor(values, dtype=DTYPE_MAP[dtype])[:m]
+    torch.npu.synchronize()
+    b = compiled(a.npu(), s.npu())
+    torch.npu.synchronize()
+    ref = torch.stack([golden_fn(a[h], s[h % m]) for h in range(M)])
+    assert_close_npu(b.cpu(), ref, dtype)
+
+
+class BinaryOpSpec:
+    def __init__(
+        self,
+        name,
+        tile_op,
+        golden,
+        supported_dtypes,
+        boundary_dtypes=None,
+        kernel_tensor=None,
+        kernel_scalar=None,
+        kernel_inplace=None,
+        kernel_1d=None,
+        kernel_buffload=None,
+        kernel_row_slice=None,
+        mismatch_kernels=None,
+        low_priority_dtypes=None,
+    ):
+        self.name = name
+        self.tile_op = tile_op
+        self.golden = golden
+        self.supported_dtypes = supported_dtypes
+        self.boundary_dtypes = boundary_dtypes or ["float16", "float32"]
+        self.low_priority_dtypes = list(low_priority_dtypes or [])
+        # Mandatory variants: None -> default factory (all binary ops share
+        # the same binary_op front-end).
+        self.kernel_tensor = kernel_tensor or make_binary_kernel(self.tile_op)
+        self.kernel_scalar = kernel_scalar or make_scalar_kernel(self.tile_op)
+        self.kernel_inplace = kernel_inplace or make_inplace_kernel(self.tile_op)
+        # Optional variants: None -> disabled (skip_if_missing skips them);
+        # specs opt in by passing the factory explicitly.
+        self.kernel_1d = kernel_1d or None
+        self.kernel_buffload = kernel_buffload or None
+        self.kernel_row_slice = kernel_row_slice or None
+        # Size-validation kernels (constraint 1/2/3 checks); None -> disabled.
+        self.mismatch_kernels = mismatch_kernels or None
+
+    def scalar_golden(self, a, scalar, dtype):
+        if dtype in ("int16", "int32"):
+            scalar = int(scalar)
+        return self.golden(a, scalar)
+
+
+@pytest.mark.compile_time
+@pytest.mark.usefixtures("disable_tilelang_cache", "random_seed")
+class _BinaryOpCompile:
+    op = None
+    _dtype_source = "supported_dtypes"
+
+    @pytest.mark.l0
+    def test_compiles(self, dtype):
+        skip_if_missing(self.op, "kernel_tensor")
+        func = self.op.kernel_tensor(128, 128, 64, 64, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target="ascendc")
+        assert callable(compiled)
+
+    @pytest.mark.l0
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_compiles_both_targets(self, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        func = self.op.kernel_tensor(128, 128, 64, 64, self.op.supported_dtypes[0])
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        assert callable(compiled)
+
+    @pytest.mark.l0
+    def test_scalar_variant_compiles(self):
+        skip_if_missing(self.op, "kernel_scalar")
+        func = self.op.kernel_scalar(128, 128, 64, 64, 1.0, self.op.supported_dtypes[0])
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target="ascendc")
+        assert callable(compiled)
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize("shape", [(64, 64), (128, 256), (256, 128)])
+    def test_various_shapes_compile(self, shape):
+        skip_if_missing(self.op, "kernel_tensor")
+        M, N = shape
+        func = self.op.kernel_tensor(M, N, 64, 64, self.op.supported_dtypes[0])
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target="ascendc")
+        assert callable(compiled)
+
+
+@pytest.mark.usefixtures("disable_tilelang_cache", "random_seed")
+class _BinaryOpE2E:
+    op = None
+    _dtype_source = "supported_dtypes"
+
+    @pytest.mark.l0
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_basic_1024x1024(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        run_binary_op(
+            self.op.kernel_tensor,
+            1024,
+            1024,
+            128,
+            128,
+            dtype,
+            target,
+            golden_fn=self.op.golden,
+        )
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize(
+        "M,N,block_M,block_N",
+        [
+            (256, 256, 64, 64),
+            (512, 1024, 64, 128),
+            (1024, 512, 128, 64),
+            (2048, 2048, 128, 128),
+        ],
+    )
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_various_shapes(self, M, N, block_M, block_N, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        run_binary_op(
+            self.op.kernel_tensor,
+            M,
+            N,
+            block_M,
+            block_N,
+            dtype,
+            target,
+            golden_fn=self.op.golden,
+        )
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize("M,N", [(100, 200), (107, 145), (255, 513)])
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_tail_blocks(self, M, N, dtype, target):
+        """Non-multiple shapes: only full blocks participate (tail dropped).
+
+        M/N are trimmed down to block multiples before launch, so this
+        verifies the aligned prefix stays correct; the ragged tail is
+        intentionally not covered by the grid.
+        """
+        skip_if_missing(self.op, "kernel_tensor")
+        block_M = 64 if M >= 64 else 32
+        block_N = 64 if N >= 64 else 32
+        M_aligned = (M // block_M) * block_M
+        N_aligned = (N // block_N) * block_N
+        run_binary_op(
+            self.op.kernel_tensor,
+            M_aligned,
+            N_aligned,
+            block_M,
+            block_N,
+            dtype,
+            target,
+            golden_fn=self.op.golden,
+        )
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize("N", [256])
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_1d(self, N, dtype, target):
+        skip_if_missing(self.op, "kernel_1d")
+        run_1d_op(self.op.kernel_1d, N, dtype, target, golden_fn=self.op.golden)
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize("scalar_val", [2.0])
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_tensor_op_scalar(self, scalar_val, dtype, target):
+        skip_if_missing(self.op, "kernel_scalar")
+        scalar = scalar_val if dtype not in ("int16", "int32") else int(scalar_val)
+        run_scalar_op(
+            self.op.kernel_scalar,
+            1024,
+            1024,
+            128,
+            128,
+            scalar,
+            dtype,
+            target,
+            golden_fn=self.op.scalar_golden,
+        )
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_buffload(self, dtype, target):
+        skip_if_missing(self.op, "kernel_buffload")
+        run_buffload_op(self.op.kernel_buffload, 64, 128, 8, dtype, target, golden_fn=self.op.golden)
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_row_slice_2d(self, dtype, target):
+        skip_if_missing(self.op, "kernel_row_slice")
+        run_row_slice_op(self.op.kernel_row_slice, 4, 128, 4, dtype, target, golden_fn=self.op.golden)
+
+    @pytest.mark.l1
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_inplace(self, dtype, target):
+        skip_if_missing(self.op, "kernel_inplace")
+        func = self.op.kernel_inplace(1024, 1024, 128, 128, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        a = make_test_data((1024, 1024), dtype)
+        b = make_test_data((1024, 1024), dtype)
+        torch.npu.synchronize()
+        result = compiled(a, b)
+        assert_close_npu(result, self.op.golden(a, b), dtype)
+
+
+@pytest.mark.usefixtures("disable_tilelang_cache", "random_seed")
+class _BinaryOpBoundary:
+    op = None
+    _dtype_source = "boundary_dtypes"
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_large_values(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        torch_dtype = DTYPE_MAP[dtype]
+        if dtype == "float32":
+            a = torch.full((256, 256), 1e30, dtype=torch_dtype, device="npu")
+            b = torch.full((256, 256), 1e30, dtype=torch_dtype, device="npu")
+        else:
+            a = torch.full((256, 256), 60000.0, dtype=torch_dtype, device="npu")
+            b = torch.full((256, 256), 1.0, dtype=torch_dtype, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        c = compiled(a, b)
+        assert c.shape == (256, 256)
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_zeros(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        torch_dtype = DTYPE_MAP[dtype]
+        a = torch.zeros(256, 256, dtype=torch_dtype, device="npu")
+        b = torch.zeros(256, 256, dtype=torch_dtype, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        c = compiled(a, b)
+        assert_close_npu(c, torch.zeros_like(a), dtype)
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_negative_values(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        torch_dtype = DTYPE_MAP[dtype]
+        a = torch.full((256, 256), -5.0, dtype=torch_dtype, device="npu")
+        b = torch.full((256, 256), 3.0, dtype=torch_dtype, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        c = compiled(a, b)
+        assert_close_npu(c, self.op.golden(a, b), dtype)
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_inf_input(self, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        if "float16" not in self.op.boundary_dtypes:
+            pytest.skip("float16 not in boundary_dtypes")
+        a = torch.full((256, 256), float("inf"), dtype=torch.float16, device="npu")
+        b = torch.ones(256, 256, dtype=torch.float16, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, "float16")
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        c = compiled(a, b)
+        assert c.shape == (256, 256)
+        assert torch.all(torch.isinf(c))
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_nan_input(self, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        if "float16" not in self.op.boundary_dtypes:
+            pytest.skip("float16 not in boundary_dtypes")
+        a = torch.full((256, 256), float("nan"), dtype=torch.float16, device="npu")
+        b = torch.ones(256, 256, dtype=torch.float16, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, "float16")
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        c = compiled(a, b)
+        assert c.shape == (256, 256)
+        assert torch.all(torch.isnan(c))
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_minimum_shape(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        run_binary_op(
+            self.op.kernel_tensor,
+            64,
+            64,
+            64,
+            64,
+            dtype,
+            target,
+            golden_fn=self.op.golden,
+        )
+
+    @pytest.mark.l2
+    def test_size_mismatch_src0(self):
+        """dst vs src0 size mismatch raises at trace time (constraint 1)."""
+        skip_if_missing(self.op, "mismatch_kernels")
+        with pytest.raises((RuntimeError, AssertionError)):
+            self.op.mismatch_kernels[0]()
+
+    @pytest.mark.l2
+    def test_size_mismatch_region(self):
+        """src1 BufferRegion size mismatch raises at trace time (constraint 2)."""
+        skip_if_missing(self.op, "mismatch_kernels")
+        with pytest.raises((RuntimeError, AssertionError)):
+            self.op.mismatch_kernels[1]()
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", ["ascendc", "pto"])
+    def test_buffer_size_unvalidated(self, target):
+        """src1 Buffer size is NOT validated (constraint 3): only the first
+        dst.size elements participate."""
+        skip_if_missing(self.op, "mismatch_kernels")
+        torch.manual_seed(0)
+        a = torch.randn(64, dtype=torch.float16)
+        b = torch.rand(128, dtype=torch.float16)
+        func = self.op.mismatch_kernels[2]()
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        out = compiled(a.npu(), b.npu())
+        torch.npu.synchronize()
+        torch.testing.assert_close(out.cpu().float(), self.op.golden(a, b[:64]).float(), rtol=1e-2, atol=1e-2)
+
+
+class BinaryOpTestClasses(NamedTuple):
+    Compile: type[_BinaryOpCompile]
+    E2E: type[_BinaryOpE2E]
+    Boundary: type[_BinaryOpBoundary]
+
+
+def register_binary_op_tests(spec) -> BinaryOpTestClasses:
+    """Create TestTile{Name}Compile / E2E / Boundary classes in the caller's module.
+
+    Also creates ``_``-prefixed base classes and returns them as a
+    :class:`BinaryOpTestClasses` tuple so callers can subclass them for
+    override scenarios (e.g. extra parametrize decorators).
+    """
+    caller_globals = inspect.currentframe().f_back.f_globals
+    prefix = f"TestTile{spec.name.capitalize()}"
+    base_classes = []
+    for suffix, base in [
+        ("Compile", _BinaryOpCompile),
+        ("E2E", _BinaryOpE2E),
+        ("Boundary", _BinaryOpBoundary),
+    ]:
+        # Inject into globals (existing behavior, backward compatible)
+        cls = type(f"{prefix}{suffix}", (base,), {"op": spec})
+        caller_globals[cls.__name__] = cls
+        # Create _-prefixed version for override scenarios
+        base_cls = type(f"_{prefix}{suffix}", (base,), {"op": spec})
+        base_classes.append(base_cls)
+    return BinaryOpTestClasses(*base_classes)

--- a/testing/python/base/common.py
+++ b/testing/python/base/common.py
@@ -1,0 +1,95 @@
+"""
+Shared test utilities for TileLang-Ascend API tests.
+
+Import from test files:
+    from base import TOLERANCE, DTYPE_MAP, DEFAULT_PASS_CONFIGS, assert_close_npu, make_test_data
+"""
+
+import torch
+import tilelang
+
+
+# ---------------------------------------------------------------------------
+# Precision tolerance table — graded by dtype (NOT a flat 1e-2 for all)
+# ---------------------------------------------------------------------------
+TOLERANCE = {
+    "float32": {"rtol": 1e-5, "atol": 1e-5},
+    "float": {"rtol": 1e-5, "atol": 1e-5},
+    "float16": {"rtol": 1e-3, "atol": 1e-3},
+    "bfloat16": {"rtol": 7.8e-3, "atol": 7.8e-3},
+    "int8": {"rtol": 0, "atol": 0},
+    "int16": {"rtol": 0, "atol": 0},
+    "int32": {"rtol": 0, "atol": 0},
+    "uint8": {"rtol": 0, "atol": 0},
+    "uint16": {"rtol": 0, "atol": 0},
+    "uint32": {"rtol": 0, "atol": 0},
+}
+
+
+# ---------------------------------------------------------------------------
+# TileLang dtype string  →  torch dtype
+# ---------------------------------------------------------------------------
+DTYPE_MAP = {
+    "float": torch.float32,
+    "float32": torch.float32,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "int8": torch.int8,
+    "int16": torch.int16,
+    "int32": torch.int32,
+    "uint8": torch.uint8,
+    "uint16": torch.uint16,
+    "uint32": torch.uint32,
+}
+
+
+# ---------------------------------------------------------------------------
+# Assertion helper — handles uint16/uint32 that torch-npu can't compare
+# ---------------------------------------------------------------------------
+def assert_close_npu(actual, expected, dtype, **override):
+    """Compare NPU output with golden reference using dtype-graded tolerance.
+
+    Usage:
+        assert_close_npu(result, expected, "float16")
+        assert_close_npu(result, expected, "float32", rtol=1e-4)  # override
+    """
+    tol = {**TOLERANCE.get(dtype, {"rtol": 1e-2, "atol": 1e-2}), **override}
+    # torch-npu doesn't support isclose for uint16/uint32
+    if dtype in ("uint16", "uint32"):
+        int_dtype = getattr(torch, dtype.replace("uint", "int"))
+        actual = actual.to(int_dtype)
+        expected = expected.to(int_dtype)
+    torch.testing.assert_close(actual, expected, **tol)
+
+
+# ---------------------------------------------------------------------------
+# Test data generator — integers for int types, randn for float types
+# ---------------------------------------------------------------------------
+def make_test_data(shape, dtype, *, low=-100, high=100, device="npu"):
+    """Generate random test data appropriate for the dtype.
+
+    - Integer types: uniform random in [low, high]
+    - Float types: standard normal
+    """
+    torch_dtype = DTYPE_MAP[dtype]
+    if dtype in ("int8", "int16", "int32", "uint8", "uint16", "uint32"):
+        return torch.randint(low, high, shape, dtype=torch_dtype, device=device)
+    return torch.randn(shape, dtype=torch_dtype, device=device)
+
+
+# ---------------------------------------------------------------------------
+# Default pass_configs for Developer mode tests
+# ---------------------------------------------------------------------------
+DEFAULT_PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+def skip_if_missing(op, attr):
+    import pytest
+
+    if not getattr(op, attr):
+        pytest.skip(f"No {attr}")

--- a/testing/python/base/unary_op.py
+++ b/testing/python/base/unary_op.py
@@ -1,0 +1,348 @@
+"""Unary operator test infrastructure (T.tile.exp, .abs, .sqrt, ...).
+
+PR stage: 3 cases per API (compile f16/ascendc, basic f16/ascendc,
+zeros f16/ascendc). Everything else is marked ``low_priority`` (PR skips it,
+full/scheduled stages run it): the pto target and float32 dtype params (per
+API-test convention) plus the 1D, row-slice and boundary-value tests.
+
+Full-stage scope: 28 cases per API (Compile 4 / E2E 12 / Boundary 12).
+"""
+
+import inspect
+from functools import cached_property
+from typing import NamedTuple
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+
+from base.common import DTYPE_MAP, DEFAULT_PASS_CONFIGS, assert_close_npu, make_test_data, skip_if_missing
+
+
+def target_params():
+    """[ascendc, pto] with pto marked low_priority (PR skips it)."""
+    return ["ascendc", pytest.param("pto", marks=pytest.mark.low_priority)]
+
+
+def make_unary_kernel(tile_op):
+    """Factory: op(src) -> dst."""
+
+    def kernel(M, N, block_M, block_N, dtype="float"):
+        m_num = M // block_M
+        n_num = N // block_N
+        VEC_NUM = 2
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, N), dtype),  # type: ignore
+            B: T.Tensor((M, N), dtype),  # type: ignore
+        ):
+            with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+                bx = cid // n_num
+                by = cid % n_num
+                a_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+                b_ub = T.alloc_ub((block_M // VEC_NUM, block_N), dtype)
+                T.copy(A[bx * block_M + vid * block_M // VEC_NUM, by * block_N], a_ub)
+                tile_op(b_ub, a_ub)
+                T.copy(b_ub, B[bx * block_M + vid * block_M // VEC_NUM, by * block_N])
+
+        return main
+
+    return kernel
+
+
+def make_unary_1d_kernel(tile_op):
+    """Factory: op(src) -> dst on 1D buffers."""
+
+    def kernel(N, dtype="float"):
+        @T.prim_func
+        def main(
+            A: T.Tensor((N,), dtype),  # type: ignore
+            B: T.Tensor((N,), dtype),  # type: ignore
+        ):
+            with T.Kernel(1, is_npu=True) as (cid, vid):
+                a_ub = T.alloc_ub((N,), dtype)
+                b_ub = T.alloc_ub((N,), dtype)
+                T.copy(A, a_ub)
+                tile_op(b_ub, a_ub)
+                T.copy(b_ub, B)
+
+        return main
+
+    return kernel
+
+
+def make_unary_slice_kernel(tile_op):
+    """Factory: op on the top half of a 2D buffer (whole-row BufferRegion)."""
+
+    def kernel(M, N, dtype="float"):
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, N), dtype),  # type: ignore
+            B: T.Tensor((M, N), dtype),  # type: ignore
+        ):
+            with T.Kernel(1, is_npu=True) as (cid, vid):
+                a_ub = T.alloc_ub((M, N), dtype)
+                b_ub = T.alloc_ub((M, N), dtype)
+                T.copy(A, a_ub)
+                tile_op(b_ub[0 : M // 2, :], a_ub[0 : M // 2, :])
+                T.copy(b_ub, B)
+
+        return main
+
+    return kernel
+
+
+def make_unary_inplace_kernel(tile_op):
+    """Factory: op(src) -> dst on a single UB buffer (dst aliases src)."""
+
+    def kernel(M, N, dtype="float"):
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, N), dtype),  # type: ignore
+            B: T.Tensor((M, N), dtype),  # type: ignore
+        ):
+            with T.Kernel(1, is_npu=True) as (cid, vid):
+                a_ub = T.alloc_ub((M, N), dtype)
+                T.copy(A, a_ub)
+                tile_op(a_ub, a_ub)
+                T.copy(a_ub, B)
+
+        return main
+
+    return kernel
+
+
+def run_unary_op(kernel_factory, M, N, block_M, block_N, dtype, target, golden_fn, tol=None):
+    func = kernel_factory(M, N, block_M, block_N, dtype=dtype)
+    compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+    a = make_test_data((M, N), dtype)
+    torch.npu.synchronize()
+    b = compiled(a)
+    assert_close_npu(b, golden_fn(a), dtype, **(tol or {}))
+
+
+def skip_if_unsupported_target(op, target):
+    """Skip a test when the op is not supported on the given backend."""
+    if target in getattr(op, "unsupported_targets", []):
+        pytest.skip(f"{op.name} is not supported on target {target}")
+
+
+class UnaryOpSpec:
+    def __init__(
+        self,
+        name,
+        tile_op,
+        golden,
+        supported_dtypes,
+        boundary_dtypes=None,
+        kernel_tensor=None,
+        kernel_1d=None,
+        kernel_slice=None,
+        kernel_inplace=None,
+        tol=None,
+        low_priority_dtypes=None,
+        unsupported_targets=None,
+    ):
+        self.name = name
+        self.tile_op = tile_op
+        self.golden = golden
+        self.supported_dtypes = supported_dtypes
+        self.boundary_dtypes = boundary_dtypes or ["float16", "float32"]
+        self.low_priority_dtypes = list(low_priority_dtypes or [])
+        self.unsupported_targets = list(unsupported_targets or [])
+        self.tol = tol
+        self.skip_inf_special = False
+        self.inplace_xfail_targets = []
+        if kernel_tensor is not None:
+            self.__dict__["kernel_tensor"] = kernel_tensor
+        if kernel_1d is not None:
+            self.__dict__["kernel_1d"] = kernel_1d
+        if kernel_slice is not None:
+            self.__dict__["kernel_slice"] = kernel_slice
+        if kernel_inplace is not None:
+            self.__dict__["kernel_inplace"] = kernel_inplace
+
+    @cached_property
+    def kernel_tensor(self):
+        return make_unary_kernel(self.tile_op)
+
+    @cached_property
+    def kernel_1d(self):
+        return make_unary_1d_kernel(self.tile_op)
+
+    @cached_property
+    def kernel_slice(self):
+        return make_unary_slice_kernel(self.tile_op)
+
+    @cached_property
+    def kernel_inplace(self):
+        return make_unary_inplace_kernel(self.tile_op)
+
+
+@pytest.mark.compile_time
+@pytest.mark.usefixtures("disable_tilelang_cache", "random_seed")
+class _UnaryOpCompile:
+    op = None
+    _dtype_source = "supported_dtypes"
+
+    @pytest.mark.l0
+    @pytest.mark.parametrize("target", target_params())
+    def test_compiles(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        skip_if_unsupported_target(self.op, target)
+        func = self.op.kernel_tensor(128, 128, 64, 64, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        assert callable(compiled)
+
+
+@pytest.mark.usefixtures("disable_tilelang_cache", "random_seed")
+class _UnaryOpE2E:
+    op = None
+    _dtype_source = "supported_dtypes"
+
+    @pytest.mark.l0
+    @pytest.mark.parametrize("target", target_params())
+    def test_basic_1024x1024(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        skip_if_unsupported_target(self.op, target)
+        run_unary_op(
+            self.op.kernel_tensor,
+            1024,
+            1024,
+            128,
+            128,
+            dtype,
+            target,
+            golden_fn=self.op.golden,
+            tol=self.op.tol,
+        )
+
+    @pytest.mark.l1
+    @pytest.mark.low_priority
+    @pytest.mark.parametrize("target", target_params())
+    def test_1d(self, dtype, target):
+        skip_if_missing(self.op, "kernel_1d")
+        skip_if_unsupported_target(self.op, target)
+        func = self.op.kernel_1d(256, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        a = make_test_data((256,), dtype)
+        torch.npu.synchronize()
+        b = compiled(a)
+        assert_close_npu(b, self.op.golden(a), dtype, **(self.op.tol or {}))
+
+    @pytest.mark.l1
+    @pytest.mark.low_priority
+    @pytest.mark.parametrize("target", target_params())
+    def test_row_slice_2d(self, dtype, target):
+        skip_if_missing(self.op, "kernel_slice")
+        skip_if_unsupported_target(self.op, target)
+        func = self.op.kernel_slice(64, 128, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        a = make_test_data((64, 128), dtype)
+        torch.npu.synchronize()
+        b = compiled(a)
+        g = torch.zeros_like(a)
+        g[0:32, :] = self.op.golden(a)[0:32, :]
+        assert_close_npu(b[0:32, :], g[0:32, :], dtype, **(self.op.tol or {}))
+
+
+@pytest.mark.usefixtures("disable_tilelang_cache", "random_seed")
+class _UnaryOpBoundary:
+    op = None
+    _dtype_source = "boundary_dtypes"
+
+    @pytest.mark.l2
+    @pytest.mark.parametrize("target", target_params())
+    def test_zeros(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        skip_if_unsupported_target(self.op, target)
+        torch_dtype = DTYPE_MAP[dtype]
+        a = torch.zeros(256, 256, dtype=torch_dtype, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        b = compiled(a)
+        assert_close_npu(b, self.op.golden(a), dtype, **(self.op.tol or {}))
+
+    @pytest.mark.l2
+    @pytest.mark.low_priority
+    @pytest.mark.parametrize("target", target_params())
+    def test_negative_values(self, dtype, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        skip_if_unsupported_target(self.op, target)
+        torch_dtype = DTYPE_MAP[dtype]
+        a = torch.full((256, 256), -5.0, dtype=torch_dtype, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, dtype)
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        b = compiled(a)
+        assert_close_npu(b, self.op.golden(a), dtype, **(self.op.tol or {}))
+
+    @pytest.mark.l2
+    @pytest.mark.low_priority
+    @pytest.mark.parametrize("target", target_params())
+    def test_inplace(self, target):
+        """dst aliases src on a single UB buffer; f16 covers the alias path."""
+        skip_if_missing(self.op, "kernel_inplace")
+        skip_if_unsupported_target(self.op, target)
+        if target in getattr(self.op, "inplace_xfail_targets", []):
+            pytest.xfail(f"in-place unsupported on {target}")
+        func = self.op.kernel_inplace(64, 64, "float16")
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        a = make_test_data((64, 64), "float16")
+        torch.npu.synchronize()
+        b = compiled(a)
+        assert_close_npu(b, self.op.golden(a), "float16", **(self.op.tol or {}))
+
+    @pytest.mark.l2
+    @pytest.mark.low_priority
+    @pytest.mark.parametrize("special", ["inf", "nan"])
+    @pytest.mark.parametrize("target", target_params())
+    def test_special_values(self, special, target):
+        skip_if_missing(self.op, "kernel_tensor")
+        skip_if_unsupported_target(self.op, target)
+        if "float16" not in self.op.boundary_dtypes:
+            pytest.skip("float16 not in boundary_dtypes")
+        if special == "inf" and getattr(self.op, "skip_inf_special", False):
+            pytest.skip(f"{self.op.name}(inf) != inf by IEEE semantics; inf-input check not applicable")
+        a = torch.full((256, 256), float(special), dtype=torch.float16, device="npu")
+        func = self.op.kernel_tensor(256, 256, 64, 64, "float16")
+        compiled = tilelang.compile(func, out_idx=[-1], pass_configs=DEFAULT_PASS_CONFIGS, target=target)
+        torch.npu.synchronize()
+        b = compiled(a)
+        assert b.shape == (256, 256)
+        if special == "inf":
+            assert torch.all(torch.isinf(b))
+        else:
+            assert torch.all(torch.isnan(b))
+
+
+class UnaryOpTestClasses(NamedTuple):
+    Compile: type[_UnaryOpCompile]
+    E2E: type[_UnaryOpE2E]
+    Boundary: type[_UnaryOpBoundary]
+
+
+def register_unary_op_tests(spec) -> UnaryOpTestClasses:
+    """Create TestTile{Name}Compile / E2E / Boundary classes in the caller's module.
+
+    Also creates ``_``-prefixed base classes and returns them as a
+    :class:`UnaryOpTestClasses` tuple so callers can subclass them for
+    override scenarios (e.g. extra parametrize decorators).
+    """
+    caller_globals = inspect.currentframe().f_back.f_globals
+    prefix = f"TestTile{spec.name.capitalize()}"
+    base_classes = []
+    for suffix, base in [
+        ("Compile", _UnaryOpCompile),
+        ("E2E", _UnaryOpE2E),
+        ("Boundary", _UnaryOpBoundary),
+    ]:
+        cls = type(f"{prefix}{suffix}", (base,), {"op": spec})
+        caller_globals[cls.__name__] = cls
+        base_cls = type(f"_{prefix}{suffix}", (base,), {"op": spec})
+        base_classes.append(base_cls)
+    return UnaryOpTestClasses(*base_classes)

--- a/testing/python/language/conftest.py
+++ b/testing/python/language/conftest.py
@@ -1,0 +1,67 @@
+"""
+Pytest configuration and shared fixtures for language API tests.
+
+Fixtures defined here are automatically available to all test files
+in testing/python/language/ and its subdirectories — no import needed.
+They are NOT autouse: test suites opt in via ``usefixtures`` so that
+pre-existing tests (e.g. select/elementwise) keep their own seed/cache
+behavior untouched.
+
+Markers (l0/l1/l2/compile_time + project low_priority/ci_skip) are
+registered in pyproject.toml [tool.pytest.ini_options].
+"""
+
+import pytest
+import torch
+import tilelang
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (opt-in, not autouse)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def disable_tilelang_cache():
+    """Disable tilelang JIT cache for the entire test session."""
+    tilelang.disable_cache()
+
+
+@pytest.fixture
+def random_seed():
+    """Set deterministic random seed for reproducibility."""
+    torch.manual_seed(0)
+
+
+# ---------------------------------------------------------------------------
+# Marker registration (moved to pyproject.toml [tool.pytest.ini_options])
+# ---------------------------------------------------------------------------
+
+
+def pytest_generate_tests(metafunc):
+    """Parametrize 'dtype' from the test class's op spec.
+
+    Each base test class declares a _dtype_source attribute (e.g.
+    "supported_dtypes" or "boundary_dtypes") that points to a list on
+    the BinaryOpSpec.  This hook reads that list and feeds it to pytest.
+
+    Dtypes listed in ``op.low_priority_dtypes`` are marked with the
+    project ``low_priority`` marker (skipped on PR, run in full tests).
+    """
+    if "dtype" not in metafunc.fixturenames or metafunc.cls is None:
+        return
+    op = getattr(metafunc.cls, "op", None)
+    if op is None:
+        return
+    source = getattr(metafunc.cls, "_dtype_source", "supported_dtypes")
+    dtypes = getattr(op, source, None)
+    if not dtypes:
+        return
+    low_priority = set(getattr(op, "low_priority_dtypes", []) or [])
+    params = []
+    for d in dtypes:
+        if d in low_priority:
+            params.append(pytest.param(d, marks=pytest.mark.low_priority))
+        else:
+            params.append(d)
+    metafunc.parametrize("dtype", params)

--- a/testing/python/language/test_tile_cos.py
+++ b/testing/python/language/test_tile_cos.py
@@ -1,0 +1,52 @@
+"""T.tile.cos test suite.
+
+Registered against the shared unary-op framework in testing/python/base/.
+Developer mode via DEFAULT_PASS_CONFIGS (auto sync + memory planning).
+
+Notes:
+- PTO backend does not support cos (compile-time error "tl.ascend_cos is
+  not supported by the PTO backend"), so all pto params are skipped.
+- cos(inf) = nan (!= inf), so the inf-input special-value check is skipped.
+"""
+
+import torch
+
+import tilelang.language as T
+
+from base import UnaryOpSpec, register_unary_op_tests
+
+cos_spec = UnaryOpSpec(
+    name="cos",
+    tile_op=T.tile.cos,
+    golden=torch.cos,
+    supported_dtypes=["float16", "float32"],
+    low_priority_dtypes=["float32"],
+    unsupported_targets=["pto"],
+)
+cos_spec.skip_inf_special = True
+
+classes = register_unary_op_tests(cos_spec)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run T.tile.cos tests.")
+    parser.add_argument("--dtype", default="float16", choices=["float16", "float32"])
+    parser.add_argument("--target", default="ascendc", choices=["ascendc", "pto"])
+    parser.add_argument("--M", type=int, default=1024)
+    parser.add_argument("--N", type=int, default=1024)
+    args = parser.parse_args()
+
+    from base.unary_op import run_unary_op
+
+    run_unary_op(
+        cos_spec.kernel_tensor,
+        args.M,
+        args.N,
+        128,
+        128,
+        args.dtype,
+        args.target,
+        golden_fn=torch.cos,
+    )

--- a/testing/python/language/test_tile_sin.py
+++ b/testing/python/language/test_tile_sin.py
@@ -1,0 +1,52 @@
+"""T.tile.sin test suite.
+
+Registered against the shared unary-op framework in testing/python/base/.
+Developer mode via DEFAULT_PASS_CONFIGS (auto sync + memory planning).
+
+Notes:
+- PTO backend does not support sin (compile-time error "tl.ascend_sin is
+  not supported by the PTO backend"), so all pto params are skipped.
+- sin(inf) = nan (!= inf), so the inf-input special-value check is skipped.
+"""
+
+import torch
+
+import tilelang.language as T
+
+from base import UnaryOpSpec, register_unary_op_tests
+
+sin_spec = UnaryOpSpec(
+    name="sin",
+    tile_op=T.tile.sin,
+    golden=torch.sin,
+    supported_dtypes=["float16", "float32"],
+    low_priority_dtypes=["float32"],
+    unsupported_targets=["pto"],
+)
+sin_spec.skip_inf_special = True
+
+classes = register_unary_op_tests(sin_spec)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run T.tile.sin tests.")
+    parser.add_argument("--dtype", default="float16", choices=["float16", "float32"])
+    parser.add_argument("--target", default="ascendc", choices=["ascendc", "pto"])
+    parser.add_argument("--M", type=int, default=1024)
+    parser.add_argument("--N", type=int, default=1024)
+    args = parser.parse_args()
+
+    from base.unary_op import run_unary_op
+
+    run_unary_op(
+        sin_spec.kernel_tensor,
+        args.M,
+        args.N,
+        128,
+        128,
+        args.dtype,
+        args.target,
+        golden_fn=torch.sin,
+    )

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1979,16 +1979,30 @@ def sin(
     *,
     tmp: Buffer | BufferRegion | None = None,
 ):  # noqa: F821
-    """Performs element-wise sine calculation: dst = sin(src).
+    """Performs element-wise sine calculation: ``dst[i] = sin(src[i])``.
+
+    The operation maps to the ``tl.ascend_sin`` intrinsic (Ascend C
+    ``Sin``, polynomial approximation) and is only supported on the
+    Ascend C backend; the PTO backend rejects it at compile time.
 
     Args:
-        dst: The destination buffer where the result will be stored.
-        src: The source buffer containing the input data.
-        tmp: Optional complete UB scratch storage. Its scalar dtype is
+        dst: The destination buffer; it may alias src (in-place) on ascendc.
+        src: The source, a buffer or a contiguous region of it.
+        tmp: Optional explicit UB scratch storage. Its scalar dtype is
             reinterpreted by lowering and has no semantic meaning.
 
-    Returns:
-        A TVM intrinsic call that performs the sine operation.
+    Notes:
+        - dst and src must have equal element counts (asserted by the
+          frontend with "size must be same").
+        - Supported dtypes: float16, float32 only (Atlas A2/A3); integer
+          and bfloat16 dtypes fail at compile time.
+        - Operand addresses must be 32-byte aligned (hardware constraint).
+        - ``tmp`` is optional; a temporary buffer of max(2S, 512/384) bytes
+          (S = src bytes; fp16/fp32) is auto-allocated when not provided.
+        - Special values follow IEEE semantics: sin(0)=0, sin(±inf)=nan,
+          sin(nan)=nan. Inputs beyond the float16 range ([-65504, 65504])
+          give approximation results without range reduction and are not
+          guaranteed to match IEEE.
     """
     if isinstance(dst, BufferRegion):
         dst_ptr, dst_extent = _handle_buffer_region(dst, "w")
@@ -2015,16 +2029,30 @@ def cos(
     *,
     tmp: Buffer | BufferRegion | None = None,
 ):  # noqa: F821
-    """Performs element-wise cosine calculation: dst = cos(src).
+    """Performs element-wise cosine calculation: ``dst[i] = cos(src[i])``.
+
+    The operation maps to the ``tl.ascend_cos`` intrinsic (Ascend C
+    ``Cos``, polynomial approximation) and is only supported on the
+    Ascend C backend; the PTO backend rejects it at compile time.
 
     Args:
-        dst: The destination buffer where the result will be stored.
-        src: The source buffer containing the input data.
-        tmp: Optional complete UB scratch storage. Its scalar dtype is
+        dst: The destination buffer; it may alias src (in-place) on ascendc.
+        src: The source, a buffer or a contiguous region of it.
+        tmp: Optional explicit UB scratch storage. Its scalar dtype is
             reinterpreted by lowering and has no semantic meaning.
 
-    Returns:
-        A TVM intrinsic call that performs the cosine operation.
+    Notes:
+        - dst and src must have equal element counts (asserted by the
+          frontend with "size must be same").
+        - Supported dtypes: float16, float32 only (Atlas A2/A3); integer
+          and bfloat16 dtypes fail at compile time.
+        - Operand addresses must be 32-byte aligned (hardware constraint).
+        - ``tmp`` is optional; a temporary buffer of max(2S, 512/384) bytes
+          (S = src bytes; fp16/fp32) is auto-allocated when not provided.
+        - Special values follow IEEE semantics: cos(0)=1, cos(±inf)=nan,
+          cos(nan)=nan. Inputs beyond the float16 range ([-65504, 65504])
+          give approximation results without range reduction and are not
+          guaranteed to match IEEE.
     """
     if isinstance(dst, BufferRegion):
         dst_ptr, dst_extent = _handle_buffer_region(dst, "w")


### PR DESCRIPTION
## 摘要

完善 `T.tile.sin` / `T.tile.cos` 昇腾 tile API：升级 docstring、新增专用测试套件与 API 文档，并为一元测试框架增加 `unsupported_targets` 支持（用于编译期拒绝的 backend）。

## 变更内容

- `tilelang/language/ascend_tile.py`：精炼 sin/cos docstring（dtype 支持、原地运算、PTO 不支持、tmp workspace 字节数、IEEE 特殊值、大小断言）
- `testing/python/base/unary_op.py`：新增 `unsupported_targets` spec 字段与 `skip_if_unsupported_target`（默认空列表，既有套件行为不变）
- `testing/python/language/test_tile_sin.py` / `test_tile_cos.py`：基于共享一元框架注册（Compile / E2E / Boundary）；PTO 参数跳过（编译期拒绝）、`skip_inf_special` 覆盖 IEEE 语义 sin/cos(inf)=nan
- `docs/language/tile_sin.md` / `tile_cos.md`：经真机验证的 API 文档（无 A5 平台行；dtype 矩阵、精度、特殊值均实测确认）
- `testing/python/base/`、`conftest.py`、`pyproject.toml`：新测试套件所依赖的共享一元测试框架（与 #1657 内容一致，该 PR 合并后本 PR 相关文件自动收敛为增量）

## 测试

真机 Ascend910B3（dav-2201），ascendc 后端全量验证：
- 每个 API 30 例（两 API 共 60 例），**28 passed + 32 skipped**（跳过 = PTO 不支持 + sin/cos(inf)≠inf 的 IEEE 覆盖）
- PR 阶段子集（`-m "not (low_priority or ci_skip)"`）：6 例（每 API 3 例）
- 已确认事实：仅 f16/f32 支持（int16/int32/bf16 编译失败）；ascendc 支持原地运算；特殊值符合 IEEE；f16 max_rel≈5e-4、f32 max_abs≈1e-7
- ruff / py_compile / git diff --check 全部通过

详见 `request/说明和审查/`（本地工作文档，不入库）：T.tile.sin等2个一元API更新说明.md、框架.md。
