### PR TITLE
fix(pto): preserve packed mask stride after UB reuse

### DIFF
--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -437,6 +437,29 @@ CodeGenTileLangAscendPto::GetCompareMaskInfo(const CallNode *dst_call,
   int32_t col = shape[1].as<IntImmNode>()->value;
   int32_t valid_col = shape[3].as<IntImmNode>()->value;
 
+  // Memory planning may reuse a wider tensor buffer for the packed uint8
+  // predicate.  In that case buffer_shapess_ describes the backing storage
+  // (for example [4, 64] half) rather than the logical mask ([4, 8] uint8).
+  // Recover the mask width from its access extent so PTO sees the same
+  // 32-byte-aligned row stride as it would for a standalone mask allocation.
+  const DataType access_dtype = dst_call->args[0].dtype();
+  const auto dtype_it = buffer_dtypes_.find(buffer_var.get());
+  const bool is_retyped =
+      dtype_it != buffer_dtypes_.end() && dtype_it->second != access_dtype;
+  if (is_retyped) {
+    const auto *extent_imm = dst_call->args[3].as<IntImmNode>();
+    row = src_info.row;
+    ICHECK_GT(row, 0);
+    if (extent_imm) {
+      ICHECK_EQ(extent_imm->value % row, 0)
+          << "Compare mask extent must be divisible by its row count";
+      valid_col = static_cast<int32_t>(extent_imm->value / row);
+    } else {
+      valid_col = (src_info.col + 7) / 8;
+    }
+    col = GetValidShape(valid_col, getType(access_dtype));
+  }
+
   int32_t slice_valid_row = src_info.slice_valid_row;
   int32_t slice_valid_col =
       std::min(valid_col, (src_info.slice_valid_col + 7) / 8);

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -782,6 +782,14 @@ def test_mixed_unary_scalar_select_emits_all_tail_paths(target, dtype):
         assert "tl::ascend_pto::compare_scalar(" in src, src
         assert "TSELS(" in src, src
         assert "pto::DYNAMIC" in src, src
+        mask_view = "TileUbDataND<uint8_t, 4, 32, pto::DYNAMIC"
+        assert src.count(mask_view) == 2, src
+        if dtype == "float16":
+            # The planner reuses a half tensor allocation for the short-lived
+            # uint8 predicate in this pipeline.  The mask must retain its
+            # packed, 32-byte-aligned row stride instead of inheriting the
+            # backing half tensor's 64-column shape.
+            assert "TileUbDataND<uint8_t, 4, 64, pto::DYNAMIC" not in src, src
 
 
 @pytest.mark.parametrize("target", TAIL_TARGETS)


### PR DESCRIPTION
## What

- Recover the logical packed-mask shape when memory planning reuses a differently typed UB allocation.
- Preserve the required 32-byte PTO predicate row stride instead of inheriting the backing tensor shape.
- Add codegen regression coverage for both compare and select mask views.

## Why

For the mixed unary/scalar-select tail pipeline with `float16` and PTO, memory planning may reuse a `[4, 64]` half UB allocation for the short-lived `uint8` predicate mask.

The PTO codegen previously inherited the backing allocation's 64-column shape, while the packed predicate requires an 8-byte logical width aligned to a 32-byte UB row stride. This corrupted values in the final tail block and caused:

`test_mixed_unary_scalar_select_tail[float16-pto]`

to report 3 mismatched elements.

## Validation

- Incremental C++ build succeeded.
- `test_tilelang_ascend_language_tail_mask_codegen.py`: 127 passed.
- Generated PTO mask views are now `TileUbDataND<uint8_t, 4, 32, ...>`.