### PR TITLE
ci: isolate caches by runner and pin A3 to device 0

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -542,7 +542,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: build-cache/
-          key: tilelang-build-${{ runner.name }}-${{ runner.arch }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
+          key: tilelang-build-${{ runner.name }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
       
       # 全量编译，清理所有残留编译产物
       - name: Clean build artifacts for full build
@@ -754,7 +754,7 @@ jobs:
       - name: Delete old cache for overwrite
         if: always() && env.FULL_BUILD == 'true'
         run: |
-          KEY="tilelang-build-${{ runner.name }}-${{ runner.arch }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}"
+          KEY="tilelang-build-${{ runner.name }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}"
           echo "🗑️ Deleting old cache to allow overwrite: $KEY"
           curl -s -L \
             -X DELETE \
@@ -772,7 +772,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: build-cache/
-          key: tilelang-build-${{ runner.name }}-${{ runner.arch }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
+          key: tilelang-build-${{ runner.name }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
           
       - name: Check pass rate
         id: check_results

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -542,7 +542,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: build-cache/
-          key: tilelang-build-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
+          key: tilelang-build-${{ runner.name }}-${{ runner.arch }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
       
       # 全量编译，清理所有残留编译产物
       - name: Clean build artifacts for full build
@@ -628,7 +628,15 @@ jobs:
             PYTEST_MARKERS="not (low_priority or ci_skip)"
           fi
 
+          NPU_DEVICE_ARGS=()
+
+          if [[ "${RUNNER_NAME:-}" == "ascend_cicd_a3" ]]; then
+            NPU_DEVICE_ARGS+=(-e "ASCEND_RT_VISIBLE_DEVICES=0")
+            echo "A3 runner detected: limiting Ascend runtime visibility to logical device 0"
+          fi
+
           docker exec \
+            "${NPU_DEVICE_ARGS[@]}" \
             -w $GITHUB_WORKSPACE \
             -e GITHUB_ENV=$GITHUB_ENV \
             -e GITHUB_OUTPUT=$GITHUB_OUTPUT \
@@ -746,7 +754,7 @@ jobs:
       - name: Delete old cache for overwrite
         if: always() && env.FULL_BUILD == 'true'
         run: |
-          KEY="tilelang-build-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}"
+          KEY="tilelang-build-${{ runner.name }}-${{ runner.arch }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}"
           echo "🗑️ Deleting old cache to allow overwrite: $KEY"
           curl -s -L \
             -X DELETE \
@@ -764,7 +772,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: build-cache/
-          key: tilelang-build-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
+          key: tilelang-build-${{ runner.name }}-${{ runner.arch }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
           
       - name: Check pass rate
         id: check_results


### PR DESCRIPTION
## 概述

对现有 A2/A3 共享 CI 增加两项最小兼容调整：

1. 按实际执行任务的 Runner 隔离构建缓存；
2. 主仓 A3 Runner 固定使用逻辑设备 0。

本 PR 仅修改现有 workflow，不改变 A2/A3 的任务路由和测试语义。

## 主要修改

### 1. 按 Runner 隔离构建缓存

在构建缓存 key 中加入：

```yaml
${{ runner.name }}
```

最终形式：

```yaml
tilelang-build-${{ runner.name }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'requirements.txt', 'install_ascend.sh') }}
```

该修改已同步应用于缓存的：

* restore；
* delete；
* save。

由此，不同自托管 Runner 使用各自独立的构建缓存，避免 A2、A3 或其他环境复用不兼容的二进制构建产物。

### 2. 主仓 A3 固定使用逻辑设备 0

当实际执行任务的 Runner name 为：

```text
ascend_cicd_a3
```

时，通过 `docker exec -e` 向容器传递：

```text
ASCEND_RT_VISIBLE_DEVICES=0
```

实现方式使用安全的 Bash 参数数组：

```bash
npu_device_args=()

if [[ "${RUNNER_NAME:-}" == "ascend_cicd_a3" ]]; then
    npu_device_args=(-e "ASCEND_RT_VISIBLE_DEVICES=0")
fi
```

因此：

* `ascend_cicd_a3` 固定使用逻辑设备 0；
* A2 和其他 Runner 不设置该变量；
* 不会影响未来其他 ARM64 Runner 的设备配置。

## 保持不变

本 PR 不修改：

* `runs-on` 及现有 Runner 标签；
* Docker 容器名和执行路径；
* `BASH_ENV=/root/.bashrc`；
* CANN、Python 和测试环境；
* pytest 的 `--forked`、并发数量及重试语义；
* workflow 触发条件和任务调度方式；
* Runner、Docker、NPU、systemd 或服务器配置。

## 修改文件

```text
.github/workflows/ci_cd.yml
```

## 验证

已进行以下静态检查：

* Workflow YAML 解析；
* 修改涉及的 Shell 语法检查；
* `git diff --check`；
* cache restore/delete/save key 一致性检查；
* A2 与 A3 条件分支检查；
* 与最新 `upstream/ascendc_pto` 的差异检查。