### PR TITLE
fix(doc): remove dead enable_auto_sync func_attr

### DIFF
--- a/.agents/skills/tilelang-pass-analyzer/references/pass-designs/ascend_sync_insert_technical_doc.md
+++ b/.agents/skills/tilelang-pass-analyzer/references/pass-designs/ascend_sync_insert_technical_doc.md
@@ -498,6 +498,5 @@ print(func.ir_module['main'])
 
 **配置选项**：
 - Pass 配置：`tl.ascend_auto_sync`（Bool）
-- 函数属性：`enable_auto_sync`
 
 **注册**：`TVM_REGISTER_GLOBAL("tl.transform.AscendSyncInsert")`

--- a/README.md
+++ b/README.md
@@ -363,8 +363,6 @@ def vec_add(M, N, block_M, block_N, dtype="float"):
             B: T.Tensor((M, N), dtype),
             C: T.Tensor((M, N), dtype),
     ):
-        # Enable by setting the enable_auto_sync attribute
-        T.func_attr({"enable_auto_sync": True})
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
             by = cid % n_num

--- a/examples/softmax/example_online_softmax.py
+++ b/examples/softmax/example_online_softmax.py
@@ -48,7 +48,6 @@ def online_softmax(M, N, block_M, block_N, dtype="float"):
         A: T.Tensor([M, N], dtype),
         B: T.Tensor([M, N], dtype),
     ):
-        T.func_attr({"enable_auto_sync": True})
         # One core process one block row
         with T.Kernel(m_num, is_npu=True) as (cid, vid):
             bx = cid

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -1939,7 +1939,6 @@ def cos(M, N, block_M, block_N, dtype="float"):
         A: T.Tensor([M, N], dtype),  # type: ignore
         B: T.Tensor([M, N], dtype),  # type: ignore
     ):
-        T.func_attr({"enable_auto_sync": True})
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
             by = cid % n_num
@@ -1989,7 +1988,6 @@ def cos_slice(M, N, block_M, block_N, dtype="float"):
         A: T.Tensor([M, N], dtype),  # type: ignore
         B: T.Tensor([M, N], dtype),  # type: ignore
     ):
-        T.func_attr({"enable_auto_sync": True})
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
             by = cid % n_num
@@ -3943,7 +3941,6 @@ def sin(M, N, block_M, block_N, dtype="float"):
         A: T.Tensor([M, N], dtype),  # type: ignore
         B: T.Tensor([M, N], dtype),  # type: ignore
     ):
-        T.func_attr({"enable_auto_sync": True})
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
             by = cid % n_num
@@ -3992,7 +3989,6 @@ def sin_slice(M, N, block_M, block_N, dtype="float"):
         A: T.Tensor([M, N], dtype),  # type: ignore
         B: T.Tensor([M, N], dtype),  # type: ignore
     ):
-        T.func_attr({"enable_auto_sync": True})
         with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
             bx = cid // n_num
             by = cid % n_num


### PR DESCRIPTION
## 问题

PR #101 将 `AscendSyncInsert` 的开关从 PrimFunc 属性 `enable_auto_sync` 重构为 PassContext 配置 `tl.ascend_auto_sync`（src/transform/ascend_sync_insert.cc:68），此后该 func_attr 在 `src/` 中无任何读取者，成为死代码。

但残留的 attr 具有误导性：
- README 的 sync 自动插入示例仍保留 `T.func_attr({"enable_auto_sync": True})`，且正文在 #101 后已改为描述 pass_configs 机制——文档自相矛盾
- 按文档写法的存量 kernel（示例、测试中均有）实际依赖文件级 pass_configs 生效，attr 本身不起任何作用

## 修改内容

纯删除，4 个文件 8 行，无行为变化：

| 文件 | 改动 |
|---|---|
| README.md | 移除示例中死 attr 及其注释（正文 pass_configs 说明已正确，保持不变） |
| examples/softmax/example_online_softmax.py | 移除 1 处死 attr |
| testing/python/language/test_tilelang_ascend_language_elementwise.py | 移除 cos/cos_slice/sin/sin_slice 共 4 处死 attr |
| .agents/skills/tilelang-pass-analyzer/references/.../ascend_sync_insert_technical_doc.md | 配置选项列表删除「函数属性：enable_auto_sync」失实项 |
