### PR TITLE
ci: isolate build cache and pin A3 device

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -542,7 +542,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: build-cache/
-          key: tilelang-build-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
+          key: tilelang-build-${{ runner.arch }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
       
       # 全量编译，清理所有残留编译产物
       - name: Clean build artifacts for full build
@@ -628,7 +628,15 @@ jobs:
             PYTEST_MARKERS="not (low_priority or ci_skip)"
           fi
 
+          NPU_DEVICE_ARGS=()
+
+          if [[ "${RUNNER_ARCH:-}" == "ARM64" ]]; then
+            NPU_DEVICE_ARGS+=(-e "ASCEND_RT_VISIBLE_DEVICES=0")
+            echo "ARM64 runner detected: limiting Ascend runtime visibility to device 0"
+          fi
+
           docker exec \
+            "${NPU_DEVICE_ARGS[@]}" \
             -w $GITHUB_WORKSPACE \
             -e GITHUB_ENV=$GITHUB_ENV \
             -e GITHUB_OUTPUT=$GITHUB_OUTPUT \
@@ -746,7 +754,7 @@ jobs:
       - name: Delete old cache for overwrite
         if: always() && env.FULL_BUILD == 'true'
         run: |
-          KEY="tilelang-build-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}"
+          KEY="tilelang-build-${{ runner.arch }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}"
           echo "🗑️ Deleting old cache to allow overwrite: $KEY"
           curl -s -L \
             -X DELETE \
@@ -764,7 +772,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: build-cache/
-          key: tilelang-build-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
+          key: tilelang-build-${{ runner.arch }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
           
       - name: Check pass rate
         id: check_results


### PR DESCRIPTION
## 概述

对现有 A2/A3 共享 CI 做两项最小兼容调整，避免不同架构复用构建缓存，并限制 A3 Runner 使用逻辑设备 0。

## 主要修改

### 1. 按 Runner 架构隔离构建缓存

在构建缓存 key 中加入：

```yaml
${{ runner.arch }}
```

并同步应用于缓存的 restore、delete 和 save 操作。

由此实现：

* A2/X64 使用独立缓存；
* A3/ARM64 使用独立缓存；
* 避免不同 CPU 架构之间复用不兼容的二进制构建产物；
* 保留原有缓存路径、分支区分和文件哈希逻辑。

### 2. A3 固定使用逻辑设备 0

当检测到：

```text
RUNNER_ARCH=ARM64
```

时，通过 `docker exec -e` 向容器传递：

```text
ASCEND_RT_VISIBLE_DEVICES=0
```

由此限制 A3 CI 使用逻辑设备 0。

A2/X64 路径不会设置该变量，原有执行行为保持不变。

## 兼容性

* 不修改原有 Runner 标签和任务路由；
* 不修改 Docker 容器名及执行路径；
* 不修改 CANN、Python 或测试环境；
* 不修改 pytest 的 `--forked`、并发数量及测试语义；
* 不修改构建、失败处理和退出码传播逻辑；
* 不修改 Runner、Docker、NPU、systemd 或服务器配置。

## 修改文件

```text
.github/workflows/ci_cd.yml
```

## 验证

已完成：

* Workflow YAML 解析检查；
* 修改后 `run:` Shell 语法检查；
* `git diff --check`；
* 缓存 restore/delete/save key 一致性检查；
* ARM64 与 X64 条件分支静态检查；
* 与最新 `upstream/ascendc_pto` 的差异检查。
