### PR TITLE
[Fix] Reject straddling double-buffered L0A/L0B/L0C layouts at compile time 🤖

### DIFF
--- a/src/transform/ascend_collect_buffer_shape.cc
+++ b/src/transform/ascend_collect_buffer_shape.cc
@@ -202,14 +202,13 @@ tvm::transform::Pass CreateFlatten2DPass() {
       final_layouts.Set(buffer_var, aligned_shape);
     }
 
-    // 5. Attach the final logic shapes and remove the intermediate attribute.
+    // 5. Attach the final logic shapes. The intermediate initial shapes are
+    // kept: AscendMemoryPlanning consumes them to recover the leading
+    // double-buffer stage extent (e.g. L0B allocated as [2, ...]) after this
+    // pass has flattened the logical shapes to 2D.
     Map<String, ObjectRef> final_dict;
     if (f->attrs.defined()) {
-      for (const auto &kv : f->attrs->dict) {
-        if (kv.first != kInitialBufferShapes) {
-          final_dict.Set(kv.first, kv.second);
-        }
-      }
+      final_dict = f->attrs->dict;
     }
 
     final_dict.Set(kLogicBufferShapes, final_layouts);

--- a/src/transform/ascend_memory_planning.cc
+++ b/src/transform/ascend_memory_planning.cc
@@ -79,8 +79,41 @@ public:
                                .value();
     }
 
+    // Recover the pre-flatten leading extent (double-buffer stage count) of
+    // every buffer from the initial shapes. A buffer declared as [2, ...] in
+    // L0A/L0B/L0C uses the hardware ping-pong convention whose slots are
+    // guarded by per-side ownership tokens, which constrains how its address
+    // range may overlap another such buffer (see
+    // ValidatePreAllocatedDoubleBuffers). Names conflicting across buffers
+    // are marked -1 so the validation skips them.
+    Map<Var, Array<PrimExpr>> initial_shape_map;
+    if (fn_attr->dict.count(kInitialBufferShapes)) {
+      initial_shape_map = fn_attr->dict.at(kInitialBufferShapes)
+                              .as<Map<Var, Array<PrimExpr>>>()
+                              .value();
+    }
+    std::unordered_map<std::string, int64_t> initial_leading_extents;
+    for (const auto &kv : initial_shape_map) {
+      const Array<PrimExpr> &shape = kv.second;
+      if (shape.empty()) {
+        continue;
+      }
+      const IntImmNode *imm = shape[0].as<IntImmNode>();
+      if (imm == nullptr) {
+        continue;
+      }
+      const std::string &name = kv.first->name_hint;
+      auto it = initial_leading_extents.find(name);
+      if (it == initial_leading_extents.end()) {
+        initial_leading_extents.emplace(name, static_cast<int64_t>(imm->value));
+      } else if (it->second != static_cast<int64_t>(imm->value)) {
+        it->second = -1;
+      }
+    }
+
     AscendMemoryPlanner planner(f, external_address_map, external_shape_map,
-                                auto_ascend_memory_planning);
+                                auto_ascend_memory_planning,
+                                initial_leading_extents);
     auto address_map = planner.GetAddressMap();
     auto buffer_sizes = planner.GetBufferSizes();
 
@@ -106,11 +139,14 @@ private:
     explicit AscendMemoryPlanner(const PrimFunc &func,
                                  Map<Var, PrimExpr> external_address_map,
                                  Map<Var, Array<PrimExpr>> external_shape_map,
-                                 bool auto_plan = false) {
+                                 bool auto_plan = false,
+                                 const std::unordered_map<std::string, int64_t>
+                                     &initial_leading_extents = {}) {
       memory_auto_plan = auto_plan;
       // Preserve layouts needed by CalculateBufferSize.
       // PTO 4D shapes are [physical_M, physical_N, valid_M, valid_N].
       external_shape_map_ = external_shape_map;
+      initial_leading_extents_ = initial_leading_extents;
       memory_limits_ = {{"shared.l1", ASCEND_SHARED_DYN_MEM_SIZE},
                         {"wmma.matrix_a", ASCEND_WMMA_MATRIX_A_MEM_SIZE},
                         {"wmma.matrix_b", ASCEND_WMMA_MATRIX_B_MEM_SIZE},
@@ -121,6 +157,7 @@ private:
       SetTmpBuffers(external_shape_map);
 
       operator()(func->body);
+      ValidatePreAllocatedDoubleBuffers();
       PlanMemory();
     }
 
@@ -296,6 +333,109 @@ private:
         std::string scope = GetPtrStorageScope(kv.first);
         if (!pre_alloc_buffer_.count(buf->name_hint) && scope == "shared.ub") {
           tmp_buffers.push_back(buf);
+        }
+      }
+    }
+
+    /*!
+     * \brief Reject pre-allocated double-buffered L0A/L0B/L0C buffers whose
+     *        ping-pong slots straddle each other.
+     *
+     * A buffer allocated as [2, ...] in an L0 scope follows the hardware
+     * double-buffer convention: its two slots live at [base, base + size/2)
+     * and [base + size/2, base + size), and ownership is transferred with one
+     * token per side. When two such buffers are given overlapping addresses
+     * via T.annotate_address, every slot of one buffer must lie inside a
+     * single slot (side) of the other; otherwise a slot straddles the other
+     * buffer's side boundary, and the per-side token of the straddled region
+     * can return while MMAD is still reading the other side, producing the
+     * hardware error "507015: L0B read/write conflict in the MTE (same
+     * address)" (issue #1664). Aligned overlap (identical side boundary
+     * points) and disjoint ranges are both valid; only the straddling layout
+     * is rejected.
+     */
+    void ValidatePreAllocatedDoubleBuffers() {
+      static const std::unordered_set<std::string> kDoubleBufferedScopes = {
+          "wmma.matrix_a", "wmma.matrix_b", "wmma.accumulator"};
+
+      struct Entry {
+        std::string name;
+        std::string scope;
+        int64_t base;
+        int64_t size;
+      };
+      std::vector<Entry> entries;
+      for (const auto &kv : buffer_scopes_) {
+        const VarNode *buf = kv.first;
+        if (kDoubleBufferedScopes.count(kv.second) == 0) {
+          continue;
+        }
+        auto pre = pre_alloc_buffer_.find(buf->name_hint);
+        if (pre == pre_alloc_buffer_.end()) {
+          continue;
+        }
+        auto lead = initial_leading_extents_.find(buf->name_hint);
+        if (lead == initial_leading_extents_.end() || lead->second != 2) {
+          continue;
+        }
+        auto size_it = buffer_sizes_.find(buf);
+        if (size_it == buffer_sizes_.end()) {
+          continue;
+        }
+        entries.push_back({buf->name_hint, kv.second, pre->second,
+                           static_cast<int64_t>(size_it->second)});
+      }
+
+      for (size_t i = 0; i < entries.size(); ++i) {
+        for (size_t j = i + 1; j < entries.size(); ++j) {
+          const Entry &a = entries[i];
+          const Entry &b = entries[j];
+          // L0A, L0B and L0C are separate physical memories: only buffers
+          // sharing one scope can actually conflict.
+          if (a.scope != b.scope) {
+            continue;
+          }
+          if (a.base + a.size <= b.base || b.base + b.size <= a.base) {
+            continue; // disjoint ranges are always fine
+          }
+          int64_t a_slot = a.size / 2;
+          int64_t b_slot = b.size / 2;
+          std::string l0_name =
+              a.scope == "wmma.matrix_a"
+                  ? "L0A"
+                  : (a.scope == "wmma.matrix_b" ? "L0B" : "L0C");
+          for (int sa = 0; sa < 2; ++sa) {
+            for (int sb = 0; sb < 2; ++sb) {
+              if (sa == sb) {
+                continue; // same side: the shared token protects the region
+              }
+              int64_t a_lo = a.base + sa * a_slot;
+              int64_t a_hi = a.base + (sa + 1) * a_slot;
+              int64_t b_lo = b.base + sb * b_slot;
+              int64_t b_hi = b.base + (sb + 1) * b_slot;
+              if (a_lo < b_hi && b_lo < a_hi) {
+                LOG(FATAL)
+                    << "Double-buffered " << l0_name
+                    << " buffer conflict: pre-allocated "
+                    << "buffers " << a.name << " [" << a.base << ", "
+                    << a.base + a.size << ") and " << b.name << " [" << b.base
+                    << ", " << b.base + b.size
+                    << ") overlap, but their ping-pong slot boundaries differ ("
+                    << a.base + a_slot << " vs " << b.base + b_slot
+                    << "): " << b.name << "'s slot " << sb << " [" << b_lo
+                    << ", " << b_hi << ") straddles " << a.name << "'s slot "
+                    << sa << " [" << a_lo << ", " << a_hi
+                    << "). A per-side ownership token cannot protect the "
+                    << "straddled region, so MTE may overwrite " << l0_name
+                    << " data that MMAD is still reading (runtime error 507015 "
+                    << "\"" << l0_name
+                    << " read/write conflict in the MTE\"). Shift one base so "
+                    << "both buffers share the same side boundary point (every "
+                    << "slot of one buffer inside a single slot of the other), "
+                    << "or give the buffers disjoint address ranges.";
+              }
+            }
+          }
         }
       }
     }
@@ -1017,6 +1157,9 @@ private:
         buffer_sizes_; // buffer bytes size
     // Layout map used to size PTO 4D tiles by physical footprint.
     Map<Var, Array<PrimExpr>> external_shape_map_;
+    // Pre-flatten leading extent (double-buffer stage count) per buffer name;
+    // -1 marks ambiguous names. Used to identify [2, ...] ping-pong buffers.
+    std::unordered_map<std::string, int64_t> initial_leading_extents_;
     std::unordered_map<const VarNode *, size_t>
         first_use_; // buffer first use stmt scope
     std::unordered_map<std::string, int>

--- a/testing/python/language/test_ascend_l0_double_buffer_straddle.py
+++ b/testing/python/language/test_ascend_l0_double_buffer_straddle.py
@@ -1,0 +1,319 @@
+"""Regression tests for double-buffered L0 address straddle (issue #1664).
+
+A buffer allocated as ``[2, ...]`` in L0A/L0B/L0C follows the hardware
+ping-pong convention: its two slots live at ``[base, base + size/2)`` and
+``[base + size/2, base + size)``, and ownership is transferred with one token
+per side.  When ``T.annotate_address`` gives two such buffers overlapping
+ranges whose side boundary points differ, a slot of one buffer straddles both
+slots of the other; the per-side token then returns while MMAD may still be
+reading the straddled region, and the kernel dies at runtime with::
+
+    507015: L0B read/write conflict in the MTE (same address)
+
+The original bug (``flashattn_fwd_v4`` in the GQA backward example, commit
+f55c24f7) placed GEMM1's ``[2, 192, 64]`` L0B (24KB slots) and GEMM2's
+``[2, 64, 128]`` L0B (16KB slots) both at base 0.  AscendMemoryPlanning now
+rejects that layout at compile time.  These tests reproduce the exact shapes
+and verify the accepted alternatives (aligned overlap — the fix proposed in
+the issue — plus equal-slot and disjoint layouts).
+"""
+
+import re
+
+import pytest
+
+import tilelang
+import tilelang.language as T
+
+M, DK, BN, DV = 32, 192, 64, 128
+
+# Expert-style config of the original kernel: linear memory planning takes
+# annotate_address ranges as given, which is where the straddle used to pass.
+PASS_EXPERT_LINEAR = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: False,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: False,
+}
+
+# Same, but with the auto sync passes enabled: the guard must be independent
+# of the planning strategy and of the sync insertion mode.
+PASS_AUTO_SYNC = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: False,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: False,
+}
+
+CONFLICT_HEADER = "Double-buffered"
+
+# (g2_l0b base, g2_l0a base) for the issue-shaped kernel. GEMM1's L0A is 24KB
+# (12KB slots) at base 0; GEMM2's L0A (8KB, 4KB slots) sits disjoint at 24KB
+# exactly like the original kernel, so only the L0B layout varies.
+ISSUE_BASE0 = (0, 24576)
+ISSUE_FIXED = (8192, 24576)  # 8KB shift: both L0B side boundaries at 24KB
+
+
+@pytest.fixture(scope="module", autouse=True)
+def clear_cache():
+    tilelang.disable_cache()
+    yield
+
+
+def gqa_style_kernel(g2_l0b_base=0, g2_l0a_base=0):
+    """Two double-buffered GEMM groups with the issue #1664 L0B shapes.
+
+    GEMM1 (QK^T): B operand ``[2, DK, BN]`` -> 24KB slots.
+    GEMM2 (PV):   B operand ``[2, BN, DV]`` -> 16KB slots.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, DK), "float16"),  # type: ignore
+        Kq: T.Tensor((BN, DK), "float16"),  # type: ignore
+        P: T.Tensor((M, BN), "float16"),  # type: ignore
+        Vq: T.Tensor((BN, DV), "float16"),  # type: ignore
+        C1: T.Tensor((M, BN), "float"),  # type: ignore
+        C2: T.Tensor((M, DV), "float"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_l1 = T.alloc_L1((M, DK), "float16")
+            k_l1 = T.alloc_L1((BN, DK), "float16")
+            p_l1 = T.alloc_L1((M, BN), "float16")
+            v_l1 = T.alloc_L1((BN, DV), "float16")
+
+            g1_l0a = T.alloc_L0A((2, M, DK), "float16")
+            g1_l0b = T.alloc_L0B((2, DK, BN), "float16")
+            g1_l0c = T.alloc_L0C((M, BN), "float")
+            g2_l0a = T.alloc_L0A((2, M, BN), "float16")
+            g2_l0b = T.alloc_L0B((2, BN, DV), "float16")
+            g2_l0c = T.alloc_L0C((M, DV), "float")
+
+            T.annotate_address({g1_l0a: 0, g1_l0b: 0, g2_l0a: g2_l0a_base, g2_l0b: g2_l0b_base})
+            with T.Scope("C"):
+                T.barrier_all()
+                T.copy(A, a_l1)
+                T.copy(Kq, k_l1)
+                T.copy(P, p_l1)
+                T.copy(Vq, v_l1)
+                T.barrier_all()
+
+                # GEMM1: A @ Kq^T (K operand double-buffered, 24KB slots)
+                for s in T.serial(2):
+                    T.copy(a_l1, g1_l0a[s, :, :])
+                    T.copy(k_l1, g1_l0b[s, :, :], transpose=True)
+                    T.barrier_all()
+                    T.mma(g1_l0a[s, :, :], g1_l0b[s, :, :], g1_l0c[:, :], init=(s == 0))
+                    T.barrier_all()
+                T.copy(g1_l0c[:, :], C1[:, :])
+                T.barrier_all()
+
+                # GEMM2: P @ Vq (V operand double-buffered, 16KB slots)
+                for s in T.serial(2):
+                    T.copy(p_l1, g2_l0a[s, :, :])
+                    T.copy(v_l1, g2_l0b[s, :, :])
+                    T.barrier_all()
+                    T.mma(g2_l0a[s, :, :], g2_l0b[s, :, :], g2_l0c[:, :], init=(s == 0))
+                    T.barrier_all()
+                T.copy(g2_l0c[:, :], C2[:, :])
+                T.barrier_all()
+
+    return main
+
+
+def equal_slot_kernel(g2_l0b_base=0):
+    """Two double-buffered L0B groups with identical slot sizes (mtgr style).
+
+    Both B operands are ``[2, BN, DV]`` -> 16KB slots, so any same-base overlap
+    is aligned and must be accepted.
+    """
+
+    @T.prim_func
+    def main(
+        A1: T.Tensor((M, BN), "float16"),  # type: ignore
+        B1: T.Tensor((BN, DV), "float16"),  # type: ignore
+        A2: T.Tensor((M, BN), "float16"),  # type: ignore
+        B2: T.Tensor((BN, DV), "float16"),  # type: ignore
+        C1: T.Tensor((M, DV), "float"),  # type: ignore
+        C2: T.Tensor((M, DV), "float"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a1_l1 = T.alloc_L1((M, BN), "float16")
+            b1_l1 = T.alloc_L1((BN, DV), "float16")
+            a2_l1 = T.alloc_L1((M, BN), "float16")
+            b2_l1 = T.alloc_L1((BN, DV), "float16")
+
+            g1_l0a = T.alloc_L0A((2, M, BN), "float16")
+            g1_l0b = T.alloc_L0B((2, BN, DV), "float16")
+            g1_l0c = T.alloc_L0C((M, DV), "float")
+            g2_l0a = T.alloc_L0A((2, M, BN), "float16")
+            g2_l0b = T.alloc_L0B((2, BN, DV), "float16")
+            g2_l0c = T.alloc_L0C((M, DV), "float")
+
+            T.annotate_address({g1_l0b: 0, g2_l0b: g2_l0b_base})
+
+            with T.Scope("C"):
+                T.barrier_all()
+                T.copy(A1, a1_l1)
+                T.copy(B1, b1_l1)
+                T.copy(A2, a2_l1)
+                T.copy(B2, b2_l1)
+                T.barrier_all()
+
+                for s in T.serial(2):
+                    T.copy(a1_l1, g1_l0a[s, :, :])
+                    T.copy(b1_l1, g1_l0b[s, :, :])
+                    T.barrier_all()
+                    T.mma(g1_l0a[s, :, :], g1_l0b[s, :, :], g1_l0c[:, :], init=(s == 0))
+                    T.barrier_all()
+                T.copy(g1_l0c[:, :], C1[:, :])
+                T.barrier_all()
+
+                for s in T.serial(2):
+                    T.copy(a2_l1, g2_l0a[s, :, :])
+                    T.copy(b2_l1, g2_l0b[s, :, :])
+                    T.barrier_all()
+                    T.mma(g2_l0a[s, :, :], g2_l0b[s, :, :], g2_l0c[:, :], init=(s == 0))
+                    T.barrier_all()
+                T.copy(g2_l0c[:, :], C2[:, :])
+                T.barrier_all()
+
+    return main
+
+
+def _get_buffer_offsets(kernel_source: str) -> dict[str, int]:
+    """Parse buffer byte offsets from the generated AscendC source."""
+    offsets = {}
+    for line in kernel_source.split("\n"):
+        m = re.search(
+            r"auto\s+(\w+)\s*=.*GetWithOffset<[^>]+>\(\s*\d+\s*,\s*(\d+)\s*\)",
+            line,
+        )
+        if m:
+            offsets[m.group(1)] = int(m.group(2))
+    return offsets
+
+
+def _compile_and_get_offsets(program, pass_configs):
+    kernel = tilelang.compile(program, pass_configs=pass_configs, target="ascendc", out_idx=[])
+    return _get_buffer_offsets(kernel.get_kernel_source())
+
+
+# ---------------------------------------------------------------------------
+# Rejected layouts
+# ---------------------------------------------------------------------------
+
+
+def test_issue_straddle_l0b_base0_rejected():
+    """The issue #1664 layout: both L0B groups at base 0, 24KB vs 16KB slots.
+
+    GEMM2's slot 1 [16KB, 32KB) covers the tail of GEMM1's slot 0 and the head
+    of GEMM1's slot 1, so compilation must fail with the straddle diagnostic.
+    """
+    with pytest.raises(Exception, match=re.escape(CONFLICT_HEADER)) as exc_info:
+        tilelang.compile(
+            gqa_style_kernel(*ISSUE_BASE0),
+            pass_configs=PASS_EXPERT_LINEAR,
+            target="ascendc",
+            out_idx=[],
+        )
+    assert "straddles" in str(exc_info.value)
+    assert "g1_l0b" in str(exc_info.value) and "g2_l0b" in str(exc_info.value)
+
+
+def test_issue_straddle_l0b_base0_rejected_auto_sync():
+    """The guard must also fire with the auto sync passes enabled."""
+    with pytest.raises(Exception, match=re.escape(CONFLICT_HEADER)):
+        tilelang.compile(
+            gqa_style_kernel(*ISSUE_BASE0),
+            pass_configs=PASS_AUTO_SYNC,
+            target="ascendc",
+            out_idx=[],
+        )
+
+
+def test_straddle_l0a_rejected():
+    """Same hazard in L0A: mismatched slots with a straddling base.
+
+    L0B uses the issue's fixed layout (base 8KB), while GEMM2's L0A
+    ([2, M, BN] -> 4KB slots) sits at 4KB inside GEMM1's L0A ([2, M, DK] ->
+    12KB slots): GEMM2's slot 1 [8KB, 12KB) straddles GEMM1's side boundary.
+    """
+    with pytest.raises(Exception, match=re.escape(CONFLICT_HEADER)) as exc_info:
+        tilelang.compile(
+            gqa_style_kernel(g2_l0b_base=ISSUE_FIXED[0], g2_l0a_base=4096),
+            pass_configs=PASS_EXPERT_LINEAR,
+            target="ascendc",
+            out_idx=[],
+        )
+    assert "l0a" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Accepted layouts
+# ---------------------------------------------------------------------------
+
+
+def test_issue_fixed_layout_base8k_accepted():
+    """The fix proposed in issue #1664: shift GEMM2's L0B base to 8KB.
+
+    Both groups then share the side boundary at 24KB and every GEMM2 slot lies
+    inside a single GEMM1 slot, so the original per-side ownership tokens keep
+    protecting the whole region.
+    """
+    offsets = _compile_and_get_offsets(gqa_style_kernel(*ISSUE_FIXED), PASS_EXPERT_LINEAR)
+    assert offsets["g1_l0b"] == 0
+    assert offsets["g2_l0b"] == 8192
+
+
+def test_aligned_equal_slots_accepted():
+    """Equal slot sizes at the same base (mtgr-style overlap) stay valid."""
+    offsets = _compile_and_get_offsets(equal_slot_kernel(0), PASS_EXPERT_LINEAR)
+    assert offsets["g1_l0b"] == 0
+    assert offsets["g2_l0b"] == 0
+
+
+def test_disjoint_equal_slots_accepted():
+    """Disjoint address ranges are always valid."""
+    offsets = _compile_and_get_offsets(equal_slot_kernel(32768), PASS_EXPERT_LINEAR)
+    assert offsets["g1_l0b"] == 0
+    assert offsets["g2_l0b"] == 32768
+
+
+def test_single_double_buffered_l0b_accepted():
+    """A single pre-allocated double-buffered L0B has no pair and must pass."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, BN), "float16"),  # type: ignore
+        B: T.Tensor((BN, DV), "float16"),  # type: ignore
+        C: T.Tensor((M, DV), "float"),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            a_l1 = T.alloc_L1((M, BN), "float16")
+            b_l1 = T.alloc_L1((BN, DV), "float16")
+            a_l0a = T.alloc_L0A((2, M, BN), "float16")
+            b_l0b = T.alloc_L0B((2, BN, DV), "float16")
+            c_l0c = T.alloc_L0C((M, DV), "float")
+            T.annotate_address({a_l0a: 0, b_l0b: 0})
+            with T.Scope("C"):
+                T.barrier_all()
+                T.copy(A, a_l1)
+                T.copy(B, b_l1)
+                T.barrier_all()
+                for s in T.serial(2):
+                    T.copy(a_l1, a_l0a[s, :, :])
+                    T.copy(b_l1, b_l0b[s, :, :])
+                    T.barrier_all()
+                    T.mma(a_l0a[s, :, :], b_l0b[s, :, :], c_l0c[:, :], init=(s == 0))
+                    T.barrier_all()
+                T.copy(c_l0c[:, :], C[:, :])
+                T.barrier_all()
+
+    offsets = _compile_and_get_offsets(main, PASS_EXPERT_LINEAR)
+    assert offsets["b_l0b"] == 0
+    assert offsets["a_l0a"] == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Closes #1664. The issue reported that `flashattn_fwd_v4` in the GQA backward example placed GEMM1's and GEMM2's double-buffered L0B groups both at base 0 with different slot sizes (24KB vs 16KB), so GEMM2's slot 1 straddled GEMM1's side boundary — the per-side ownership token could not protect the straddled region and the kernel failed at runtime with `507015: L0B read/write conflict in the MTE (same address)`.

That hand-written kernel was already removed by the Developer-mode rewrite (#1623) and the bug no longer reproduces at HEAD. This PR adds a compile-time guard so this hazard class can never silently return: it compiled cleanly and only failed on hardware under load.

## Changes

- `AscendMemoryPlanning` (`src/transform/ascend_memory_planning.cc`): new `ValidatePreAllocatedDoubleBuffers()` — when two pre-allocated (`T.annotate_address`) `[2, ...]` buffers **in the same L0A/L0B/L0C scope** overlap and their ping-pong slot boundary points differ (a slot of one straddles both slots of the other), fail with a diagnostic naming the buffers, their ranges and the remedies. Aligned overlap (the issue's proposed 8KB base shift, where both side boundaries coincide at 24KB) and disjoint ranges remain valid. Runs in both linear (Expert) and auto planning modes. L1/UB manual aliasing is intentionally out of scope.
- `Flatten2DBuffer` (`src/transform/ascend_collect_buffer_shape.cc`): keep `kInitialBufferShapes` on the function so the planner can recover the leading double-buffer stage extent after logical shapes are flattened to 2D.
- `testing/python/language/test_ascend_l0_double_buffer_straddle.py`: regression tests reproducing the issue's exact GEMM1/GEMM2 L0B shapes (`[2, 192, 64]` vs `[2, 64, 128]` at base 0 → rejected), plus the accepted layouts: the issue's fixed 8KB-shift layout (address-verified), mtgr-style equal-slot overlap, disjoint ranges, a single double-buffered group, an L0A straddle variant, and the auto-sync pass configuration.

## Testing

On Ascend910_9362 (910B3-class), CANN 9.1.0, this workspace:

- New tests: `pytest testing/python/language/test_ascend_l0_double_buffer_straddle.py` → **7/7 passed** (the issue's layout now fails at compile time with `Double-buffered L0B buffer conflict ... straddles ...`).
- Regression suites: `test_ascend_memory_planning.py` **32/32** (ascendc + pto), `test_tilelang_ascend_language_kernel_driven_mma.py` **3/3**, `test_tilelang_ascend_language_l1_to_l0.py` **156/156**, `test_tilelang_ascend_language_mma.py` **2/2**.
- In-tree Expert kernels with hand-placed L0 addresses: `mtgr_ragged_segment_attention.py` (D=128, equal slots) compile + run + golden **PASS**; `example_gqa_sink_fwd_varlen.py` compile + run + precision **PASS**.
- The issue's own example: `examples_experiment/example_gqa_bwd/test_gqa_bwd.py --level l0` → **6/6 PASS** (incl. production shape B=8 H=32 N=1024 D_qk=192 D_v=128 g=16).
- The issue's stress methodology (8 independent processes bound to one NPU, production shape under `do_bench` on fwd and bwd, pre/post-stress precision gates): **8/8 PASS**, zero 507015 / OOM / timeout, forward output bitwise deterministic — measured both before and after this change.

Note: the guard also exposes a latent hazard in `examples/generative_recommendation/mtgr_ragged_segment_attention.py` if it were ever run with `dim != block_N` (its `l0a_s`/`l0a_o` share base 0 with per-side tokens); the standard D=128 configuration is aligned and unaffected.

🤖 Generated with CANNBot