### PR TITLE
[Test] Migrate the two heaviest tile_kernels operators to Pytest

### DIFF
--- a/ci/operator_test_manifest.yaml
+++ b/ci/operator_test_manifest.yaml
@@ -206,6 +206,10 @@ mappings:
 
   # examples/tile_kernels/moe
   examples/tile_kernels/moe/moe_topk_gate.py: examples/tile_kernels/moe/test_moe_topk_gate.py
+  examples/tile_kernels/moe/moe_topk_sum_and_topk_group_idx.py: examples/tile_kernels/moe/test_moe_topk_sum_and_topk_group_idx.py
+
+  # examples/tile_kernels/quant
+  examples/tile_kernels/quant/per_block_cast_lossless_kernel.py: examples/tile_kernels/quant/test_per_block_cast_lossless_kernel.py
 
   # examples/topk_selector
   examples/topk_selector/example_topk_selector.py: examples/topk_selector/test_example_topk_selector.py

--- a/examples/tile_kernels/moe/test_moe_topk_sum_and_topk_group_idx.py
+++ b/examples/tile_kernels/moe/test_moe_topk_sum_and_topk_group_idx.py
@@ -1,0 +1,152 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+# The cases a pull request runs; everything else is low_priority and waits for
+# the scheduled run. Both kernels compile per (num_groups, num_experts_per_group,
+# num_topk_groups, num_topk_sum), so these five cover both num_topk_sum paths --
+# the only one that changes which reduction is generated -- both num_topk_groups,
+# all three num_tokens including the single-token edge, and five of the six
+# experts-per-group values, spanning the extremes of the 32-element alignment:
+# 6 padded up to 32, 32 exact, and 64 exact.
+_SMOKE_CASES = frozenset(
+    {
+        (1, 72, 12, 1, 2),  # single token, experts_per_group=6 padded to 32, top-1
+        (4001, 256, 4, 2, 4),  # experts_per_group=64, top-2, four groups kept
+        (4001, 72, 8, 2, 2),  # experts_per_group=9, top-2
+        (8001, 256, 8, 1, 4),  # largest token count, experts_per_group=32 exact, top-1
+        (1, 256, 16, 2, 2),  # single token, most groups, experts_per_group=16
+    }
+)
+
+
+def _test_params() -> list:
+    params = []
+    for num_tokens in (1, 4001, 8001):
+        for num_experts in (72, 256):
+            for num_groups in (4, 8, 12, 16):
+                if num_experts % num_groups:
+                    continue
+                for num_group_sum_topk in (1, 2):
+                    for num_topk_groups in (2, 4):
+                        case = {
+                            "num_tokens": num_tokens,
+                            "num_experts": num_experts,
+                            "num_groups": num_groups,
+                            "num_group_sum_topk": num_group_sum_topk,
+                            "num_topk_groups": num_topk_groups,
+                        }
+                        params.append(
+                            pytest.param(
+                                case,
+                                id=(
+                                    f"tok={num_tokens}_exp={num_experts}_grp={num_groups}_sumk={num_group_sum_topk}_topk={num_topk_groups}"
+                                ),
+                                marks=(
+                                    ()
+                                    if (num_tokens, num_experts, num_groups, num_group_sum_topk, num_topk_groups) in _SMOKE_CASES
+                                    else pytest.mark.low_priority
+                                ),
+                            )
+                        )
+    return params
+
+
+@pytest.fixture
+def isolated_kernel_cache(tmp_path):
+    """Give the case its own kernel cache directory.
+
+    The Example clears the kernel cache when it is imported, and here that
+    import happens inside every fork. Against the shared directory that would
+    delete kernels the other operator tests in the same Pytest invocation are
+    compiling into; against this one it deletes nothing anyone else holds.
+    """
+    import tilelang.cache
+
+    previous = tilelang.cache.get_cache_dir()
+    tilelang.cache.set_cache_dir(str(tmp_path))
+    try:
+        yield
+    finally:
+        tilelang.cache.set_cache_dir(str(previous))
+
+
+def _load_moe_topk_sum_example() -> ModuleType:
+    source = Path(__file__).with_name("moe_topk_sum_and_topk_group_idx.py")
+    spec = importlib.util.spec_from_file_location("_moe_topk_sum_example_for_test", source)
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    try:
+        # moe_topk_sum_and_topk_group_idx.py reads arguments at import time. Hide
+        # Pytest's own arguments while loading it, without changing the Example.
+        sys.argv = [str(source)]
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+    return module
+
+
+@pytest.mark.parametrize("params", _test_params())
+def test_topk_sum_and_topk_group_idx(params: dict, isolated_kernel_cache) -> None:
+    import numpy as np
+    import torch
+
+    example = _load_moe_topk_sum_example()
+
+    num_groups = params["num_groups"]
+    num_group_sum_topk = params["num_group_sum_topk"]
+    num_topk_groups = params["num_topk_groups"]
+    num_experts_per_group = params["num_experts"] // num_groups
+
+    torch.manual_seed(42)
+    scores = torch.randn((params["num_tokens"], num_groups, num_experts_per_group), dtype=torch.float32)
+    topk_idx_ref = example.ref_topk_sum_and_topk_group_idx(scores, num_group_sum_topk, num_topk_groups)
+
+    if hasattr(torch, "npu") and torch.npu.is_available():
+        scores = scores.to("npu").contiguous()
+    elif torch.cuda.is_available():
+        scores = scores.to("cuda").contiguous()
+
+    topk_idx = example.topk_sum_and_topk_group_idx(scores, num_group_sum_topk, num_topk_groups)
+    np.testing.assert_equal(topk_idx.cpu().numpy(), topk_idx_ref.cpu().numpy())
+
+
+@pytest.mark.parametrize("params", _test_params())
+def test_topk_sum_and_topk_group_idx_backward(params: dict, isolated_kernel_cache) -> None:
+    import numpy as np
+    import torch
+
+    example = _load_moe_topk_sum_example()
+
+    num_groups = params["num_groups"]
+    num_group_sum_topk = params["num_group_sum_topk"]
+    num_topk_groups = params["num_topk_groups"]
+    num_experts_per_group = params["num_experts"] // num_groups
+
+    torch.manual_seed(42)
+    scores = torch.randn((params["num_tokens"], num_groups, num_experts_per_group), dtype=torch.float32)
+    grad_out = torch.randn((params["num_tokens"], num_topk_groups), dtype=torch.float32)
+
+    topk_idx = example.ref_topk_sum_and_topk_group_idx(scores, num_group_sum_topk, num_topk_groups)
+    grad_scores_ref = example.ref_topk_sum_and_topk_group_idx_backward(grad_out, scores, topk_idx, num_group_sum_topk)
+
+    if hasattr(torch, "npu") and torch.npu.is_available():
+        scores = scores.to("npu").contiguous()
+        grad_out = grad_out.to("npu").contiguous()
+        topk_idx = topk_idx.to("npu").contiguous()
+    elif torch.cuda.is_available():
+        scores = scores.to("cuda").contiguous()
+        grad_out = grad_out.to("cuda").contiguous()
+        topk_idx = topk_idx.to("cuda").contiguous()
+
+    grad_scores_tl = example.topk_sum_and_topk_group_idx_backward(grad_out, scores, topk_idx, num_group_sum_topk)
+
+    np.testing.assert_allclose(
+        grad_scores_tl.cpu().numpy(),
+        grad_scores_ref.cpu().numpy(),
+        atol=1e-5,
+        rtol=1e-5,
+    )

--- a/examples/tile_kernels/quant/test_per_block_cast_lossless_kernel.py
+++ b/examples/tile_kernels/quant/test_per_block_cast_lossless_kernel.py
@@ -1,0 +1,129 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+# The cases a pull request runs; everything else is low_priority and waits for
+# the scheduled run. One case per distinct combination of the three parameters
+# that select a kernel path -- the input and output scale-factor encodings and
+# the output block -- which is twelve of them, alternating hidden between the
+# smallest and largest in the grid so both ends of the block_k derivation in
+# _derive_cast_layout are covered. num_tokens is a T.symbolic dimension and so
+# not part of the compile key, which is why one value of it stands in for both.
+_SMOKE_CASES = frozenset(
+    {
+        (4001, 576, False, False, (1, 128)),
+        (4001, 7168, False, False, (32, 32)),
+        (4001, 576, False, False, (128, 128)),
+        (4001, 7168, False, True, (1, 128)),
+        (4001, 576, False, True, (32, 32)),
+        (4001, 7168, False, True, (128, 128)),
+        (4001, 576, True, False, (1, 128)),
+        (4001, 7168, True, False, (32, 32)),
+        (4001, 576, True, False, (128, 128)),
+        (4001, 7168, True, True, (1, 128)),
+        (4001, 576, True, True, (32, 32)),
+        (4001, 7168, True, True, (128, 128)),
+    }
+)
+
+
+def _test_params() -> list:
+    params = []
+    for num_tokens in (4001, 8001):
+        for hidden in (576, 2048, 2560, 3072, 4096, 6144, 7168):
+            for in_tma, in_round, in_packed in ((False, True, False), (True, True, True)):
+                for out_tma, out_round, out_packed in ((False, True, False), (True, True, True)):
+                    for out_sf_block in ((1, 128), (32, 32), (128, 128)):
+                        for in_sf_block in ((1, 32),):
+                            if out_sf_block[0] % in_sf_block[0] or out_sf_block[1] % in_sf_block[1]:
+                                continue
+                            case = {
+                                "num_tokens": num_tokens,
+                                "hidden": hidden,
+                                "in_use_tma_aligned_col_major_sf": in_tma,
+                                "in_round_sf": in_round,
+                                "in_use_packed_ue8m0": in_packed,
+                                "out_use_tma_aligned_col_major_sf": out_tma,
+                                "out_round_sf": out_round,
+                                "out_use_packed_ue8m0": out_packed,
+                                "out_sf_block": out_sf_block,
+                                "in_sf_block": in_sf_block,
+                            }
+                            params.append(
+                                pytest.param(
+                                    case,
+                                    id=(
+                                        f"num_tokens={num_tokens}_hidden={hidden}"
+                                        f"_in_packed={in_packed}_out_packed={out_packed}"
+                                        f"_out_sf_block={out_sf_block[0]}x{out_sf_block[1]}"
+                                    ),
+                                    marks=(
+                                        ()
+                                        if (num_tokens, hidden, in_packed, out_packed, out_sf_block) in _SMOKE_CASES
+                                        else pytest.mark.low_priority
+                                    ),
+                                )
+                            )
+    return params
+
+
+@pytest.fixture
+def isolated_kernel_cache(tmp_path):
+    """Give the case its own kernel cache directory.
+
+    The Example clears the kernel cache when it is imported, and here that
+    import happens inside every fork. Against the shared directory that would
+    delete kernels the other operator tests in the same Pytest invocation are
+    compiling into; against this one it deletes nothing anyone else holds. Each
+    case runs in its own fork, so nothing it compiles was reusable regardless.
+    """
+    import tilelang.cache
+
+    previous = tilelang.cache.get_cache_dir()
+    tilelang.cache.set_cache_dir(str(tmp_path))
+    try:
+        yield
+    finally:
+        tilelang.cache.set_cache_dir(str(previous))
+
+
+def _load_per_block_cast_example() -> ModuleType:
+    source = Path(__file__).with_name("per_block_cast_lossless_kernel.py")
+    spec = importlib.util.spec_from_file_location("_per_block_cast_example_for_test", source)
+    module = importlib.util.module_from_spec(spec)
+    original_argv = sys.argv
+    original_path = list(sys.path)
+    # The Example resolves its helpers as a top-level `utils`, a name
+    # examples/xllm_kernels also claims. Both can be collected by one Pytest
+    # invocation, so put this directory first and take the entry back after.
+    original_utils = sys.modules.pop("utils", None)
+    try:
+        # per_block_cast_lossless_kernel.py reads arguments at import time. Hide
+        # Pytest's own arguments while loading it, without changing the Example.
+        sys.argv = [str(source)]
+        sys.path.insert(0, str(source.parent))
+        spec.loader.exec_module(module)
+    finally:
+        sys.argv = original_argv
+        sys.path[:] = original_path
+        if original_utils is not None:
+            sys.modules["utils"] = original_utils
+    return module
+
+
+@pytest.mark.parametrize("params", _test_params())
+def test_per_block_cast_lossless(params: dict, isolated_kernel_cache) -> None:
+    import torch
+
+    example = _load_per_block_cast_example()
+
+    _, x_bf16, cast_func = example.generate_test_data(params)
+    out, _ = cast_func()
+    if hasattr(torch, "npu"):
+        torch.npu.synchronize()
+
+    out_ref = example.compute_reference_out(x_bf16, params)
+    example.assert_equal(out, out_ref, check_stride=False)


### PR DESCRIPTION
## 改动内容

把 `examples/tile_kernels/` 下用例最多的两个算子接入 Pytest 执行路径，并给大部分用例打上 `low_priority`，让它们只在 schedule / workflow_dispatch 跑。

| 算子 | 用例数 | 现状 |
|---|---|---|
| `tile_kernels/quant/per_block_cast_lossless_kernel.py` | 168 | 未登记，全量 bench 里**最后一个**完成 |
| `tile_kernels/moe/moe_topk_sum_and_topk_group_idx.py` | 144（forward + backward） | 未登记，同批次靠后完成 |

改动三个文件：新增两个 `test_*.py`，`ci/operator_test_manifest.yaml` 增加两条登记（140 → 142 条，生效条目 21 → 23）。**两个算子的源文件一行未改。**



## 用例的取舍

按**「这个参数换不换编译配置」**划分，不按数量。换 kernel 路径的留在 PR，只改数据规模的推到 schedule。

| 算子 | PR 上跑 | 打 `low_priority` |
|---|---|---|
| `per_block_cast_lossless_kernel` | 12 / 168 | 156 |
| `moe_topk_sum_and_topk_group_idx` | 10 / 144 | 134 |

### per_block_cast 留的 12 个

`get_per_block_cast_lossless_kernel` 的编译 key 里，真正选择不同 kernel 路径的是三个参数：输入 scale factor 编码、输出 scale factor 编码、输出 block，组合数 `2 × 2 × 3 = 12`。留的就是**这 12 种各一个**，并让 `hidden` 在网格的最小值 576 和最大值 7168 之间交替，使 `_derive_cast_layout` 里 `block_k` 的推导两端都被覆盖。

`num_tokens` 是 `T.symbolic` 维度，不进编译 key —— 4001 与 8001 复用同一份编译产物，所以一个取值可以代表两个。

### moe 留的 10 个（5 组参数 × forward / backward）

两个 kernel 都按 `(num_groups, num_experts_per_group, num_topk_groups, num_topk_sum)` 编译，共 24 种组合，10 个覆盖不全，取以下 5 组：

| 参数 | 覆盖到什么 |
|---|---|
| `tok=1, exp=72, grp=12, sumk=1, topk=2` | 单 token 边界；`experts_per_group=6` 补齐到 32（padding 最大）；top-1 |
| `tok=4001, exp=256, grp=4, sumk=2, topk=4` | `experts_per_group=64` 无 padding；top-2；保留 4 组 |
| `tok=4001, exp=72, grp=8, sumk=2, topk=2` | `experts_per_group=9`；top-2 |
| `tok=8001, exp=256, grp=8, sumk=1, topk=4` | 最大 token 数；`experts_per_group=32` 精确对齐；top-1 |
| `tok=1, exp=256, grp=16, sumk=2, topk=2` | 单 token 边界；最多分组 |

覆盖：`num_topk_sum` 的两条路径（**唯一改变生成代码的参数**）、`num_topk_groups` 两个取值、`num_tokens` 三个取值含单 token 边界、`experts_per_group` 六个里的五个且跨越 32 对齐的两端（6 → 32、32、64），forward 与 backward 两个 kernel 都跑到。

## 加载方式

与已登记的那些测试一致：参数表是模块级的纯 Python 字面量，算子在 **test 函数体内**用
`importlib.util.spec_from_file_location` 按路径加载，加载前后隔离 `sys.argv`（两个源文件都在 import 期读参数）。这样加载失败只让单个用例失败，而不是变成 collection error。

有两处是这两个文件特有的：

**每个用例一个 kernel cache 目录。** 两个源文件都在模块级调 `tilelang.cache.clear_cache()`，而这里的 import 发生在每一个 fork 内部。对着共享目录，它会删掉同一次 Pytest 调用中其它算子测试正在写入的编译产物；`clear_cache()` 只有进程内的线程锁，实测出现过：

```
os.makedirs(cache_path, exist_ok=True)
FileNotFoundError: [Errno 2] No such file or directory: '.../660fd2fa...'
```

改用 `tilelang.cache.set_cache_dir(tmp_path)` 后互不影响；每个用例本来就跑在自己的 fork 里，编译产物也不存在跨用例复用。

**`utils` 这个顶层模块名的隔离。** `per_block_cast_lossless_kernel.py` 通过 `from utils import *` 取 helper，而 `examples/xllm_kernels` 也占用同一个名字，两边可能被同一次 Pytest 调用收集。加载时把该目录插到 `sys.path` 最前并在结束后取回条目，同时暂存与还原 `sys.modules["utils"]`。

## 验证结果

- `pytest --collect-only`：144 / 168 例全部收集到；加 `-m "not (low_priority or ci_skip)"` 后分别为 **10 / 144（134 deselected）** 与 **12 / 168（156 deselected）**，被过滤掉的与上表一致
- `ruff check` / `ruff format --check`：本机 0.16.0 与 `requirements-lint.txt` 锁定的 0.6.5 **两个版本都通过**
- `resolve_operator_tests.py validate` 退出 0；`list-tests` 由 21 条增至 23 条，两个新文件在列；`check-orphans` 未新增孤儿
- 在 Ascend 910B A3 上用 CI 的原样命令（`pytest --forked -v -n 8`，以及带 `-m` 的 PR 形态）跑过全部四种组合，用例全部通过，无 OOM、无 aicore 异常；另在共享 cache 目录放置哨兵文件，四轮跑完后哨兵仍在，确认没有波及其它算子的编译产物

## 参考

- #1489：建立 `ci/operator_test_manifest.yaml` 与 CI 路由机制
- #1528：把已登记算子的测试接入 Pytest 执行路径
- #1549：非侵入式 pytest 测试的写法
- #1604：登记表条目指向已移动算子时报告而不是失败