### PR TITLE
[Fix] hadamard_transform: fix float16/bfloat16 compile failure (#1504)

### DIFF
--- a/examples_experiment/hadamard_transform/example_hadamard_transform.py
+++ b/examples_experiment/hadamard_transform/example_hadamard_transform.py
@@ -24,6 +24,10 @@ def hadamard_block_intra(b, n, block_size, dtype="float"):
     """
     Execute in-block butterfly operations (first log2(block_size) stages)
     Each block processes one chunk
+
+    FP16/BF16 compute in FP32 (T.tile.cast in/out) to avoid half-precision
+    scalar errors and BF16 vector add/sub hardware limitation.
+    Ping-pong 2D UB avoids in-place overwrite during butterfly.
     """
     assert is_pow_of_2(n), "n must be a power of 2"
     assert is_pow_of_2(block_size), "block_size must be a power of 2"
@@ -32,6 +36,9 @@ def hadamard_block_intra(b, n, block_size, dtype="float"):
     log_block = int(math.log2(block_size))
     num_blocks_per_batch = n // block_size
     total_blocks = b * num_blocks_per_batch
+
+    need_cast = dtype in ("float16", "bfloat16")
+    compute_dtype = "float32" if need_cast else dtype
 
     @T.prim_func
     def main(A: T.Tensor((b, n), dtype), B: T.Tensor((b, n), dtype)):
@@ -42,22 +49,35 @@ def hadamard_block_intra(b, n, block_size, dtype="float"):
                 offset = block_id_in_batch * block_size
 
                 data_ub = T.alloc_ub((block_size,), dtype)
+                work_ub = T.alloc_ub((2, block_size), compute_dtype)
 
                 T.copy(A[batch_id, offset : offset + block_size], data_ub)
 
+                if need_cast:
+                    T.tile.cast(work_ub[0, 0:block_size], data_ub, "CAST_NONE", block_size)
+                else:
+                    T.copy(data_ub, work_ub[0, 0:block_size])
+
                 for stage in T.serial(log_block):
+                    src_idx = stage % 2
+                    dst_idx = 1 - src_idx
                     chunk_size = 1 << (stage + 1)
                     chunk_num = block_size // chunk_size
+                    half = chunk_size // 2
 
                     for chunk_idx in T.serial(chunk_num):
                         base = chunk_idx * chunk_size
-                        half = chunk_size // 2
-
                         for k in T.serial(half):
-                            a_val = data_ub[base + k]
-                            b_val = data_ub[base + k + half]
-                            data_ub[base + k] = a_val + b_val
-                            data_ub[base + k + half] = a_val - b_val
+                            a_val = work_ub[src_idx, base + k]
+                            b_val = work_ub[src_idx, base + k + half]
+                            work_ub[dst_idx, base + k] = a_val + b_val
+                            work_ub[dst_idx, base + k + half] = a_val - b_val
+
+                final_idx = log_block % 2
+                if need_cast:
+                    T.tile.cast(data_ub, work_ub[final_idx, 0:block_size], "CAST_RINT", block_size)
+                else:
+                    T.copy(work_ub[final_idx, 0:block_size], data_ub)
 
                 T.copy(data_ub, B[batch_id, offset : offset + block_size])
 
@@ -71,6 +91,8 @@ def hadamard_cross_block_pair(b, n, block_size, cross_stage, dtype="float"):
     Handles butterfly with chunk_size = 2^(cross_stage+1)
 
     Cross-block butterfly is needed when cross_stage >= log2(block_size)
+
+    Vectorised using T.tile.add/sub. FP16/BF16 compute in FP32.
     """
     assert is_pow_of_2(n), "n must be a power of 2"
     assert is_pow_of_2(block_size), "block_size must be a power of 2"
@@ -85,35 +107,55 @@ def hadamard_cross_block_pair(b, n, block_size, cross_stage, dtype="float"):
     num_chunks_per_batch = n // chunk_size
     total_chunks = b * num_chunks_per_batch
 
+    need_cast = dtype in ("float16", "bfloat16")
+    compute_dtype = "float32" if need_cast else dtype
+
     @T.prim_func
     def main(A: T.Tensor((b, n), dtype), B: T.Tensor((b, n), dtype)):
         with T.Kernel(total_chunks, is_npu=True) as (cid, vid):
             batch_id = cid // num_chunks_per_batch
             chunk_id_in_batch = cid % num_chunks_per_batch
 
-            data_ub = T.alloc_ub((half,), dtype)
-            data2_ub = T.alloc_ub((half,), dtype)
-            tmp_ub = T.alloc_ub((half,), dtype)
-
             src_offset = chunk_id_in_batch * chunk_size
             dst_offset = src_offset + half
 
-            T.copy(A[batch_id, src_offset : src_offset + half], data_ub)
-            T.copy(A[batch_id, dst_offset : dst_offset + half], data2_ub)
+            if need_cast:
+                data_ub = T.alloc_ub((half,), dtype)
+                data2_ub = T.alloc_ub((half,), dtype)
+                data_fp32 = T.alloc_ub((half,), compute_dtype)
+                data2_fp32 = T.alloc_ub((half,), compute_dtype)
+                add_fp32 = T.alloc_ub((half,), compute_dtype)
+                sub_fp32 = T.alloc_ub((half,), compute_dtype)
+                tmp_ub = T.alloc_ub((half,), dtype)
 
-            for k in T.serial(half):
-                a_val = data_ub[k]
-                b_val = data2_ub[k]
-                tmp_ub[k] = a_val + b_val
+                T.copy(A[batch_id, src_offset : src_offset + half], data_ub)
+                T.copy(A[batch_id, dst_offset : dst_offset + half], data2_ub)
 
-            T.copy(tmp_ub, B[batch_id, src_offset : src_offset + half])
+                T.tile.cast(data_fp32, data_ub, "CAST_NONE", half)
+                T.tile.cast(data2_fp32, data2_ub, "CAST_NONE", half)
 
-            for k in T.serial(half):
-                a_val = data_ub[k]
-                b_val = data2_ub[k]
-                tmp_ub[k] = a_val - b_val
+                T.tile.add(add_fp32, data_fp32, data2_fp32)
+                T.tile.sub(sub_fp32, data_fp32, data2_fp32)
 
-            T.copy(tmp_ub, B[batch_id, dst_offset : dst_offset + half])
+                T.tile.cast(tmp_ub, add_fp32, "CAST_RINT", half)
+                T.copy(tmp_ub, B[batch_id, src_offset : src_offset + half])
+
+                T.tile.cast(tmp_ub, sub_fp32, "CAST_RINT", half)
+                T.copy(tmp_ub, B[batch_id, dst_offset : dst_offset + half])
+            else:
+                data_ub = T.alloc_ub((half,), compute_dtype)
+                data2_ub = T.alloc_ub((half,), compute_dtype)
+                add_ub = T.alloc_ub((half,), compute_dtype)
+                sub_ub = T.alloc_ub((half,), compute_dtype)
+
+                T.copy(A[batch_id, src_offset : src_offset + half], data_ub)
+                T.copy(A[batch_id, dst_offset : dst_offset + half], data2_ub)
+
+                T.tile.add(add_ub, data_ub, data2_ub)
+                T.tile.sub(sub_ub, data_ub, data2_ub)
+
+                T.copy(add_ub, B[batch_id, src_offset : src_offset + half])
+                T.copy(sub_ub, B[batch_id, dst_offset : dst_offset + half])
 
     return main
 
@@ -158,8 +200,9 @@ def ref_hadamard(x: torch.Tensor):
     assert x.ndim == 2
     dim = x.shape[-1]
     assert is_pow_of_2(dim)
-    H = torch.tensor(scipy.linalg.hadamard(dim, dtype=float), dtype=x.dtype, device=x.device)
-    return torch.nn.functional.linear(x, H)
+    H = torch.tensor(scipy.linalg.hadamard(dim, dtype=float), dtype=torch.float32, device=x.device)
+    x_fp32 = x.to(torch.float32)
+    return torch.nn.functional.linear(x_fp32, H).to(x.dtype)
 
 
 def main():
@@ -206,8 +249,15 @@ def main():
     y = transform(x)
 
     y_ref = ref_hadamard(x.cpu()).npu()
-    rtol = 1e-2 if dtype in ["float16", "bfloat16"] else 1e-3
-    atol = 1e-2 if dtype in ["float16", "bfloat16"] else 1e-3
+    if dtype == "bfloat16":
+        rtol = 1e-1
+        atol = 2.0
+    elif dtype == "float16":
+        rtol = 1e-2
+        atol = 1e-1
+    else:
+        rtol = 1e-3
+        atol = 1e-3
     torch.testing.assert_close(y.cpu(), y_ref.cpu(), rtol=rtol, atol=atol)
     print(f"Test passed! (rtol={rtol}, atol={atol})")
 


### PR DESCRIPTION
Fixes #1504

## Root cause

Hadamard kernel 对 half 精度（float16/bfloat16）做**标量**加减 `a_val + b_val`。Ascend aicore 禁止 half 精度标量运算（half 只能走 Vector 单元），导致 FP16/BF16 编译失败：

```
error: half precision operation is not allowed in aicore function
            data_ub.SetValue(..., (a_val + b_val));
```

float32 正常（标量 float32 运算允许）。

## What this PR does

- **跨块蝶形 `hadamard_cross_block_pair`**：向量化 `T.tile.add/sub`。FP16/BF16 走
  `BF16/FP16 UB → T.tile.cast → FP32 UB → FP32 add/sub → T.tile.cast → BF16/FP16 UB`；
  float32 直接向量运算。（`half` 在此处是编译期常量，codegen 可处理。）
- **块内蝶形 `hadamard_block_intra`**：FP16/BF16 边界 `T.tile.cast` 到 FP32，FP32 标量蝶形 + ping-pong 2D UB 避免原地覆盖，算完 cast 回。
- **`ref_hadamard`**：FP32 计算再转回，与 kernel 计算路径匹配。
- **容差分级**（Hadamard 放大舍入误差 √N 倍）：float `1e-3`、float16 `1e-2/1e-1`、bfloat16 `1e-1/2.0`。

## Test results

Ascend910 / CANN 9.0.0。3 dtype × 3 模式 = 9/9 PASS。`ruff check --line-length 100` clean。

| dtype | single-block (2048) | multi-block (4096, block=1024) | small (64) |
|-------|---|---|---|
| float | ✅ | ✅ | ✅ |
| float16 | ✅ | ✅ | ✅ |
| bfloat16 | ✅ | ✅ | ✅ |

## vs PR #1513

- BF16 不再 `xfail`：本 PR 编过且精度通过；#1513 因标量 `T.cast` 不支持 BF16（dav-c220 上生成 `((float)x)` 转不对）而 xfail。
- 跨块蝶形已向量化（呼应 platelett 建议）；#1513 仍保留标量蝶形包标量 cast。
- 本 PR 全程不用标量 `T.cast`，改用 buffer 级 `T.tile.cast`（正确 lower 为 `AscendC::Cast(dst, src, round, count)`）。

## ⚠️ 仍存在更深层次的问题（后续跟踪）

本 PR 解决了 issue 字面的编译失败问题，但仍存在两个更深层次的问题，后续单独跟踪修复：

1. **块内蝶形未向量化** — 仍是 FP32 标量。受限于 codegen 对"TIR 变量驱动 if-else + buffer 切片"的处理能力（`half = chunk_size // 2` 依赖循环变量 `stage`，折不成编译期常量）。跨块已向量化（`half` 在那里是编译期常量）。
2. **后端标量 `T.cast` CodeGen 缺口** — 标量 `T.cast` 生成 `((float)x)` 而非 `AscendC::Cast(x)`，标量 BF16↔FP32 仍不正确。本 PR 用 buffer 级 `T.tile.cast` 绕开，未修后端。

## 测试期发现（超范围，FYI）

绕过 argparse 扩展测试发现 `T.tile.add/sub` 在 dav-c220 上**不支持 int8/uint8 向量运算**
（lower 成 `vadd/vsub` 只认 `half*`）。int16/int32/float32 正常。
这影响"块内完全向量化"对 8 位 int 的可行性（需 dtype 分流）。
不在本 issue 范围（example 只支持 float/float16/bfloat16）。
