### PR TITLE
feat(ascendc): add native A5 target support

### DIFF
--- a/docs/notebook/aot_jit.ipynb
+++ b/docs/notebook/aot_jit.ipynb
@@ -204,6 +204,7 @@
     "%%bash\n",
     "# 手动编译 .so\n",
     "bisheng --npu-arch=dav-2201 \\\n",
+    "-DCATLASS_ARCH=2201 \\\n",
     "-O2 \\\n",
     "-std=c++17 \\\n",
     "-xasc \\\n",

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -9,10 +9,10 @@
 #include <tvm/arith/analyzer.h>
 #include <tvm/ir/transform.h>
 #include <tvm/runtime/registry.h>
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/expr.h>
 #include <tvm/tir/index_map.h>
 #include <tvm/tir/op.h>
-
-#include <tvm/tir/expr.h>
 
 #include <cmath>
 #include <sstream>
@@ -1274,12 +1274,14 @@ void CodeGenTileLangAscend::AddFunction(const GlobalVar &gvar,
     if (f->buffer_map.find(v) != f->buffer_map.end()) {
       tir::Buffer buffer = f->buffer_map[v];
       for (size_t j = 0; j < buffer->shape.size(); j++) {
-        auto shape_var = buffer->shape[j].as<VarNode>();
-        if ((std::find(shape_vars.begin(), shape_vars.end(), shape_var) ==
-             shape_vars.end()) &&
-            shape_var != 0) {
-          (void)AllocVarID(shape_var);
-          shape_vars.push_back(shape_var);
+        for (const tir::Var &shape_var_ref :
+             tir::UndefinedVars(buffer->shape[j], f->params)) {
+          const auto *shape_var = shape_var_ref.get();
+          if (std::find(shape_vars.begin(), shape_vars.end(), shape_var) ==
+              shape_vars.end()) {
+            (void)AllocVarID(shape_var);
+            shape_vars.push_back(shape_var);
+          }
         }
       }
     }

--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -39,9 +39,9 @@ namespace codegen {
 
 #define ASCEND_A5_L0A_SIZE (ASCEND_A2A3_L0A_SIZE)
 #define ASCEND_A5_L0B_SIZE (ASCEND_A2A3_L0B_SIZE)
-#define ASCEND_A5_L1_SIZE (ASCEND_A2A3_L1_SIZE)
+#define ASCEND_A5_L1_SIZE (524288)
 #define ASCEND_A5_L0C_SIZE (262144)
-#define ASCEND_A5_UB_SIZE (262144)
+#define ASCEND_A5_UB_SIZE (253952)
 
 std::string getType(const DataType &dtype) {
   if (dtype.is_float16()) {

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -110,9 +110,7 @@ CATLASS_DEVICE void copy_l1_to_l0a(LocalTensor<T> dstTensor,
   auto src = tla::MakeTensor(srcTensor, src_LAYOUT,
                              tla::MakeCoord(0u, 0u), Arch::PositionL1{});
 
-  constexpr auto layoutA = tla::MakeLayout<T, LayoutL0A>(srcM, srcN);
-  auto layoutAInL0 = tla::GetTileLayout(
-      layoutA, tla::MakeShape(dstM, dstN), tla::MakeCoord(0u, 0u));
+  auto layoutAInL0 = tla::MakeLayout<T, LayoutL0A>(dstM, dstN);
   auto dst = tla::MakeTensor(dstTensor, layoutAInL0,
                              tla::MakeCoord(0u, 0u), Arch::PositionL0A{});
   TileCopyTla<ArchTag, decltype(src), decltype(dst)> tileCopier;
@@ -134,9 +132,7 @@ CATLASS_DEVICE void copy_l1_to_l0b(LocalTensor<T> dstTensor,
   auto src = tla::MakeTensor(srcTensor, src_LAYOUT,
                              tla::MakeCoord(0u, 0u), Arch::PositionL1{});
 
-  constexpr auto layoutB = tla::MakeLayout<T, LayoutL0B>(srcM, srcN);
-  auto layoutBInL0 = tla::GetTileLayout(
-      layoutB, tla::MakeShape(dstM, dstN), tla::MakeCoord(0u, 0u));
+  auto layoutBInL0 = tla::MakeLayout<T, LayoutL0B>(dstM, dstN);
   auto dst = tla::MakeTensor(dstTensor, layoutBInL0,
                              tla::MakeCoord(0u, 0u), Arch::PositionL0B{});
 

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -99,20 +99,17 @@ template <typename T, uint32_t srcM, uint32_t srcN, bool transpose = false>
 CATLASS_DEVICE void copy_l1_to_l0a(LocalTensor<T> dstTensor,
                                    LocalTensor<T> srcTensor, uint32_t dstM,
                                    uint32_t dstN) {
-  using LayoutL1Tag =
-      std::conditional_t<transpose,
-                         LayoutL1T,
-                         LayoutL1>;
+  using LayoutL1Tag = std::conditional_t<transpose, LayoutL1T, LayoutL1>;
   constexpr auto layout = tla::MakeLayout<T, LayoutL1Tag>(
       transpose ? srcN : srcM, transpose ? srcM : srcN);
-  auto src_LAYOUT = tla::GetTileLayout(
-      layout, tla::MakeShape(dstM, dstN), tla::MakeCoord(0u, 0u));
-  auto src = tla::MakeTensor(srcTensor, src_LAYOUT,
-                             tla::MakeCoord(0u, 0u), Arch::PositionL1{});
+  auto src_LAYOUT = tla::GetTileLayout(layout, tla::MakeShape(dstM, dstN),
+                                       tla::MakeCoord(0u, 0u));
+  auto src = tla::MakeTensor(srcTensor, src_LAYOUT, tla::MakeCoord(0u, 0u),
+                             Arch::PositionL1{});
 
   auto layoutAInL0 = tla::MakeLayout<T, LayoutL0A>(dstM, dstN);
-  auto dst = tla::MakeTensor(dstTensor, layoutAInL0,
-                             tla::MakeCoord(0u, 0u), Arch::PositionL0A{});
+  auto dst = tla::MakeTensor(dstTensor, layoutAInL0, tla::MakeCoord(0u, 0u),
+                             Arch::PositionL0A{});
   TileCopyTla<ArchTag, decltype(src), decltype(dst)> tileCopier;
   tileCopier(dst, src);
 }
@@ -121,20 +118,17 @@ template <typename T, uint32_t srcM, uint32_t srcN, bool transpose = false>
 CATLASS_DEVICE void copy_l1_to_l0b(LocalTensor<T> dstTensor,
                                    LocalTensor<T> srcTensor, uint32_t dstM,
                                    uint32_t dstN) {
-  using LayoutL1Tag =
-      std::conditional_t<transpose,
-                         LayoutL1T,
-                         LayoutL1>;
+  using LayoutL1Tag = std::conditional_t<transpose, LayoutL1T, LayoutL1>;
   constexpr auto layout = tla::MakeLayout<T, LayoutL1Tag>(
       transpose ? srcN : srcM, transpose ? srcM : srcN);
-  auto src_LAYOUT = tla::GetTileLayout(
-      layout, tla::MakeShape(dstM, dstN), tla::MakeCoord(0u, 0u));
-  auto src = tla::MakeTensor(srcTensor, src_LAYOUT,
-                             tla::MakeCoord(0u, 0u), Arch::PositionL1{});
+  auto src_LAYOUT = tla::GetTileLayout(layout, tla::MakeShape(dstM, dstN),
+                                       tla::MakeCoord(0u, 0u));
+  auto src = tla::MakeTensor(srcTensor, src_LAYOUT, tla::MakeCoord(0u, 0u),
+                             Arch::PositionL1{});
 
   auto layoutBInL0 = tla::MakeLayout<T, LayoutL0B>(dstM, dstN);
-  auto dst = tla::MakeTensor(dstTensor, layoutBInL0,
-                             tla::MakeCoord(0u, 0u), Arch::PositionL0B{});
+  auto dst = tla::MakeTensor(dstTensor, layoutBInL0, tla::MakeCoord(0u, 0u),
+                             Arch::PositionL0B{});
 
   TileCopyTla<ArchTag, decltype(src), decltype(dst)> tileCopier;
   tileCopier(dst, src);

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -27,10 +27,22 @@ using namespace Catlass::Gemm::Tile;
 using namespace Catlass::Gemm::Block;
 using namespace AscendC;
 
+#if CATLASS_ARCH == 3510
+using ArchTag = Arch::Ascend950;
+#elif CATLASS_ARCH == 2201
 using ArchTag = Arch::AtlasA2;
+#else
+#error "Unsupported CATLASS_ARCH: expected 2201 or 3510"
+#endif
 using LayoutGM = layout::RowMajor;
 
+#if CATLASS_ARCH == 3510
+// Ascend950's L1->L0A TileCopyTla consumes zN on both sides. AtlasA2 keeps
+// the legacy zZ destination contract.
+using LayoutL0A = layout::zN;
+#else
 using LayoutL0A = layout::zZ;
+#endif
 using LayoutL0B = layout::nZ;
 using LayoutL1 = layout::zN;
 using LayoutL1T = layout::nZ;
@@ -72,14 +84,12 @@ copy_gm_to_l1(LocalTensor<T> dstTensor, GlobalTensor<T> srcTensor,
     AscendC::PipeBarrier<PIPE_MTE2>();
   }
   auto layout = MakeLayoutFromTag(LayoutGM{tailM, realSrcN});
-  auto src_LAYOUT = MakeLayoutTile(layout, tla::MakeShape(tailM, tailN));
-  auto src = tla::MakeTensor<decltype(srcTensor), decltype(src_LAYOUT),
-                             AscendC::TPosition::GM>(srcTensor, src_LAYOUT);
+  auto src_LAYOUT =
+      tla::MakeLayout(tla::MakeShape(tailM, tailN), layout.stride());
+  auto src = tla::MakeTensor(srcTensor, src_LAYOUT, Arch::PositionGM{});
 
-  using LayoutL1_ = Catlass::detail::TagToLayout_t<T, LayoutL1>;
-  constexpr auto layoutInL1 = tla::MakeLayout<T, LayoutL1_>(dstM, dstN);
-  auto dst = tla::MakeTensor<decltype(dstTensor), decltype(layoutInL1),
-                             AscendC::TPosition::A1>(dstTensor, layoutInL1);
+  constexpr auto layoutInL1 = tla::MakeLayout<T, LayoutL1>(dstM, dstN);
+  auto dst = tla::MakeTensor(dstTensor, layoutInL1, Arch::PositionL1{});
 
   TileCopyTla<ArchTag, decltype(src), decltype(dst)> tileCopier;
   tileCopier(dst, src);
@@ -89,20 +99,22 @@ template <typename T, uint32_t srcM, uint32_t srcN, bool transpose = false>
 CATLASS_DEVICE void copy_l1_to_l0a(LocalTensor<T> dstTensor,
                                    LocalTensor<T> srcTensor, uint32_t dstM,
                                    uint32_t dstN) {
-  using LayoutL1_ =
+  using LayoutL1Tag =
       std::conditional_t<transpose,
-                         Catlass::detail::TagToLayout_t<T, LayoutL1T>,
-                         Catlass::detail::TagToLayout_t<T, LayoutL1>>;
-  constexpr auto layout = transpose ? tla::MakeLayout<T, LayoutL1_>(srcN, srcM)
-                                    : tla::MakeLayout<T, LayoutL1_>(srcM, srcN);
-  auto src_LAYOUT = MakeLayoutTile(layout, tla::MakeShape(dstM, dstN));
-  auto src = MakeTensor<decltype(srcTensor), decltype(src_LAYOUT),
-                        AscendC::TPosition::A1>(srcTensor, src_LAYOUT);
+                         LayoutL1T,
+                         LayoutL1>;
+  constexpr auto layout = tla::MakeLayout<T, LayoutL1Tag>(
+      transpose ? srcN : srcM, transpose ? srcM : srcN);
+  auto src_LAYOUT = tla::GetTileLayout(
+      layout, tla::MakeShape(dstM, dstN), tla::MakeCoord(0u, 0u));
+  auto src = tla::MakeTensor(srcTensor, src_LAYOUT,
+                             tla::MakeCoord(0u, 0u), Arch::PositionL1{});
 
-  using LayoutL0A_ = Catlass::detail::TagToLayout_t<T, LayoutL0A>;
-  auto layoutAInL0 = tla::MakeLayout<T, LayoutL0A_>(dstM, dstN);
-  auto dst = tla::MakeTensor<decltype(dstTensor), decltype(layoutAInL0),
-                             AscendC::TPosition::A2>(dstTensor, layoutAInL0);
+  constexpr auto layoutA = tla::MakeLayout<T, LayoutL0A>(srcM, srcN);
+  auto layoutAInL0 = tla::GetTileLayout(
+      layoutA, tla::MakeShape(dstM, dstN), tla::MakeCoord(0u, 0u));
+  auto dst = tla::MakeTensor(dstTensor, layoutAInL0,
+                             tla::MakeCoord(0u, 0u), Arch::PositionL0A{});
   TileCopyTla<ArchTag, decltype(src), decltype(dst)> tileCopier;
   tileCopier(dst, src);
 }
@@ -111,20 +123,22 @@ template <typename T, uint32_t srcM, uint32_t srcN, bool transpose = false>
 CATLASS_DEVICE void copy_l1_to_l0b(LocalTensor<T> dstTensor,
                                    LocalTensor<T> srcTensor, uint32_t dstM,
                                    uint32_t dstN) {
-  using LayoutL1_ =
+  using LayoutL1Tag =
       std::conditional_t<transpose,
-                         Catlass::detail::TagToLayout_t<T, LayoutL1T>,
-                         Catlass::detail::TagToLayout_t<T, LayoutL1>>;
-  constexpr auto layout = transpose ? tla::MakeLayout<T, LayoutL1_>(srcN, srcM)
-                                    : tla::MakeLayout<T, LayoutL1_>(srcM, srcN);
-  auto src_LAYOUT = MakeLayoutTile(layout, tla::MakeShape(dstM, dstN));
-  auto src = MakeTensor<decltype(srcTensor), decltype(src_LAYOUT),
-                        AscendC::TPosition::A1>(srcTensor, src_LAYOUT);
+                         LayoutL1T,
+                         LayoutL1>;
+  constexpr auto layout = tla::MakeLayout<T, LayoutL1Tag>(
+      transpose ? srcN : srcM, transpose ? srcM : srcN);
+  auto src_LAYOUT = tla::GetTileLayout(
+      layout, tla::MakeShape(dstM, dstN), tla::MakeCoord(0u, 0u));
+  auto src = tla::MakeTensor(srcTensor, src_LAYOUT,
+                             tla::MakeCoord(0u, 0u), Arch::PositionL1{});
 
-  using LayoutL0B_ = Catlass::detail::TagToLayout_t<T, LayoutL0B>;
-  auto layoutBInL0 = tla::MakeLayout<T, LayoutL0B_>(dstM, dstN);
-  auto dst = tla::MakeTensor<decltype(dstTensor), decltype(layoutBInL0),
-                             AscendC::TPosition::B2>(dstTensor, layoutBInL0);
+  constexpr auto layoutB = tla::MakeLayout<T, LayoutL0B>(srcM, srcN);
+  auto layoutBInL0 = tla::GetTileLayout(
+      layoutB, tla::MakeShape(dstM, dstN), tla::MakeCoord(0u, 0u));
+  auto dst = tla::MakeTensor(dstTensor, layoutBInL0,
+                             tla::MakeCoord(0u, 0u), Arch::PositionL0B{});
 
   TileCopyTla<ArchTag, decltype(src), decltype(dst)> tileCopier;
   tileCopier(dst, src);
@@ -174,15 +188,14 @@ copy_l0c_to_gm(GlobalTensor<T2> dstTensor, LocalTensor<T1> srcTensor,
   uint32_t tailM = realTailM == 0 ? srcM : realTailM;
   uint32_t tailN = realTailN == 0 ? srcN : realTailN;
   auto layoutInL0C = tla::MakeLayoutL0C(srcM, srcN);
-  auto src = tla::MakeTensor<decltype(srcTensor), decltype(layoutInL0C),
-                             AscendC::TPosition::CO1>(srcTensor, layoutInL0C);
+  auto src = tla::MakeTensor(srcTensor, layoutInL0C, Arch::PositionL0C{});
   LayoutGM gm{tailM, realDstN};
   auto layout = MakeLayoutFromTag(gm);
   auto dTensor = MakeTensor(dstTensor, layout, Arch::PositionGM{});
   auto layout_ = dTensor.layout();
-  auto dst_LAYOUT = MakeLayoutTile(layout_, tla::MakeShape(tailM, tailN));
-  auto dst = MakeTensor<decltype(dstTensor), decltype(dst_LAYOUT),
-                        AscendC::TPosition::GM>(dstTensor, dst_LAYOUT);
+  auto dst_LAYOUT =
+      tla::MakeLayout(tla::MakeShape(tailM, tailN), layout_.stride());
+  auto dst = MakeTensor(dstTensor, dst_LAYOUT, Arch::PositionGM{});
 
   CopyL0CToGmTla<ArchTag, decltype(src), decltype(dst),
                  ScaleGranularity::NO_QUANT, enRelu>

--- a/src/transform/ascend_memory_planning.cc
+++ b/src/transform/ascend_memory_planning.cc
@@ -32,11 +32,17 @@
 #include "./common/attr.h"
 #include "./common/collector.h"
 
-#define ASCEND_SHARED_MEM_SIZE 196352
-#define ASCEND_SHARED_DYN_MEM_SIZE 524032
-#define ASCEND_WMMA_MATRIX_A_MEM_SIZE 65536
-#define ASCEND_WMMA_MATRIX_B_MEM_SIZE 65536
-#define ASCEND_WMMA_ACCUMULATOR_MEM_SIZE 131072
+#define ASCEND_A2A3_SHARED_MEM_SIZE 196352
+#define ASCEND_A2A3_SHARED_DYN_MEM_SIZE 524032
+#define ASCEND_A2A3_WMMA_MATRIX_A_MEM_SIZE 65536
+#define ASCEND_A2A3_WMMA_MATRIX_B_MEM_SIZE 65536
+#define ASCEND_A2A3_WMMA_ACCUMULATOR_MEM_SIZE 131072
+
+#define ASCEND_A5_SHARED_MEM_SIZE 253952
+#define ASCEND_A5_SHARED_DYN_MEM_SIZE 524288
+#define ASCEND_A5_WMMA_MATRIX_A_MEM_SIZE 65536
+#define ASCEND_A5_WMMA_MATRIX_B_MEM_SIZE 65536
+#define ASCEND_A5_WMMA_ACCUMULATOR_MEM_SIZE 262144
 
 namespace tvm {
 namespace tl {
@@ -79,8 +85,10 @@ public:
                                .value();
     }
 
+    std::string platform =
+        f->GetAttr<String>("npu_platform").value_or(String("A3"));
     AscendMemoryPlanner planner(f, external_address_map, external_shape_map,
-                                auto_ascend_memory_planning);
+                                platform, auto_ascend_memory_planning);
     auto address_map = planner.GetAddressMap();
     auto buffer_sizes = planner.GetBufferSizes();
 
@@ -106,16 +114,27 @@ private:
     explicit AscendMemoryPlanner(const PrimFunc &func,
                                  Map<Var, PrimExpr> external_address_map,
                                  Map<Var, Array<PrimExpr>> external_shape_map,
+                                 const std::string &platform,
                                  bool auto_plan = false) {
       memory_auto_plan = auto_plan;
       // Preserve layouts needed by CalculateBufferSize.
       // PTO 4D shapes are [physical_M, physical_N, valid_M, valid_N].
       external_shape_map_ = external_shape_map;
-      memory_limits_ = {{"shared.l1", ASCEND_SHARED_DYN_MEM_SIZE},
-                        {"wmma.matrix_a", ASCEND_WMMA_MATRIX_A_MEM_SIZE},
-                        {"wmma.matrix_b", ASCEND_WMMA_MATRIX_B_MEM_SIZE},
-                        {"wmma.accumulator", ASCEND_WMMA_ACCUMULATOR_MEM_SIZE},
-                        {"shared.ub", ASCEND_SHARED_MEM_SIZE}};
+      if (platform == "A5") {
+        memory_limits_ = {
+            {"shared.l1", ASCEND_A5_SHARED_DYN_MEM_SIZE},
+            {"wmma.matrix_a", ASCEND_A5_WMMA_MATRIX_A_MEM_SIZE},
+            {"wmma.matrix_b", ASCEND_A5_WMMA_MATRIX_B_MEM_SIZE},
+            {"wmma.accumulator", ASCEND_A5_WMMA_ACCUMULATOR_MEM_SIZE},
+            {"shared.ub", ASCEND_A5_SHARED_MEM_SIZE}};
+      } else {
+        memory_limits_ = {
+            {"shared.l1", ASCEND_A2A3_SHARED_DYN_MEM_SIZE},
+            {"wmma.matrix_a", ASCEND_A2A3_WMMA_MATRIX_A_MEM_SIZE},
+            {"wmma.matrix_b", ASCEND_A2A3_WMMA_MATRIX_B_MEM_SIZE},
+            {"wmma.accumulator", ASCEND_A2A3_WMMA_ACCUMULATOR_MEM_SIZE},
+            {"shared.ub", ASCEND_A2A3_SHARED_MEM_SIZE}};
+      }
 
       SetPreAllocBuffer(external_address_map);
       SetTmpBuffers(external_shape_map);
@@ -865,6 +884,9 @@ private:
           }
         }
 
+        if (free_blocks.empty()) {
+          return static_cast<size_t>(-1);
+        }
         auto &last_block = free_blocks[free_blocks.size() - 1];
         if ((last_block.first + last_block.second) == next_new_offset_) {
           next_new_offset_ = memory_limit_;

--- a/src/transform/ascend_memory_planning.cc
+++ b/src/transform/ascend_memory_planning.cc
@@ -614,7 +614,7 @@ private:
 
     void PlanMemoryForScopeLinear(const std::string &scope,
                                   const std::vector<const VarNode *> &buffers) {
-      bool check_overflow = false; // reserve memory overflow check
+      bool check_overflow = true;
       int64_t current_offset = 0;
       int64_t max_offset = 0;
 

--- a/src/transform/ascend_memory_planning.cc
+++ b/src/transform/ascend_memory_planning.cc
@@ -117,6 +117,12 @@ private:
                                  const std::string &platform,
                                  bool auto_plan = false) {
       memory_auto_plan = auto_plan;
+      // Keep the legacy A2/A3 linear planner behavior intact.  Existing
+      // kernels rely on the historical behavior that permitted a 256-byte
+      // guard-band overcommit; tightening that contract is a separate
+      // migration.  A5 is new in this backend, so its verified usable capacity
+      // is enforced from the first release.
+      enforce_linear_memory_limit_ = platform == "A5";
       // Preserve layouts needed by CalculateBufferSize.
       // PTO 4D shapes are [physical_M, physical_N, valid_M, valid_N].
       external_shape_map_ = external_shape_map;
@@ -614,7 +620,6 @@ private:
 
     void PlanMemoryForScopeLinear(const std::string &scope,
                                   const std::vector<const VarNode *> &buffers) {
-      bool check_overflow = true;
       int64_t current_offset = 0;
       int64_t max_offset = 0;
 
@@ -622,7 +627,8 @@ private:
       auto alloc_buffer = [&](const VarNode *buffer, int64_t &offset,
                               const std::string &err_prefix) -> bool {
         int64_t buf_size = buffer_sizes_[buffer];
-        if (offset + buf_size > memory_limits_[scope] && check_overflow) {
+        if (offset + buf_size > memory_limits_[scope] &&
+            enforce_linear_memory_limit_) {
           LOG(FATAL) << err_prefix << " Out of memory in scope: " << scope
                      << "\nBuffer: " << buffer->name_hint
                      << "\nRequired size: " << buf_size
@@ -1063,6 +1069,7 @@ private:
 
     size_t scope_level_{0};
     bool memory_auto_plan{false};
+    bool enforce_linear_memory_limit_{false};
   };
 };
 

--- a/testing/cpp/test_ascend_l0_packed_layout.cpp
+++ b/testing/cpp/test_ascend_l0_packed_layout.cpp
@@ -1,0 +1,50 @@
+#include <cstddef>
+#include <cstdint>
+
+using std::size_t;
+
+#include "tla/layout.hpp"
+
+using Catlass::layout::nZ;
+using Catlass::layout::zN;
+using Catlass::layout::zZ;
+
+// K split: a full 128-element child tile remains packed independently of L1.
+constexpr auto k_l1_parent = tla::MakeLayout<uint16_t, zZ>(64u, 256u);
+constexpr auto k_l1_split = tla::GetTileLayout(
+    k_l1_parent, tla::MakeShape(64u, 128u), tla::MakeCoord(0u, 0u));
+constexpr auto k_l0_split = tla::MakeLayout<uint16_t, zZ>(64u, 128u);
+static_assert(tla::get<0, 1>(k_l1_split.stride()) == 4096);
+static_assert(tla::get<0, 1>(k_l0_split.stride()) == 2048);
+
+// K tail: an 80-element L1 view keeps its 64x256 parent stride, while the
+// independently allocated L0 destination is packed.
+constexpr auto k_l1_tail = tla::GetTileLayout(
+    k_l1_parent, tla::MakeShape(64u, 80u), tla::MakeCoord(0u, 0u));
+constexpr auto k_l0_tail = tla::MakeLayout<uint16_t, zZ>(64u, 80u);
+static_assert(tla::get<0, 1>(k_l1_tail.stride()) == 4096);
+static_assert(tla::get<0, 1>(k_l0_tail.stride()) == 1280);
+
+// N split: a 128x128 L0B tile must not inherit the 256x512 L1 stride.
+constexpr auto n_l1_parent = tla::MakeLayout<uint16_t, nZ>(256u, 512u);
+constexpr auto n_l1_tile = tla::GetTileLayout(
+    n_l1_parent, tla::MakeShape(128u, 128u), tla::MakeCoord(0u, 0u));
+constexpr auto n_l0_tile = tla::MakeLayout<uint16_t, nZ>(128u, 128u);
+static_assert(tla::get<0, 1>(n_l1_tile.stride()) == 8192);
+static_assert(tla::get<0, 1>(n_l0_tile.stride()) == 2048);
+
+// Rectangular transpose-A: dstM,dstN are already post-transpose logical axes.
+constexpr auto at_l1_parent = tla::MakeLayout<uint16_t, zN>(192u, 64u);
+constexpr auto at_l1_tile = tla::GetTileLayout(
+    at_l1_parent, tla::MakeShape(64u, 80u), tla::MakeCoord(0u, 0u));
+constexpr auto at_l0_tile = tla::MakeLayout<uint16_t, zN>(64u, 80u);
+static_assert(tla::get<1, 1>(at_l1_tile.stride()) == 3072);
+static_assert(tla::get<1, 1>(at_l0_tile.stride()) == 1024);
+
+// Rectangular transpose-B uses the same logical-axis contract.
+constexpr auto bt_l1_parent = tla::MakeLayout<uint16_t, nZ>(192u, 64u);
+constexpr auto bt_l1_tile = tla::GetTileLayout(
+    bt_l1_parent, tla::MakeShape(80u, 112u), tla::MakeCoord(0u, 0u));
+constexpr auto bt_l0_tile = tla::MakeLayout<uint16_t, nZ>(80u, 112u);
+static_assert(tla::get<0, 1>(bt_l1_tile.stride()) == 1024);
+static_assert(tla::get<0, 1>(bt_l0_tile.stride()) == 1792);

--- a/testing/python/language/test_ascend_compile_flags.py
+++ b/testing/python/language/test_ascend_compile_flags.py
@@ -91,7 +91,7 @@ def test_no_environ_mutation(clean_env):
 # ---------------------------------------------------------------------------
 
 
-def _bisheng_command(target, compile_flags, env=None):
+def _bisheng_command(target, compile_flags, env=None, platform="A3"):
     """Build the bisheng command without running it."""
     captured = {}
 
@@ -102,7 +102,7 @@ def _bisheng_command(target, compile_flags, env=None):
         captured["cmd"] = list(cmd)
         return _Ret()
 
-    gen = LibraryGenerator(target, "A3", compile_flags)
+    gen = LibraryGenerator(target, platform, compile_flags)
     gen.update_lib_code("// x")
     with (
         mock.patch("tilelang.jit.adapter.libgen._get_ascend_home_path", return_value="/a"),
@@ -128,6 +128,26 @@ def test_libgen_direct_caller_falls_back_to_derived():
     # compile_flags=None (direct/legacy caller) -> framework defaults, env still honored.
     assert "-O2" in _bisheng_command("ascendc", None)
     assert "-O3" in _bisheng_command("ascendc", None, {"TL_CCE_OPT_LEVEL": "3"})
+
+
+@pytest.mark.parametrize(
+    "target, platform, expected_arch",
+    [
+        ("ascendc", "A2", "dav-2201"),
+        ("ascendc", "A3", "dav-2201"),
+        ("ascendc", "A5", "dav-3510"),
+        ("auto", "A5", "dav-3510"),
+    ],
+)
+def test_libgen_selects_native_arch_for_platform(target, platform, expected_arch):
+    cmd = _bisheng_command(target, None, platform=platform)
+    assert f"--npu-arch={expected_arch}" in cmd
+    assert len([arg for arg in cmd if arg.startswith("--npu-arch=")]) == 1
+
+
+def test_libgen_rejects_unknown_native_platform():
+    with pytest.raises(ValueError, match="Unsupported AscendC platform"):
+        _bisheng_command("ascendc", None, platform="A9")
 
 
 # ---------------------------------------------------------------------------

--- a/testing/python/language/test_ascend_compile_flags.py
+++ b/testing/python/language/test_ascend_compile_flags.py
@@ -185,15 +185,23 @@ class _FakeRuntimeNpu:
         return self.name
 
 
-def test_load_lib_rejects_runtime_device_mismatch_before_dlopen():
-    fake_npu = _FakeRuntimeNpu("Ascend910B")
+@pytest.mark.parametrize(
+    "platform, runtime_name",
+    [
+        ("A5", "Ascend910B"),
+        ("A3", "Ascend910B"),
+        ("A2", "Ascend910C"),
+    ],
+)
+def test_load_lib_rejects_runtime_device_mismatch_before_dlopen(platform, runtime_name):
+    fake_npu = _FakeRuntimeNpu(runtime_name)
     with (
         mock.patch.object(torch, "npu", fake_npu, create=True),
         mock.patch("tilelang.jit.adapter.libgen.ctypes.CDLL") as dlopen,
         mock.patch.dict("os.environ", {"TL_RUN_MODE": "npu"}),
-        pytest.raises(RuntimeError, match="compiled target platform is A5"),
+        pytest.raises(RuntimeError, match=f"compiled target platform is {platform}"),
     ):
-        LibraryGenerator("ascendc", "A5").load_lib("/tmp/not-loaded.so")
+        LibraryGenerator("ascendc", platform).load_lib("/tmp/not-loaded.so")
     dlopen.assert_not_called()
 
 

--- a/testing/python/language/test_ascend_compile_flags.py
+++ b/testing/python/language/test_ascend_compile_flags.py
@@ -9,6 +9,8 @@ the final NPU-gated regression covers the intentionally unsynchronized runtime
 case.
 """
 
+import json
+from pathlib import Path
 import types
 from unittest import mock
 
@@ -143,11 +145,27 @@ def test_libgen_selects_native_arch_for_platform(target, platform, expected_arch
     cmd = _bisheng_command(target, None, platform=platform)
     assert f"--npu-arch={expected_arch}" in cmd
     assert len([arg for arg in cmd if arg.startswith("--npu-arch=")]) == 1
+    expected_catlass_arch = "3510" if platform == "A5" else "2201"
+    assert f"-DCATLASS_ARCH={expected_catlass_arch}" in cmd
+    assert len([arg for arg in cmd if arg.startswith("-DCATLASS_ARCH=")]) == 1
 
 
 def test_libgen_rejects_unknown_native_platform():
     with pytest.raises(ValueError, match="Unsupported AscendC platform"):
         _bisheng_command("ascendc", None, platform="A9")
+
+
+def test_documented_manual_a2_aot_sets_catlass_arch():
+    """Manual Bisheng callers must match the native A2 LibraryGenerator flags."""
+    notebook = Path(__file__).parents[3] / "docs/notebook/aot_jit.ipynb"
+    cells = json.loads(notebook.read_text())["cells"]
+    manual_a2_commands = [
+        "".join(cell.get("source", []))
+        for cell in cells
+        if "bisheng --npu-arch=dav-2201" in "".join(cell.get("source", []))
+    ]
+    assert manual_a2_commands
+    assert all("-DCATLASS_ARCH=2201" in command for command in manual_a2_commands)
 
 
 # ---------------------------------------------------------------------------

--- a/testing/python/language/test_ascend_compile_flags.py
+++ b/testing/python/language/test_ascend_compile_flags.py
@@ -59,9 +59,21 @@ def _pc(target, vs):
         ("pto", None, {}, None, ["-O3"]),  # pto defaults VS on; never gets the auto-sync flag
         # env vars are lenient legacy fallbacks
         ("ascendc", False, {"TL_CCE_AUTO_SYNC": "off"}, None, ["-O2", "--cce-auto-sync=off"]),
-        ("ascendc", False, {"TL_CCE_AUTO_SYNC": "garbage"}, None, ["-O2"]),  # malformed -> on, never raises
+        (
+            "ascendc",
+            False,
+            {"TL_CCE_AUTO_SYNC": "garbage"},
+            None,
+            ["-O2"],
+        ),  # malformed -> on, never raises
         ("pto", False, {"TL_PTO_DEBUG": "1"}, None, ["-O2", "-D_DEBUG", "--cce-enable-print"]),
-        ("ascendc", False, {"TL_PTO_DEBUG": "1"}, None, ["-O2"]),  # AscendC never gets the PTO debug flags
+        (
+            "ascendc",
+            False,
+            {"TL_PTO_DEBUG": "1"},
+            None,
+            ["-O2"],
+        ),  # AscendC never gets the PTO debug flags
         # caller flags are appended last, so they win (bisheng is last-wins)
         ("ascendc", True, {}, ["-O0"], ["-O3", "--cce-auto-sync=off", "-O0"]),
         ("ascendc", False, {}, "-O3", ["-O2", "-O3"]),  # a bare str is accepted
@@ -155,17 +167,80 @@ def test_libgen_rejects_unknown_native_platform():
         _bisheng_command("ascendc", None, platform="A9")
 
 
+class _FakeRuntimeNpu:
+    def __init__(self, name, available=True):
+        self.name = name
+        self.available = available
+
+    def is_available(self):
+        return self.available
+
+    def device_count(self):
+        return 1 if self.available else 0
+
+    def current_device(self):
+        return 0
+
+    def get_device_name(self, _device):
+        return self.name
+
+
+def test_load_lib_rejects_runtime_device_mismatch_before_dlopen():
+    fake_npu = _FakeRuntimeNpu("Ascend910B")
+    with (
+        mock.patch.object(torch, "npu", fake_npu, create=True),
+        mock.patch("tilelang.jit.adapter.libgen.ctypes.CDLL") as dlopen,
+        mock.patch.dict("os.environ", {"TL_RUN_MODE": "npu"}),
+        pytest.raises(RuntimeError, match="compiled target platform is A5"),
+    ):
+        LibraryGenerator("ascendc", "A5").load_lib("/tmp/not-loaded.so")
+    dlopen.assert_not_called()
+
+
+def test_load_lib_allows_matching_a5_runtime_device():
+    fake_npu = _FakeRuntimeNpu("Ascend950DT_9575")
+    with (
+        mock.patch.object(torch, "npu", fake_npu, create=True),
+        mock.patch("tilelang.jit.adapter.libgen.ctypes.CDLL", return_value=object()) as dlopen,
+        mock.patch.dict("os.environ", {"TL_RUN_MODE": "npu"}),
+    ):
+        LibraryGenerator("ascendc", "A5").load_lib("/tmp/matching.so")
+    dlopen.assert_called_once_with("/tmp/matching.so")
+
+
 def test_documented_manual_a2_aot_sets_catlass_arch():
     """Manual Bisheng callers must match the native A2 LibraryGenerator flags."""
     notebook = Path(__file__).parents[3] / "docs/notebook/aot_jit.ipynb"
     cells = json.loads(notebook.read_text())["cells"]
     manual_a2_commands = [
-        "".join(cell.get("source", []))
-        for cell in cells
-        if "bisheng --npu-arch=dav-2201" in "".join(cell.get("source", []))
+        "".join(cell.get("source", [])) for cell in cells if "bisheng --npu-arch=dav-2201" in "".join(cell.get("source", []))
     ]
     assert manual_a2_commands
     assert all("-DCATLASS_ARCH=2201" in command for command in manual_a2_commands)
+
+
+def _extract_template_body(source: str, function_name: str) -> str:
+    start = source.index(f"CATLASS_DEVICE void {function_name}")
+    next_template = source.find("\ntemplate <", start + 1)
+    return source[start:] if next_template < 0 else source[start:next_template]
+
+
+@pytest.mark.parametrize(
+    "function_name, layout_name, discriminator",
+    [
+        ("copy_l1_to_l0a", "LayoutL0A", "K split 128"),
+        ("copy_l1_to_l0a", "LayoutL0A", "K tail 80"),
+        ("copy_l1_to_l0b", "LayoutL0B", "N split 128"),
+        ("copy_l1_to_l0a", "LayoutL0A", "transpose A rectangular 64x80"),
+        ("copy_l1_to_l0b", "LayoutL0B", "transpose B rectangular 64x112"),
+    ],
+)
+def test_l0_destination_layout_is_packed_for_logical_tile(function_name, layout_name, discriminator):
+    common_h = Path(__file__).parents[3] / "src/tl_templates/ascend/common.h"
+    body = _extract_template_body(common_h.read_text(), function_name)
+    assert f"tla::MakeLayout<T, {layout_name}>(dstM, dstN)" in body, discriminator
+    assert "transpose ? srcN : srcM, transpose ? srcM : srcN" in body, discriminator
+    assert body.count("tla::GetTileLayout(") == 1, discriminator
 
 
 # ---------------------------------------------------------------------------
@@ -259,7 +334,10 @@ def test_autotuner_restore_threads_full_signature(tmp_path):
         captured.update(kw)
         return "K"
 
-    with mock.patch.object(JITKernel, "from_database", _spy), mock.patch.dict("os.environ", {"TL_PLATFORM": "A5"}):
+    with (
+        mock.patch.object(JITKernel, "from_database", _spy),
+        mock.patch.dict("os.environ", {"TL_PLATFORM": "A5"}),
+    ):
         result = ap.AutotuneResult._load_kernel_from_disk(
             ap.AutotuneResult,
             tmp_path,

--- a/testing/python/language/test_ascend_memory_planning.py
+++ b/testing/python/language/test_ascend_memory_planning.py
@@ -909,7 +909,7 @@ def test_letstmt_buffer_load_shared_no_crash(target):
 # ---------------------------------------------------------------------------
 
 
-def _lower_single_ub_allocation(num_bytes: int, platform: str):
+def _lower_single_ub_allocation(num_bytes: int, platform: str, pass_configs=PASS_AUTO):
     @T.prim_func
     def main(
         A: T.Tensor((num_bytes,), "uint8"),  # type: ignore
@@ -920,12 +920,13 @@ def _lower_single_ub_allocation(num_bytes: int, platform: str):
             T.copy(A, tmp)
             T.copy(tmp, B)
 
-    with tvm.transform.PassContext(opt_level=3, config=PASS_AUTO):
+    with tvm.transform.PassContext(opt_level=3, config=pass_configs):
         return tilelang.lower(main, target="ascendc", platform=platform)
 
 
-def test_a5_memory_planner_accepts_full_usable_ub_capacity():
-    artifact = _lower_single_ub_allocation(253952, "A5")
+@pytest.mark.parametrize("pass_configs", [PASS_AUTO, PASS_LINEAR], ids=["auto", "linear"])
+def test_a5_memory_planner_accepts_full_usable_ub_capacity(pass_configs):
+    artifact = _lower_single_ub_allocation(253952, "A5", pass_configs)
     assert "GetWithOffset<uint8_t>(253952, 0)" in artifact.kernel_source
 
 
@@ -934,9 +935,10 @@ def test_a3_memory_planner_rejects_a5_only_ub_capacity():
         _lower_single_ub_allocation(253952, "A3")
 
 
-def test_a5_memory_planner_preserves_aligned_overflow_check():
-    with pytest.raises(tvm.error.TVMError, match="Memory allocation failed"):
-        _lower_single_ub_allocation(253952 + 32, "A5")
+@pytest.mark.parametrize("pass_configs", [PASS_AUTO, PASS_LINEAR], ids=["auto", "linear"])
+def test_a5_memory_planner_preserves_aligned_overflow_check(pass_configs):
+    with pytest.raises(tvm.error.TVMError, match="[Mm]emory allocation failed"):
+        _lower_single_ub_allocation(253952 + 32, "A5", pass_configs)
 
 
 if __name__ == "__main__":

--- a/testing/python/language/test_ascend_memory_planning.py
+++ b/testing/python/language/test_ascend_memory_planning.py
@@ -955,8 +955,9 @@ def test_a3_memory_planner_rejects_a5_only_ub_capacity():
         _lower_single_ub_allocation(253952, "A3")
 
 
-def test_a3_linear_planner_preserves_three_64k_ub_example():
-    artifact = _lower_three_ub_allocations(65536, "A3")
+@pytest.mark.parametrize("platform", ["A2", "A3"])
+def test_a2_a3_linear_planner_preserves_three_64k_ub_example(platform):
+    artifact = _lower_three_ub_allocations(65536, platform)
     offsets = _get_buffer_offsets(artifact.kernel_source)
     assert offsets["a_ub"] == 0
     assert offsets["b_ub"] == 65536

--- a/testing/python/language/test_ascend_memory_planning.py
+++ b/testing/python/language/test_ascend_memory_planning.py
@@ -924,6 +924,26 @@ def _lower_single_ub_allocation(num_bytes: int, platform: str, pass_configs=PASS
         return tilelang.lower(main, target="ascendc", platform=platform)
 
 
+def _lower_three_ub_allocations(num_bytes: int, platform: str):
+    @T.prim_func
+    def main(
+        A: T.Tensor((num_bytes,), "uint8"),  # type: ignore
+        B: T.Tensor((num_bytes,), "uint8"),  # type: ignore
+        C: T.Tensor((num_bytes,), "uint8"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_ub = T.alloc_ub((num_bytes,), "uint8")
+            b_ub = T.alloc_ub((num_bytes,), "uint8")
+            c_ub = T.alloc_ub((num_bytes,), "uint8")
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            T.tile.add(c_ub, a_ub, b_ub)
+            T.copy(c_ub, C)
+
+    with tvm.transform.PassContext(opt_level=3, config=PASS_LINEAR):
+        return tilelang.lower(main, target="ascendc", platform=platform)
+
+
 @pytest.mark.parametrize("pass_configs", [PASS_AUTO, PASS_LINEAR], ids=["auto", "linear"])
 def test_a5_memory_planner_accepts_full_usable_ub_capacity(pass_configs):
     artifact = _lower_single_ub_allocation(253952, "A5", pass_configs)
@@ -933,6 +953,14 @@ def test_a5_memory_planner_accepts_full_usable_ub_capacity(pass_configs):
 def test_a3_memory_planner_rejects_a5_only_ub_capacity():
     with pytest.raises(tvm.error.TVMError, match="Memory allocation failed"):
         _lower_single_ub_allocation(253952, "A3")
+
+
+def test_a3_linear_planner_preserves_three_64k_ub_example():
+    artifact = _lower_three_ub_allocations(65536, "A3")
+    offsets = _get_buffer_offsets(artifact.kernel_source)
+    assert offsets["a_ub"] == 0
+    assert offsets["b_ub"] == 65536
+    assert offsets["c_ub"] == 131072
 
 
 @pytest.mark.parametrize("pass_configs", [PASS_AUTO, PASS_LINEAR], ids=["auto", "linear"])

--- a/testing/python/language/test_ascend_memory_planning.py
+++ b/testing/python/language/test_ascend_memory_planning.py
@@ -904,5 +904,40 @@ def test_letstmt_buffer_load_shared_no_crash(target):
     )
 
 
+# ---------------------------------------------------------------------------
+# 14. Platform-specific memory capacity and overflow boundaries
+# ---------------------------------------------------------------------------
+
+
+def _lower_single_ub_allocation(num_bytes: int, platform: str):
+    @T.prim_func
+    def main(
+        A: T.Tensor((num_bytes,), "uint8"),  # type: ignore
+        B: T.Tensor((num_bytes,), "uint8"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            tmp = T.alloc_ub((num_bytes,), "uint8")
+            T.copy(A, tmp)
+            T.copy(tmp, B)
+
+    with tvm.transform.PassContext(opt_level=3, config=PASS_AUTO):
+        return tilelang.lower(main, target="ascendc", platform=platform)
+
+
+def test_a5_memory_planner_accepts_full_usable_ub_capacity():
+    artifact = _lower_single_ub_allocation(253952, "A5")
+    assert "GetWithOffset<uint8_t>(253952, 0)" in artifact.kernel_source
+
+
+def test_a3_memory_planner_rejects_a5_only_ub_capacity():
+    with pytest.raises(tvm.error.TVMError, match="Memory allocation failed"):
+        _lower_single_ub_allocation(253952, "A3")
+
+
+def test_a5_memory_planner_preserves_aligned_overflow_check():
+    with pytest.raises(tvm.error.TVMError, match="Memory allocation failed"):
+        _lower_single_ub_allocation(253952 + 32, "A5")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-n", "8"])

--- a/testing/python/language/test_tilelang_ascend_language_alloc_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_alloc_codegen.py
@@ -132,7 +132,7 @@ def dev_ub_explicit_splice(dim, block_N=128, block_size=128, live_max=64):
     return main
 
 
-def _compile_and_get_source(target):
+def _compile_and_get_source(target, platform="auto"):
     prim_func = dev_L1_explicit_splice(dim=64)
     with (
         patch("tilelang.jit.adapter.libgen.LibraryGenerator.compile_lib") as mock_compile,
@@ -147,11 +147,12 @@ def _compile_and_get_source(target):
             out_idx=[2],
             pass_configs=DEV_CONFIGS,
             target=target,
+            platform=platform,
         )
     return compiled.get_kernel_source()
 
 
-def _compile_ub_and_get_source(target):
+def _compile_ub_and_get_source(target, platform="auto"):
     prim_func = dev_ub_explicit_splice(dim=64)
     with (
         patch("tilelang.jit.adapter.libgen.LibraryGenerator.compile_lib") as mock_compile,
@@ -166,6 +167,7 @@ def _compile_ub_and_get_source(target):
             out_idx=[2],
             pass_configs=DEV_CONFIGS,
             target=target,
+            platform=platform,
         )
     return compiled.get_kernel_source()
 
@@ -218,6 +220,17 @@ def test_ub_splice_codegen(target):
         assert "TileMatL1" not in k_ub_alloc_line[0], (
             f"k_ub was incorrectly allocated as TileMatL1 instead of TileUbDataND:\n{k_ub_alloc_line[0]}"
         )
+
+
+def test_a5_native_codegen_uses_dav3510_usable_memory_sizes():
+    code = tilelang.lower(
+        dev_ub_explicit_splice(dim=64),
+        target="ascendc",
+        platform="A5",
+    ).kernel_source
+    assert "pipe.InitBuffer(ascend_l1, 524288)" in code
+    assert "pipe.InitBuffer(ascend_l0c, 262144)" in code
+    assert "pipe.InitBuffer(ascend_ub, 253952)" in code
 
 
 # ---------------------------------------------------------------------------

--- a/testing/python/language/test_tilelang_ascend_language_alloc_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_alloc_codegen.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest import mock
 
 import tilelang
 import tilelang.language as T
@@ -218,6 +219,26 @@ def test_a5_native_codegen_uses_dav3510_usable_memory_sizes():
     assert "pipe.InitBuffer(ascend_ub, 253952)" in code
 
 
+def test_a5_lowering_binds_dav3510_mcpu_to_target():
+    artifact = tilelang.lower(
+        dev_ub_explicit_splice(dim=64),
+        target="ascendc",
+        platform="A5",
+    )
+    func = artifact.device_mod.functions_items()[0][1]
+    assert func.attrs["target"].mcpu == "dav-3510"
+
+
+def test_lowering_rejects_explicit_mcpu_platform_conflict():
+    target = tvm.target.Target({"kind": "llvm", "model": "ascendc", "mcpu": "dav-2201"})
+    with pytest.raises(ValueError, match="conflicts with Ascend platform A5"):
+        tilelang.lower(
+            dev_ub_explicit_splice(dim=64),
+            target=target,
+            platform="A5",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Regression tests for issue #1301: PTO codegen "Find undefined Variable batch"
 # when a buffer's shape is a composite symbolic expression (e.g. batch + 1)
@@ -286,6 +307,38 @@ def _nested_composite_shape():
     return main
 
 
+def _only_composite_shape():
+    """A symbol with no standalone input extent cannot be recovered at runtime."""
+    batch = T.symbolic("batch")
+
+    @T.prim_func
+    def main(A: T.Tensor([batch + 1], "float32")):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            s = T.alloc_var("int32", init=0)
+            for _i in T.serial(batch):
+                s = s + 1
+
+    return main
+
+
+def _reversed_composite_abi_shape():
+    """Composite order is seq,batch while standalone providers are batch,seq."""
+    batch = T.symbolic("batch")
+    seq = T.symbolic("seq")
+
+    @T.prim_func
+    def main(
+        Composite: T.Tensor([seq + batch], "int32"),
+        Carrier: T.Tensor([batch, seq], "float32"),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            s = T.alloc_var("int32", init=0)
+            for _i in T.serial(batch):
+                s = s + 1
+
+    return main
+
+
 def _compile_symbolic_and_get_source(prim_func, target, platform="auto"):
     # This suite validates lowering/codegen only.  Going through
     # ``tilelang.compile`` also constructs the Cython runtime adapter, which
@@ -337,6 +390,69 @@ def test_nested_composite_shape_codegen(target):
     _assert_shape_var_in_signature(code, "batch")
 
 
+def test_only_composite_shape_is_collected_by_native_codegen():
+    code = _compile_symbolic_and_get_source(_only_composite_shape(), target="ascendc", platform="A5")
+    _assert_shape_var_in_signature(code, "batch")
+
+
+def test_only_composite_shape_without_runtime_provider_is_rejected():
+    tilelang.disable_cache()
+    with pytest.raises(ValueError, match="no runtime provider for: batch"):
+        tilelang.compile(
+            _only_composite_shape(),
+            target="ascendc",
+            platform="A5",
+            out_idx=[],
+        )
+
+
+def test_compiled_a5_host_and_device_symbolic_abi_order_match():
+    class _FakeWrapper:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def __getattr__(self, name):
+            if name.startswith("set_"):
+                return lambda *_args, **_kwargs: self
+            raise AttributeError(name)
+
+        def forward(self, _inputs, stream=-1):
+            return stream
+
+    tilelang.disable_cache()
+    with (
+        mock.patch("tilelang.jit.adapter.cython.adapter.CythonKernelWrapper", _FakeWrapper),
+        mock.patch(
+            "tilelang.jit.adapter.cython.adapter.torch.device",
+            return_value=mock.sentinel.npu_device,
+        ),
+        mock.patch("tilelang.jit.adapter.libgen.LibraryGenerator.compile_lib"),
+        mock.patch(
+            "tilelang.jit.adapter.libgen.LibraryGenerator.load_lib",
+            return_value=object(),
+        ),
+    ):
+        compiled = tilelang.compile(
+            _reversed_composite_abi_shape(),
+            target="ascendc",
+            platform="A5",
+            out_idx=[],
+        )
+
+    source = compiled.get_kernel_source()
+    kernel_signature = next(line for line in source.splitlines() if "main_kernel" in line and "(" in line)
+    host_signature = next(line for line in source.splitlines() if 'extern "C" void call(' in line)
+    assert kernel_signature.index("int64_t seq") < kernel_signature.index("int64_t batch")
+    assert host_signature.index("int64_t seq") < host_signature.index("int64_t batch")
+    assert kernel_signature.count("int64_t seq") == kernel_signature.count("int64_t batch") == 1
+    assert host_signature.count("int64_t seq") == host_signature.count("int64_t batch") == 1
+
+    symbols = list(compiled.adapter.dynamic_symbolic_map)
+    assert [str(symbol) for symbol in symbols] == ["seq", "batch"]
+    assert compiled.adapter.dynamic_symbolic_map[symbols[0]] == (1, 1)
+    assert compiled.adapter.dynamic_symbolic_map[symbols[1]] == (1, 0)
+
+
 def test_a5_native_ascendc_symbolic_shape_uses_one_runtime_abi():
     """A5 shape generalization is one ABI, not one kernel per shape.
 
@@ -349,11 +465,7 @@ def test_a5_native_ascendc_symbolic_shape_uses_one_runtime_abi():
         target="ascendc",
         platform="A5",
     )
-    signatures = [
-        line
-        for line in code.splitlines()
-        if 'extern "C"' in line and "main_kernel" in line and "(" in line
-    ]
+    signatures = [line for line in code.splitlines() if 'extern "C"' in line and "main_kernel" in line and "(" in line]
     assert len(signatures) == 1, f"expected one A5 kernel entry point, got:\n{signatures}"
     assert "int64_t batch" in signatures[0]
     assert "int64_t seq" in signatures[0]

--- a/testing/python/language/test_tilelang_ascend_language_alloc_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_alloc_codegen.py
@@ -229,6 +229,18 @@ def test_a5_lowering_binds_dav3510_mcpu_to_target():
     assert func.attrs["target"].mcpu == "dav-3510"
 
 
+def test_explicit_dav3510_mcpu_selects_a5_before_auto_runtime_fallback():
+    target = tvm.target.Target({"kind": "llvm", "model": "ascendc", "mcpu": "dav-3510"})
+    artifact = tilelang.lower(
+        dev_ub_explicit_splice(dim=64),
+        target=target,
+        platform="auto",
+    )
+    func = artifact.device_mod.functions_items()[0][1]
+    assert func.attrs["target"].mcpu == "dav-3510"
+    assert func.attrs["npu_platform"] == "A5"
+
+
 def test_lowering_rejects_explicit_mcpu_platform_conflict():
     target = tvm.target.Target({"kind": "llvm", "model": "ascendc", "mcpu": "dav-2201"})
     with pytest.raises(ValueError, match="conflicts with Ascend platform A5"):

--- a/testing/python/language/test_tilelang_ascend_language_alloc_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_alloc_codegen.py
@@ -1,8 +1,9 @@
 import pytest
-from unittest.mock import patch
 
 import tilelang
 import tilelang.language as T
+from tilelang import tvm
+from tilelang.transform.pass_config import process_default_pass_config
 
 
 DEV_CONFIGS = {
@@ -134,42 +135,26 @@ def dev_ub_explicit_splice(dim, block_N=128, block_size=128, live_max=64):
 
 def _compile_and_get_source(target, platform="auto"):
     prim_func = dev_L1_explicit_splice(dim=64)
-    with (
-        patch("tilelang.jit.adapter.libgen.LibraryGenerator.compile_lib") as mock_compile,
-        patch(
-            "tilelang.jit.adapter.libgen.LibraryGenerator.load_lib",
-            return_value=None,
-        ),
-    ):
-        mock_compile.return_value = None
-        compiled = tilelang.compile(
+    pass_configs = process_default_pass_config(target, DEV_CONFIGS)
+    with tvm.transform.PassContext(opt_level=3, config=pass_configs):
+        compiled = tilelang.lower(
             prim_func,
-            out_idx=[2],
-            pass_configs=DEV_CONFIGS,
             target=target,
             platform=platform,
         )
-    return compiled.get_kernel_source()
+    return compiled.kernel_source
 
 
 def _compile_ub_and_get_source(target, platform="auto"):
     prim_func = dev_ub_explicit_splice(dim=64)
-    with (
-        patch("tilelang.jit.adapter.libgen.LibraryGenerator.compile_lib") as mock_compile,
-        patch(
-            "tilelang.jit.adapter.libgen.LibraryGenerator.load_lib",
-            return_value=None,
-        ),
-    ):
-        mock_compile.return_value = None
-        compiled = tilelang.compile(
+    pass_configs = process_default_pass_config(target, DEV_CONFIGS)
+    with tvm.transform.PassContext(opt_level=3, config=pass_configs):
+        compiled = tilelang.lower(
             prim_func,
-            out_idx=[2],
-            pass_configs=DEV_CONFIGS,
             target=target,
             platform=platform,
         )
-    return compiled.get_kernel_source()
+    return compiled.kernel_source
 
 
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
@@ -301,17 +286,20 @@ def _nested_composite_shape():
     return main
 
 
-def _compile_symbolic_and_get_source(prim_func, target):
-    with (
-        patch("tilelang.jit.adapter.libgen.LibraryGenerator.compile_lib") as mock_compile,
-        patch(
-            "tilelang.jit.adapter.libgen.LibraryGenerator.load_lib",
-            return_value=None,
-        ),
-    ):
-        mock_compile.return_value = None
-        compiled = tilelang.compile(prim_func, target=target)
-    return compiled.get_kernel_source()
+def _compile_symbolic_and_get_source(prim_func, target, platform="auto"):
+    # This suite validates lowering/codegen only.  Going through
+    # ``tilelang.compile`` also constructs the Cython runtime adapter, which
+    # requires a torch build that has registered the ``npu`` device even though
+    # compile/load are mocked.  ``lower`` is the direct, device-independent
+    # consumer for the generated source under test, but it must use the same
+    # target defaults and PassContext as production ``compile``.
+    pass_configs = process_default_pass_config(target, None)
+    with tvm.transform.PassContext(opt_level=3, config=pass_configs):
+        return tilelang.lower(
+            prim_func,
+            target=target,
+            platform=platform,
+        ).kernel_source
 
 
 def _assert_shape_var_in_signature(code, *var_names):
@@ -347,6 +335,28 @@ def test_nested_composite_shape_codegen(target):
     ``batch``."""
     code = _compile_symbolic_and_get_source(_nested_composite_shape(), target)
     _assert_shape_var_in_signature(code, "batch")
+
+
+def test_a5_native_ascendc_symbolic_shape_uses_one_runtime_abi():
+    """A5 shape generalization is one ABI, not one kernel per shape.
+
+    ``batch`` and ``seq`` must remain runtime parameters in the single emitted
+    AscendC entry point.  This deliberately tests ``platform="A5"`` so the
+    generic symbolic-shape coverage cannot mask a DAV3510 lowering regression.
+    """
+    code = _compile_symbolic_and_get_source(
+        _multi_var_composite_shape(),
+        target="ascendc",
+        platform="A5",
+    )
+    signatures = [
+        line
+        for line in code.splitlines()
+        if 'extern "C"' in line and "main_kernel" in line and "(" in line
+    ]
+    assert len(signatures) == 1, f"expected one A5 kernel entry point, got:\n{signatures}"
+    assert "int64_t batch" in signatures[0]
+    assert "int64_t seq" in signatures[0]
 
 
 if __name__ == "__main__":

--- a/testing/python/test_ascend_arch_a5.py
+++ b/testing/python/test_ascend_arch_a5.py
@@ -1,0 +1,97 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+
+def _load_ascend_arch_module():
+    """Load the leaf modules without importing carver's torch_npu-only modules."""
+    arch_dir = Path(__file__).parents[2] / "tilelang" / "carver" / "arch"
+    package_name = "_tilelang_a5_arch_test"
+    package = ModuleType(package_name)
+    package.__path__ = [str(arch_dir)]
+
+    loaded_names = [package_name, f"{package_name}.arch_base", f"{package_name}.ascend"]
+    try:
+        sys.modules[package_name] = package
+        base_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.arch_base", arch_dir / "arch_base.py"
+        )
+        base_module = importlib.util.module_from_spec(base_spec)
+        sys.modules[base_spec.name] = base_module
+        base_spec.loader.exec_module(base_module)
+
+        ascend_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.ascend", arch_dir / "ascend.py"
+        )
+        ascend_module = importlib.util.module_from_spec(ascend_spec)
+        sys.modules[ascend_spec.name] = ascend_module
+        ascend_spec.loader.exec_module(ascend_module)
+        return ascend_module
+    finally:
+        for module_name in loaded_names:
+            sys.modules.pop(module_name, None)
+
+
+ascend_arch = _load_ascend_arch_module()
+
+
+class _FakeNpu:
+    def __init__(self, name, cube_core_num, l2_cache_size):
+        self._props = SimpleNamespace(
+            name=name,
+            cube_core_num=cube_core_num,
+            L2_cache_size=l2_cache_size,
+        )
+
+    def is_available(self):
+        return True
+
+    def device_count(self):
+        return 1
+
+    def current_device(self):
+        return 0
+
+    def get_device_properties(self, _device):
+        return self._props
+
+
+@pytest.mark.parametrize(
+    "name, cube_cores",
+    [
+        ("Ascend950PR_950z", 4),
+        ("Ascend950DT_9575", 28),
+        ("Ascend910_9599", 36),
+    ],
+)
+def test_a5_resources_use_runtime_sku_properties(name, cube_cores):
+    fake_torch = SimpleNamespace(npu=_FakeNpu(name, cube_cores, 96 * 1024 * 1024))
+    with (
+        mock.patch.object(ascend_arch, "_TORCH_NPU_AVAILABLE", True),
+        mock.patch.object(ascend_arch, "torch", fake_torch),
+    ):
+        arch = ascend_arch.Ascend(SimpleNamespace(mcpu="dav-3510"))
+
+    assert arch.chip_name == "Ascend950"
+    assert arch.compute_max_core == cube_cores
+    assert arch.ub_cap == 248 * 1024
+    assert arch.l1_cap == 512 * 1024
+    assert arch.l0c_cap == 256 * 1024
+    assert arch.l2_cache_size_bytes == 96 * 1024 * 1024
+    assert ascend_arch.is_cube_supported_precision("float16", "float32", arch)
+    assert ascend_arch.is_cube_supported_precision("bfloat16", "bfloat16", arch)
+    assert not ascend_arch.is_cube_supported_precision("float32", "float32", arch)
+    assert not ascend_arch.is_cube_supported_precision("float16", "int32", arch)
+
+
+def test_a5_without_runtime_core_query_fails_loud():
+    with (
+        mock.patch.object(ascend_arch, "_TORCH_NPU_AVAILABLE", False),
+        pytest.raises(RuntimeError, match="core count is device/SKU-specific"),
+    ):
+        ascend_arch.Ascend(SimpleNamespace(mcpu="dav-3510"), chip_name="Ascend950")

--- a/testing/python/test_ascend_arch_a5.py
+++ b/testing/python/test_ascend_arch_a5.py
@@ -98,6 +98,8 @@ def test_a5_without_runtime_core_query_fails_loud():
     [
         ("dav-3510", "Ascend910B"),
         ("dav-910b", "Ascend950PR_950z"),
+        ("dav-910c", "Ascend910B"),
+        ("dav-910b", "Ascend910C"),
     ],
 )
 def test_target_mcpu_profile_rejects_runtime_device_mismatch(mcpu, runtime_name):

--- a/testing/python/test_ascend_arch_a5.py
+++ b/testing/python/test_ascend_arch_a5.py
@@ -18,16 +18,12 @@ def _load_ascend_arch_module():
     loaded_names = [package_name, f"{package_name}.arch_base", f"{package_name}.ascend"]
     try:
         sys.modules[package_name] = package
-        base_spec = importlib.util.spec_from_file_location(
-            f"{package_name}.arch_base", arch_dir / "arch_base.py"
-        )
+        base_spec = importlib.util.spec_from_file_location(f"{package_name}.arch_base", arch_dir / "arch_base.py")
         base_module = importlib.util.module_from_spec(base_spec)
         sys.modules[base_spec.name] = base_module
         base_spec.loader.exec_module(base_module)
 
-        ascend_spec = importlib.util.spec_from_file_location(
-            f"{package_name}.ascend", arch_dir / "ascend.py"
-        )
+        ascend_spec = importlib.util.spec_from_file_location(f"{package_name}.ascend", arch_dir / "ascend.py")
         ascend_module = importlib.util.module_from_spec(ascend_spec)
         sys.modules[ascend_spec.name] = ascend_module
         ascend_spec.loader.exec_module(ascend_module)
@@ -95,3 +91,20 @@ def test_a5_without_runtime_core_query_fails_loud():
         pytest.raises(RuntimeError, match="core count is device/SKU-specific"),
     ):
         ascend_arch.Ascend(SimpleNamespace(mcpu="dav-3510"), chip_name="Ascend950")
+
+
+@pytest.mark.parametrize(
+    "mcpu, runtime_name",
+    [
+        ("dav-3510", "Ascend910B"),
+        ("dav-910b", "Ascend950PR_950z"),
+    ],
+)
+def test_target_mcpu_profile_rejects_runtime_device_mismatch(mcpu, runtime_name):
+    fake_torch = SimpleNamespace(npu=_FakeNpu(runtime_name, 4, 96 * 1024 * 1024))
+    with (
+        mock.patch.object(ascend_arch, "_TORCH_NPU_AVAILABLE", True),
+        mock.patch.object(ascend_arch, "torch", fake_torch),
+        pytest.raises(RuntimeError, match="does not match runtime device profile"),
+    ):
+        ascend_arch.Ascend(SimpleNamespace(mcpu=mcpu))

--- a/tilelang/carver/arch/ascend.py
+++ b/tilelang/carver/arch/ascend.py
@@ -1,4 +1,5 @@
-from typing import Optional, List
+from __future__ import annotations
+
 from tvm.target import Target
 from .arch_base import TileDevice
 from tilelang.utils.target import ascend_platform_from_device_name, ascend_platform_from_mcpu
@@ -7,7 +8,7 @@ import logging
 # check if torch_npu is available, if not, degrade using CHIP_SPECS only
 try:
     import torch
-    import torch_npu
+    import torch_npu  # noqa: F401  # Registers the torch.npu device backend.
 
     _TORCH_NPU_AVAILABLE = True
 except ImportError:
@@ -68,14 +69,14 @@ CHIP_SPECS = {
 DEFAULT_CHIP = "Ascend910A"
 
 
-class CubeInstruction(object):
-    def __init__(self, name: str, shape: List[int]):
+class CubeInstruction:
+    def __init__(self, name: str, shape: list[int]):
         self.name = name
         self.shape = shape
 
 
 class Ascend(TileDevice):
-    def __init__(self, target: Target | str = "llvm -keys=ascend", chip_name: Optional[str] = None):
+    def __init__(self, target: Target | str = "llvm -keys=ascend", chip_name: str | None = None):
         if isinstance(target, str):
             target = Target(target)
         self.target = target
@@ -138,9 +139,8 @@ class Ascend(TileDevice):
                 requested_platform = "A2"
             elif requested_chip_name == "Ascend910A":
                 requested_platform = "A3"
-        if requested_platform is not None and runtime_platform is not None:
-            if runtime_platform not in requested_platform.split("/"):
-                raise RuntimeError(f"Target profile {requested_chip_name} does not match runtime device profile {runtime_chip_name}")
+        if requested_platform is not None and runtime_platform is not None and runtime_platform not in requested_platform.split("/"):
+            raise RuntimeError(f"Target profile {requested_chip_name} does not match runtime device profile {runtime_chip_name}")
 
         # Explicit chip_name, then target mcpu, then runtime detection, then fallback.
         chip_name = requested_chip_name or runtime_chip_name or DEFAULT_CHIP
@@ -200,7 +200,7 @@ class Ascend(TileDevice):
         return self.cube_spec[-1]
 
     @property
-    def cube_shape(self) -> List[int]:
+    def cube_shape(self) -> list[int]:
         """
         Return the full dimensions of the CUBE unit [M, N, K].
         """

--- a/tilelang/carver/arch/ascend.py
+++ b/tilelang/carver/arch/ascend.py
@@ -1,6 +1,7 @@
 from typing import Optional, List
 from tvm.target import Target
 from .arch_base import TileDevice
+from tilelang.utils.target import ascend_platform_from_device_name, ascend_platform_from_mcpu
 import logging
 
 # check if torch_npu is available, if not, degrade using CHIP_SPECS only
@@ -72,6 +73,7 @@ class CubeInstruction(object):
         self.name = name
         self.shape = shape
 
+
 class Ascend(TileDevice):
     def __init__(self, target: Target | str = "llvm -keys=ascend", chip_name: Optional[str] = None):
         if isinstance(target, str):
@@ -79,16 +81,40 @@ class Ascend(TileDevice):
         self.target = target
         self.platform = "ascend"
 
+        target_platform = ascend_platform_from_mcpu(getattr(target, "mcpu", None))
+        target_chip_name = None
+        if target_platform == "A5":
+            target_chip_name = "Ascend950"
+        elif target_platform == "A3":
+            target_chip_name = "Ascend910A"
+        elif target_platform == "A2":
+            mcpu = str(getattr(target, "mcpu", "")).lower()
+            target_chip_name = "Ascend910B" if "910b" in mcpu else "Ascend910A"
+
+        requested_chip_name = chip_name or target_chip_name
+
         # Query properties whenever possible.  In particular, an explicit A5
         # profile still cannot supply a SKU-independent core count.
         detected_cores = None
         L2_cache_size_bytes = None
-        if _TORCH_NPU_AVAILABLE and (chip_name is None or chip_name == "Ascend950"):
+        runtime_chip_name = None
+        runtime_platform = None
+        if _TORCH_NPU_AVAILABLE:
             try:
                 if torch.npu.is_available() and torch.npu.device_count() > 0:
                     # Get the current NPU device properties
                     props = torch.npu.get_device_properties(torch.npu.current_device())
                     npu_name = props.name.upper()  # e.g., "ASCEND910B"
+
+                    runtime_platform = ascend_platform_from_device_name(npu_name)
+                    if runtime_platform == "A5":
+                        runtime_chip_name = "Ascend950"
+                    elif "910B" in npu_name:
+                        runtime_chip_name = "Ascend910B"
+                    elif "310P" in npu_name:
+                        runtime_chip_name = "Ascend310P"
+                    elif runtime_platform in {"A2", "A3"}:
+                        runtime_chip_name = "Ascend910A"
 
                     if hasattr(props, "cube_core_num"):
                         detected_cores = props.cube_core_num
@@ -100,41 +126,18 @@ class Ascend(TileDevice):
                     elif hasattr(props, "l2_cache_size"):
                         L2_cache_size_bytes = props.l2_cache_size
 
-                    if chip_name is None:
-                        if "950" in npu_name or "910_95" in npu_name or "3510" in npu_name:
-                            chip_name = "Ascend950"
-                        elif "910B" in npu_name:
-                            chip_name = "Ascend910B"
-                        elif "310P" in npu_name:
-                            chip_name = "Ascend310P"
-                        elif "910" in npu_name:
-                            chip_name = "Ascend910A"
-
-                    logger.debug(
-                        f"Detected Ascend NPU: {npu_name}, using chip profile: {chip_name}"
-                    )
+                    logger.debug(f"Detected Ascend NPU: {npu_name}, runtime profile: {runtime_chip_name}")
             except Exception as e:
-                logger.warning(
-                    f"Failed to detect Ascend NPU properties from torch_npu: {e}"
-                )
+                logger.warning(f"Failed to detect Ascend NPU properties from torch_npu: {e}")
 
-        # Else determine chip properties from CHIP_SPEC if not chip name provided
-        if chip_name is None:
-            mcpu = getattr(target, "mcpu", None)
-            if mcpu:
-                mcpu = mcpu.lower()
-                if "950" in mcpu or "910_95" in mcpu or "3510" in mcpu:
-                    chip_name = "Ascend950"
-                elif "910b" in mcpu:
-                    chip_name = "Ascend910B"
-                elif "310p" in mcpu:
-                    chip_name = "Ascend310P"
-                elif "910" in mcpu:
-                    chip_name = "Ascend910A"
-                else:
-                    chip_name = DEFAULT_CHIP
-            else:
-                chip_name = DEFAULT_CHIP
+        if requested_chip_name is not None and runtime_chip_name is not None:
+            requested_is_a5 = requested_chip_name == "Ascend950"
+            runtime_is_a5 = runtime_chip_name == "Ascend950"
+            if requested_is_a5 != runtime_is_a5:
+                raise RuntimeError(f"Target profile {requested_chip_name} does not match runtime device profile {runtime_chip_name}")
+
+        # Explicit chip_name, then target mcpu, then runtime detection, then fallback.
+        chip_name = requested_chip_name or runtime_chip_name or DEFAULT_CHIP
 
         self.chip_name = chip_name
         spec = CHIP_SPECS.get(chip_name, CHIP_SPECS[DEFAULT_CHIP]).copy()
@@ -160,8 +163,7 @@ class Ascend(TileDevice):
             self.l2_cache_size_bytes = L2_cache_size_bytes
         elif spec["L2"] is None:
             raise RuntimeError(
-                f"{chip_name} L2 size is device/SKU-specific; "
-                "query torch.npu.get_device_properties(...).L2_cache_size on the target device"
+                f"{chip_name} L2 size is device/SKU-specific; query torch.npu.get_device_properties(...).L2_cache_size on the target device"
             )
         else:
             self.l2_cache_size_bytes = spec["L2"]
@@ -203,10 +205,9 @@ class Ascend(TileDevice):
         return (self.cube_spec[0], self.cube_spec[1])
 
     def get_avaliable_tensorintrin_shapes(self):
-        self.available_cube_instructions = (
-            CubeInstruction("Davich", [16, 16]),
-        )
+        self.available_cube_instructions = (CubeInstruction("Davich", [16, 16]),)
         return [t.shape for t in self.available_cube_instructions]
+
 
 # TODO: consider the dtype of the input a and b seperately
 # As the tensorcore may supports e4m3_float8 * e5m2
@@ -215,8 +216,13 @@ def is_cube_supported_precision(in_dtype: str, accum_dtype: str, arch: TileDevic
         return False
     if arch.chip_name in {"Ascend910A", "Ascend910B", "Ascend310P", "Ascend950"}:
         # Ascend NPU supports float16 and bfloat16 tensor core operations
-        return in_dtype in ["float16", "bfloat16"] and accum_dtype in ["float16", "bfloat16", "float32"]
+        return in_dtype in ["float16", "bfloat16"] and accum_dtype in [
+            "float16",
+            "bfloat16",
+            "float32",
+        ]
     else:
         raise ValueError(f"Unsupported architecture: {arch}")
+
 
 __all__ = ["Ascend", "is_ascend_arch", "is_cube_supported_precision"]

--- a/tilelang/carver/arch/ascend.py
+++ b/tilelang/carver/arch/ascend.py
@@ -21,6 +21,18 @@ def is_ascend_arch(arch: TileDevice) -> bool:
 
 # Chip specifications (sizes in bytes)
 CHIP_SPECS = {
+    "Ascend950": {
+        # DAV_3510 core counts vary by physical SKU and vNPU profile.  They
+        # must come from the active device instead of a model-name default.
+        "cores": None,
+        "UB": 248 * 1024,
+        "L1": 512 * 1024,
+        "L0A": 64 * 1024,
+        "L0B": 64 * 1024,
+        "L0C": 256 * 1024,
+        "L2": None,
+        "cube": [16, 16, 16],
+    },
     "Ascend910A": {
         "cores": 32,
         "UB": 256 * 1024,
@@ -67,10 +79,11 @@ class Ascend(TileDevice):
         self.target = target
         self.platform = "ascend"
 
-        # detect npu properties if chip_name is not provided
+        # Query properties whenever possible.  In particular, an explicit A5
+        # profile still cannot supply a SKU-independent core count.
         detected_cores = None
         L2_cache_size_bytes = None
-        if chip_name is None and _TORCH_NPU_AVAILABLE:
+        if _TORCH_NPU_AVAILABLE and (chip_name is None or chip_name == "Ascend950"):
             try:
                 if torch.npu.is_available() and torch.npu.device_count() > 0:
                     # Get the current NPU device properties
@@ -79,15 +92,23 @@ class Ascend(TileDevice):
 
                     if hasattr(props, "cube_core_num"):
                         detected_cores = props.cube_core_num
-                    if hasattr(props, "l2_cache_size"):
+                    # torch_npu exposes this with a capital ``L2``.  Keep the
+                    # lowercase fallback for older vendor builds, but prefer
+                    # the public property spelling used by current CANN.
+                    if hasattr(props, "L2_cache_size"):
+                        L2_cache_size_bytes = props.L2_cache_size
+                    elif hasattr(props, "l2_cache_size"):
                         L2_cache_size_bytes = props.l2_cache_size
 
-                    if "910B" in npu_name:
-                        chip_name = "Ascend910B"
-                    elif "310P" in npu_name:
-                        chip_name = "Ascend310P"
-                    elif "910" in npu_name:
-                        chip_name = "Ascend910A"
+                    if chip_name is None:
+                        if "950" in npu_name or "910_95" in npu_name or "3510" in npu_name:
+                            chip_name = "Ascend950"
+                        elif "910B" in npu_name:
+                            chip_name = "Ascend910B"
+                        elif "310P" in npu_name:
+                            chip_name = "Ascend310P"
+                        elif "910" in npu_name:
+                            chip_name = "Ascend910A"
 
                     logger.debug(
                         f"Detected Ascend NPU: {npu_name}, using chip profile: {chip_name}"
@@ -102,7 +123,9 @@ class Ascend(TileDevice):
             mcpu = getattr(target, "mcpu", None)
             if mcpu:
                 mcpu = mcpu.lower()
-                if "910b" in mcpu:
+                if "950" in mcpu or "910_95" in mcpu or "3510" in mcpu:
+                    chip_name = "Ascend950"
+                elif "910b" in mcpu:
                     chip_name = "Ascend910B"
                 elif "310p" in mcpu:
                     chip_name = "Ascend310P"
@@ -119,6 +142,11 @@ class Ascend(TileDevice):
         # AI Core size
         if detected_cores is not None and detected_cores > 0:
             self.compute_max_core = detected_cores
+        elif spec["cores"] is None:
+            raise RuntimeError(
+                f"{chip_name} core count is device/SKU-specific; "
+                "query torch.npu.get_device_properties(...).cube_core_num on the target device"
+            )
         else:
             self.compute_max_core = spec["cores"]
 
@@ -130,6 +158,11 @@ class Ascend(TileDevice):
         self.l0c_cap = spec["L0C"]
         if L2_cache_size_bytes is not None and L2_cache_size_bytes > 0:
             self.l2_cache_size_bytes = L2_cache_size_bytes
+        elif spec["L2"] is None:
+            raise RuntimeError(
+                f"{chip_name} L2 size is device/SKU-specific; "
+                "query torch.npu.get_device_properties(...).L2_cache_size on the target device"
+            )
         else:
             self.l2_cache_size_bytes = spec["L2"]
 
@@ -180,7 +213,7 @@ class Ascend(TileDevice):
 def is_cube_supported_precision(in_dtype: str, accum_dtype: str, arch: TileDevice) -> bool:
     if not isinstance(arch, Ascend):
         return False
-    if arch.chip_name == "Ascend910A" or arch.chip_name == "Ascend910B" or arch.chip_name == "Ascend310P":
+    if arch.chip_name in {"Ascend910A", "Ascend910B", "Ascend310P", "Ascend950"}:
         # Ascend NPU supports float16 and bfloat16 tensor core operations
         return in_dtype in ["float16", "bfloat16"] and accum_dtype in ["float16", "bfloat16", "float32"]
     else:

--- a/tilelang/carver/arch/ascend.py
+++ b/tilelang/carver/arch/ascend.py
@@ -130,10 +130,16 @@ class Ascend(TileDevice):
             except Exception as e:
                 logger.warning(f"Failed to detect Ascend NPU properties from torch_npu: {e}")
 
-        if requested_chip_name is not None and runtime_chip_name is not None:
-            requested_is_a5 = requested_chip_name == "Ascend950"
-            runtime_is_a5 = runtime_chip_name == "Ascend950"
-            if requested_is_a5 != runtime_is_a5:
+        requested_platform = target_platform
+        if requested_platform is None and requested_chip_name is not None:
+            if requested_chip_name == "Ascend950":
+                requested_platform = "A5"
+            elif requested_chip_name in {"Ascend910B", "Ascend310P"}:
+                requested_platform = "A2"
+            elif requested_chip_name == "Ascend910A":
+                requested_platform = "A3"
+        if requested_platform is not None and runtime_platform is not None:
+            if runtime_platform not in requested_platform.split("/"):
                 raise RuntimeError(f"Target profile {requested_chip_name} does not match runtime device profile {runtime_chip_name}")
 
         # Explicit chip_name, then target mcpu, then runtime detection, then fallback.

--- a/tilelang/carver/roller/policy/ascend.py
+++ b/tilelang/carver/roller/policy/ascend.py
@@ -14,6 +14,9 @@ This module provides:
 - AscendDefaultPolicy: Base policy for Ascend SIMD architecture (replaces DefaultPolicy)
 - AscendCubePolicy: CUBE unit optimization (similar to TensorCorePolicy)
 """
+
+from __future__ import annotations
+
 from collections.abc import Iterable
 from queue import PriorityQueue
 
@@ -33,53 +36,53 @@ logger = logging.getLogger(__name__)
 class AscendDefaultPolicy(DefaultPolicy):
     """
     Default Policy for Ascend NPU SIMD architecture.
-    
+
     This policy adapts the GPU-oriented DefaultPolicy for Ascend's SIMD architecture:
     - No thread/warp concept - uses AI Core level parallelism
     - SIMD vector operations instead of thread-level parallelism
     - Memory hierarchy: L0A, L0B, L0C, L1, UB (instead of shared memory)
     - DMA alignment requirements (32 bytes)
     - Vector alignment for SIMD operations
-    
+
     Key adaptations:
     1. block_size -> 1 (no thread parallelism, AI Core executes sequentially)
     2. thread config -> vector config (SIMD width)
     3. shared memory -> L0/UB buffer
     4. coalesced access -> DMA aligned access
     """
-    
+
     def __init__(self, arch: TileDevice, tags: dict | None = None) -> None:
         assert arch.platform == "ascend", "AscendDefaultPolicy requires Ascend architecture."
         super().__init__(arch, tags)
-        
+
         # Integrate all Ascend hardware parameters from arch into Policy
         # SIMD and DMA parameters (fixed for Ascend architecture)
         self.simd_width = 32  # Unified Buffer alignment (32 bytes)
         self.dma_alignment = 32  # DMA requires 32-byte alignment
-        
+
         # AI Core configuration - use actual hardware value
         self.num_ai_cores = getattr(arch, "compute_max_core", None)
         if not isinstance(self.num_ai_cores, int) or self.num_ai_cores <= 0:
             raise ValueError("Ascend core count must be supplied by the architecture/device query")
-        
+
         # Memory hierarchy capacities (bytes) - prioritize arch values
         self.l0a_capacity = getattr(arch, "l0a_cap", 64 * 1024)
         self.l0b_capacity = getattr(arch, "l0b_cap", 64 * 1024)
         self.l0c_capacity = getattr(arch, "l0c_cap", 256 * 1024)
         self.l1_capacity = getattr(arch, "l1_cap", 1024 * 1024)
         self.ub_capacity = getattr(arch, "ub_cap", 256 * 1024)
-        
+
         # L2 cache and additional parameters
         self.l2_cache_size = getattr(arch, "l2_cache_size_bytes", 16 * 1024 * 1024)
-        
+
         # CUBE unit specification [M, N, K]
         self.cube_shape = getattr(arch, "cube_spec", [16, 16, 16])
         self.cube_dim = self.cube_shape[-1]  # K dimension
         self.fractal_shape = (self.cube_shape[0], self.cube_shape[1])  # (M, N)
-        
+
         # Chip identification
         self.chip_name = getattr(arch, "chip_name", "Ascend910A")
-        
+
         # L0 buffer alignment requirements (bytes)
         # ref: https://www.hiascend.com/document/detail/zh/canncommercial/83RC1/opdevg/Ascendcopdevg/atlas_ascendc_10_0010.html
         # These are architecture constants that depend on the CUBE shape and data format
@@ -88,16 +91,16 @@ class AscendDefaultPolicy(DefaultPolicy):
         self.l0a_alignment = 512  # L0A: 512-byte aligned (input A)
         self.l0b_alignment = 512  # L0B: 512-byte aligned (input B)
         self.l0c_alignment = 64  # L0C: 64-byte aligned (16x16 fp16 block)
-        
+
         # DMA transaction parameters
         self.transaction_size = getattr(arch, "transaction_size", [32, 32])
         self.bandwidth = getattr(arch, "bandwidth", [900000, 900000])
-        
+
         logger.debug(
             f"AscendDefaultPolicy initialized for {self.chip_name}:\n"
             f"  AI Cores: {self.num_ai_cores}\n"
-            f"  Memory: L0A={self.l0a_capacity//1024}KB, L0B={self.l0b_capacity//1024}KB, "
-            f"L0C={self.l0c_capacity//1024}KB, L1={self.l1_capacity//1024}KB, UB={self.ub_capacity//1024}KB\n"
+            f"  Memory: L0A={self.l0a_capacity // 1024}KB, L0B={self.l0b_capacity // 1024}KB, "
+            f"L0C={self.l0c_capacity // 1024}KB, L1={self.l1_capacity // 1024}KB, UB={self.ub_capacity // 1024}KB\n"
             f"  CUBE: {self.cube_shape}, Fractal: {self.fractal_shape}"
         )
 
@@ -105,41 +108,35 @@ class AscendDefaultPolicy(DefaultPolicy):
         """Get total buffer capacity (analogous to smem_cap on GPU)."""
         # For general operations, use UB as the primary buffer
         return self.ub_capacity
-    
+
     def _get_tile_buffer_capacity(self) -> int:
         """Get buffer capacity for tile validation.
-        
+
         For AscendDefaultPolicy (vector operations): use UB capacity.
         Subclasses (e.g., AscendCubePolicy) can override to use different capacity.
         """
         buffer_cap = self._get_buffer_capacity()
         logger.debug(f"Using UB buffer capacity: {buffer_cap} bytes")
         return buffer_cap
-    
+
     def _get_total_l0_capacity(self) -> int:
         """Get total L0 buffer capacity (sum of L0A + L0B + L0C)."""
         return self.l0a_capacity + self.l0b_capacity + self.l0c_capacity
-    
+
     def _get_l0_capacities(self) -> tuple[int, int, int]:
         """Get individual L0 buffer capacities (L0A, L0B, L0C)."""
         return self.l0a_capacity, self.l0b_capacity, self.l0c_capacity
-    
-    def _check_l0_usage(
-        self, 
-        a_size: int, 
-        b_size: int, 
-        c_size: int,
-        pipeline_stage: int = 1
-    ) -> bool:
+
+    def _check_l0_usage(self, a_size: int, b_size: int, c_size: int, pipeline_stage: int = 1) -> bool:
         """
         Check if L0 buffer usage is within limits.
-        
+
         Args:
             a_size: Size of matrix A tile in bytes
-            b_size: Size of matrix B tile in bytes  
+            b_size: Size of matrix B tile in bytes
             c_size: Size of output C tile in bytes
             pipeline_stage: Pipeline depth multiplier for double buffering
-            
+
         Returns:
             True if usage is within L0 capacity limits
         """
@@ -148,19 +145,17 @@ class AscendDefaultPolicy(DefaultPolicy):
         b_usage = b_size * pipeline_stage
         # L0C typically doesn't need double buffering (accumulator)
         c_usage = c_size
-        
-        return (a_usage <= self.l0a_capacity and 
-                b_usage <= self.l0b_capacity and 
-                c_usage <= self.l0c_capacity)
-    
+
+        return a_usage <= self.l0a_capacity and b_usage <= self.l0b_capacity and c_usage <= self.l0c_capacity
+
     def _align_to_l0(self, size: int, buffer_type: str = "a") -> int:
         """
         Align size to L0 buffer alignment requirement.
-        
+
         Args:
             size: Size in bytes
             buffer_type: "a" for L0A, "b" for L0B, "c" for L0C
-            
+
         Returns:
             Aligned size in bytes
         """
@@ -170,24 +165,24 @@ class AscendDefaultPolicy(DefaultPolicy):
             alignment = self.l0b_alignment
         else:  # "c"
             alignment = self.l0c_alignment
-        
+
         return ((size + alignment - 1) // alignment) * alignment
 
     # ==================== Tile Search (adapted for SIMD) ====================
-    
+
     def dfs_smem_tile(self, init_tile, rstep_map) -> Iterable[TileDict]:
         """
         DFS search for tile candidates.
-        
+
         For SIMD architecture:
         - Prefer tiles aligned to SIMD width
         - Consider DMA alignment for memory efficiency
         - Optimize for AI Core utilization
         """
         _steps = [get_all_factors(n) for n in self.output_nodes[0].get_space_dim()]
-        steps = [step[step.index(t):] for step, t in zip(_steps, init_tile)]
+        steps = [step[step.index(t) :] for step, t in zip(_steps, init_tile)]
         logger.debug(f"Initial steps: {steps}")
-        
+
         # Add SIMD-friendly tile sizes (multiples of common SIMD widths)
         simd_friendly_sizes = [16, 32, 64, 128, 256]
         for i in range(len(steps)):
@@ -195,13 +190,14 @@ class AscendDefaultPolicy(DefaultPolicy):
                 filter(
                     lambda s: s < steps[i][-1] and s > steps[i][0] and s not in steps[i],
                     simd_friendly_sizes,
-                ))
+                )
+            )
             steps[i].extend(added)
             steps[i] = sorted(steps[i])
-        
+
         visited_tiles = {}
         queue = PriorityQueue()
-        
+
         def prio(td: TileDict):
             """Priority function for SIMD architecture."""
             # For SIMD, prioritize:
@@ -210,15 +206,15 @@ class AscendDefaultPolicy(DefaultPolicy):
             # 3. SIMD-aligned tiles
             traffic_score = td.traffic + 1
             wave_score = td.num_wave
-            
+
             # Bonus for SIMD-aligned tiles
             alignment_bonus = 1.0
             for t in td.output_tile:
                 if t % 16 == 0:
                     alignment_bonus *= 0.1  # Better alignment = lower priority value
-            
+
             return traffic_score * wave_score * alignment_bonus
-        
+
         def add_to_queue(tile):
             if tuple(tile) in visited_tiles:
                 return
@@ -226,7 +222,7 @@ class AscendDefaultPolicy(DefaultPolicy):
             visited_tiles[tuple(tile)] = td
             if td.valid:
                 queue.put([prio(td), tile])
-        
+
         add_to_queue(init_tile)
         while not (queue.empty() or len(visited_tiles) > 2000):
             _, tile = queue.get()
@@ -236,7 +232,7 @@ class AscendDefaultPolicy(DefaultPolicy):
                     new_tile = tile.copy()
                     new_tile[i] = steps[i][dim_ids[i] + 1]
                     add_to_queue(new_tile)
-        
+
         visited_tiles = filter(lambda td: td.valid, visited_tiles.values())
         sorted_tiles = sorted(visited_tiles, key=lambda td: prio(td))
         logger.debug(f"Found {len(sorted_tiles)} valid tile candidates for Ascend target.")
@@ -245,7 +241,7 @@ class AscendDefaultPolicy(DefaultPolicy):
     def compute_tile_dict(self, output_tile: list[int], rstep_map) -> TileDict:
         """
         Compute TileDict for Ascend architecture.
-        
+
         Key points:
         - Use _get_tile_buffer_capacity() to determine memory constraint
         - Use AI Core count instead of SM count
@@ -253,33 +249,31 @@ class AscendDefaultPolicy(DefaultPolicy):
         td = TileDict(output_tile)
         td.rstep_map = rstep_map
         td.traffic, td.tile_map = self._compute_memory_traffic(output_tile)
-        logger.debug(f"corresponding to the output tile {output_tile}, "
-                    f"the traffic is {td.traffic}, tile_map is {td.tile_map}")
-        
+        logger.debug(f"corresponding to the output tile {output_tile}, the traffic is {td.traffic}, tile_map is {td.tile_map}")
+
         # Compute buffer usage
         td.smem_cost, td.cached_tensors_map = self._compute_shared_memory_usage(td)
-        logger.debug(f"the shared memory cost is {td.smem_cost},"
-                    f" cached tensors map is {td.cached_tensors_map}")
-        
+        logger.debug(f"the shared memory cost is {td.smem_cost}, cached tensors map is {td.cached_tensors_map}")
+
         # Get buffer capacity (subclass can override to use different capacity)
         buffer_cap = self._get_tile_buffer_capacity()
-        
+
         if td.smem_cost > buffer_cap:
             logger.debug(f"Tile invalid: smem cost={td.smem_cost} > buffer cap={buffer_cap}")
             td.valid = False
             return td
-        
+
         output_shape = self.output_nodes[0].get_space_dim()
         td.grid_size = int(np.prod([(y + x - 1) // x for x, y in zip(output_tile, output_shape)]))
-        
+
         # AI Core parallel execution
         td.block_per_SM = 1
         td.num_wave = int(np.ceil(td.grid_size / self.num_ai_cores))
-        
+
         return td
 
     # ==================== Block/Thread Assignment (adapted for SIMD) ====================
-    
+
     def recommend_block_size(self, td: TileDict):
         """
         For SIMD architecture, block_size concept doesn't apply.
@@ -288,120 +282,118 @@ class AscendDefaultPolicy(DefaultPolicy):
         # SIMD: no thread-level parallelism within a tile
         # The "block_size" is effectively 1 (single instruction stream per AI Core)
         return [1]
-    
+
     def _assign_block_size(self, node: PrimFuncNode, td: TileDict, block_size: int):
         """
         Assign configuration for SIMD execution.
-        
+
         For SIMD architecture:
         - No thread decomposition (thread = [1, 1, ...])
         - Vectorization is implicit in SIMD operations
         - Focus on DMA-aligned data access
         """
         tile, rsteps = td.get_tile(node), td.get_rstep(node)
-        ndim = len(tile)
-        
+
         codegen_dict = Hint()
         codegen_dict.block = tile
-        
+
         # SIMD: no thread-level parallelism
         # thread = [1] means single execution stream per AI Core
         codegen_dict.thread = [1 for _ in tile]
-        
+
         codegen_dict.rstep = [rsteps[ax.var.name] for ax in node.raxis]
         codegen_dict.reduce_thread = [1 for _ in node.raxis]  # No thread reduction
         codegen_dict.cached_tensors = td.cached_tensors_map.get(node, [])
         codegen_dict.rasterization_plan = NoRasterization()
-        
+
         # Plan vectorize for SIMD
         codegen_dict.vectorize = self._plan_vectorize_simd(node, td)
         codegen_dict.arch = self.arch
         codegen_dict.opt_shapes = node.get_tag("opt_shapes")
-        
+
         return codegen_dict
-    
+
     def _plan_vectorize_simd(self, node: PrimFuncNode, td: TileDict):
         """
         Plan vectorization for SIMD architecture.
-        
+
         For Ascend SIMD:
         - Vectorization is based on SIMD width (256 bits)
         - Must respect DMA alignment (32 bytes)
         - Different from GPU where vectorization is per-thread
         """
+
         def is_aligned(shape, factor):
             """Check if shape is aligned to factor."""
             return int(np.prod(shape)) % factor == 0
-        
+
         def is_dma_aligned(shape, dtype_bytes, vec):
             """Check if access is DMA aligned (32 bytes)."""
             access_bytes = dtype_bytes * vec
             return access_bytes % self.dma_alignment == 0 or self.dma_alignment % access_bytes == 0
-        
+
         def is_type_allowed(dtype, vec):
             """Check if vectorization fits SIMD width."""
             return dtype.bits * vec <= self.simd_width
-        
+
         # SIMD-friendly vector sizes
         vectorize_sizes = [16, 8, 4, 2, 1]
         dtypes = node.get_reduce_inputs_dtype()
         shapes = node.propagate_reduction_inputs(td.get_tile(node), td.get_rstep(node))
         vectorize_result = {}
-        
+
         for tensor, shape in shapes.items():
             dtype_bytes = (dtypes[tensor].bits + 7) // 8
             for v in vectorize_sizes:
-                if (is_aligned(shape, v) and 
-                    is_dma_aligned(shape, dtype_bytes, v) and
-                    is_type_allowed(dtypes[tensor], v)):
+                if is_aligned(shape, v) and is_dma_aligned(shape, dtype_bytes, v) and is_type_allowed(dtypes[tensor], v):
                     vectorize_result[tensor] = v
                     break
             if tensor not in vectorize_result:
                 vectorize_result[tensor] = 1
-        
+
         return vectorize_result
 
     # ==================== Reduce Step Assignment (adapted for SIMD) ====================
-    
+
     def _assign_reduce_step(self, node):
         """
         Assign reduce step for SIMD architecture.
-        
+
         For SIMD:
         - Optimize for vector operations
         - Consider DMA alignment for reduction inputs
         """
         if node.reduction_block is None:
             return {}
-        
+
         raxis = node.raxis
         if len(raxis) == 0:
             return {}
-        
+
         tile = [1] * len(node.get_space_dim())
         # get possible steps for all nodes in the graph, padding with power of 2 if axis length is not divisible
         all_steps = self.get_node_reduce_step_candidates(node)
-        
+
         def _score(rstep_id):
             """Score function optimized for SIMD memory access."""
             rstep = {k: all_steps[k][rstep_id[k]] for k in rstep_id}
             score = 0
             shape = node.propagate_inputs(tile, rstep=rstep)
-            
+
             for i, input_buffer in enumerate(node.input_buffers):
                 dtype_bytes = (node.get_buffer_dtype(input_buffer).bits + 7) // 8
-                
+
                 # prefer DMA-aligned access, any other size would not be optimal
                 innermost = shape[i][-1] if len(shape[i]) > 0 else 1
                 dma_score = 1.0 if (innermost * dtype_bytes) % self.dma_alignment == 0 else 0.5
-                
+
                 # Prefer larger contiguous access
                 contiguous_score = coalesced_factor(shape[i], input_buffer.shape)
-                
+
                 score += dma_score * contiguous_score
-            
+
             return score
-        
+
         def _enlarge(rstep_id):
             candidates = []
             candidates.append((rstep_id, _score(rstep_id)))
@@ -413,17 +405,17 @@ class AscendDefaultPolicy(DefaultPolicy):
                 candidates.append((r, _score(r)))
             best = max(candidates, key=lambda x: x[1])
             return best
-        
+
         cur_rstep_id = {ax.var.name: 0 for ax in raxis}
         cur_score = _score(cur_rstep_id)
-        
+
         max_iterations = 100
         for _ in range(max_iterations):
             new_rstep, new_score = _enlarge(cur_rstep_id)
             if new_score <= cur_score:
                 break
             cur_rstep_id, cur_score = new_rstep, new_score
-        
+
         rstep = {k: all_steps[k][cur_rstep_id[k]] for k in cur_rstep_id}
         return rstep
 
@@ -434,15 +426,15 @@ class AscendDefaultPolicy(DefaultPolicy):
         """
         buffer_limit = self._get_buffer_capacity()
         rstep_map = td.rstep_map.copy()
-        
+
         def _optimize(node, rstep):
             all_steps = self.get_node_reduce_step_candidates(node)
             for k in all_steps:
                 all_steps[k] = list(filter(lambda x: x % rstep[k] == 0, all_steps[k]))
-            
+
             if any([v == [] for v in all_steps.values()]):
                 return rstep
-            
+
             def _score(rstep_id):
                 rstep = {k.var.name: all_steps[k.var.name][rstep_id[k.var.name]] for k in node.raxis}
                 score = 0
@@ -450,7 +442,7 @@ class AscendDefaultPolicy(DefaultPolicy):
                 for i, input_buffer in enumerate(node.input_buffers):
                     score += coalesced_factor(shape[i], input_buffer.shape)
                 return score
-            
+
             def _enlarge(rstep_id):
                 candidates = []
                 for ax in rstep_id:
@@ -462,46 +454,40 @@ class AscendDefaultPolicy(DefaultPolicy):
                 if len(candidates) == 0:
                     return None
                 return max(candidates, key=lambda x: x[1])[0]
-            
-            cur_rstep_id = {
-                k.var.name: all_steps[k.var.name].index(rstep[k.var.name]) for k in node.raxis
-            }
+
+            cur_rstep_id = {k.var.name: all_steps[k.var.name].index(rstep[k.var.name]) for k in node.raxis}
             new_rstep_map = rstep_map.copy()
-            
+
             while True:
                 new_rstep_id = _enlarge(cur_rstep_id)
                 if new_rstep_id is None:
                     break
-                new_rstep_map[node] = {
-                    k.var.name: all_steps[k.var.name][new_rstep_id[k.var.name]] for k in node.raxis
-                }
+                new_rstep_map[node] = {k.var.name: all_steps[k.var.name][new_rstep_id[k.var.name]] for k in node.raxis}
                 old_rstep_map = td.rstep_map
                 td.rstep_map = new_rstep_map
                 buffer_usage, _ = self._compute_shared_memory_usage(td)
                 td.rstep_map = old_rstep_map
-                
+
                 if buffer_usage > buffer_limit:
                     break
                 else:
                     cur_rstep_id = new_rstep_id
-            
-            rstep = {
-                k.var.name: all_steps[k.var.name][cur_rstep_id[k.var.name]] for k in node.raxis
-            }
+
+            rstep = {k.var.name: all_steps[k.var.name][cur_rstep_id[k.var.name]] for k in node.raxis}
             return rstep
-        
+
         for node in self.ordered_nodes:
             if len(node.raxis) > 0:
                 rstep = _optimize(node, rstep_map.get(node, {}))
                 rstep_map[node] = rstep
-        
+
         td.rstep_map = rstep_map
         td.smem_cost, td.cached_tensors_map = self._compute_shared_memory_usage(td)
 
     def check_tile_shape_isvalid(self, td: TileDict):
         """
         Check if tile shape is valid for SIMD architecture.
-        
+
         For Ascend SIMD:
         - Check buffer capacity (UB/L0)
         - Prefer SIMD-aligned tiles (not strictly required)
@@ -511,7 +497,7 @@ class AscendDefaultPolicy(DefaultPolicy):
         if td.smem_cost > buffer_cap:
             logger.debug(f"Tile invalid: smem cost={td.smem_cost} > buffer cap={buffer_cap}")
             return False
-        
+
         # Check that tiles can produce meaningful work
         for node in self.ordered_nodes:
             tile = td.get_tile(node)
@@ -519,7 +505,7 @@ class AscendDefaultPolicy(DefaultPolicy):
             if any(t <= 0 for t in tile):
                 logger.debug(f"Tile invalid: non-positive tile dimension in {tile} for node {node.name}")
                 return False
-        
+
         return True
 
     def plan_rasterization(self, td: TileDict):
@@ -531,19 +517,20 @@ class AscendDefaultPolicy(DefaultPolicy):
 # AscendCubePolicy: CUBE unit optimization (similar to TensorCorePolicy)
 # ============================================================================
 
+
 class AscendCubePolicy(AscendDefaultPolicy):
     """
     Policy for Ascend NPU with CUBE unit optimization.
-    
+
     CUBE unit is analogous to TensorCore on NVIDIA GPU:
     - 16x16x16 matrix operation in fractal format
     - Optimized for matmul and similar operations
     - Uses L0A/L0B for inputs, L0C for accumulator
-    
+
     This policy inherits from AscendDefaultPolicy (SIMD-adapted)
     and adds CUBE-specific optimizations similar to TensorCorePolicy.
     """
-    
+
     # CUBE unit parameters
     pipeline_stage: int = 2
     use_async_copy: bool = False
@@ -563,7 +550,7 @@ class AscendCubePolicy(AscendDefaultPolicy):
         pipeline_stage = self.prim_func_node.get_tag("pipeline_stage")
         if pipeline_stage:
             self.pipeline_stage = int(pipeline_stage)
-        
+
         block_reduction_depth = self.prim_func_node.get_tag("block_reduction_depth")
         if block_reduction_depth:
             self.block_reduction_depth = int(block_reduction_depth)
@@ -577,20 +564,20 @@ class AscendCubePolicy(AscendDefaultPolicy):
         """Compute strides for CUBE operation (similar to TensorCore strides)."""
         if rstep is None:
             rstep = {}
-        
+
         shapes = node.propagate_reduction_inputs(tile, rstep)
         AS_shape, BS_shape = shapes.values()
         CS_shape = tile
         A_ax_m, A_ax_k, B_ax_k, B_ax_n, C_ax_m, C_ax_n = node.infer_tensorcore_axis()
-        
+
         # For Ascend's 32-byte DMA alignment
         offset = 8
         A_high_ax = min(A_ax_m, A_ax_k)
         B_high_ax = min(B_ax_n, B_ax_k)
         C_high_ax = min(C_ax_m, C_ax_n)
-        A_stride = Stride(stride=np.prod(AS_shape[A_high_ax + 1:]) + offset, ax=A_high_ax)
-        B_stride = Stride(stride=np.prod(BS_shape[B_high_ax + 1:]) + offset, ax=B_high_ax)
-        C_stride = Stride(stride=np.prod(CS_shape[C_high_ax + 1:]) + offset, ax=C_high_ax)
+        A_stride = Stride(stride=np.prod(AS_shape[A_high_ax + 1 :]) + offset, ax=A_high_ax)
+        B_stride = Stride(stride=np.prod(BS_shape[B_high_ax + 1 :]) + offset, ax=B_high_ax)
+        C_stride = Stride(stride=np.prod(CS_shape[C_high_ax + 1 :]) + offset, ax=C_high_ax)
         return A_stride, B_stride, C_stride
 
     def infer_node_smem_usage(self, td: TileDict, node: PrimFuncNode):
@@ -598,10 +585,10 @@ class AscendCubePolicy(AscendDefaultPolicy):
         value, cached_tensors = super().infer_node_smem_usage(td, node)
         value *= self.pipeline_stage
         return value, cached_tensors
-    
+
     def _get_tile_buffer_capacity(self) -> int:
         """Override to use L1 capacity for CUBE operations.
-        
+
         CUBE operations use L0A/L0B/L0C buffers, which are fed from L1.
         Therefore, L1 capacity is the actual constraint for CUBE tile sizes.
         """
@@ -617,16 +604,15 @@ class AscendCubePolicy(AscendDefaultPolicy):
 
         # For CUBE nodes, align to cube_k
         target_transaction = 512  # 512 bytes optimal for Ascend L0x DMA
-        reduce_input_dtype = node.get_buffer_dtype(
-            node.block_analyzer.get_input_buffers(node.reduction_block)[0])
+        reduce_input_dtype = node.get_buffer_dtype(node.block_analyzer.get_input_buffers(node.reduction_block)[0])
         basic = (target_transaction * 8) // reduce_input_dtype.bits
-        
+
         result = {}
         for iter_info in node.raxis:
             iter_name = iter_info.var.name
             iter_dom = iter_info.dom.extent
             if iter_dom % self.cube_dim > 0:
-                result[iter_name] = (self.cube_dim if iter_dom < basic else basic)
+                result[iter_name] = self.cube_dim if iter_dom < basic else basic
             elif iter_dom % basic == 0:
                 result[iter_name] = basic
             else:
@@ -638,57 +624,53 @@ class AscendCubePolicy(AscendDefaultPolicy):
         if not node.get_tag("tensorcore_config"):
             return super().get_node_reduce_step_candidates(node)
         else:
-            return {
-                k.var.name: [
-                    x * self.cube_k for x in get_all_factors(int(k.dom.extent) // self.cube_k)
-                ] for k in node.raxis
-            }
+            return {k.var.name: [x * self.cube_k for x in get_all_factors(int(k.dom.extent) // self.cube_k)] for k in node.raxis}
 
     def _check_node_l0_capacity(self, node: PrimFuncNode, td: TileDict) -> bool:
         """
         Check if a CUBE node's tile fits in L0 buffers.
-        
+
         Args:
             node: The PrimFuncNode to check (must have tensorcore_config)
             td: The TileDict containing tile configuration
-            
+
         Returns:
             True if L0A/L0B/L0C usage is within capacity
         """
         tile = td.get_tile(node)
         rstep = td.get_rstep(node)
         shapes = node.propagate_reduction_inputs(tile, rstep)
-        
+
         if len(shapes) < 2:
             return True
-        
+
         # Get tile shapes for A, B, C
         input_shapes = list(shapes.values())
         a_shape, b_shape = input_shapes[0], input_shapes[1]
         c_shape = tile
-        
+
         # Get actual dtypes from buffers
         input_buffers = node.block_analyzer.get_input_buffers(node.reduction_block)
         output_buffers = node.block_analyzer.get_output_buffers(node.reduction_block)
-        
+
         a_dtype = node.get_buffer_dtype(input_buffers[0])
         b_dtype = node.get_buffer_dtype(input_buffers[1]) if len(input_buffers) > 1 else a_dtype
         c_dtype = node.get_buffer_dtype(output_buffers[0]) if output_buffers else a_dtype
-        
+
         a_dtype_bytes = (a_dtype.bits + 7) // 8
         b_dtype_bytes = (b_dtype.bits + 7) // 8
         c_dtype_bytes = (c_dtype.bits + 7) // 8
-        
+
         # Calculate buffer sizes
         a_size = int(np.prod(a_shape)) * a_dtype_bytes
         b_size = int(np.prod(b_shape)) * b_dtype_bytes
         c_size = int(np.prod(c_shape)) * c_dtype_bytes
-        
+
         # Check with alignment and pipeline stage
         a_aligned = self._align_to_l0(a_size, "a")
         b_aligned = self._align_to_l0(b_size, "b")
         c_aligned = self._align_to_l0(c_size, "c")
-        
+
         if not self._check_l0_usage(a_aligned, b_aligned, c_aligned, self.pipeline_stage):
             logger.debug(
                 f"L0 usage exceeds capacity for node {node.name}: "
@@ -697,7 +679,7 @@ class AscendCubePolicy(AscendDefaultPolicy):
                 f"L0C={c_aligned}/{self.l0c_capacity}"
             )
             return False
-        
+
         return True
 
     def check_tile_shape_isvalid(self, td: TileDict):
@@ -716,45 +698,45 @@ class AscendCubePolicy(AscendDefaultPolicy):
                 )
                 # CUBE requires minimum tiles
                 if block_m < self.fractal_shape[0] or block_n < self.fractal_shape[1]:
-                    logger.debug(f"Tile invalid for CUBE: block_m={block_m} < {self.fractal_shape[0]}"
-                                f" or block_n={block_n} < {self.fractal_shape[1]}")
+                    logger.debug(
+                        f"Tile invalid for CUBE: block_m={block_m} < {self.fractal_shape[0]} or block_n={block_n} < {self.fractal_shape[1]}"
+                    )
                     return False
                 if any([y % x for x, y in zip(td.tile_map[node], node.get_space_dim())]):
-                    logger.debug(f"Tile invalid for CUBE: tile {td.tile_map[node]} "
-                                f"not divisible by shape {node.get_space_dim()}")
+                    logger.debug(f"Tile invalid for CUBE: tile {td.tile_map[node]} not divisible by shape {node.get_space_dim()}")
                     return False
-        
+
         # Check L0 buffer capacity for each CUBE node (必须单独检查每个node)
         for node in self.ordered_nodes:
             if not isinstance(node, PrimFuncNode):
                 continue
             if not node.get_tag("tensorcore_config"):
                 continue
-            
+
             if not self._check_node_l0_capacity(node, td):
                 return False
-        
+
         return super().check_tile_shape_isvalid(td)
 
     def _assign_block_size(self, node: PrimFuncNode, td: TileDict, block_size: int):
         """Assign configuration for CUBE operations."""
         if not node.get_tag("tensorcore_config"):
             return super()._assign_block_size(node, td, block_size)
-        
+
         ax_m, ax_n = node.get_tag("tensorcore_config")
         tile, rsteps = td.get_tile(node), td.get_rstep(node)
         ndim = len(tile)
-        
+
         # CUBE tile size is cube_dim x cube_dim
         cube_m, cube_n = self.fractal_shape[0], self.fractal_shape[1]
         cube_tile = [1 for _ in range(ndim)]
         cube_tile[ax_m] = cube_m
         cube_tile[ax_n] = cube_n
-        
+
         if tile[ax_m] < cube_m or tile[ax_n] < cube_n:
             logger.debug(f"Tile invalid for CUBE assignment: tile {tile} smaller than cube size ")
             return None
-        
+
         codegen_dict = Hint()
         codegen_dict.block = tile
         codegen_dict.warp = cube_tile
@@ -767,24 +749,25 @@ class AscendCubePolicy(AscendDefaultPolicy):
         codegen_dict.reduce_thread = [1 for _ in node.raxis]
         codegen_dict.cached_tensors = td.cached_tensors_map.get(node, [])
         codegen_dict.rasterization_plan = NoRasterization()
-        
+
         intrin_info = node.get_tag("intrin_info")
         if intrin_info:
             codegen_dict.intrin_info = IntrinInfo(**intrin_info)
-        
+
         codegen_dict.complete_config(node)
         # CUBE operations don't need vectorization, skip vectorization planning
         codegen_dict.vectorize = {}
         codegen_dict.arch = self.arch
         codegen_dict.opt_shapes = node.get_tag("opt_shapes")
-        
-        if hasattr(codegen_dict, 'tensorcore_legalization'):
+
+        if hasattr(codegen_dict, "tensorcore_legalization"):
             codegen_dict.tensorcore_legalization()
-        
+
         return codegen_dict
 
     def _expand_reduce_axis(self, td: TileDict):
         """Expand reduce axis for CUBE operations."""
+
         def _check_small_tile(td: TileDict):
             minimal_threshold = 32
             for node in self.ordered_nodes:
@@ -792,30 +775,28 @@ class AscendCubePolicy(AscendDefaultPolicy):
                 if any([t <= minimal_threshold for t in tile]):
                     return True
             return False
-        
+
         if _check_small_tile(td):
             total_l0 = self._get_total_l0_capacity()
             l0_limit = total_l0  # No SM partitioning on Ascend
             rstep_map = td.rstep_map.copy()
-            
+
             def _optimize(node, rstep):
                 all_steps = self.get_node_reduce_step_candidates(node)
                 for k in all_steps:
                     all_steps[k] = list(filter(lambda x: x % rstep[k] == 0, all_steps[k]))
                 if any([v == [] for v in all_steps.values()]):
                     return rstep
-                
+
                 def _score(rstep_id):
-                    rstep = {
-                        k.var.name: all_steps[k.var.name][rstep_id[k.var.name]] for k in node.raxis
-                    }
+                    rstep = {k.var.name: all_steps[k.var.name][rstep_id[k.var.name]] for k in node.raxis}
                     score = 0
                     shape = node.propagate_inputs_on_reduction(td.get_tile(node), rstep=rstep)
                     input_buffers = node.block_analyzer.get_input_buffers(node.reduction_block)
                     for i, input_buffer in enumerate(input_buffers):
                         score += coalesced_factor(shape[i], input_buffer.shape)
                     return score
-                
+
                 def _enlarge(rstep_id):
                     candidates = []
                     for ax in rstep_id:
@@ -827,46 +808,40 @@ class AscendCubePolicy(AscendDefaultPolicy):
                     if len(candidates) == 0:
                         return None
                     return max(candidates, key=lambda x: x[1])[0]
-                
-                cur_rstep_id = {
-                    k.var.name: all_steps[k.var.name].index(rstep[k.var.name]) for k in node.raxis
-                }
-                
+
+                cur_rstep_id = {k.var.name: all_steps[k.var.name].index(rstep[k.var.name]) for k in node.raxis}
+
                 while True:
                     new_rstep_id = _enlarge(cur_rstep_id)
                     if new_rstep_id is None:
                         break
-                    new_rstep = {
-                        k.var.name: all_steps[k.var.name][new_rstep_id[k.var.name]]
-                        for k in node.raxis
-                    }
+                    new_rstep = {k.var.name: all_steps[k.var.name][new_rstep_id[k.var.name]] for k in node.raxis}
                     old_rstep = td.rstep_map
                     td.rstep_map = {node: new_rstep}
                     l0_usage, _ = self.infer_node_smem_usage(td, node)
                     td.rstep_map = old_rstep
-                    
+
                     if l0_usage > l0_limit:
                         break
                     else:
                         cur_rstep_id = new_rstep_id
-                
-                rstep = {
-                    k.var.name: all_steps[k.var.name][cur_rstep_id[k.var.name]] for k in node.raxis
-                }
+
+                rstep = {k.var.name: all_steps[k.var.name][cur_rstep_id[k.var.name]] for k in node.raxis}
                 return rstep
-            
+
             for node in self.ordered_nodes:
                 if len(node.raxis) > 0:
                     rstep = _optimize(node, rstep_map.get(node, {}))
                     rstep_map[node] = rstep
-            
+
             td.rstep_map = rstep_map
             td.smem_cost, td.cached_tensors_map = self._compute_shared_memory_usage(td)
-        
+
         if self.block_reduction_depth is not None:
+
             def _expand_with_tags(rstep):
                 return {k: v * self.block_reduction_depth for k, v in rstep.items()}
-            
+
             rstep_map = td.rstep_map.copy()
             for node in self.ordered_nodes:
                 if len(node.raxis) > 0 and node in rstep_map:

--- a/tilelang/carver/roller/policy/ascend.py
+++ b/tilelang/carver/roller/policy/ascend.py
@@ -58,7 +58,9 @@ class AscendDefaultPolicy(DefaultPolicy):
         self.dma_alignment = 32  # DMA requires 32-byte alignment
         
         # AI Core configuration - use actual hardware value
-        self.num_ai_cores = getattr(arch, "compute_max_core", 32)
+        self.num_ai_cores = getattr(arch, "compute_max_core", None)
+        if not isinstance(self.num_ai_cores, int) or self.num_ai_cores <= 0:
+            raise ValueError("Ascend core count must be supplied by the architecture/device query")
         
         # Memory hierarchy capacities (bytes) - prioritize arch values
         self.l0a_capacity = getattr(arch, "l0a_cap", 64 * 1024)

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -206,7 +206,11 @@ def lower(
     own device codegen implementation in jit.
     """
 
-    from tilelang.utils.target import determine_platform
+    from tilelang.utils.target import (
+        ascend_mcpu_for_platform,
+        ascend_platform_from_mcpu,
+        determine_platform,
+    )
 
     platform = determine_platform(platform)
 
@@ -221,7 +225,18 @@ def lower(
     for gvar, f in mod.functions_items():
         mod[gvar] = f.with_attr("npu_platform", platform)
 
-    target = tvm.target.Target({"kind": "llvm", "model": target})
+    platform_mcpu = ascend_mcpu_for_platform(platform)
+    if isinstance(target, tvm.target.Target):
+        explicit_mcpu = getattr(target, "mcpu", None)
+        target_platform = ascend_platform_from_mcpu(explicit_mcpu)
+        if target_platform is not None and platform not in target_platform.split("/"):
+            raise ValueError(f"Target mcpu {explicit_mcpu!r} conflicts with Ascend platform {platform}")
+        if explicit_mcpu:
+            platform_mcpu = explicit_mcpu
+        target_model = getattr(target, "model", "") or str(target)
+    else:
+        target_model = target
+    target = tvm.target.Target({"kind": "llvm", "model": str(target_model), "mcpu": platform_mcpu})
 
     # Phase 1: Lower and legalize the IR
     mod = LowerAndLegalize(mod, target)

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -212,7 +212,12 @@ def lower(
         determine_platform,
     )
 
-    platform = determine_platform(platform)
+    explicit_mcpu = getattr(target, "mcpu", None) if isinstance(target, tvm.target.Target) else None
+    target_platform = ascend_platform_from_mcpu(explicit_mcpu)
+    if platform == "auto" and target_platform is not None and "/" not in target_platform:
+        platform = target_platform
+    else:
+        platform = determine_platform(platform)
 
     mod = func_or_mod
     params = None
@@ -227,8 +232,6 @@ def lower(
 
     platform_mcpu = ascend_mcpu_for_platform(platform)
     if isinstance(target, tvm.target.Target):
-        explicit_mcpu = getattr(target, "mcpu", None)
-        target_platform = ascend_platform_from_mcpu(explicit_mcpu)
         if target_platform is not None and platform not in target_platform.split("/"):
             raise ValueError(f"Target mcpu {explicit_mcpu!r} conflicts with Ascend platform {platform}")
         if explicit_mcpu:

--- a/tilelang/jit/adapter/cython/adapter.py
+++ b/tilelang/jit/adapter/cython/adapter.py
@@ -337,7 +337,11 @@ class CythonKernelAdapter(BaseKernelAdapter):
         #     raise RuntimeError(f"Initialization failed: {error_msg}")
 
         adapter.cython_wrapper = CythonKernelWrapper(
-            adapter.result_idx, adapter.workspace_idx, adapter.auto_gm_idx, adapter.params, adapter.lib
+            adapter.result_idx,
+            adapter.workspace_idx,
+            adapter.auto_gm_idx,
+            adapter.params,
+            adapter.lib,
         )
         adapter.cython_wrapper.set_dynamic_symbolic_map(adapter.dynamic_symbolic_map)
         adapter.cython_wrapper.set_buffer_dtype_map(adapter.buffer_dtype_map)
@@ -352,23 +356,43 @@ class CythonKernelAdapter(BaseKernelAdapter):
         """Extract information about dynamic shapes from the TIR function.
 
         Maps symbolic variables to their corresponding (buffer_index, shape_dimension)
-        for runtime shape resolution.
+        for runtime shape resolution.  Device codegen orders symbols by their
+        first occurrence in all buffer shape expressions, so collect that ABI
+        order first, then resolve each symbol from an exact standalone input
+        dimension.  A composite extent cannot identify its component values.
         """
         func = self.prim_func
         params = func.params
         buffer_map = func.buffer_map
-        dynamic_symbolic_map = {}
-        temp = 0
+
+        ordered_symbols = []
+        seen_symbols = set()
+        for param in params:
+            if param not in buffer_map:
+                continue
+            for shape in buffer_map[param].shape:
+                for symbol in tir.analysis.undefined_vars(shape, params):
+                    if symbol not in seen_symbols:
+                        seen_symbols.add(symbol)
+                        ordered_symbols.append(symbol)
+
+        providers = {}
+        input_index = 0
         for i, param in enumerate(params):
-            if i in self.result_idx or i in self.workspace_idx:
-                temp += 1
+            if i in self.result_idx or i in self.workspace_idx or i in self.auto_gm_idx:
                 continue
             if param in buffer_map:
                 buffer = buffer_map[param]
                 for j, shape in enumerate(buffer.shape):
-                    if isinstance(shape, tir.Var) and (shape not in dynamic_symbolic_map) and (shape not in params):
-                        dynamic_symbolic_map[shape] = (i - temp, j)
-        return dynamic_symbolic_map
+                    if isinstance(shape, tir.Var) and shape in seen_symbols:
+                        providers.setdefault(shape, (input_index, j))
+            input_index += 1
+
+        missing = [symbol for symbol in ordered_symbols if symbol not in providers]
+        if missing:
+            names = ", ".join(str(symbol) for symbol in missing)
+            raise ValueError(f"Dynamic shape symbols require a standalone input dimension; no runtime provider for: {names}")
+        return {symbol: providers[symbol] for symbol in ordered_symbols}
 
     def _process_buffer_dtype(self) -> dict[tir.Var, tuple[int, torch.dtype]]:
         """Extract information about buffer dtypes from the TIR function.

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -9,15 +9,13 @@ import subprocess
 import logging
 from pathlib import Path
 from tilelang.env import TILELANG_TEMPLATE_PATH, TILELANG_PACKAGE_PATH
+from tilelang.utils.target import (
+    ascend_mcpu_for_platform,
+    validate_ascend_platform_device,
+)
 
 logger = logging.getLogger(__name__)
 
-
-_ASCENDC_NPU_ARCH = {
-    "A2": "dav-2201",
-    "A3": "dav-2201",
-    "A5": "dav-3510",
-}
 
 _CATLASS_ARCH = {
     "A2": "2201",
@@ -144,6 +142,17 @@ class LibraryGenerator:
         if lib_path is None:
             lib_path = self.libpath
         run_mode = os.environ.get("TL_RUN_MODE", "npu")
+        if run_mode == "npu" and self.target in ("ascendc", "auto"):
+            try:
+                import torch
+
+                if hasattr(torch, "npu") and torch.npu.is_available() and torch.npu.device_count() > 0:
+                    validate_ascend_platform_device(
+                        self.platform,
+                        torch.npu.get_device_name(torch.npu.current_device()),
+                    )
+            except ImportError:
+                pass
         if run_mode == "sim":
             ascend_home = _get_ascend_home_path()
             sim_lib_path = _get_simulator_lib_path(ascend_home, self.platform)
@@ -164,16 +173,14 @@ class LibraryGenerator:
             compile_flags = resolve_compile_flags(self.target)
         if self.target == "ascendc" or self.target == "auto":
             try:
-                npu_arch = _ASCENDC_NPU_ARCH[self.platform]
-            except KeyError as err:
-                raise ValueError(
-                    f"Unsupported AscendC platform {self.platform!r}; "
-                    f"expected one of {sorted(_ASCENDC_NPU_ARCH)}"
-                ) from err
+                npu_arch = ascend_mcpu_for_platform(self.platform)
+                catlass_arch = _CATLASS_ARCH[self.platform]
+            except (KeyError, ValueError) as err:
+                raise ValueError(f"Unsupported AscendC platform {self.platform!r}") from err
             command = [
                 "bisheng",
                 f"--npu-arch={npu_arch}",
-                f"-DCATLASS_ARCH={_CATLASS_ARCH[self.platform]}",
+                f"-DCATLASS_ARCH={catlass_arch}",
                 "-std=c++17",
                 "-xasc",
                 f"-I{ASCEND_HOME_PATH}/include",

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -13,6 +13,13 @@ from tilelang.env import TILELANG_TEMPLATE_PATH, TILELANG_PACKAGE_PATH
 logger = logging.getLogger(__name__)
 
 
+_ASCENDC_NPU_ARCH = {
+    "A2": "dav-2201",
+    "A3": "dav-2201",
+    "A5": "dav-3510",
+}
+
+
 def _get_tl_root(third_party_name="3rdparty") -> str:
     """Get TL_ROOT path, fallback to package path if not set."""
     tl_root = os.environ.get("TL_ROOT")
@@ -150,9 +157,16 @@ class LibraryGenerator:
         if compile_flags is None:
             compile_flags = resolve_compile_flags(self.target)
         if self.target == "ascendc" or self.target == "auto":
+            try:
+                npu_arch = _ASCENDC_NPU_ARCH[self.platform]
+            except KeyError as err:
+                raise ValueError(
+                    f"Unsupported AscendC platform {self.platform!r}; "
+                    f"expected one of {sorted(_ASCENDC_NPU_ARCH)}"
+                ) from err
             command = [
                 "bisheng",
-                "--npu-arch=dav-2201",
+                f"--npu-arch={npu_arch}",
                 "-std=c++17",
                 "-xasc",
                 f"-I{ASCEND_HOME_PATH}/include",

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -19,6 +19,12 @@ _ASCENDC_NPU_ARCH = {
     "A5": "dav-3510",
 }
 
+_CATLASS_ARCH = {
+    "A2": "2201",
+    "A3": "2201",
+    "A5": "3510",
+}
+
 
 def _get_tl_root(third_party_name="3rdparty") -> str:
     """Get TL_ROOT path, fallback to package path if not set."""
@@ -167,6 +173,7 @@ class LibraryGenerator:
             command = [
                 "bisheng",
                 f"--npu-arch={npu_arch}",
+                f"-DCATLASS_ARCH={_CATLASS_ARCH[self.platform]}",
                 "-std=c++17",
                 "-xasc",
                 f"-I{ASCEND_HOME_PATH}/include",

--- a/tilelang/utils/target.py
+++ b/tilelang/utils/target.py
@@ -19,6 +19,51 @@ AVALIABLE_TARGETS = {
     "llvm",
 }
 
+ASCEND_PLATFORM_MCPU = {
+    "A2": "dav-2201",
+    "A3": "dav-2201",
+    "A5": "dav-3510",
+}
+
+
+def ascend_mcpu_for_platform(platform: str) -> str:
+    try:
+        return ASCEND_PLATFORM_MCPU[platform]
+    except KeyError as err:
+        raise ValueError(f"Unsupported Ascend platform {platform!r}; expected one of {sorted(ASCEND_PLATFORM_MCPU)}") from err
+
+
+def ascend_platform_from_mcpu(mcpu: str | None) -> str | None:
+    if not mcpu:
+        return None
+    normalized = mcpu.lower()
+    if "3510" in normalized or "950" in normalized or "910_95" in normalized:
+        return "A5"
+    if "2201" in normalized:
+        return "A2/A3"
+    if "910c" in normalized or "910_93" in normalized:
+        return "A3"
+    if "910b" in normalized or "310p" in normalized or "910" in normalized:
+        return "A2"
+    return None
+
+
+def ascend_platform_from_device_name(name: str) -> str | None:
+    normalized = name.upper()
+    if "950" in normalized or "910_95" in normalized or "3510" in normalized:
+        return "A5"
+    if "910_93" in normalized or "910C" in normalized:
+        return "A3"
+    if "910B" in normalized or "310P" in normalized or "910" in normalized:
+        return "A2"
+    return None
+
+
+def validate_ascend_platform_device(platform: str, device_name: str) -> None:
+    runtime_platform = ascend_platform_from_device_name(device_name)
+    if runtime_platform is not None and runtime_platform != platform:
+        raise RuntimeError(f"Ascend runtime device {device_name!r} is {runtime_platform}, but the compiled target platform is {platform}")
+
 
 def check_cuda_availability() -> bool:
     """
@@ -142,14 +187,9 @@ def determine_platform(platform: str = "auto") -> str:
 
     name = name.upper()
 
-    if "910B" in name:
-        return "A2"
-    elif "910_93" in name or "910C" in name:
-        return "A3"
-    elif "950" in name or "910_95" in name:
-        return "A5"
-    elif "910" in name:  # Covers 910A
-        return "A2"
+    detected_platform = ascend_platform_from_device_name(name)
+    if detected_platform is not None:
+        return detected_platform
 
     # Default fallback if detection fails
     return "A3"


### PR DESCRIPTION
## Summary

- add native AscendC A5 target selection (`dav-3510`, `CATLASS_ARCH=3510`) while retaining A2/A3 `dav-2201` / `CATLASS_ARCH=2201`
- update the bundled CATLASS gitlink to the stable `v1.5.0` object `83073fedcac3d9df5b83f701b2cc00ec6a94f984`
- adapt the Ascend templates to CATLASS v1.5 tensor/layout APIs, including A5 L0A layout and tail/origin-preserving tiled layouts
- keep source-only codegen tests device-independent while applying the same target defaults and PassContext as the production compile path
- update and guard the documented manual A2 Bisheng command

## Verification

- `TL_PLATFORM=A3 python -m pytest -p no:cacheprovider -q testing/python/language/test_ascend_compile_flags.py testing/python/language/test_tilelang_ascend_language_alloc_codegen.py`: **35 passed, 1 skipped**
- no-NPU GEMM AOT compile (`m=128, n=256, k=64`) for native AscendC platforms **A5, A2, and A3**: all `rc=0`
- `git diff --check`: passed
- independent focused review: P0/P1/P2 = 0/0/0

## Not run

- repository-wide full hook/test suite was not run
- no NPU runtime or device execution was performed
