### PR TITLE
[Fix] reduce_sum float16: widen to float32 accumulation on AscendC and PTO

### DIFF
--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -2157,30 +2157,73 @@ void CodeGenTileLangAscend::ReduceOpCodegen(const CallNode *op) {
     } catch (...) {
     }
 
-    if (dtype == "half" && clear) {
-      std::string mask, repeatTime, srcRepStride;
-      constexpr int64_t ELE_NUM_PER_C0_FOR_HALF = 16;
-      if (dim_val == -1) {
-        mask = std::to_string(n_val);
-        repeatTime = std::to_string(m_val);
-        srcRepStride = std::to_string((n_val + ELE_NUM_PER_C0_FOR_HALF - 1) /
-                                      ELE_NUM_PER_C0_FOR_HALF);
-      } else if (dim_val == 0) {
-        mask = std::to_string(m_val);
-        repeatTime = std::to_string(n_val);
-        srcRepStride = std::to_string((m_val + ELE_NUM_PER_C0_FOR_HALF - 1) /
-                                      ELE_NUM_PER_C0_FOR_HALF);
-      } else {
-        mask = std::to_string(m_val * n_val);
-        repeatTime = "1";
-        srcRepStride = "0";
+    if (dtype == "half") {
+      // CANN ReduceSum<half> is rejected by a static_assert, and the historic
+      // WholeReduceSum<half> workaround is wrong for column reductions (its
+      // srcRepStride unit is a 32-byte block and cannot express a 2-byte step,
+      // issue #1683) and loses precision on random data (f16 accumulator,
+      // issue #754). Widen to float32 instead: Cast -> ReduceSum<float> ->
+      // Cast. The widened source, the float32 partial destination and the
+      // CANN scratch live in three disjoint segments of the injected reduce
+      // workspace, and clear=false keeps the template's dst merge semantics.
+      ICHECK(var_names.size() >= 3)
+          << "half reduce_sum expects an injected workspace operand";
+      // The workspace name may carry an element offset ("tmp_ub[0]"); strip
+      // it to build a valid C++ identifier for the typed view.
+      const std::string &tmp_name = var_names[2];
+      std::string tmp_base;
+      for (char c : tmp_name) {
+        if (c == '[' || c == ']') {
+          tmp_base += '_';
+        } else if (isalnum(c) || c == '_') {
+          tmp_base += c;
+        }
       }
+      // A kernel may hold several half reduce_sum calls over one merged
+      // workspace; keep every widening view name unique (#1683 review).
+      std::string tmp_view =
+          tmp_base + "_f32_" + std::to_string(this->reduce_widen_counter_++);
+      const int64_t total = m_val * n_val;
+      const int64_t result_len = (dim_val == 0) ? n_val : m_val;
+      // Workspace layout (bytes): [source | result | CANN scratch]. The
+      // scratch must not overlap the source or the result, so it only
+      // starts after both aligned segments; its size is covered by the
+      // workspace heuristic in allocate_tmp_buffer.cc.
+      const int64_t src_f32_bytes = ((total * 4 + 31) / 32) * 32;
+      const int64_t result_f32_bytes = ((result_len * 4 + 31) / 32) * 32;
+      const int64_t dst_f32_off = src_f32_bytes / 4;
+      const int64_t scratch_off_bytes = src_f32_bytes + result_f32_bytes;
 
-      std::string new_op_name = "tl::ascend::reduce_sum_half<" + dtype + ">";
-      this->stream << new_op_name << "(";
-      this->stream << var_names[0] << ", " << var_names[1];
-      this->stream << ", " << mask << ", " << repeatTime << ", " << srcRepStride
-                   << ");\n";
+      this->stream << "AscendC::LocalTensor<float> " << tmp_view << " = "
+                   << tmp_name << ".ReinterpretCast<float>();\n";
+      this->PrintIndent();
+      this->stream << "AscendC::Cast(" << tmp_view << ", " << var_names[1]
+                   << ", AscendC::RoundMode::CAST_NONE, " << total << ");\n";
+      // clear=false merges the reduced value into the destination's current
+      // contents. The template's merge path backs up and restores its float32
+      // destination, so seed that destination with the widened old value
+      // first; otherwise the merge would restore workspace garbage.
+      if (!clear) {
+        this->PrintIndent();
+        this->stream << "AscendC::Cast(" << tmp_view << "[" << dst_f32_off
+                     << "], " << var_names[0]
+                     << ", AscendC::RoundMode::CAST_NONE, " << result_len
+                     << ");\n";
+      }
+      this->PrintIndent();
+      // The sharedTmpBuffer operand is byte-typed, so index it by the byte
+      // offset of the scratch segment instead of reusing the workspace
+      // start, which would alias the widened source.
+      this->stream << "tl::ascend::reduce_sum<float, " << m_str << ", " << n_str
+                   << ", " << dim_str << ">(" << tmp_view << "[" << dst_f32_off
+                   << "], " << tmp_view << ", " << tmp_name << "["
+                   << scratch_off_bytes << "], " << clear_str << ");\n";
+      this->PrintIndent();
+      this->stream << "AscendC::Cast(" << var_names[0] << ", " << tmp_view
+                   << "[" << dst_f32_off
+                   << "], "
+                      "AscendC::RoundMode::CAST_RINT, "
+                   << result_len << ");\n";
     } else {
       std::string new_op_name = "tl::ascend::reduce_sum<" + dtype + ", " +
                                 m_str + ", " + n_str + ", " + dim_str + ">";

--- a/src/target/codegen_ascend.h
+++ b/src/target/codegen_ascend.h
@@ -69,6 +69,10 @@ private:
   std::string PrintBufferOffset(const CallNode *call_arg,
                                 bool has_offset = true);
 
+  // Disambiguates the float32 widening views when one kernel holds several
+  // half reduce_sum calls sharing a merged workspace.
+  int reduce_widen_counter_{0};
+
   DataType GetAccessPtrDataType(const PrimExpr &arg);
 
   void AddDeclStream(std::ostringstream &ss, const std::string &str);

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -3693,6 +3693,94 @@ void CodeGenTileLangAscendPto::CodegenRowReduce(const ReduceOpInfo &op_info,
     CreateUbVariableND(temp_name, tmp_cast);
   }
 
+  // A float16 sum reduces natively in f16 precision (TROWSUM on half tiles),
+  // which shows a visible accumulation error on random data (issue #754).
+  // Widen to float32 instead -- TCVT -> TROWSUM<float> -> TCVT -- so the
+  // reduction accumulates in float32 and rounds once at the end. The widened
+  // source, the TROWSUM scratch and the float32 partial destination are
+  // views over the injected workspace; its sizing rule covers the float32
+  // layout for half inputs (EstimatePTOReduceWorkspaceBytes).
+  if (op_info.kind == ReduceKind::SUM && src.type == "half") {
+    const int32_t rows = src.slice_valid_row;
+    const int32_t cols = src.slice_valid_col;
+
+    // PTO tiles require the contiguous dimension to be 32-byte aligned:
+    // a row-major (ND) tile aligns its column count, a column-major (DN)
+    // tile its row count. The widened source therefore keeps the logical
+    // column count only in its valid shape and pads the physical one.
+    const int32_t src_phys_cols = GetValidShape(cols, "float");
+    const int32_t src_f32_elems = rows * src_phys_cols;
+    // TROWSUM scratch: same sizing rule as the native path, in float32
+    // (already 32-byte aligned by GetRowReduceTmpCol).
+    const int32_t tmp_f32_cols = GetRowReduceTmpCol(cols, "float");
+    const int32_t tmp_f32_elems = rows * tmp_f32_cols;
+    // The DN destination carries the row count in the DN template's Cols
+    // slot, so the physical row count must itself stay 32-byte aligned.
+    const int32_t dst_phys_rows = GetValidShape(rows, "float");
+    // Workspace layout (float32 elements): [source | scratch | destination].
+    const int32_t dst_f32_off = src_f32_elems + tmp_f32_elems;
+
+    // Reinterpret the byte-typed workspace as float32; ReinterpretShapeInfo
+    // converts both the extent and the offset to float32 element units.
+    ShapeInfo ws = ReinterpretShapeInfo(tmp, "float");
+    std::string f32_src_name = GetTempVarName(tmp.ub_name + "_f32_src");
+    std::string f32_scratch_name = GetTempVarName(tmp.ub_name + "_f32_scratch");
+    std::string f32_dst_name = GetTempVarName(tmp.ub_name + "_f32_dst");
+
+    auto emit_subtile = [&](const std::string &name, int32_t off, int32_t nrows,
+                            int32_t phys_cols, int32_t valid_cols,
+                            bool is_dst = false) {
+      ShapeInfo view = ws;
+      view.ub_name = name;
+      view.row = nrows;
+      view.col = phys_cols;
+      view.slice_row = nrows;
+      view.slice_col = phys_cols;
+      view.slice_valid_row = nrows;
+      view.slice_valid_col = valid_cols;
+      view.is_slice = false;
+      if (off != 0) {
+        view.offset = "(" + ws.offset + " + " + std::to_string(off) + ")";
+      }
+      if (is_dst) {
+        // TROWSUM writes a DN (column-major) destination: ShapeInfo keeps
+        // row=1 x col=phys_rows so the emitted DN template carries the row
+        // count in its Cols slot, matching the native float32 row-reduce
+        // layout. The valid row count stays logical.
+        CreateUbVariableDN(name, view);
+      } else {
+        CreateUbVariableND(name, view);
+      }
+    };
+
+    emit_subtile(f32_src_name, 0, rows, src_phys_cols, cols);
+    emit_subtile(f32_scratch_name, src_f32_elems, rows, tmp_f32_cols,
+                 tmp_f32_cols);
+    emit_subtile(f32_dst_name, dst_f32_off, 1, dst_phys_rows, rows, true);
+
+    this->PrintIndent();
+    this->stream << "TCVT(" << f32_src_name << ", " << src_name
+                 << ", RoundMode::CAST_NONE);\n";
+    this->PrintIndent();
+    this->stream << "TROWSUM(" << f32_dst_name << ", " << f32_src_name << ", "
+                 << f32_scratch_name << ");\n";
+    // The final narrow cast reads the DN float32 destination; writing into
+    // a row-major (ND) half tile keeps both TCVT operands on supported
+    // same-layout combinations (a DN-to-DN TCVT is not a verified path).
+    // A sliced or synthetic destination (clear=False tmp output) has no
+    // predeclared tile of its own, so declare an offset-carrying ND view
+    // and narrow into that instead of the backing-buffer start.
+    std::string narrow_dst_name = dst.ub_name;
+    if (dst.is_slice) {
+      narrow_dst_name = GetTempVarName(dst.ub_name + "_narrow");
+      CreateUbVariableND(narrow_dst_name, dst);
+    }
+    this->PrintIndent();
+    this->stream << "TCVT(" << narrow_dst_name << ", " << f32_dst_name
+                 << ", RoundMode::CAST_RINT);\n";
+    return;
+  }
+
   this->PrintIndent();
   this->stream << op_name << "(" << dst_name << ", " << src_name << ", "
                << temp_name << ");\n";
@@ -3700,7 +3788,9 @@ void CodeGenTileLangAscendPto::CodegenRowReduce(const ReduceOpInfo &op_info,
 
 void CodeGenTileLangAscendPto::CodegenColReduce(const ReduceOpInfo &op_info,
                                                 const ShapeInfo &dst,
-                                                const ShapeInfo &src) {
+                                                const ShapeInfo &src,
+                                                const ShapeInfo &tmp,
+                                                bool has_tmp) {
   std::string op_name = GetReduceOpName(op_info.kind, ReduceDirection::COL);
 
   std::string dst_name = dst.ub_name;
@@ -3714,6 +3804,68 @@ void CodeGenTileLangAscendPto::CodegenColReduce(const ReduceOpInfo &op_info,
   if (src.is_slice) {
     src_name = GetTempVarName(src.ub_name);
     CreateUbVariableND(src_name, src);
+  }
+
+  // A float16 column sum reduces natively in f16 precision (TCOLSUM on half
+  // tiles), which shows a visible accumulation error on random data (issue
+  // #754). Widen to float32 instead -- TCVT -> TCOLSUM<float> -> TCVT --
+  // with the widened source and the float32 partial destination as views
+  // over an injected workspace.
+  if (op_info.kind == ReduceKind::SUM && src.type == "half") {
+    ICHECK(has_tmp) << "PTO float16 column reduce_sum expects an injected "
+                       "workspace for the float32 widening";
+    const int32_t rows = src.slice_valid_row;
+    const int32_t cols = src.slice_valid_col;
+
+    // PTO tiles require the contiguous dimension to be 32-byte aligned, so
+    // the widened source pads its physical column count and keeps the
+    // logical count in the valid shape only.
+    const int32_t src_phys_cols = GetValidShape(cols, "float");
+    const int32_t src_f32_elems = rows * src_phys_cols;
+    // TCOLSUM writes a row-major destination whose column count must stay
+    // 32-byte aligned in float32.
+    const int32_t dst_f32_cols = GetValidShape(cols, "float");
+
+    ShapeInfo ws = ReinterpretShapeInfo(tmp, "float");
+    std::string f32_src_name = GetTempVarName(tmp.ub_name + "_f32_src");
+    std::string f32_dst_name = GetTempVarName(tmp.ub_name + "_f32_dst");
+
+    auto emit_col_subtile = [&](const std::string &name, int32_t off,
+                                int32_t nrows, int32_t phys_cols,
+                                int32_t valid_cols) {
+      ShapeInfo view = ws;
+      view.ub_name = name;
+      view.row = nrows;
+      view.col = phys_cols;
+      view.slice_row = nrows;
+      view.slice_col = phys_cols;
+      view.slice_valid_row = nrows;
+      view.slice_valid_col = valid_cols;
+      view.is_slice = false;
+      if (off != 0) {
+        view.offset = "(" + ws.offset + " + " + std::to_string(off) + ")";
+      }
+      CreateUbVariableND(name, view);
+    };
+
+    emit_col_subtile(f32_src_name, 0, rows, src_phys_cols, cols);
+    emit_col_subtile(f32_dst_name, src_f32_elems, 1, dst_f32_cols, cols);
+
+    this->PrintIndent();
+    this->stream << "TCVT(" << f32_src_name << ", " << src_name
+                 << ", RoundMode::CAST_NONE);\n";
+    this->PrintIndent();
+    this->stream << "TCOLSUM(" << f32_dst_name << ", " << f32_src_name
+                 << ");\n";
+    // The narrow cast reads the row-major float32 destination into the ND
+    // half tile; a DN-to-DN TCVT is not a verified path. A sliced or
+    // synthetic destination (clear=False tmp output) has no predeclared
+    // tile, but the slice view declared above (dst_name) carries its
+    // offset, so narrow into that.
+    this->PrintIndent();
+    this->stream << "TCVT(" << dst_name << ", " << f32_dst_name
+                 << ", RoundMode::CAST_RINT);\n";
+    return;
   }
 
   this->PrintIndent();
@@ -3781,6 +3933,12 @@ void CodeGenTileLangAscendPto::ReduceOpCodegen(const CallNode *op) {
     std::string reduce_dst_name = GetTempVarName(reduce_dst.ub_name);
     CreateUbVariableND(reduce_dst_name, reduce_dst);
 
+    // The merge reads what the reduce just wrote into the tmp output view.
+    // A same-pipe V dependency is not ordered on its own (the native paths
+    // only worked by accident through barriers buried inside TROWSUM), so
+    // fence the pipe before the merge instruction reads the view.
+    this->PrintIndent();
+    this->stream << "pipe_barrier(PIPE_V);\n";
     this->PrintIndent();
     this->stream << GetReduceMergeOpName(op_info.kind) << "(" << dst_name
                  << ", " << dst_name << ", " << reduce_dst_name << ");\n";
@@ -3803,7 +3961,12 @@ void CodeGenTileLangAscendPto::ReduceOpCodegen(const CallNode *op) {
 
   if (!clear) {
     const bool is_row = op_info.direction == ReduceDirection::ROW;
-    const int output_tmp_index = is_row ? 4 : 3;
+    // tmp operand layout: [main tmp?] [output tmp]. A row reduce always
+    // carries a main tmp (TROWSUM scratch), and a float16 column sum has
+    // one injected for the float32 widening as well, so the output view
+    // only sits at args[3] when no main view precedes it.
+    const size_t tmp_count = clear_idx - 3;
+    const size_t output_tmp_index = tmp_count >= 2 ? 4 : 3;
     ICHECK_GT(clear_idx, output_tmp_index)
         << "PTO reduce(clear=False) expects an injected temporary output "
            "buffer.";
@@ -3815,8 +3978,13 @@ void CodeGenTileLangAscendPto::ReduceOpCodegen(const CallNode *op) {
           << "PTO row reduce expects a main tmp buffer.";
       ShapeInfo tmp = GetSliceInfo(op->args[3].as<CallNode>());
       CodegenRowReduce(op_info, tmp_dst, src, tmp);
+    } else if (tmp_count >= 2) {
+      // A float16 column sum: args[3] is the widening main workspace and
+      // args[4] the clear=False output view.
+      ShapeInfo main_tmp = GetSliceInfo(op->args[3].as<CallNode>());
+      CodegenColReduce(op_info, tmp_dst, src, main_tmp, true);
     } else {
-      CodegenColReduce(op_info, tmp_dst, src);
+      CodegenColReduce(op_info, tmp_dst, src, src, false);
     }
     emit_merge(tmp_dst);
     return;
@@ -3833,7 +4001,16 @@ void CodeGenTileLangAscendPto::ReduceOpCodegen(const CallNode *op) {
     if (is_slice) {
       dst.slice_valid_col = op_info.buffer_slice_col;
     }
-    CodegenColReduce(op_info, dst, src);
+    // A float16 column sum has an injected workspace (float32 widening);
+    // every other column reduce is workspace-free.
+    const bool col_has_tmp =
+        (clear_idx > 3) && op->args[3].as<CallNode>() &&
+        op->args[3].as<CallNode>()->op.same_as(builtin::tvm_access_ptr());
+    ShapeInfo col_tmp = src;
+    if (col_has_tmp) {
+      col_tmp = GetSliceInfo(op->args[3].as<CallNode>());
+    }
+    CodegenColReduce(op_info, dst, src, col_tmp, col_has_tmp);
   }
 }
 

--- a/src/target/codegen_ascend_pto.h
+++ b/src/target/codegen_ascend_pto.h
@@ -318,7 +318,8 @@ private:
   void CodegenRowReduce(const ReduceOpInfo &op_info, const ShapeInfo &dst,
                         const ShapeInfo &src, const ShapeInfo &tmp);
   void CodegenColReduce(const ReduceOpInfo &op_info, const ShapeInfo &dst,
-                        const ShapeInfo &src);
+                        const ShapeInfo &src, const ShapeInfo &tmp,
+                        bool has_tmp);
 
   void CodegenRowBroadcast(const ShapeInfo &dst, const ShapeInfo &src);
   void CodegenColBroadcast(const ShapeInfo &dst, const ShapeInfo &src);

--- a/src/transform/allocate_tmp_buffer.cc
+++ b/src/transform/allocate_tmp_buffer.cc
@@ -347,6 +347,16 @@ int64_t EstimatePTOReduceWorkspaceBytes(const CallNode *call,
                                         const Array<Buffer> &alloc_buffers) {
   const ReduceTemplateInfo info = ParseReduceTemplateInfo(call);
   if (info.direction == 0) {
+    // A float16 column sum widens to float32 (TCVT -> TCOLSUM<float> ->
+    // TCVT, issue #754); every other column reduce needs no workspace. The
+    // widened source pads its physical column count to the 32-byte block.
+    if (info.kind == ReduceKind::kSum && info.dtype == "half") {
+      const int64_t f32_bytes = 4;
+      const int64_t src_phys_cols = AlignReduceOutputCols(info.cols, f32_bytes);
+      const int64_t src_elems = info.rows * src_phys_cols;
+      const int64_t dst_col = AlignReduceOutputCols(info.cols, f32_bytes);
+      return (src_elems + dst_col) * f32_bytes;
+    }
     return 0;
   }
 
@@ -358,17 +368,36 @@ int64_t EstimatePTOReduceWorkspaceBytes(const CallNode *call,
 
   const int64_t dtype_bytes = src_buffer->dtype.bytes();
   const int64_t tmp_col = GetPtoRowReduceTmpCols(info.cols, dtype_bytes);
-  return info.rows * tmp_col * dtype_bytes;
+  int64_t bytes = info.rows * tmp_col * dtype_bytes;
+
+  // float16 sum widens to float32 (TCVT -> TROWSUM<float> -> TCVT, issue
+  // #754): the workspace must hold the widened source tile (physical column
+  // count aligned up to the 32-byte block), the TROWSUM scratch in float32,
+  // and the float32 partial destination (whose DN row count also stays
+  // 32-byte aligned).
+  if (info.kind == ReduceKind::kSum && info.dtype == "half") {
+    const int64_t f32_bytes = 4;
+    const int64_t src_phys_cols = AlignReduceOutputCols(info.cols, f32_bytes);
+    const int64_t src_elems = info.rows * src_phys_cols;
+    const int64_t f32_tmp_col = GetPtoRowReduceTmpCols(info.cols, f32_bytes);
+    const int64_t dst_phys_rows = AlignReduceOutputCols(info.rows, f32_bytes);
+    const int64_t widen_bytes =
+        (src_elems + info.rows * f32_tmp_col + dst_phys_rows) * f32_bytes;
+    bytes = std::max<int64_t>(bytes, widen_bytes);
+  }
+  return bytes;
 }
 
 bool AscendCReduceUsesTmp(const CallNode *call) {
   const ReduceCallLayout layout = ParseReduceCallLayout(call);
-  const ReduceTemplateInfo info = ParseReduceTemplateInfo(call);
   if (layout.physical_row > 0) {
     return false;
   }
-  return !(info.kind == ReduceKind::kSum && info.dtype == "half" &&
-           layout.clear);
+  // float16 sum also needs a workspace: the lowering widens the source to
+  // float32 (Cast -> ReduceSum<float> -> Cast) because the historic
+  // WholeReduceSum<half> workaround has an f16 accumulator (issues #754) and
+  // cannot express the 2-byte step of a column reduce (issue #1683).
+  return true;
 }
 
 int64_t
@@ -417,6 +446,41 @@ EstimateAscendCReduceWorkspaceBytes(const CallNode *call,
           info.rows * (info.cols < elements_per_repeat ? kDataBlockBytes
                                                        : kVectorRepeatBytes);
     }
+  }
+
+  // float16 sum lowers through a float32 widen: the workspace must hold the
+  // widened source tile, the float32 partial destination and the CANN
+  // scratch, as three disjoint segments. The scratch need mirrors the
+  // native float32 heuristic above (dtype_bytes == 4), recomputed on the
+  // widened shape so it never aliases the source or the result.
+  if (info.kind == ReduceKind::kSum && info.dtype == "half") {
+    const int64_t f32_bytes = 4;
+    const int64_t widen_src_bytes =
+        AlignUp(info.rows * info.cols * f32_bytes, 32);
+    const int64_t result_len = info.direction == 0 ? info.cols : info.rows;
+    const int64_t result_bytes = AlignUp(result_len * f32_bytes, 32);
+
+    int64_t scratch_bytes = 0;
+    if (info.direction == 0) {
+      const int64_t padded_row_bytes = AlignUp(info.cols * f32_bytes, 32);
+      const int64_t power = FloorPowerOfTwo(info.rows);
+      const int64_t active_rows =
+          info.rows == 1 ? 1 : (info.rows == power ? power / 2 : power);
+      scratch_bytes = active_rows * padded_row_bytes;
+    } else {
+      constexpr int64_t kVectorRepeatBytes = 256;
+      const int64_t elements_per_repeat = kVectorRepeatBytes / f32_bytes;
+      if (info.cols > elements_per_repeat) {
+        const int64_t power = FloorPowerOfTwo(info.cols);
+        const int64_t per_row_elements =
+            info.rows == 1 || info.cols != power ? power : power / 2;
+        scratch_bytes = info.rows * per_row_elements * f32_bytes;
+      }
+    }
+
+    const int64_t widen_total =
+        widen_src_bytes + result_bytes + AlignUp(scratch_bytes, 32);
+    bytes = std::max<int64_t>(bytes, widen_total);
   }
 
   // The current wrapper still has a sharedTmpBuffer parameter even when the
@@ -516,7 +580,10 @@ WorkspaceSpec GetPTOWorkspaceSpec(const CallNode *call,
   if (call->op.same_as(tl::ascend_reduce())) {
     const ReduceTemplateInfo info = ParseReduceTemplateInfo(call);
     const ReduceCallLayout layout = ParseReduceCallLayout(call);
-    if (info.direction != -1 && layout.clear) {
+    // A float16 sum widens to float32 on both directions (issue #754), so a
+    // column reduce with clear=true needs a workspace as well.
+    if (info.direction != -1 && layout.clear &&
+        !(info.kind == ReduceKind::kSum && info.dtype == "half")) {
       return NoWorkspace();
     }
     return RequireWorkspace(

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -4881,8 +4881,6 @@ def run_test_reduce_sum(M, N, block_M, block_N, dim, dtype, target):
 @pytest.mark.parametrize("dtype", ["float", "float16"])
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
 def test_reduce_sum(dim, dtype, target):
-    if dtype == "float16":
-        pytest.xfail(reason="float16 reduction sum may overflow")
     M, N = 1024, 64
     run_test_reduce_sum(M, N, 64, 64, dim, dtype, target)
 
@@ -5109,6 +5107,142 @@ def run_test_reduce_runtime_semantics(
 @pytest.mark.parametrize("target", ["ascendc", "pto"])
 def test_reduce_dim0_runtime_smoke(op, target):
     run_test_reduce_runtime_semantics(op, dim=0, target=target, clear=True)
+
+
+# float16 reduce_sum regression tests. AscendC lowers float16 sum through a
+# float32 widening (Cast -> ReduceSum<float> -> Cast) because the historic
+# WholeReduceSum<half> workaround is wrong for column reductions (issue #1683:
+# its srcRepStride unit is a 32-byte block and cannot express the 2-byte step)
+# and accumulates in f16 precision (issue #754).
+@pytest.mark.parametrize("dim", [0, -1])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_reduce_sum_float16_runtime(dim, target):
+    M, N = 64, 64
+    func = tilelang.compile(
+        reduce_runtime_semantics_kernel(M, N, "sum", dim, dtype="float16"),
+        out_idx=[-1],
+        pass_configs=pass_configs,
+        target=target,
+    )
+
+    # Fixed seed: PTO reduces natively in half precision, and an unseeded
+    # run can draw a near-zero row sum where the relative tolerance is
+    # dominated by the f16 accumulation error.
+    torch.manual_seed(0)
+    a = torch.randn(M, N, dtype=torch.float16).npu()
+    b = func(a)
+    torch.npu.synchronize()
+
+    ref_b = torch.sum(a, dim=1 if dim == -1 else 0)
+    # Both backends reduce through a float32 accumulator, so the result is
+    # bit-accurate up to the final round to half.
+    torch.testing.assert_close(b, ref_b, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("dim", [0, -1])
+def test_reduce_sum_float16_unaligned_cols_pto(dim):
+    # The widened float32 views over the injected workspace must keep their
+    # physical (32-byte aligned) column count separate from the valid one;
+    # N=5 would otherwise emit a 20-byte row and fail the PTO tile
+    # static_assert. AscendC is not covered here: its native float32 reduce
+    # has the same unaligned-column limitation, so the widened half path
+    # merely matches the platform behavior.
+    M, N = 64, 5
+    func = tilelang.compile(
+        reduce_runtime_semantics_kernel(M, N, "sum", dim, dtype="float16"),
+        out_idx=[-1],
+        pass_configs=pass_configs,
+        target="pto",
+    )
+
+    torch.manual_seed(0)
+    a = torch.randn(M, N, dtype=torch.float16).npu()
+    b = func(a)
+    torch.npu.synchronize()
+
+    ref_b = torch.sum(a, dim=1 if dim == -1 else 0)
+    torch.testing.assert_close(b, ref_b, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_reduce_sum_float16_slice_dst(target):
+    # The final narrow cast must write the offset-carrying destination view,
+    # not the backing-buffer start (PR #1724 review).
+    @T.prim_func
+    def main(A: T.Tensor((64, 64), "float16"), B: T.Tensor((128,), "float16")):  # type: ignore
+        with T.Kernel(1, is_npu=True) as (_, vid):
+            a_ub = T.alloc_ub((64, 64), "float16")
+            b_ub = T.alloc_ub((128,), "float16")
+            if vid == 0:
+                T.copy(A, a_ub)
+                T.reduce_sum(a_ub, b_ub[32:96], dim=-1)
+                T.copy(b_ub, B)
+
+    func = tilelang.compile(main, out_idx=[-1], pass_configs=pass_configs, target=target)
+    torch.manual_seed(0)
+    a = torch.randn(64, 64, dtype=torch.float16).npu()
+    b = func(a)
+    torch.npu.synchronize()
+
+    ref_b = torch.sum(a, dim=1)
+    torch.testing.assert_close(b[32:96], ref_b, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_reduce_sum_float16_two_reduces_shared_workspace(target):
+    # Memory planning merges the workspaces of the two reduces, so every
+    # widening view must stay uniquely named (PR #1724 review).
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 64), "float16"),  # type: ignore
+        B: T.Tensor((64,), "float16"),  # type: ignore
+        C: T.Tensor((64,), "float16"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (_, vid):
+            a_ub = T.alloc_ub((64, 64), "float16")
+            b_ub = T.alloc_ub((64,), "float16")
+            c_ub = T.alloc_ub((64,), "float16")
+            if vid == 0:
+                T.copy(A, a_ub)
+                T.reduce_sum(a_ub, b_ub, dim=-1)
+                T.reduce_sum(a_ub, c_ub, dim=-1)
+                T.copy(b_ub, B)
+                T.copy(c_ub, C)
+
+    func = tilelang.compile(main, out_idx=[1, 2], pass_configs=pass_configs, target=target)
+    torch.manual_seed(0)
+    a = torch.randn(64, 64, dtype=torch.float16).npu()
+    b, c = func(a)
+    torch.npu.synchronize()
+
+    ref_b = torch.sum(a, dim=1)
+    torch.testing.assert_close(b, ref_b, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(c, ref_b, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("dim", [0, -1])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_reduce_sum_float16_clear_false(dim, target):
+    # clear=False merges into the destination's current contents; the
+    # widening must seed the float32 partial with the old value (AscendC)
+    # and the merge must fence the pipe before reading the tmp output view
+    # (PTO, PR #1724 review).
+    M, N = 64, 64
+    func = tilelang.compile(
+        reduce_runtime_semantics_kernel(M, N, "sum", dim, dtype="float16", clear=False, init_value=1.25),
+        out_idx=[-1],
+        pass_configs=pass_configs,
+        target=target,
+    )
+
+    torch.manual_seed(0)
+    a = torch.randn(M, N, dtype=torch.float16).npu()
+    b = func(a)
+    torch.npu.synchronize()
+
+    ref_b = torch.sum(a.float(), dim=1 if dim == -1 else 0) + 1.25
+    # The merge adds in half precision, so allow the final round to half.
+    torch.testing.assert_close(b.float(), ref_b, rtol=1e-2, atol=1e-2)
 
 
 @pytest.mark.parametrize(

--- a/testing/python/language/test_tilelang_ascend_language_explicit_tmp.py
+++ b/testing/python/language/test_tilelang_ascend_language_explicit_tmp.py
@@ -956,18 +956,23 @@ def test_reduce_zero_workspace_paths_elide_explicit_and_implicit_tmp():
     assert len(call.args) == 4
     assert bool(call.args[3])
 
-    for case_id, kwargs in [
-        ("narrow-row", {"real_shape": [4, 4]}),
-        ("half-sum", {"dtype": "float16"}),
-    ]:
-        for arena_bytes in [0, None]:
-            reduced = _inject(_reduce_program(arena_bytes, **kwargs), "ascendc")
-            reduce_call = _collect_calls(reduced, "tl.ascend_reduce")[0]
-            assert not any(isinstance(arg, tir.Call) and arg.op.name == "tir.tvm_access_ptr" for arg in reduce_call.args[3:]), (
-                case_id,
-                arena_bytes,
-            )
-            assert "tmp_ub" not in _allocated_buffer_names(reduced), (case_id, arena_bytes)
+    # narrow-row reduce keeps the WholeReduce* zero-workspace path.
+    for arena_bytes in [0, None]:
+        reduced = _inject(_reduce_program(arena_bytes, real_shape=[4, 4]), "ascendc")
+        reduce_call = _collect_calls(reduced, "tl.ascend_reduce")[0]
+        assert not any(isinstance(arg, tir.Call) and arg.op.name == "tir.tvm_access_ptr" for arg in reduce_call.args[3:]), (arena_bytes,)
+        assert "tmp_ub" not in _allocated_buffer_names(reduced), (arena_bytes,)
+
+
+def test_ascendc_half_sum_reduce_needs_widen_workspace():
+    # float16 sum lowers through a float32 widening (Cast -> ReduceSum<float>
+    # -> Cast), so it now requires a workspace sized for the widened source
+    # plus the float32 partial destination (issues #1683 / #754).
+    func = _inject(_reduce_program(None, dtype="float16"), "ascendc")
+    call = _collect_calls(func, "tl.ascend_reduce")[0]
+    assert call.args[3].args[1].name == "tmp_ub"
+    # (8, 64) tile: 8*64 float32 source (2048 B, aligned) + 8 float32 partials.
+    assert int(call.args[3].args[3]) == 2048 + 32
 
 
 @pytest.mark.parametrize(

--- a/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
+++ b/testing/python/language/test_tilelang_ascend_language_tail_mask_codegen.py
@@ -595,9 +595,11 @@ def _native_reduce_marker(kind, *, target="ascendc", dtype="float", clear=True, 
             ("min", "col"): "TCOLMIN(",
         }[(kind, direction)]
 
-    # AscendC uses a dedicated helper for clear=true float16 sum reductions.
+    # AscendC widens clear=true float16 sum reductions to float32
+    # (Cast -> ReduceSum<float> -> Cast), since CANN ReduceSum<half> is
+    # rejected by a static_assert.
     if kind == "sum" and dtype == "float16" and clear:
-        return "tl::ascend::reduce_sum_half<"
+        return "tl::ascend::reduce_sum<float"
 
     return f"tl::ascend::reduce_{kind}<"
 

--- a/tilelang/language/reduce_ascend.py
+++ b/tilelang/language/reduce_ascend.py
@@ -471,6 +471,11 @@ def reduce_sum(
             Zero extent is allowed for backend paths that need no workspace.
             Compiler heuristics size implicit allocations and internal views;
             nonzero explicit capacity remains the caller's responsibility.
+
+    Note:
+        On the AscendC backend, float16 ``reduce_sum`` lowers through a
+        float32 widening (Cast -> ReduceSum<float> -> Cast), so the reduction
+        accumulates in float32 precision and rounds once at the end.
     """
     parsed_clear, parsed_real_shape = _parse_reduce_optional_args("reduce_sum", args, clear=clear, real_shape=real_shape)
     legalized_dim = _legalize_reduce_dim(_get_buffer_extent(buffer), dim)


### PR DESCRIPTION
## 问题描述

`T.reduce_sum` 在 float16 输入下静默产生错误或不精确的结果，两个后端均受影响，根因都藏在 f16 原生归约路径上：

- **AscendC dim=0（#1683）**：`WholeReduceSum<half>` workaround 以 32 字节块为单位计算 `srcRepStride`，无法表达列归约所需的 2 字节步进，导致每次 repeat 跳过 16 个元素中的 15 个，累加的是同一行的连续片段而非跨行同列元素。
- **AscendC dim=-1（#754）**：同一 workaround 内部以 f16 累加（VCADD），随机输入下最大相对误差约 7%；常量输入恰好通过——这解释了为何随机数据能测出问题而 `ones()` 测不出。
- **PTO 双维度**：half tile 上的 `TROWSUM/TCOLSUM` 同样以 f16 累加，产生相同的精度损失与 CI 偶发红灯，此前被一个一揽子 `pytest.xfail` 掩盖。

## 修复方案

两个后端统一走 float32 加宽——`Cast/TCVT -> 原生 float32 归约（ReduceSum<float> / TROWSUM/TCOLSUM float tile）-> Cast/TCVT`——归约在 float32 中累加，最后一次性舍入：

- `codegen_ascend.cc`：`ReduceOpCodegen` 的 half+clear 分支改为在注入的 workspace 上生成加宽序列，替代 `reduce_sum_half` 的 mask/repeat/stride 三段计算。
- `codegen_ascend_pto.cc`：`CodegenRowReduce` 与 `CodegenColReduce` 在 workspace 的 float 视图上生成 `TCVT -> TROWSUM/TCOLSUM<float> -> TCVT`（`ReinterpretShapeInfo` 处理字节到 float 的 offset 换算）。最终窄化写回原始 ND half tile：DN 到 DN 的 TCVT 不是已验证组合，会产生错乱数据。
- `allocate_tmp_buffer.cc`：`AscendCReduceUsesTmp` 不再豁免 half+sum；AscendC/PTO 两侧的尺寸估算均覆盖加宽后的源、scratch 与 float32 部分目的布局。

## 关键实施坑（记录备查）

1. DN 到 DN 的 TCVT 不是已验证组合（与 #1649 的 half 到 half TCVT 同类陷阱）——最终窄化必须写回 ND half tile。
2. PTO DN tile 的 32 字节对齐检查作用于 Cols 槽：f32 目的必须沿用原生 float32 行归约的 DN 形态（`row=1, col=rows`）。
3. TROWSUM 的 scratch 必须与源同 validRow（`rows x tmp_cols` 的 ND tile，而非 1xN 扁平视图）。

## 测试结果

- 删除 float16 的 `pytest.xfail`，恢复完整 dtype x target 矩阵（含 pto+float16）。
- 新增 `test_reduce_sum_float16_runtime`（ascendc/pto x dim=0/-1，固定种子）：两个后端均在最终舍入到 half 前位精确。
- 新增 `test_reduce_sum_float16_col_arith_progression_ascendc`：#1683 的确定性复现用例，bitwise 断言。
- 更新 tail-mask codegen 标记（`reduce_sum_half<` -> `reduce_sum<float`）与 explicit-tmp 零 workspace 预期。
- 910B3（dav-c220，CANN 8.5.2）实测：`test_reduce_sum` 矩阵 3 轮稳定通过；elementwise reduce 套件 52/52；全量 elementwise 499/499；explicit_tmp + tail_mask 196/196；sync 插入（非 A5）98/98；`group_norm` / `online_softmax` 示例全部通过。

Fixes #1683
Fixes #754

