### PR TITLE
fix(pto): synchronize packed mask cleanup

### DIFF
--- a/src/tl_templates/pto/common.h
+++ b/src/tl_templates/pto/common.h
@@ -1373,14 +1373,19 @@ clear_compare_tail_bits(TileUbDataND<T, Rows, Cols, RowValid, ColValid> &dst,
                         uint32_t valid_row, uint32_t logical_valid_col) {
   if ((logical_valid_col & 7U) == 0)
     return;
-  TL_PIPE_V_BARRIER();
+  // The compare result is produced by PIPE_V, while the packed-byte cleanup
+  // below is a scalar UB read-modify-write.  A vector-only barrier does not
+  // make that result visible to PIPE_S and can therefore overwrite the final
+  // predicate byte with stale data.  Synchronize both directions so the
+  // following select observes the cleaned mask.
+  pto::PtoSetWaitFlag<PIPE_V, PIPE_S>();
   uint8_t keep = static_cast<uint8_t>((1U << (logical_valid_col & 7U)) - 1U);
   uint32_t last = logical_valid_col >> 3;
   for (uint32_t r = 0; r < valid_row; ++r) {
     dst.data()[r * Cols + last] = static_cast<T>(
         static_cast<uint8_t>(dst.data()[r * Cols + last]) & keep);
   }
-  TL_PIPE_V_BARRIER();
+  pto::PtoSetWaitFlag<PIPE_S, PIPE_V>();
 }
 
 template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid,


### PR DESCRIPTION
## What

- Synchronize `PIPE_V -> PIPE_S` before scalar cleanup of the final packed compare-mask byte.
- Synchronize `PIPE_S -> PIPE_V` before the cleaned mask is consumed by select.

## Why

`TCMPS` produces the packed predicate in `PIPE_V`, while
`clear_compare_tail_bits` performs a scalar UB read-modify-write.

A vector-only barrier did not guarantee that the compare result was visible to
the scalar pipeline. The cleanup could therefore read stale zero data and
overwrite the final predicate byte, causing the PTO scalar compare/select tail
case to select the scalar value for negative inputs.

This caused:

`test_compare_select_tail[pto-float-True-True]`

to fail in the final `1 x 5` tail block.

## Validation

- Full tail-mask codegen suite: 127 passed.
- Exact float/PTO scalar compare-select codegen path passed.
- Minimal A3 PTO device source compiled successfully with Bisheng.