### PR TITLE
[Fix] Use acl to get NPU device name, avoiding torch_npu fork error 🤖

### DIFF
--- a/testing/python/language/test_tilelang_ascend_language_auto_platform.py
+++ b/testing/python/language/test_tilelang_ascend_language_auto_platform.py
@@ -4,7 +4,16 @@ from unittest.mock import MagicMock
 from tilelang.utils.target import determine_platform
 
 
-def _mock_npu(monkeypatch, device_name=None, available=True):
+def _mock_acl(monkeypatch, soc_name=None):
+    mock_acl = MagicMock()
+    if soc_name is not None:
+        mock_acl.get_soc_name.return_value = soc_name
+    monkeypatch.setitem(sys.modules, "acl", mock_acl)
+    monkeypatch.delenv("TL_PLATFORM", raising=False)
+
+
+def _mock_torch_fallback(monkeypatch, device_name=None, available=True):
+    monkeypatch.setitem(sys.modules, "acl", None)
     mock_torch = MagicMock()
     mock_torch.npu.is_available.return_value = available
     if device_name is not None:
@@ -19,21 +28,43 @@ def test_determine_platform_explicit():
     assert determine_platform("A5") == "A5"
 
 
+def test_determine_platform_env(monkeypatch):
+    monkeypatch.setenv("TL_PLATFORM", "A2")
+    assert determine_platform("auto") == "A2"
+    monkeypatch.setenv("TL_PLATFORM", "A5")
+    assert determine_platform("auto") == "A5"
+
+
 def test_determine_platform_auto_910B(monkeypatch):
-    _mock_npu(monkeypatch, device_name="Ascend910B")
+    _mock_acl(monkeypatch, soc_name="Ascend910B")
     assert determine_platform("auto") == "A2"
 
 
 def test_determine_platform_auto_910C(monkeypatch):
-    _mock_npu(monkeypatch, device_name="Ascend910_93")
+    _mock_acl(monkeypatch, soc_name="Ascend910_93")
     assert determine_platform("auto") == "A3"
 
 
 def test_determine_platform_auto_950D(monkeypatch):
-    _mock_npu(monkeypatch, device_name="Ascend950")
+    _mock_acl(monkeypatch, soc_name="Ascend950")
+    assert determine_platform("auto") == "A5"
+
+
+def test_determine_platform_auto_unknown_device(monkeypatch):
+    _mock_acl(monkeypatch, soc_name="AscendUnknown")
+    assert determine_platform("auto") == "A3"
+
+
+def test_determine_platform_auto_910B_torch_fallback(monkeypatch):
+    _mock_torch_fallback(monkeypatch, device_name="Ascend910B")
+    assert determine_platform("auto") == "A2"
+
+
+def test_determine_platform_auto_950D_torch_fallback(monkeypatch):
+    _mock_torch_fallback(monkeypatch, device_name="Ascend950")
     assert determine_platform("auto") == "A5"
 
 
 def test_determine_platform_auto_fallback(monkeypatch):
-    _mock_npu(monkeypatch, available=False)
+    _mock_torch_fallback(monkeypatch, available=False)
     assert determine_platform("auto") == "A3"

--- a/tilelang/utils/target.py
+++ b/tilelang/utils/target.py
@@ -129,31 +129,27 @@ def determine_platform(platform: str = "auto") -> str:
     if env_platform:
         return env_platform
 
-    # Detect platform based on NPU device name.
-    # NOTE: use get_device_name() instead of get_device_properties(current_device())
-    # because the latter triggers _lazy_init() which initializes the CANN device
-    # context. If that happens at module-import time (e.g. via pytest marks),
-    # the CANN handle becomes stale after fork() and the forked child crashes
-    # with SIGSEGV on the first NPU operation. get_device_name() does not
-    # trigger _lazy_init() and is fork-safe.
+    name = ""
     try:
+        import acl
+
+        name = acl.get_soc_name()
+    except ImportError:
         import torch
 
         if hasattr(torch, "npu") and torch.npu.is_available():
-            name = torch.npu.get_device_name().upper()
+            name = torch.npu.get_device_name()
 
-            if "910B" in name:
-                return "A2"
-            elif "910_93" in name or "910C" in name:
-                return "A3"
-            elif "950" in name or "910_95" in name:
-                return "A5"
-            elif "910" in name:  # Covers 910A
-                return "A2"
-            else:
-                pass
-    except Exception:
-        pass
+    name = name.upper()
+
+    if "910B" in name:
+        return "A2"
+    elif "910_93" in name or "910C" in name:
+        return "A3"
+    elif "950" in name or "910_95" in name:
+        return "A5"
+    elif "910" in name:  # Covers 910A
+        return "A2"
 
     # Default fallback if detection fails
     return "A3"


### PR DESCRIPTION
## 背景

`determine_platform()` 函数内使用的 `torch.npu.get_device_name()` 在调用时会触发 `torch_npu` 内部的 `_lazy_init()`，从而初始化 NPU 设备。

## 问题

如果执行了该操作的进程被 fork 出子进程，`torch_npu` 检测到后会报错：

```
RuntimeError: Cannot re-initialize NPU in forked subprocess. To use NPU with multiprocessing, you must use the 'spawn' start method
```

批跑测试时使用的 `pytest --forked -n ...` 属于此场景：新版 `pytest-forked >= 1.7.5` 开始使用 `multiprocessing` 标准库 fork 进程，会触发 `torch_npu` 的检测，导致 `testing/python/language/test_tilelang_ascend_language_copy_cv.py` 因 `torch_npu` 报错而失败。

## 解决方案

修改 `determine_platform()` 获取 NPU 设备名的逻辑：优先尝试通过 CANN 包内部提供的 `acl` 模块获取（在 source 了 CANN 环境变量后即可导入），避免触发 `torch_npu` 的 NPU 设备初始化；`acl` 不可用时再回退到 `torch.npu.get_device_name()`。

## 测试

```bash
pytest --forked testing/python/language/test_tilelang_ascend_language_copy_cv.py -v -n 1 -x
```