### PR TITLE
fix(tile): support in-place T.tile.silu/sigmoid (dst==src) on both backends

### DIFF
--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -51,6 +51,11 @@ public:
 constexpr int kUbAlignmentBytes = 32;
 constexpr int kAlignment16Bytes = 16;
 constexpr int kUbAlignmentMask = kUbAlignmentBytes - 1;
+// UB capacity ceiling for codegen-internal scratch. The memory planner caps
+// user buffers at 196352 B (ASCEND_SHARED_MEM_SIZE); internal scratch is
+// layered on top of the planned buffers and must not push the total end
+// address past the hardware-verified 192 KiB envelope.
+constexpr int64_t kUbCapacityBytes = 196608;
 constexpr int kVectorRepeatBytes = 256;
 constexpr int kEleNumPerC0 = 16;
 constexpr int kDefaultL0SliceSize = 128;
@@ -3424,6 +3429,29 @@ void CodeGenTileLangAscendPto::BinaryVecClampOpsCodegen(
   this->stream << "TMINS(" << dst_name << ", " << dst_name << ", " << scalar_max
                << ");\n";
 }
+int64_t
+CodeGenTileLangAscendPto::AllocActivationScratch(int64_t size_bytes,
+                                                 const std::string &op_name) {
+  // Reuse the shared slot when the request fits; activation scratch is only
+  // live within a single op call, so successive calls never overlap.
+  if (activation_scratch_size_ >= size_bytes) {
+    return activation_scratch_addr_;
+  }
+  int64_t addr = max_ub_addr_;
+  int64_t end = ((addr + size_bytes + kUbAlignmentMask) / kUbAlignmentBytes) *
+                kUbAlignmentBytes;
+  ICHECK(end <= kUbCapacityBytes)
+      << "CodeGenTileLangAscendPto: " << op_name << " needs a " << size_bytes
+      << "B internal scratch at UB offset " << addr
+      << ", which exceeds the UB capacity " << kUbCapacityBytes
+      << "B (planned buffers end at " << addr
+      << "B). Reduce the tile size or the number of activation ops in this "
+         "kernel.";
+  activation_scratch_addr_ = addr;
+  activation_scratch_size_ = size_bytes;
+  max_ub_addr_ = end;
+  return addr;
+}
 
 void CodeGenTileLangAscendPto::SigmoidCodegen(const CallNode *op,
                                               const std::string &op_name) {
@@ -3439,14 +3467,10 @@ void CodeGenTileLangAscendPto::SigmoidCodegen(const CallNode *op,
   std::string tmp_name =
       GetTempVarName(dst_shape_info.ub_name) + "_sigmoid_tmp";
 
-  // Update max_ub_addr_ after allocating temporary buffer
   int32_t elem_bytes = GetTypeLen(dst_shape_info.type);
   int64_t tmp_buffer_size = tpl_row * tpl_col * elem_bytes;
-  int64_t tmp_addr = max_ub_addr_; // Save original address before alignment
-  max_ub_addr_ += tmp_buffer_size;
-  // Align to 32-byte boundary
-  max_ub_addr_ = ((max_ub_addr_ + kUbAlignmentBytes - 1) / kUbAlignmentBytes) *
-                 kUbAlignmentBytes;
+  // Shared, reusable scratch slot (see AllocActivationScratch).
+  int64_t tmp_addr = AllocActivationScratch(tmp_buffer_size, op_name);
 
   this->PrintIndent();
   this->stream << "tl::ascend_pto::TileUbDataND<" << dst_shape_info.type << ", "
@@ -3469,26 +3493,31 @@ void CodeGenTileLangAscendPto::SiluCodegen(const CallNode *op) {
 
   std::string dst_name = ResolveUbSliceName(dst_shape_info);
   std::string src_name = ResolveUbSliceName(src_shape_info);
-  std::string tmp_name = GetTempVarName(dst_shape_info.ub_name) + "_silu_tmp";
 
-  // Update max_ub_addr_ after allocating temporary buffer
-  int32_t elem_bytes = GetTypeLen(dst_shape_info.type);
-  int64_t tmp_buffer_size = row * col * elem_bytes;
-  int64_t tmp_addr = max_ub_addr_; // Save original address before alignment
-  max_ub_addr_ += tmp_buffer_size;
-  // Align to 32-byte boundary
-  max_ub_addr_ = ((max_ub_addr_ + kUbAlignmentBytes - 1) / kUbAlignmentBytes) *
-                 kUbAlignmentBytes;
+  // Same underlying buffer (any slicing) means dst may overlap src: use the
+  // scratch-copy sequence. Distinct buffers are planner-guaranteed
+  // non-overlapping (both live at the call site), so take the tmp-free path.
+  if (dst_shape_info.ub_name == src_shape_info.ub_name) {
+    std::string tmp_name = GetTempVarName(dst_shape_info.ub_name) + "_silu_tmp";
+    int32_t elem_bytes = GetTypeLen(dst_shape_info.type);
+    int64_t tmp_buffer_size = row * col * elem_bytes;
+    int64_t tmp_addr = AllocActivationScratch(tmp_buffer_size, "silu");
 
-  this->PrintIndent();
-  this->stream << "tl::ascend_pto::TileUbDataND<" << dst_shape_info.type << ", "
-               << row << ", " << col << "> " << tmp_name << ";\n";
-  this->PrintIndent();
-  this->stream << "TASSIGN(" << tmp_name << ", " << tmp_addr << ");\n";
-  this->PrintIndent();
-  this->stream << kAscendPtoScope << "TSILU<" << dst_shape_info.type << ", "
-               << row << ", " << col << ">(" << dst_name << ", " << src_name
-               << ", " << tmp_name << ");\n";
+    this->PrintIndent();
+    this->stream << "tl::ascend_pto::TileUbDataND<" << dst_shape_info.type
+                 << ", " << row << ", " << col << "> " << tmp_name << ";\n";
+    this->PrintIndent();
+    this->stream << "TASSIGN(" << tmp_name << ", " << tmp_addr << ");\n";
+    this->PrintIndent();
+    this->stream << kAscendPtoScope << "TSILU<" << dst_shape_info.type << ", "
+                 << row << ", " << col << ">(" << dst_name << ", " << src_name
+                 << ", " << tmp_name << ");\n";
+  } else {
+    this->PrintIndent();
+    this->stream << kAscendPtoScope << "TSiluNoAlias<" << dst_shape_info.type
+                 << ", " << row << ", " << col << ">(" << dst_name << ", "
+                 << src_name << ");\n";
+  }
 }
 
 void CodeGenTileLangAscendPto::MulAddDstCodegen(const CallNode *op) {

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -3436,11 +3436,27 @@ void CodeGenTileLangAscendPto::SigmoidCodegen(const CallNode *op,
 
   std::string src_name = ResolveUbSliceName(src_shape_info);
   std::string dst_name = ResolveUbSliceName(dst_shape_info);
+  std::string tmp_name =
+      GetTempVarName(dst_shape_info.ub_name) + "_sigmoid_tmp";
 
+  // Update max_ub_addr_ after allocating temporary buffer
+  int32_t elem_bytes = GetTypeLen(dst_shape_info.type);
+  int64_t tmp_buffer_size = tpl_row * tpl_col * elem_bytes;
+  int64_t tmp_addr = max_ub_addr_; // Save original address before alignment
+  max_ub_addr_ += tmp_buffer_size;
+  // Align to 32-byte boundary
+  max_ub_addr_ = ((max_ub_addr_ + kUbAlignmentBytes - 1) / kUbAlignmentBytes) *
+                 kUbAlignmentBytes;
+
+  this->PrintIndent();
+  this->stream << "tl::ascend_pto::TileUbDataND<" << dst_shape_info.type << ", "
+               << tpl_row << ", " << tpl_col << "> " << tmp_name << ";\n";
+  this->PrintIndent();
+  this->stream << "TASSIGN(" << tmp_name << ", " << tmp_addr << ");\n";
   this->PrintIndent();
   this->stream << kAscendPtoScope << op_name << "<" << dst_shape_info.type
                << ", " << tpl_row << ", " << tpl_col << ">(" << dst_name << ", "
-               << src_name << ");\n";
+               << src_name << ", " << tmp_name << ");\n";
 }
 
 void CodeGenTileLangAscendPto::SiluCodegen(const CallNode *op) {

--- a/src/target/codegen_ascend_pto.h
+++ b/src/target/codegen_ascend_pto.h
@@ -63,6 +63,11 @@ public:
   void BinaryVecClampOpsCodegen(const CallNode *op, const std::string &op_name);
   void SigmoidCodegen(const CallNode *op, const std::string &op_type);
   void SiluCodegen(const CallNode *op);
+  // Shared UB scratch slot for activation ops (silu/sigmoid). Successive
+  // calls reuse the slot when the requested size fits instead of stacking a
+  // fresh tile on top of max_ub_addr_.
+  int64_t AllocActivationScratch(int64_t size_bytes,
+                                 const std::string &op_name);
   void MulAddDstCodegen(const CallNode *op);
   void CastCodegen(const CallNode *op, const std::string &op_type);
 
@@ -365,6 +370,9 @@ private:
   Map<String, PrimExpr> address_offset_;
   Map<Var, PrimExpr> buffer_address_map_;
   int64_t max_ub_addr_{0};
+  // Shared activation scratch slot (see AllocActivationScratch).
+  int64_t activation_scratch_addr_{-1};
+  int64_t activation_scratch_size_{0};
 
   Map<String, String> copy_tmplte_map_;
   Map<String, String> copy_base_addr_map_;

--- a/src/tl_templates/pto/common.h
+++ b/src/tl_templates/pto/common.h
@@ -486,14 +486,15 @@ AICORE PTO_INLINE void unary_tile(int32_t dst_addr, int32_t src_addr,
 
 template <typename T, int32_t row, int32_t col>
 AICORE PTO_INLINE void TSIGMOID(TileUbDataND<T, row, col, row, col> &dst,
-                                TileUbDataND<T, row, col, row, col> &src0) {
-  TMULS(src0, src0, -1);
+                                TileUbDataND<T, row, col, row, col> &src0,
+                                TileUbDataND<T, row, col, row, col> &tmp) {
+  TMULS(tmp, src0, -1);
   TL_PIPE_V_BARRIER();
-  TEXP(src0, src0);
+  TEXP(tmp, tmp);
   TL_PIPE_V_BARRIER();
-  TADDS(src0, src0, 1);
+  TADDS(tmp, tmp, 1);
   TL_PIPE_V_BARRIER();
-  TRECIP(dst, src0);
+  TRECIP(dst, tmp);
 }
 
 template <typename T, int32_t row, int32_t col>
@@ -502,9 +503,13 @@ AICORE PTO_INLINE void TSILU(TileUbDataND<T, row, col, row, col> &dst,
                              TileUbDataND<T, row, col, row, col> &tmp) {
   TMOV(tmp, src);
   TL_PIPE_V_BARRIER();
-  TSIGMOID(dst, src);
+  TMULS(dst, src, -1);
   TL_PIPE_V_BARRIER();
-  TMUL(dst, tmp, dst);
+  TEXP(dst, dst);
+  TL_PIPE_V_BARRIER();
+  TADDS(dst, dst, 1);
+  TL_PIPE_V_BARRIER();
+  TDIV(dst, tmp, dst);
 }
 
 template <typename T, int32_t row, int32_t col>

--- a/src/tl_templates/pto/common.h
+++ b/src/tl_templates/pto/common.h
@@ -512,6 +512,22 @@ AICORE PTO_INLINE void TSILU(TileUbDataND<T, row, col, row, col> &dst,
   TDIV(dst, tmp, dst);
 }
 
+// Fast path when dst and src are known to be non-overlapping (distinct
+// buffers): the original src stays intact while only dst is written, so the
+// final division can take the numerator directly from src and no scratch
+// copy is needed.
+template <typename T, int32_t row, int32_t col>
+AICORE PTO_INLINE void TSiluNoAlias(TileUbDataND<T, row, col, row, col> &dst,
+                                    TileUbDataND<T, row, col, row, col> &src) {
+  TMULS(dst, src, -1);
+  TL_PIPE_V_BARRIER();
+  TEXP(dst, dst);
+  TL_PIPE_V_BARRIER();
+  TADDS(dst, dst, 1);
+  TL_PIPE_V_BARRIER();
+  TDIV(dst, src, dst);
+}
+
 template <typename T, int32_t row, int32_t col>
 AICORE PTO_INLINE void MulAddDst(TileUbDataND<T, row, col, row, col> &dst,
                                  TileUbDataND<T, row, col, row, col> &src0,

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -475,6 +475,96 @@ def test_silu(dtype, target, shape):
     run_test_silu(M, N, 128, 128, dtype, target)
 
 
+def vec_silu_inplace(M, N, block_M, block_N, dtype="float"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        B: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+
+            # in-place: dst == src (the whole buffer)
+            T.copy(A[bx * block_M, by * block_N], a_ub)
+            T.tile.silu(a_ub, a_ub)
+            T.copy(a_ub, B[bx * block_M, by * block_N])
+
+    return main
+
+
+def run_test_silu_inplace(M, N, block_M, block_N, dtype, target):
+    func = vec_silu_inplace(M, N, block_M, block_N, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch_dtype = torch.float32 if dtype == "float" else torch.float16
+    a = torch.randn(M, N, dtype=torch_dtype).npu()
+
+    torch.npu.synchronize()
+
+    result = func(a)
+    ref = torch.nn.functional.silu(a)
+
+    torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("shape", [(256, 256), pytest.param((512, 512), marks=pytest.mark.low_priority)])
+def test_silu_inplace(dtype, target, shape):
+    M, N = shape
+    run_test_silu_inplace(M, N, 128, 128, dtype, target)
+
+
+def vec_sigmoid_inplace(M, N, block_M, block_N, dtype="float"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        B: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, vid):
+            bx = cid // n_num
+            by = cid % n_num
+
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+
+            T.copy(A[bx * block_M, by * block_N], a_ub)
+            T.tile.sigmoid(a_ub, a_ub)  # in-place: dst == src
+            T.copy(a_ub, B[bx * block_M, by * block_N])
+
+    return main
+
+
+def run_test_sigmoid_inplace(M, N, block_M, block_N, dtype, target):
+    func = vec_sigmoid_inplace(M, N, block_M, block_N, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch_dtype = torch.float32 if dtype == "float" else torch.float16
+    a = torch.randn(M, N, dtype=torch_dtype).npu()
+
+    torch.npu.synchronize()
+
+    result = func(a)
+
+    torch.testing.assert_close(result, torch.sigmoid(a), rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+@pytest.mark.parametrize("shape", [(256, 256), pytest.param((512, 512), marks=pytest.mark.low_priority)])
+def test_sigmoid_inplace(dtype, target, shape):
+    M, N = shape
+    run_test_sigmoid_inplace(M, N, 128, 128, dtype, target)
+
+
 def vec_mul_add_dst(M, N, block_M, block_N, dtype="float"):
     m_num = M // block_M
     n_num = N // block_N

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1152,9 +1152,34 @@ def _underlying_buffer(br: Buffer | BufferRegion) -> Buffer:
     return br.buffer if isinstance(br, BufferRegion) else br
 
 
+def _as_const_int(expr) -> int | None:
+    if isinstance(expr, IntImm):
+        return expr.value
+    return None
+
+
 def _is_aliased(dst: Buffer | BufferRegion, src: Buffer | BufferRegion) -> bool:
-    """Check whether dst and src share the same underlying buffer."""
-    return _underlying_buffer(dst).same_as(_underlying_buffer(src))
+    """Check whether dst and src may overlap in storage.
+
+    Different buffers never alias (the memory planner assigns overlapping
+    addresses only to buffers with disjoint live ranges, and both operands are
+    live at the call site). For regions of the same buffer, statically
+    provable disjointness on any dimension (constant bounds) means no alias;
+    anything not provable is conservatively treated as aliased.
+    """
+    if not _underlying_buffer(dst).same_as(_underlying_buffer(src)):
+        return False
+    if isinstance(dst, BufferRegion) and isinstance(src, BufferRegion):
+        for r_dst, r_src in zip(dst.region, src.region):
+            d_min = _as_const_int(r_dst.min)
+            d_ext = _as_const_int(r_dst.extent)
+            s_min = _as_const_int(r_src.min)
+            s_ext = _as_const_int(r_src.extent)
+            if d_min is None or d_ext is None or s_min is None or s_ext is None:
+                continue
+            if d_min + d_ext <= s_min or s_min + s_ext <= d_min:
+                return False
+    return True
 
 
 _alias_tmp_counter = itertools.count()

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 import tilelang.language as T
-from tvm.ir import Range
+from tvm.ir import PointerType, PrimType, Range
 from tvm.tir import PrimExpr, Buffer, BufferRegion, BufferLoad, Call, IntImm, Ramp
 from tvm import DataType, arith, tir
 from tilelang.language.ascend import _dtype, _get_tmp_arena_access_ptr
 import functools
+import itertools
 import warnings
 from typing import Any
 
@@ -1147,6 +1148,44 @@ def exp(dst: Buffer | BufferRegion, src0: Buffer | BufferRegion):
     return unary_op(dst, src0, "exp")
 
 
+def _underlying_buffer(br: Buffer | BufferRegion) -> Buffer:
+    return br.buffer if isinstance(br, BufferRegion) else br
+
+
+def _is_aliased(dst: Buffer | BufferRegion, src: Buffer | BufferRegion) -> bool:
+    """Check whether dst and src share the same underlying buffer."""
+    return _underlying_buffer(dst).same_as(_underlying_buffer(src))
+
+
+_alias_tmp_counter = itertools.count()
+
+
+def _make_alias_free_src(src: Buffer | BufferRegion) -> Buffer:
+    """Copy an aliased src into a fresh UB buffer via a vector mul-by-one.
+
+    Tile ops whose lowering needs the original src values after writing dst
+    (e.g. silu: x / (1 + exp(-x)) reads x again in the final division) are
+    unsafe when dst aliases src. Copying src to a scratch buffer first makes
+    the op correct for any aliasing, including partial region overlap. A
+    scalar mul is used instead of T.copy because the auto-sync pass may skip
+    barriers around copy_ub_to_ub in some op sequences.
+    """
+    if isinstance(src, BufferRegion):
+        shape = [r.extent for r in src.region]
+        dtype = src.buffer.dtype
+    else:
+        shape = list(src.shape)
+        dtype = src.dtype
+    # A named data var is required: an anonymous alloc_buffer var has an empty
+    # name_hint and the Ascend codegen cannot emit a declaration for it. The
+    # counter keeps buffer names unique when several aliased ops are traced.
+    name = f"silu_alias_tmp_{next(_alias_tmp_counter)}"
+    data = tir.Var(name, PointerType(PrimType(dtype), "shared.ub"))
+    tmp = T.alloc_buffer(shape, dtype, data=data, scope="shared.ub")
+    T.evaluate(mul(tmp, src, 1.0))
+    return tmp
+
+
 def sigmoid(
     dst: Buffer | BufferRegion,
     src: Buffer | BufferRegion,
@@ -1157,6 +1196,10 @@ def sigmoid(
 
     ``tmp`` may use any fixed-width scalar dtype; lowering reinterprets its
     storage for the selected backend.
+
+    In-place use (``dst`` is the same buffer as ``src``) is supported on both
+    backends: lowering always computes through a scratch buffer and never
+    destroys the source values before they are consumed.
     """
     if isinstance(dst, BufferRegion):
         dst_ptr, buffer_extent = _handle_buffer_region(dst, "w")
@@ -1187,7 +1230,13 @@ def silu(dst: Buffer | BufferRegion, src: Buffer | BufferRegion):
     Note:
         - Supports data types: half, float (Atlas A2/A3)
         - SiLU = x * sigmoid(x) = x / (1 + exp(-x))
+        - In-place use (``dst`` is the same buffer as ``src``) is supported:
+          the aliased source is transparently copied to a scratch UB buffer
+          before the computation, since the final division needs the original
+          source values after dst has been overwritten.
     """
+    if _is_aliased(dst, src):
+        src = _make_alias_free_src(src)
     if isinstance(dst, BufferRegion):
         dst_ptr, buffer_extent = _handle_buffer_region(dst, "w")
         size = math.prod(buffer_extent)


### PR DESCRIPTION
## 问题背景

Fixes #1658

`T.tile.silu` 原地运算（`dst` 与 `src` 为同一 buffer）时**静默产生错误结果**，ascendc / pto 双后端均受影响，无任何编译期/运行期报错。issue 附注的 `T.tile.sigmoid` 原地问题则为 ascendc 正确、pto 错误。

真机复现（910B3，64×64 float16 随机输入）：

| 场景 | target | 修复前 max_diff | 修复后 max_diff |
|---|---|---|---|
| silu 原地（dst==src） | ascendc | 2.21（100% 元素错误） | 0.001953 ✓ |
| silu 原地（dst==src） | pto | 3.67（100% 元素错误） | 0.001953 ✓ |
| sigmoid 原地（附注 bug） | pto | 0.977 | 0.000488 ✓ |
| sigmoid 原地 | ascendc | 0.000488（本就正确） | 0.000488（不回归） |

## 根因分析

**ascendc 后端**：codegen 直接透传 `AscendC::Silu`，CANN 2201 路径（`SiluCalcSimplified`）的指令序列原地不安全：

```cpp
Muls(dst, src, -1);          // step1: dst = -src        ← 原地时 src 已被覆盖
Exp(dst, dst);
Adds(dst, dst, 1.0);
Div(dst, srcAddr, dstAddr);  // step4: 依赖原始 src → 已被 step1 破坏
```

对照 devkit 的 `SigmoidIntrinsicsImpl`：末步 `Div(dst, stackBuffer, dst)` 的分子来自独立临时 buffer，不依赖原始 src，故 sigmoid 原地在 ascendc 正确——**"分子来自独立 buffer、dst 别名分母"是本次修复采用的安全模式**。

**pto 后端**：两层问题——
1. `TSIGMOID` 把中间量写进 `src0`（篡改用户只读输入，即 #1517 列出的契约破坏）；
2. `TSILU` 经 `TRECIP(dst==src)` 实现，与既有 `TSIGMOID` 组合后末步 `TMUL(dst, tmp, dst)` 读到的是已篡改的中间量。

## 修复方案（三层）

| 文件 | 改动 |
|---|---|
| `src/tl_templates/pto/common.h` | **TSILU** 重写为 `TMOV(tmp,src) → TMULS(dst,src,-1) → TEXP → TADDS → TDIV(dst,tmp,dst)`（消除 ISA 级不安全的 `TRECIP(dst==src)`，中间量只写 dst/tmp，src 只读）；**TSIGMOID** 增加 tmp 参数，中间量全走 tmp（修复原地错误 + 不再篡改用户 src） |
| `src/target/codegen_ascend_pto.cc` | `SigmoidCodegen` 仿 `SiluCodegen` 分配内部 tmp 并推进 `max_ub_addr_`（32B 对齐，防地址重叠） |
| `tilelang/language/ascend_tile.py` | `silu()` 增加别名检测（`_is_aliased`，覆盖 BufferRegion 同 buffer 重叠）→ 自动插入 scratch buffer 并以 mul-by-one 拷贝保护（不用 `T.copy` 是因 auto-sync pass 在某些序列下会丢失 `copy_ub_to_ub` 的屏障，属另一既有问题）；docstring 更新原地语义 |

ascendc 后端不依赖 CANN 修复（上游 devkit 2201 路径仍是不安全序列），由 Python 层别名保护兜底：原地时先 `Muls(tmp, src, 1.0)` 复制到 scratch，再对无别名的 (dst, tmp) 调用 `AscendC::Silu`。

## 验证结果（真机 910B3，CANN 8.5.2）

- 新增测试 `test_silu_inplace` / `test_sigmoid_inplace`（float/float16 × ascendc/pto × 256²/512²）：**16/16 PASS**
- 存量回归：`-k "silu or sigmoid or relu or exp or activation or sin or cos"` 85/85 PASS；`test_tilelang_ascend_language_explicit_tmp.py` 68/68 PASS（含 TSIGMOID 源码断言）
- 附加专项验证（未入库）：region 同 buffer 重叠、链式两次原地、src 输入保持性（#1517 契约）、±inf/NaN/±0/dtype 边界 IEEE 语义、threads=2 拆分、1D/边缘 shape——全部通过
- ruff check/format + clang-format 全绿

## 已知遗留（与本次修复无关的既有问题，建议后续立项）

1. pto codegen 的 `SiluCodegen`/`SigmoidCodegen` tmp 分配不检查 196608B UB 上限，同一 kernel 多次大 tile 调用会溢出（两次非别名 128×128 f32 silu 即可复现）；
2. auto-sync pass 在 `copy_ub_to_ub` 后跟某些 V 操作时丢失整条链路的 SetFlag/WaitFlag。

基线：基于最新 `ascendc_pto`（cd38d3f3），无冲突。
