### PR TITLE
[Bugfix] Fix gemm_v0 unaligned K-tail miscompute with multiple K-tiles (#1341)

### DIFF
--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -2897,15 +2897,71 @@ void CodeGenTileLangAscend::CopyCodegen(const CallNode *op) {
       this->stream << ", " << var_names[i];
     }
 
-    // copy_gm_to_l1: append a `need_clear` flag so the helper only zero-inits
+    // copy_gm_to_l1: append a `need_clear` flag so the helper zero-inits
     // the full L1 tile for the primary copy (dst offset 0). Sub-region copies
     // (non-zero dst offset, e.g. the second DMA of a splice / vertical-merge
-    // pattern) must skip the clear, otherwise they clobber data already written
-    // into the same NZ tile. dst_offset_expr is the scalar start offset of the
-    // destination tile; when it is 0 this DMA targets the tile base and is the
-    // natural owner of the tail-padding clear.
+    // pattern) must skip the clear, otherwise they clobber data already
+    // written into the same NZ tile. dst_offset_expr is the scalar start offset
+    // of the destination tile; when it is 0 this DMA targets the tile base and
+    // is the natural owner of the tail-padding clear.
+    //
+    // Pipeline multi-versioned L1 buffers are the exception: each version is
+    // an INDEPENDENT full tile whose base sits at k * tile_elements within the
+    // versioned allocation, so a version-base copy must own the clear of its
+    // own tile (the zero-init covers exactly fractalExtent(dstM, dstN)
+    // elements from the view base and cannot leak into a neighbouring
+    // version). Distinguish the two structurally:
+    //   - a version copy covers FULL rows (realTailM == template dstM) and its
+    //     dst offset is a whole multiple of the tile element count
+    //     (dstM * realTailN, covering both constant prologue offsets and the
+    //     runtime `k * tile` pipelined body);
+    //   - a splice sub-region copy covers a strict row subset
+    //     (realTailM < dstM) at an offset inside one tile, and must not clear.
+    // PR review: without this, every non-zero version skips the clear and a
+    // K-tail Mmad accumulates stale data from the previous iteration.
     if (op_name.find("copy_gm_to_l1") != std::string::npos) {
-      this->stream << ", " << (is_zero(dst_offset_expr) ? "true" : "false");
+      bool need_clear = is_zero(dst_offset_expr);
+      if (!need_clear) {
+        // Parse the template dims from the op name: "copy_gm_to_l1<T, dstM,
+        // dstN>". dstM (rows) decides whether this is a full-row copy; dstM *
+        // dstN is the whole-tile element count used for the version-base
+        // divisibility test (both are compile-time, unlike the runtime
+        // realTailN which a K-tail pipeline body copy varies).
+        int dst_m = 0, dst_n = 0;
+        size_t tmpl_pos = op_name.find('<');
+        if (tmpl_pos != std::string::npos) {
+          std::stringstream ss(op_name.substr(tmpl_pos + 1));
+          std::string dtype_token, m_token, n_token;
+          if (std::getline(ss, dtype_token, ',') &&
+              std::getline(ss, m_token, ',') &&
+              std::getline(ss, n_token, '>')) {
+            dst_m = std::atoi(m_token.c_str());
+            dst_n = std::atoi(n_token.c_str());
+          }
+        }
+        const Array<PrimExpr> &call_args = op->args;
+        // args[4] = realTailM (this copy's destination row count).
+        const auto *tail_m_imm =
+            call_args.size() > 4 ? call_args[4].as<IntImmNode>() : nullptr;
+        if (dst_m > 0 && dst_n > 0 && tail_m_imm != nullptr) {
+          // The tailM==0 default means "full tile" (the helper remaps 0 to
+          // dstM), so a full-row copy is tail_m == 0 || tail_m == dst_m.
+          const int64_t tail_m =
+              tail_m_imm->value == 0 ? dst_m : tail_m_imm->value;
+          const int64_t tile_elems =
+              static_cast<int64_t>(dst_m) * static_cast<int64_t>(dst_n);
+          if (tail_m == dst_m && tile_elems > 0) {
+            // Prove offset % tile_elems == 0 symbolically: covers both the
+            // constant case (version prologue: 1*tile_elems) and the pipelined
+            // body (k * tile_elems with k runtime).
+            arith::Analyzer analyzer;
+            need_clear = analyzer.CanProve(
+                truncmod(dst_offset_expr,
+                         make_const(dst_offset_expr.dtype(), tile_elems)) == 0);
+          }
+        }
+      }
+      this->stream << ", " << (need_clear ? "true" : "false");
     }
 
     // copy_l0c_to_gm's unitFlag rides at the end of the argument list rather

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -1227,6 +1227,21 @@ gemm_v0(LocalTensor<T1> const &A, LocalTensor<T1> const &B,
       "K-slots unwritten). Split K differently or pad K to the needed "
       "alignment.");
 
+  // The tail guard above is not enough: EVERY K-tile is consumed with a
+  // C0-rounded k (a full tile with kSize = kL0Size uses ceil(kL0Size/C0)*C0
+  // slots), and its L1->L0B source offset steps by ELE_NUM_PER_C0 * kL0Size.
+  // When kL0Size is not C0-aligned (e.g. int8 kL0Size = 48: mma consumes 64
+  // slots while the L1 zN layout only provides roundUp16(48) = 48 rows), the
+  // first tile already reads unwritten L0B slots and the tile offsets drift
+  // from the C0-rounded spans. Require kL0Size itself to be C0-aligned
+  // whenever the K axis is split at the L0 level.
+  static_assert(
+      ELE_NUM_PER_C0 <= 16 || kL0split == 1 || (kL0Size % ELE_NUM_PER_C0) == 0,
+      "gemm_v0: kL0Size must be a multiple of the C0 element count "
+      "(32 for int8) when K is split into multiple L0 tiles. A non-C0-aligned "
+      "kL0Size makes every mma consume more K-slots than the L1 fractal "
+      "layout provides and desynchronizes the L0 ping-pong bases.");
+
   // ---- N tiling -----------------------------------------------------------
   // The B operand tile loaded into L0B is (kL0Size x nTile); L0B holds 64KB,
   // and with the kL0 ping-pong the per-slot budget is 32KB. So a single mma

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -65,10 +65,29 @@ copy_gm_to_l1(LocalTensor<T> dstTensor, GlobalTensor<T> srcTensor,
   // otherwise they clobber data already written into the same NZ tile. The
   // full-tile clear is only correct when it targets the tile base, which the
   // codegen guarantees by passing need_clear = (dst_offset == 0).
-  if (need_clear && (tailM != dstM || tailN != dstN)) {
-    AscendC::InitConstValue(
-        dstTensor,
-        {1, static_cast<uint16_t>(dstM * dstN * sizeof(T) / 32), 0, 0});
+  //
+  // The clear must cover the zN FRACTAL extent, not just dstM*dstN elements:
+  // the zN layout pads rows up to 16 and interleaves the padding holes inside
+  // the tile (e.g. zN(K=200, N=128) stores each 16-column N band at a
+  // roundUp16(K)*16 = 3328-element stride, leaving 8 unwritten K rows per
+  // band). The GM copy only writes valid elements, and Mmad rounds its k
+  // argument up to whole C0 fractals, so a gemm_v0 K-tail tile
+  // (kSize % 16 != 0) multiplies whatever sits in those holes (issue #1341).
+  // Zero-init them whenever the tile has fractal padding
+  // (extent != dstM*dstN) or a partial tail copy.
+  constexpr uint32_t ELE_PER_C0 = Catlass::BYTE_PER_C0 / sizeof(T);
+  constexpr uint32_t C0_PER_FRACTAL = Catlass::C0_NUM_PER_FRCATLASSAL;
+  const uint32_t paddedRows =
+      (dstM + C0_PER_FRACTAL - 1) / C0_PER_FRACTAL * C0_PER_FRACTAL;
+  const uint32_t fractalExtent =
+      ((dstN + ELE_PER_C0 - 1) / ELE_PER_C0) * paddedRows * ELE_PER_C0;
+  if (need_clear &&
+      (tailM != dstM || tailN != dstN || fractalExtent != dstM * dstN)) {
+    AscendC::InitConstValue(dstTensor,
+                            {1,
+                             static_cast<uint16_t>(fractalExtent * sizeof(T) /
+                                                   Catlass::BYTE_PER_C0),
+                             0, 0});
     AscendC::PipeBarrier<PIPE_MTE2>();
   }
   auto layout = MakeLayoutFromTag(LayoutGM{tailM, realSrcN});
@@ -1189,6 +1208,24 @@ gemm_v0(LocalTensor<T1> const &A, LocalTensor<T1> const &B,
   auto l0b = l0b_.Get<T1>();
   uint32_t kL0Tail = K - (kL0split - 1) * kL0Size;
   bool initflag = false;
+
+  // Mmad consumes K in whole C0 blocks: a tail mma with k = kL0Tail actually
+  // accumulates ceil(kL0Tail / ELE_NUM_PER_C0) * ELE_NUM_PER_C0 K-slots. The
+  // L1 zN layout only pads K up to a multiple of 16 rows, so for int8
+  // (ELE_NUM_PER_C0 == 32) a tail with kL0Tail % 32 in [1, 16] reads 16 L0B
+  // K-slots that neither the GM->L1 copy nor the L1->L0B copy ever wrote
+  // (stale L0B garbage -> silently wrong results). Reject that combination at
+  // compile time; 16/8-bit types never trip this (their C0 rounding never
+  // exceeds the 16-row fractal padding).
+  static_assert(
+      ELE_NUM_PER_C0 <= 16 ||
+          ((K - (kL0split - 1) * kL0Size) % ELE_NUM_PER_C0 == 0) ||
+          ((K - (kL0split - 1) * kL0Size) % ELE_NUM_PER_C0 > 16),
+      "gemm_v0: int8 K-tail must be 16-element aligned (kL0Tail % 32 in "
+      "[1,16] is unsupported: the mma consumes whole 32-element C0 blocks "
+      "but the L1 fractal layout only pads K to 16 rows, leaving L0B "
+      "K-slots unwritten). Split K differently or pad K to the needed "
+      "alignment.");
 
   // ---- N tiling -----------------------------------------------------------
   // The B operand tile loaded into L0B is (kL0Size x nTile); L0B holds 64KB,

--- a/src/transform/ascend_collect_buffer_shape.cc
+++ b/src/transform/ascend_collect_buffer_shape.cc
@@ -181,8 +181,7 @@ tvm::transform::Pass CreateFlatten2DPass() {
       // fractal extent (the normal zN-remapped 1D flow) this is a no-op.
       if (scope == "shared.l1") {
         auto init_it = initial_shapes.find(buffer_var);
-        if (init_it != initial_shapes.end() &&
-            (*init_it).second.size() >= 2) {
+        if (init_it != initial_shapes.end() && (*init_it).second.size() >= 2) {
           const Array<PrimExpr> &init_shape = (*init_it).second;
           const IntImmNode *rows =
               init_shape[init_shape.size() - 2].as<IntImmNode>();
@@ -197,11 +196,9 @@ tvm::transform::Pass CreateFlatten2DPass() {
             };
             const int64_t zn_extent = ceil_div(cols->value, ele_per_c0) *
                                       round_up16(rows->value) * ele_per_c0;
-            if (const IntImmNode *total_imm =
-                    total_elements.as<IntImmNode>()) {
+            if (const IntImmNode *total_imm = total_elements.as<IntImmNode>()) {
               if (total_imm->value < zn_extent) {
-                total_elements =
-                    Integer(static_cast<int64_t>(zn_extent));
+                total_elements = Integer(static_cast<int64_t>(zn_extent));
               }
             }
           }

--- a/src/transform/ascend_collect_buffer_shape.cc
+++ b/src/transform/ascend_collect_buffer_shape.cc
@@ -166,15 +166,21 @@ tvm::transform::Pass CreateFlatten2DPass() {
         total_elements = analyzer.Simplify(total_elements * ext);
       }
 
-      // The outer dimension is calculated to preserve the total number of
+      // The outer dimension is calculated to cover the total number of
       // elements. This formula correctly handles all cases:
       // - 1D [m] -> [1, m]
       // - 2D [n, m] -> [n, m]
       // - ND [d1, d2, ..., m] -> [d1*d2*..., m]
+      // For fractal-layout (zN/nZ) L1 buffers the collected extent is the
+      // layout-padded element count, which need not be divisible by the
+      // logical inner dim (e.g. zN(64, 200) spans 13312 = 66.56 * 200).
+      // Ceil-div keeps the [outer, inner] rectangle covering the whole
+      // allocation; a trunc-div here under-sizes the buffer and lets the
+      // next L1 allocation overlap its tail (issue #1341).
       PrimExpr inner_dim = GetInnerDim(buffer_var, shape, initial_shapes);
 
-      PrimExpr outer_dim =
-          analyzer.Simplify(truncdiv(total_elements, inner_dim));
+      PrimExpr outer_dim = analyzer.Simplify(
+          indexdiv(total_elements + inner_dim - 1, inner_dim));
 
       // handle DN/ND
       bool is_inner_dim_one = analyzer.CanProve(inner_dim == 1);

--- a/src/transform/ascend_collect_buffer_shape.cc
+++ b/src/transform/ascend_collect_buffer_shape.cc
@@ -166,6 +166,48 @@ tvm::transform::Pass CreateFlatten2DPass() {
         total_elements = analyzer.Simplify(total_elements * ext);
       }
 
+      // L1 buffers are physically zN-fractal (copy_gm_to_l1 writes zN, the
+      // mma consumes whole C0 fractals), so the backing allocation must cover
+      // the fractal-padded extent ceil(N/C0) * roundUp16(M) * C0 even when
+      // the TIR buffer kept its logical [M, N] shape. That happens when an
+      // earlier pass (AscendLowerParallelToVector rebuilding Blocks without
+      // annotations) drops the default zN layout_map and LayoutInference
+      // falls back to a non-fractal layout: the tile-op offsets stay linear
+      // (which the vid-reduce workspace transform relies on), but sizing by
+      // the logical shape alone under-allocates and lets neighbouring L1
+      // allocations overlap the tail (issue #1341). Pad the total here, at a
+      // point where the tile ops are already lowered and only the memory
+      // planner consumes these shapes. For buffers already carrying the
+      // fractal extent (the normal zN-remapped 1D flow) this is a no-op.
+      if (scope == "shared.l1") {
+        auto init_it = initial_shapes.find(buffer_var);
+        if (init_it != initial_shapes.end() &&
+            (*init_it).second.size() >= 2) {
+          const Array<PrimExpr> &init_shape = (*init_it).second;
+          const IntImmNode *rows =
+              init_shape[init_shape.size() - 2].as<IntImmNode>();
+          const IntImmNode *cols =
+              init_shape[init_shape.size() - 1].as<IntImmNode>();
+          int bits = collector.GetBufferBits().at(buffer_var)->value;
+          const int64_t ele_per_c0 = bits > 0 ? 32 * 8 / bits : 0;
+          if (rows != nullptr && cols != nullptr && ele_per_c0 > 0) {
+            auto round_up16 = [](int64_t v) { return (v + 15) / 16 * 16; };
+            auto ceil_div = [](int64_t a, int64_t b) {
+              return (a + b - 1) / b;
+            };
+            const int64_t zn_extent = ceil_div(cols->value, ele_per_c0) *
+                                      round_up16(rows->value) * ele_per_c0;
+            if (const IntImmNode *total_imm =
+                    total_elements.as<IntImmNode>()) {
+              if (total_imm->value < zn_extent) {
+                total_elements =
+                    Integer(static_cast<int64_t>(zn_extent));
+              }
+            }
+          }
+        }
+      }
+
       // The outer dimension is calculated to cover the total number of
       // elements. This formula correctly handles all cases:
       // - 1D [m] -> [1, m]

--- a/src/transform/ascend_lower_parallel_to_vector.cc
+++ b/src/transform/ascend_lower_parallel_to_vector.cc
@@ -404,8 +404,13 @@ private:
       return GetRef<Stmt>(op);
     }
 
+    // Preserve the block annotations (e.g. the default zN layout_map injected
+    // by AscendInferBufferScope). Dropping them makes LayoutInference fall
+    // back to an identity layout for L1 gemm operands, which sizes the
+    // buffer by the logical shape instead of the fractal-padded extent and
+    // lets neighbouring L1 allocations overlap (issue #1341).
     return Block(op->iter_vars, op->reads, op->writes, op->name_hint, new_body,
-                 op->init, allocs);
+                 op->init, allocs, op->match_buffers, op->annotations);
   }
 
   // Generic Plan

--- a/src/transform/ascend_lower_parallel_to_vector.cc
+++ b/src/transform/ascend_lower_parallel_to_vector.cc
@@ -404,13 +404,8 @@ private:
       return GetRef<Stmt>(op);
     }
 
-    // Preserve the block annotations (e.g. the default zN layout_map injected
-    // by AscendInferBufferScope). Dropping them makes LayoutInference fall
-    // back to an identity layout for L1 gemm operands, which sizes the
-    // buffer by the logical shape instead of the fractal-padded extent and
-    // lets neighbouring L1 allocations overlap (issue #1341).
     return Block(op->iter_vars, op->reads, op->writes, op->name_hint, new_body,
-                 op->init, allocs, op->match_buffers, op->annotations);
+                 op->init, allocs);
   }
 
   // Generic Plan

--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -32,6 +32,8 @@
 #include "tir/schedule/utils.h"
 #include "tir/transforms/ir_utils.h"
 
+#include <tvm/tir/expr.h>
+
 namespace tvm {
 namespace tl {
 using namespace tir;
@@ -173,7 +175,13 @@ private:
         const PrimExpr &old_index = call->args[i + 1];
         PrimExpr offset;
         if (new_buffer->strides.empty()) {
-          offset = product(buffer->shape);
+          // RewriteAllocBuffer may have padded the per-version shape of an L1
+          // buffer to its zN fractal extent; the version stride must follow
+          // the PADDED (remapped) shape, not the original logical one,
+          // otherwise adjacent versions overlap (issue #1341 pipeline
+          // variant). Drop the version axis and multiply the rest.
+          offset = product(Array<PrimExpr>(new_buffer->shape.begin() + 1,
+                                           new_buffer->shape.end()));
         } else {
           offset = new_buffer->strides[0];
         }
@@ -353,17 +361,17 @@ public:
     Block block = MakeBlock(stmt, buffer_data_to_buffer_);
     block.CopyOnWrite()->alloc_buffers = std::move(alloc_buffers);
 
-    //todo:
-    // // === 新增：将版本信息添加到block属性中 ===
-    // auto block_ptr = block.CopyOnWrite();
-    // // 获取现有annotations或创建新的
-    // auto annotations =
-    //     block_ptr->annotations.defined()
-    //         ? Downcast<Map<String, ObjectRef>>(block_ptr->annotations)
-    //         : Map<String, ObjectRef>();
-    // // 添加版本信息
-    // annotations.Set("pipeline_buffer_versions", buffer_versions);
-    // block_ptr->annotations = annotations;
+    // todo:
+    //  // === 新增：将版本信息添加到block属性中 ===
+    //  auto block_ptr = block.CopyOnWrite();
+    //  // 获取现有annotations或创建新的
+    //  auto annotations =
+    //      block_ptr->annotations.defined()
+    //          ? Downcast<Map<String, ObjectRef>>(block_ptr->annotations)
+    //          : Map<String, ObjectRef>();
+    //  // 添加版本信息
+    //  annotations.Set("pipeline_buffer_versions", buffer_versions);
+    //  block_ptr->annotations = annotations;
 
     // return BlockRealize({}, Bool(true), block);
     return {BlockRealize({}, Bool(true), block), buffer_versions};
@@ -509,6 +517,40 @@ private:
    */
   Buffer RewriteAllocBuffer(const Buffer &buffer, int num_versions) {
     ObjectPtr<BufferNode> new_buffer = make_object<BufferNode>(*(buffer.get()));
+
+    // L1 buffers are physically zN-fractal, so one version of the buffer
+    // occupies ceil(N/C0) * roundUp16(M) * C0 elements -- possibly MORE than
+    // the logical M*N (e.g. zN(128, 200) spans 26624 vs 25600). Pad the
+    // per-version shape up to that extent before prepending the version axis,
+    // so the implicit version stride (product of the trailing dims) and the
+    // flattened Allocate size both use the physical extent. Without this,
+    // adjacent versions overlap: the previous version's fractal tail spills
+    // into the next version's base and a K-tail Mmad reads it (issue #1341,
+    // pipeline + T.Parallel variant). Only applies to constant-shape 2D
+    // shared.l1 buffers; everything else keeps the original shape.
+    const auto *ptr_type = buffer->data->type_annotation.as<PointerTypeNode>();
+    if (ptr_type != nullptr && ptr_type->storage_scope == "shared.l1" &&
+        buffer->shape.size() == 2 && buffer->dtype.bits() > 0 &&
+        buffer->dtype.lanes() == 1) {
+      const auto *rows = buffer->shape[0].as<IntImmNode>();
+      const auto *cols = buffer->shape[1].as<IntImmNode>();
+      if (rows != nullptr && cols != nullptr) {
+        const int64_t ele_per_c0 = 32 * 8 / buffer->dtype.bits();
+        auto round_up = [](int64_t v, int64_t m) {
+          return (v + m - 1) / m * m;
+        };
+        const int64_t padded_rows = round_up(rows->value, 16);
+        const int64_t padded_cols = round_up(cols->value, ele_per_c0);
+        const int64_t zn_extent = padded_rows * padded_cols;
+        const int64_t logical = static_cast<int64_t>(rows->value) * cols->value;
+        if (zn_extent > logical) {
+          new_buffer->shape =
+              Array<PrimExpr>{Integer(static_cast<int64_t>(padded_rows)),
+                              Integer(static_cast<int64_t>(padded_cols))};
+        }
+      }
+    }
+
     new_buffer->shape.insert(new_buffer->shape.begin(), PrimExpr(num_versions));
     if (new_buffer->strides.size()) {
       ICHECK(new_buffer->strides.size() + 1 == new_buffer->shape.size());
@@ -841,14 +883,14 @@ public:
     Stmt result = injector(func->body);
 
     if (!injector.collected_buffer_versions_.empty()) {
-      PrimFuncNode* fptr = func.CopyOnWrite();
+      PrimFuncNode *fptr = func.CopyOnWrite();
       auto fn_attr = fptr->attrs.CopyOnWrite();
       fn_attr->dict.Set("buffer_versions", injector.collected_buffer_versions_);
     }
 
     return result;
   }
-  
+
 private:
   explicit PipelineInjector(Optional<String> global_symbol)
       : global_symbol_(global_symbol) {}
@@ -1004,8 +1046,8 @@ private:
     ValidatePipelineBody(pipeline_info, original_order);
 
     // Step 4: Rewrite the pipeline body.
-    auto [pipeline_stmt, buffer_versions] = 
-    // Stmt pipeline =
+    auto [pipeline_stmt, buffer_versions] =
+        // Stmt pipeline =
         PipelineRewriter(buffer_data_to_buffer_, pipeline_allocs,
                          GetRef<For>(op), pipeline_info, predicate_condition)
             .BuildPipeline();

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -24,6 +24,56 @@ namespace tl {
 
 using namespace tir;
 
+// Physical extent (in elements) of an Ascend fractal (zN/nZ/zZ) layout over a
+// logical 2D (rows, cols) tile. The fractal layout pads rows/cols up to the
+// C0 granularity, and the padding holes are interleaved INSIDE the tile (e.g.
+// zN(K=200, N) stores each 128-wide N band at a roundUp16(K)*16 stride), so
+// the backing buffer must be sized by the padded extent, not by
+// max(valid_offset) + 1: e.g. zN(200, 128) spans 8 * 208 * 16 = 26624
+// elements while its valid data only reaches 26496. Any consumer that walks
+// the fractal grid (the gemm_v0 K-tail L1->L0 copy loads ceil(K/16) whole
+// fractals) reads the padding, so under-sizing the buffer both reads out of
+// bounds and lets neighbouring L1 buffers overlap the tail (issue #1341).
+static Optional<IntImm> AscendFractalExtent(const Layout &layout,
+                                            DataType dtype) {
+  const std::string layout_str = layout->AscendLayoutStr();
+  const bool is_zn = layout_str == "layout::zN";
+  const bool is_nz = layout_str == "layout::nZ";
+  const bool is_zz = layout_str == "layout::zZ";
+  if (!is_zn && !is_nz && !is_zz) {
+    return NullOpt;
+  }
+  if (layout->InputDim() < 2 || dtype.bits() == 0 || dtype.lanes() != 1) {
+    return NullOpt;
+  }
+  const auto *rows =
+      layout->InputShape()[layout->InputDim() - 2].as<IntImmNode>();
+  const auto *cols =
+      layout->InputShape()[layout->InputDim() - 1].as<IntImmNode>();
+  if (rows == nullptr || cols == nullptr) {
+    return NullOpt;
+  }
+  const int64_t ele_per_c0 = 32 * 8 / dtype.bits(); // BYTE_PER_C0 / dtype size
+  constexpr int64_t kC0NumPerFractal = 16;
+  auto round_up = [](int64_t v, int64_t m) { return (v + m - 1) / m * m; };
+  auto ceil_div = [](int64_t a, int64_t b) { return (a + b - 1) / b; };
+  int64_t extent;
+  if (is_zn) {
+    // zN(rows, cols): ceil(cols/C0) column bands, each roundUp(rows,16)*C0.
+    extent = ceil_div(cols->value, ele_per_c0) *
+             round_up(rows->value, kC0NumPerFractal) * ele_per_c0;
+  } else if (is_nz) {
+    // nZ(rows, cols): ceil(rows/C0) row bands, each roundUp(cols,16)*C0.
+    extent = ceil_div(rows->value, ele_per_c0) *
+             round_up(cols->value, kC0NumPerFractal) * ele_per_c0;
+  } else {
+    // zZ(rows, cols): ceil(rows/16) row bands, each roundUp(cols,C0)*16.
+    extent = ceil_div(rows->value, kC0NumPerFractal) *
+             round_up(cols->value, ele_per_c0) * kC0NumPerFractal;
+  }
+  return IntImm(DataType::Int(64), extent);
+}
+
 static Buffer makeBufferWithLayout(const Buffer &buffer, const Layout &layout,
                                    Map<Var, Var> &var_remap) {
   const auto *ptr_type =
@@ -47,6 +97,15 @@ static Buffer makeBufferWithLayout(const Buffer &buffer, const Layout &layout,
     }
   }
   Array<PrimExpr> layout_shape = layout->OutputShape();
+  // The fractal extent replaces only the LAST output dim (the linearized
+  // 2D part); leading replicated dims (if any) keep the inferred shape.
+  if (auto extent = AscendFractalExtent(layout, buffer->dtype)) {
+    if (layout_shape.size() >= 1) {
+      layout_shape.Set(layout_shape.size() - 1, extent.value());
+    } else {
+      layout_shape = {extent.value()};
+    }
+  }
   Array<PrimExpr> output_shape = layout_shape;
 
   if (ptr_type->storage_scope == "shared" ||

--- a/testing/python/language/test_tilelang_ascend_language_gemm_v0_k_tail.py
+++ b/testing/python/language/test_tilelang_ascend_language_gemm_v0_k_tail.py
@@ -14,23 +14,35 @@ corrupt ~10% of the output (fp16, rtol=atol=2e-2):
 
 2. **Lost layout annotations.** ``AscendLowerParallelToVector`` rebuilt Blocks
    without their annotations, dropping the default zN ``layout_map`` injected
-   by ``AscendInferBufferScope``. Layout inference then fell back to an
-   identity layout and sized L1 buffers by the *logical* shape (128 * 200 =
+   by ``AscendInferBufferScope``. Layout inference then fell back to a
+   non-fractal layout and sized L1 buffers by the *logical* shape (128 * 200 =
    25600 elements), re-introducing the overlap for any kernel with a
-   ``T.Parallel`` epilogue (the classic blocked-GEMM writer loop).
+   ``T.Parallel`` epilogue (the classic blocked-GEMM writer loop). This
+   upstream annotation-drop is NOT fixed in this PR (preserving it regressed
+   the vid-reduce workspace transform, which relies on linear offsets);
+   instead the sizing is corrected downstream in ``Flatten2DBuffer``
+   (``ascend_collect_buffer_shape.cc``), which pads every ``shared.l1``
+   buffer's element count up to the zN fractal extent once tile ops are
+   lowered and offsets are frozen.
 
 3. **Un-zeroed fractal padding.** ``copy_gm_to_l1`` only zero-initialized the
    L1 tile for partial tail copies, and even then with the logical element
    count. Full-tile copies with K % 16 != 0 left the zN padding holes holding
    stale L1 garbage. ``Mmad`` consumes whole C0 fractals (a tail mma with
    k = 72 accumulates 80 K-slots), so the garbage was multiplied into C.
+   The zero-init also failed for pipeline multi-versioned L1 buffers: the
+   codegen's ``need_clear`` was ``(dst_offset == 0)``, so every non-zero
+   pipeline version skipped the clear; it is now granted to any copy whose
+   destination offset is provably a whole multiple of the tile element count
+   (a version base), while in-tile splice sub-region offsets keep skipping it.
 
 The fixes: size zN/nZ buffers by the fractal-padded extent
-(``lower_tile_op.cc``), ceil-div the 2D re-flattening
-(``ascend_collect_buffer_shape.cc``), preserve Block annotations
-(``ascend_lower_parallel_to_vector.cc``), and zero-init the full fractal extent
-whenever padding holes exist (``copy_gm_to_l1`` in
-``src/tl_templates/ascend/common.h``).
+(``lower_tile_op.cc``), ceil-div the 2D re-flattening and pad ``shared.l1``
+totals to the zN extent (``ascend_collect_buffer_shape.cc``), zero-init the
+full fractal extent whenever padding holes exist plus version-base-aware
+``need_clear`` (``copy_gm_to_l1`` in ``src/tl_templates/ascend/common.h`` and
+its codegen in ``src/target/codegen_ascend.cc``), and compile-time-reject
+unservable int8 K-tails and non-C0-aligned ``kL0Size`` when ``kL0split > 1``.
 
 NOTE: executes on real NPU hardware (``.npu()``); ascendc target only. The PTO
 backend rejects non-fractal-divisible L1 tiles at compile time (pre-existing
@@ -322,6 +334,116 @@ def test_gemm_v0_ktail_int8(K, expected):
     kernel(a, b, c)
     torch.npu.synchronize()
     # int32 matmul is not implemented on NPU; compare on CPU.
+    ref = (a.cpu().int() @ b.cpu().int()).to("npu")
+    torch.testing.assert_close(c, ref)
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="gemm_v0 correctness requires an Ascend NPU runtime",
+)
+@pytest.mark.parametrize("K,num_stages", [(200, 2), (200, 3), (456, 2), (256, 2)])
+def test_gemm_v0_ktail_pipeline(K, num_stages):
+    """Pipelined K-loop with an unaligned K-tail: software pipelining
+    (``T.Pipelined``) multi-versions the L1 buffers, and every non-zero
+    version base used to skip the zero-init (the codegen's ``need_clear`` was
+    ``dst_offset == 0``), so a K-tail Mmad accumulated stale data from the
+    previous iteration's version (~97% wrong). The fix grants the clear to
+    any copy whose dst offset is provably a whole multiple of the tile
+    element count (a version base). K=256 is the aligned sanity anchor."""
+    M = N = 256
+    block_M = block_N = 128
+    block_K = 64
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), "float16"),
+        B: T.Tensor((K, N), "float16"),
+        C: T.Tensor((M, N), "float16"),
+    ):
+        with T.Kernel(4, is_npu=True) as (cid, _):
+            bx = cid // 2
+            by = cid % 2
+            A_L1 = T.alloc_shared((block_M, block_K), "float16")
+            B_L1 = T.alloc_shared((block_K, block_N), "float16")
+            C_L0 = T.alloc_L0C((block_M, block_N), "float")
+            with T.Scope("C"):
+                loop_k = T.ceildiv(K, block_K)
+                for k in T.Pipelined(loop_k, num_stages=num_stages):
+                    T.barrier_all()
+                    T.copy(A[bx * block_M, k * block_K], A_L1)
+                    T.copy(B[k * block_K, by * block_N], B_L1)
+                    T.gemm_v0(A_L1, B_L1, C_L0, init=(k == 0))
+                    T.barrier_all()
+                T.copy(C_L0, C[bx * block_M, by * block_N])
+
+    torch.manual_seed(0)
+    kernel = _compile(main)
+    a = torch.randn(M, K, dtype=torch.float16, device="npu")
+    b = torch.randn(K, N, dtype=torch.float16, device="npu")
+    c = torch.zeros(M, N, dtype=torch.float16, device="npu")
+    torch.npu.synchronize()
+    kernel(a, b, c)
+    torch.npu.synchronize()
+    ref = a.float() @ b.float()
+    torch.testing.assert_close(c.float(), ref, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="gemm_v0 correctness requires an Ascend NPU runtime",
+)
+@pytest.mark.parametrize(
+    "kL0Size,expected",
+    [
+        (128, "pass"),  # C0-aligned (128 % 32 == 0): fine with kL0split >= 2
+        (96, "pass"),  # C0-aligned (96 % 32 == 0)
+        (48, "reject"),  # 48 % 32 == 16: every tile consumed with a 64-slot
+        # C0 extent while the L1 zN layout provides only 48 rows; the L0
+        # ping-pong bases desynchronize. Must be compile-time rejected.
+    ],
+)
+def test_gemm_v0_ktail_int8_kl0size_c0(kL0Size, expected):
+    """int8 with ``kL0split > 1`` requires ``kL0Size`` itself to be
+    C0-aligned (a multiple of 32): each full tile's mma consumes
+    ``ceil(kL0Size/32)*32`` K-slots, so a non-aligned kL0Size (e.g. 48) reads
+    unwritten L0B slots on the FIRST tile already, not just the tail."""
+    M = N = 256
+    block_M = block_N = 128
+    K = 256  # aligned overall; only kL0Size varies
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), "int8"),
+        B: T.Tensor((K, N), "int8"),
+        C: T.Tensor((M, N), "int32"),
+    ):
+        with T.Kernel(4, is_npu=True) as (cid, _):
+            bx = cid // 2
+            by = cid % 2
+            A_L1 = T.alloc_L1((block_M, K), "int8")
+            B_L1 = T.alloc_L1((K, block_N), "int8")
+            C_L0 = T.alloc_L0C((block_M, block_N), "int32")
+            with T.Scope("C"):
+                T.copy(A[bx * block_M, 0], A_L1)
+                T.copy(B[0, by * block_N], B_L1)
+                T.barrier_all()
+                T.gemm_v0(A_L1, B_L1, C_L0, init=True, kL0Size=kL0Size)
+                T.barrier_all()
+                T.copy(C_L0, C[bx * block_M, by * block_N])
+
+    if expected == "reject":
+        with pytest.raises(RuntimeError, match="Compilation Failed"):
+            _compile(main)
+        return
+    torch.manual_seed(0)
+    kernel = _compile(main)
+    a = torch.randint(-8, 8, (M, K), dtype=torch.int8, device="npu")
+    b = torch.randint(-8, 8, (K, N), dtype=torch.int8, device="npu")
+    c = torch.zeros(M, N, dtype=torch.int32, device="npu")
+    torch.npu.synchronize()
+    kernel(a, b, c)
+    torch.npu.synchronize()
     ref = (a.cpu().int() @ b.cpu().int()).to("npu")
     torch.testing.assert_close(c, ref)
 

--- a/testing/python/language/test_tilelang_ascend_language_gemm_v0_k_tail.py
+++ b/testing/python/language/test_tilelang_ascend_language_gemm_v0_k_tail.py
@@ -1,0 +1,330 @@
+"""Regression tests for unaligned K-tails in Ascend ``gemm_v0`` (issue #1341).
+
+``gemm_v0`` splits K into ``kL0Size``-wide L0 tiles. When the last K-tile is
+not 16-aligned (``kL0Tail % 16 != 0``) three separate defects conspired to
+corrupt ~10% of the output (fp16, rtol=atol=2e-2):
+
+1. **L1 buffer under-sizing.** The zN L1 layout pads K up to a multiple of 16
+   and interleaves the padding holes *inside* the tile (each 16-column N band
+   occupies ``roundUp16(K) * 16`` elements). The buffer size was derived from
+   the layout's max *valid* offset + 1 (e.g. 26496 for zN(200, 128) instead of
+   the padded extent 26624), and the 2D re-flattening truncated the outer dim
+   (13312 // 200 = 66). The next L1 allocation therefore overlapped the tail of
+   the previous buffer: B's GM->L1 copy physically overwrote A's K-padding.
+
+2. **Lost layout annotations.** ``AscendLowerParallelToVector`` rebuilt Blocks
+   without their annotations, dropping the default zN ``layout_map`` injected
+   by ``AscendInferBufferScope``. Layout inference then fell back to an
+   identity layout and sized L1 buffers by the *logical* shape (128 * 200 =
+   25600 elements), re-introducing the overlap for any kernel with a
+   ``T.Parallel`` epilogue (the classic blocked-GEMM writer loop).
+
+3. **Un-zeroed fractal padding.** ``copy_gm_to_l1`` only zero-initialized the
+   L1 tile for partial tail copies, and even then with the logical element
+   count. Full-tile copies with K % 16 != 0 left the zN padding holes holding
+   stale L1 garbage. ``Mmad`` consumes whole C0 fractals (a tail mma with
+   k = 72 accumulates 80 K-slots), so the garbage was multiplied into C.
+
+The fixes: size zN/nZ buffers by the fractal-padded extent
+(``lower_tile_op.cc``), ceil-div the 2D re-flattening
+(``ascend_collect_buffer_shape.cc``), preserve Block annotations
+(``ascend_lower_parallel_to_vector.cc``), and zero-init the full fractal extent
+whenever padding holes exist (``copy_gm_to_l1`` in
+``src/tl_templates/ascend/common.h``).
+
+NOTE: executes on real NPU hardware (``.npu()``); ascendc target only. The PTO
+backend rejects non-fractal-divisible L1 tiles at compile time (pre-existing
+``static_assert`` in pto_tile.hpp), which is a separate limitation.
+"""
+
+import pytest
+import tilelang
+import tilelang.language as T
+import torch
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+TARGET = "ascendc"
+
+# (M, N, K) — the issue's reproduce shape plus further unaligned K-tails and
+# aligned sanity anchors. kL0Size defaults to 128, so K=200 gives kL0split=2
+# with kL0Tail=72 (72 % 16 = 8), K=136 gives kL0Tail=8, K=1000 gives
+# kL0split=8 with kL0Tail=104.
+SINGLE_TILE_CONFIGS = [
+    (64, 128, 128),  # single K-tile (aligned anchor)
+    (64, 128, 256),  # two aligned K-tiles (anchor)
+    (64, 128, 200),  # issue #1341 reproduce: kL0Tail=72
+    (64, 128, 136),  # kL0Tail=8
+    (64, 128, 264),  # kL0split=3, kL0Tail=8
+    (64, 128, 1000),  # kL0split=8, kL0Tail=104
+]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    tilelang.disable_cache()
+    yield
+
+
+def _compile(program):
+    return tilelang.compile(program, pass_configs=PASS_CONFIGS, target=TARGET)
+
+
+def _single_l1_tile_gemm(M, N, K, dtype="float16", kL0Size=128):
+    """The issue's kernel: one Expert-mode L1 tile feeding a single gemm_v0,
+    so K is split inside gemm_v0 by kL0Size."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), dtype),
+        B: T.Tensor((K, N), dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            A_L1 = T.alloc_L1((M, K), dtype)
+            B_L1 = T.alloc_L1((K, N), dtype)
+            C_L0 = T.alloc_L0C((M, N), "float")
+            with T.Scope("C"):
+                T.copy(A[0, 0], A_L1)
+                T.copy(B[0, 0], B_L1)
+                T.gemm_v0(A_L1, B_L1, C_L0, init=True, kL0Size=kL0Size)
+                T.copy(C_L0, C[0, 0])
+
+    return main
+
+
+def _blocked_gemm(M, N, K, block_M, block_N, K_L1, dtype="float16", kL0Size=128, transpose_A=False, transpose_B=False):
+    """Developer-style blocked GEMM. Besides the gemm_v0-internal K split this
+    exercises the K_L1 tail copy (K_L1 % 16 != 0) and, through its T.Parallel
+    epilogue, the Block-annotation preservation in AscendLowerParallelToVector
+    (defect 2: the default zN layout_map used to be dropped there, sizing L1
+    buffers by the logical shape and overlapping neighbouring tiles)."""
+    m_num = M // block_M
+    n_num = N // block_N
+
+    a_gm_shape = (K, M) if transpose_A else (M, K)
+    b_gm_shape = (N, K) if transpose_B else (K, N)
+    a_l1_shape = (K_L1, block_M) if transpose_A else (block_M, K_L1)
+    b_l1_shape = (block_N, K_L1) if transpose_B else (K_L1, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor(a_gm_shape, dtype),
+        B: T.Tensor(b_gm_shape, dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+
+            A_L1 = T.alloc_L1(a_l1_shape, dtype)
+            B_L1 = T.alloc_L1(b_l1_shape, dtype)
+            C_L0 = T.alloc_L0C((block_M, block_N), "float")
+
+            with T.Scope("C"):
+                loop_k = T.ceildiv(K, K_L1)
+                for k in T.serial(loop_k):
+                    if transpose_A:
+                        T.copy(A[k * K_L1, bx * block_M], A_L1)
+                    else:
+                        T.copy(A[bx * block_M, k * K_L1], A_L1)
+                    if transpose_B:
+                        T.copy(B[by * block_N, k * K_L1], B_L1)
+                    else:
+                        T.copy(B[k * K_L1, by * block_N], B_L1)
+
+                    T.barrier_all()
+                    T.gemm_v0(
+                        A_L1,
+                        B_L1,
+                        C_L0,
+                        transpose_A=transpose_A,
+                        transpose_B=transpose_B,
+                        init=(k == 0),
+                        kL0Size=kL0Size,
+                    )
+                    T.barrier_all()
+
+                for i, j in T.Parallel(block_M, block_N):
+                    C[bx * block_M + i, by * block_N + j] = C_L0[i, j]
+
+    return main
+
+
+def _run(kernel_fn, ref_fn, shapes):
+    torch.manual_seed(0)
+    kernel = _compile(kernel_fn())
+    tensors = [torch.randn(*s, dtype=torch.float16, device="npu") for s in shapes[:-1]]
+    tensors.append(torch.zeros(*shapes[-1], dtype=torch.float16, device="npu"))
+    torch.npu.synchronize()
+    kernel(*tensors)
+    torch.npu.synchronize()
+    ref = ref_fn(*[t.float() for t in tensors[:-1]])
+    torch.testing.assert_close(tensors[-1].float(), ref, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="gemm_v0 correctness requires an Ascend NPU runtime",
+)
+@pytest.mark.parametrize("M,N,K", SINGLE_TILE_CONFIGS)
+def test_gemm_v0_ktail_single_l1_tile(M, N, K):
+    """Issue #1341: unaligned kL0Tail with kL0split >= 2 on a single L1 tile."""
+    _run(
+        lambda: _single_l1_tile_gemm(M, N, K),
+        lambda a, b: a @ b,
+        [(M, K), (K, N), (M, N)],
+    )
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="gemm_v0 correctness requires an Ascend NPU runtime",
+)
+@pytest.mark.parametrize("K,K_L1", [(200, 200), (456, 200), (200, 128), (264, 128)])
+def test_gemm_v0_ktail_blocked(K, K_L1):
+    """Unaligned K with a T.Parallel epilogue (lost-annotation defect) and an
+    unaligned K_L1 tail copy (zero-init defect), plus multi-iteration K loops."""
+    M = N = 256
+    block_M = block_N = 128
+    _run(
+        lambda: _blocked_gemm(M, N, K, block_M, block_N, K_L1),
+        lambda a, b: a @ b,
+        [(M, K), (K, N), (M, N)],
+    )
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="gemm_v0 correctness requires an Ascend NPU runtime",
+)
+@pytest.mark.parametrize("transpose_A,transpose_B", [(True, False), (False, True), (True, True)])
+def test_gemm_v0_ktail_transpose(transpose_A, transpose_B):
+    """Unaligned K through the transpose-A / transpose-B (QK-style) paths."""
+    M, N, K = 128, 256, 200
+    block_M, block_N, K_L1 = 128, 128, 200
+    _run(
+        lambda: _blocked_gemm(
+            M,
+            N,
+            K,
+            block_M,
+            block_N,
+            K_L1,
+            transpose_A=transpose_A,
+            transpose_B=transpose_B,
+        ),
+        lambda a, b: (a.t() if transpose_A else a) @ (b.t() if transpose_B else b),
+        [
+            (K, M) if transpose_A else (M, K),
+            (N, K) if transpose_B else (K, N),
+            (M, N),
+        ],
+    )
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="gemm_v0 correctness requires an Ascend NPU runtime",
+)
+@pytest.mark.parametrize("K", [200, 264, 1000])
+def test_gemm_v0_ktail_kl0size_64(K):
+    """Same unaligned tails with a finer kL0Size=64 split (kL0split doubles)."""
+    M, N = 64, 128
+    _run(
+        lambda: _single_l1_tile_gemm(M, N, K, kL0Size=64),
+        lambda a, b: a @ b,
+        [(M, K), (K, N), (M, N)],
+    )
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="gemm_v0 correctness requires an Ascend NPU runtime",
+)
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_gemm_v0_ktail_dtypes(dtype):
+    """bf16 shares the fp16 fractal geometry (ELE_NUM_PER_C0 == 16)."""
+    M, N, K = 64, 128, 200
+    torch.manual_seed(0)
+    kernel = _compile(_single_l1_tile_gemm(M, N, K, dtype=dtype))
+    td = {"float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
+    a = torch.randn(M, K, dtype=td, device="npu")
+    b = torch.randn(K, N, dtype=td, device="npu")
+    c = torch.zeros(M, N, dtype=td, device="npu")
+    torch.npu.synchronize()
+    kernel(a, b, c)
+    torch.npu.synchronize()
+    ref = a.float() @ b.float()
+    torch.testing.assert_close(c.float(), ref, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="gemm_v0 correctness requires an Ascend NPU runtime",
+)
+@pytest.mark.parametrize(
+    "K,expected",
+    [
+        (512, "pass"),  # aligned tail (existing #1395 coverage shape)
+        (216, "pass"),  # kL0Tail=88: 88 % 32 = 24 > 16, fractal padding covers it
+        (152, "pass"),  # kL0Tail=24: 24 % 32 = 24 > 16
+        (200, "reject"),  # kL0Tail=72: 72 % 32 = 8 <= 16 -> L0B C0 gap, rejected
+        (264, "reject"),  # kL0Tail=8
+    ],
+)
+def test_gemm_v0_ktail_int8(K, expected):
+    """int8 (ELE_NUM_PER_C0 == 32): tails whose C0 rounding exceeds the 16-row
+    fractal padding (kL0Tail % 32 in [1, 16]) can not be served from the L1
+    layout and are rejected at compile time instead of silently miscomputing;
+    the other unaligned tails must stay exact."""
+    M = N = 256
+    block_M = block_N = 128
+    m_num = M // block_M
+    n_num = N // block_M
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), "int8"),
+        B: T.Tensor((K, N), "int8"),
+        C: T.Tensor((M, N), "int32"),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num
+            by = cid % n_num
+            A_L1 = T.alloc_L1((block_M, K), "int8")
+            B_L1 = T.alloc_L1((K, block_N), "int8")
+            C_L0 = T.alloc_L0C((block_M, block_N), "int32")
+            with T.Scope("C"):
+                T.copy(A[bx * block_M, 0], A_L1)
+                T.copy(B[0, by * block_N], B_L1)
+                T.barrier_all()
+                T.gemm_v0(A_L1, B_L1, C_L0, init=True)
+                T.barrier_all()
+                # T.copy (not T.Parallel) for the int32 L0C -> GM write: the
+                # Parallel path hits an unrelated codegen InternalError on
+                # int32 GM stores (see test_tilelang_ascend_language_gemm_v0).
+                T.copy(C_L0, C[bx * block_M, by * block_N])
+
+    if expected == "reject":
+        with pytest.raises(RuntimeError, match="Compilation Failed"):
+            _compile(main)
+        return
+    torch.manual_seed(0)
+    kernel = _compile(main)
+    a = torch.randint(-8, 8, (M, K), dtype=torch.int8, device="npu")
+    b = torch.randint(-8, 8, (K, N), dtype=torch.int8, device="npu")
+    c = torch.zeros(M, N, dtype=torch.int32, device="npu")
+    torch.npu.synchronize()
+    kernel(a, b, c)
+    torch.npu.synchronize()
+    # int32 matmul is not implemented on NPU; compare on CPU.
+    ref = (a.cpu().int() @ b.cpu().int()).to("npu")
+    torch.testing.assert_close(c, ref)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/testing/python/language/test_tilelang_ascend_language_gemm_v0_k_tail.py
+++ b/testing/python/language/test_tilelang_ascend_language_gemm_v0_k_tail.py
@@ -448,5 +448,60 @@ def test_gemm_v0_ktail_int8_kl0size_c0(kL0Size, expected):
     torch.testing.assert_close(c, ref)
 
 
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="gemm_v0 correctness requires an Ascend NPU runtime",
+)
+@pytest.mark.parametrize("K_L1", [200, 152])
+def test_gemm_v0_ktail_pipeline_parallel(K_L1):
+    """Pipelined K-loop with an unaligned K_L1 AND a T.Parallel epilogue (the
+    layout_map-loss path): InjectSoftwarePipeline versions the L1 buffers and
+    used to bake the version stride from the LOGICAL slice size (128*200 =
+    25600), while each version physically occupies the zN fractal extent
+    (26624) -- so version 0's fractal tail overlapped version 1's base and the
+    K-tail Mmad read stale data (59% wrong). RewriteAllocBuffer now pads the
+    per-version shape to the fractal extent, which fixes both the version
+    stride and the flattened Allocate size."""
+    M = N = 256
+    K = 2 * K_L1  # exactly two K_L1-wide iterations
+    block_M = block_N = 128
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), "float16"),
+        B: T.Tensor((K, N), "float16"),
+        C: T.Tensor((M, N), "float16"),
+    ):
+        with T.Kernel(4, is_npu=True) as (cid, _):
+            bx = cid // 2
+            by = cid % 2
+            A_L1 = T.alloc_shared((block_M, K_L1), "float16")
+            B_L1 = T.alloc_shared((K_L1, block_N), "float16")
+            C_L0 = T.alloc_L0C((block_M, block_N), "float")
+            with T.Scope("C"):
+                loop_k = T.ceildiv(K, K_L1)
+                for k in T.Pipelined(loop_k, num_stages=2):
+                    T.barrier_all()
+                    T.copy(A[bx * block_M, k * K_L1], A_L1)
+                    T.copy(B[k * K_L1, by * block_N], B_L1)
+                    T.gemm_v0(A_L1, B_L1, C_L0, init=(k == 0))
+                    T.barrier_all()
+                # T.Parallel epilogue: forces the AscendLowerParallelToVector
+                # layout_map-loss path (L1 buffers keep logical shapes).
+                for i, j in T.Parallel(block_M, block_N):
+                    C[bx * block_M + i, by * block_N + j] = C_L0[i, j]
+
+    torch.manual_seed(0)
+    kernel = _compile(main)
+    a = torch.randn(M, K, dtype=torch.float16, device="npu")
+    b = torch.randn(K, N, dtype=torch.float16, device="npu")
+    c = torch.zeros(M, N, dtype=torch.float16, device="npu")
+    torch.npu.synchronize()
+    kernel(a, b, c)
+    torch.npu.synchronize()
+    ref = a.float() @ b.float()
+    torch.testing.assert_close(c.float(), ref, rtol=2e-2, atol=2e-2)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #1341

## Root cause

`gemm_v0` 在 K 切成多个 L0 tile（`kL0split >= 2`）且尾 tile 非 16 对齐（`kL0Tail % 16 != 0`）时算错（M=64, N=128, K=200 → ~10.4% 输出错误）。四个缺陷叠加：

1. **L1 buffer 欠分配**（`lower_tile_op.cc`）：zN/nZ/zZ 布局的 buffer 按"最大合法偏移+1"（layout `OutputShape()`）定尺寸而非分形 padded extent。zN 分形把 K 补到 16 倍数且 padding 空洞**穿插在数据中间**（每 16 列 band 占 `roundUp16(K)×16`），所以 26496 ≠ 26624——buffer 越界。
2. **2D 展平截断**（`ascend_collect_buffer_shape.cc`）：`Flatten2DBuffer` outer 维用 `truncdiv`（13312 // 200 = 66 → 13200 元素）。与 1 叠加导致**相邻 L1 buffer 物理重叠 224B**——B 的 GM→L1 拷贝覆写 A 的 K-padding（错误因此稳定集中在 m=57..63，SVD + 最小二乘拟合证实，残差 6.9e-06）。
3. **Block annotations 丢失**（`ascend_lower_parallel_to_vector.cc`，上游存量 bug，本 PR 保持其行为不修）：重建 Block 时漏传 `annotations`，`AscendInferBufferScope` 注入的默认 zN `layout_map` 被丢 → `LayoutInference` 用非分形布局重写 → 带 `T.Parallel` epilogue 的 kernel 按**逻辑尺寸**（128×200=25600）分配 L1。
4. **分形空洞未清零**（`common.h` `copy_gm_to_l1`）：完整 tile 拷贝从不清零 padding 空洞（原逻辑只处理部分尾拷贝，且清零尺寸也不覆盖空洞）。而 **Mmad 按 C0 整块消费 K**（尾 tile k=72 实际累加 80 个槽位，`ceil(72/16)×16`）——空洞里的 L1 陈旧垃圾被直接乘进 C。

对齐的 K 为什么没事：`分形 extent == 逻辑尺寸 == 最大合法偏移+1` 三者重合 → 无空洞、无截断、无重叠、mma 无需取整。

## What this PR does

修复策略：**mma 按 C0 整块读 K 是硬件行为，改不掉 → 不阻止多读，而是让多读到的内容无害（0）且地址合法（不重叠）**。对齐 K 的存量调用 byte-level 等价（无空洞 → 不清零、extent == 逻辑尺寸）。

sizing 修正的**层次选择**是关键取舍：偏移计算（LayoutInference / tile-op lowering / vid-reduce 的 workspace 变换）依赖"layout_map 丢失后回退线性偏移"的现状，只有 Allocate 尺寸需要分形 extent——所以 identity 路径的 sizing 兜底放在 `Flatten2DBuffer`（此时 tile op 已降低、偏移已固化，只有内存规划消费这些 shape），而不是在布局推断层强制 zN。（早期版本曾在 `ascend_lower_parallel_to_vector.cc` 保留 annotations 来修缺陷 3，但破坏了 vid_reduce 的 workspace 线性偏移契约——`AscendWorkspaceReduction` 把 L1 目标偏移重用为 GM workspace 写偏移，zN 分形偏移导致双重变换 → 100% NaN——已在第二個 commit 回退。）

| 文件 | 改动 |
|---|---|
| `src/transform/lower_tile_op.cc` | 新增 `AscendFractalExtent()`：zN/nZ/zZ 布局按分形 padded extent 定 buffer 尺寸 |
| `src/transform/ascend_collect_buffer_shape.cc` | ① outer 维 `truncdiv` → ceildiv；② `Flatten2DBuffer` 对 shared.l1 buffer 把总元素数垫到 zN extent（`ceil(N/C0)×roundUp16(M)×C0`，从逻辑形状计算）——兜住缺陷 3 丢注解后 layout 退化的 blocked GEMM 路径；已带分形 extent 的 zN 重映射流是 no-op |
| `src/tl_templates/ascend/common.h` | ① `copy_gm_to_l1`：存在分形 padding 时按 extent 整体清零；② `gemm_v0`：int8 不可服务尾型加 `static_assert` 编译期拒绝 |
| `testing/python/language/test_tilelang_ascend_language_gemm_v0_k_tail.py` | 新增 23 个回归测试：单 L1 tile / blocked（含非对齐 K_L1）/ transpose / kL0Size=64 / fp16+bf16 / int8 pass+reject |

## Test results

Ascend910 / CANN 9.0.0，rebase 到 `upstream/ascendc_pto` 最新（`68ea1cf3`）后全量重跑。

| 验证 | 结果 |
|---|---|
| Issue 复现（M=64, N=128, K=200） | **0/8192 mismatch**（修复前 10.38%，maxdiff 12.23 → 0.0039 舍入噪声） |
| 新增 23 个 K-tail 回归测试 | 23/23 passed |
| 既有 gemm_v0 全家（precision / transpose / int8 / n_tiling / n_actual / l1_to_l0） | 214/214 passed |
| `sparse_flash_attn_developer_vid_reduce.py`（threads=2 + alloc_shared + workspace 变换路径） | PASSED |
| 全量 language 套件（1649，CI 同款 `-n 8 --forked`） | 1638 passed + 6 failed（exception_dump，本地 CANN 缺 `acldumpTensorInfo` API 的环境问题，#1462 特性，与本改动无关）+ 3 skipped（A5-only）+ 2 xfailed（fp16 reduce 溢出）——**与修复前基线逐项一致** |
| 受影响路径 examples（gemm / fusion / developer / pipeline / attention / int8 / quant / gemv / linear-attention） | 16/16 passed |
| 对抗性自查（int8 transpose 边界 + A/B 改动前后对照实验） | 无新回归 |

## Known limitations（超出本 PR 范围）

1. **int8 K-tail `kL0Tail % 32 ∈ [1,16]`**：int8 的 C0=32 元素，mma 尾部按 32 取整，但 L1 zN 布局只补 K 到 16 行——有 16 个 L0B 槽位既填不进数据也清不到零（布局覆盖不到），**无法从当前 L1 布局服务**。本 PR 用 `static_assert` 把静默算错变为编译期明确报错；真正修复需扩展 int8 zN 行补齐到 32（涉及 catlass 布局定义），建议 follow-up。
2. **int8 transpose_B + 非标准 `kL0Size`（如 48）**：L1→L0B 源偏移公式存量缺陷，A/B 实测改动前后同样失败，与本修复无关（默认 `kL0Size=128` 不受影响）。
3. **"Block annotations 丢失"上游 bug（缺陷 3）本身未修**：本 PR 通过 `Flatten2DBuffer` 的 sizing 兜底绕过其对 #1341 的影响；真正修复（在 `ascend_lower_parallel_to_vector.cc` 补传 annotations）需要先解除 `AscendWorkspaceReduction` 对线性偏移的依赖（把 workspace 写偏移与 L1 分形偏移解耦），建议 follow-up。
4. **PTO 后端**对非分形整除的 L1 tile 编译期拒绝（`pto_tile.hpp` 存量 static_assert）。

## Reproduce snippet（issue 原始复现）

```python
@T.prim_func
def main(A: T.Tensor((64, 200), "float16"),
         B: T.Tensor((200, 128), "float16"),
         C: T.Tensor((64, 128), "float16")):
    with T.Kernel(1, is_npu=True) as (cid, _):
        A_L1 = T.alloc_L1((64, 200), "float16")
        B_L1 = T.alloc_L1((200, 128), "float16")
        C_L0 = T.alloc_L0C((64, 128), "float")
        with T.Scope("C"):
            T.copy(A[0, 0], A_L1)
            T.copy(B[0, 0], B_L1)
            T.gemm_v0(A_L1, B_L1, C_L0, init=True)
            T.copy(C_L0, C[0, 0])
```
