### PR TITLE
test: fix int32 right-shift random bound

### DIFF
--- a/testing/python/language/parallel/test_tilelang_ascend_language_parallel.py
+++ b/testing/python/language/parallel/test_tilelang_ascend_language_parallel.py
@@ -419,7 +419,7 @@ class TestTileLangKernels:
 
     def test_shiftright_operation(self, clear_cache, setup_random_seed):
         """Test bitwise right shift kernel"""
-        scalar_value = random.randint(1, 32)
+        scalar_value = random.randint(1, 31)
 
         def kernel_func(M, N, block_M, block_N):
             return self.unary_op_kernel_int(M, N, block_M, block_N, op_func=lambda a: a >> scalar_value, dtype="int32")


### PR DESCRIPTION
## 关联 Issue

Fixes #1663 
## 问题背景

`test_shiftright_operation` 使用以下代码随机生成 `int32` 右移位数：

```python
scalar_value = random.randint(1, 32)
```

Python 的 `random.randint(1, 32)` 使用闭区间，因此可能生成 `32`。但对于 `int32`，合法移位量必须满足：

```text
0 <= shift < 32
```

当随机值恰好为 `32` 时，TVM 在构造 TIR 表达式阶段会报错：

```text
Shift amount must be non-negative and less than 32 for type int32
```

这会导致该测试用例偶发失败，并非 CANN 或 NPU 执行异常。

## 修改内容

将随机移位范围由：

```python
scalar_value = random.randint(1, 32)
```

修正为：

```python
scalar_value = random.randint(1, 31)
```

确保生成的所有移位量均在 `int32` 的合法范围内。

## 影响范围

本次仅修改一行测试代码：

```text
testing/python/language/parallel/test_tilelang_ascend_language_parallel.py
```

未修改 TileLang 实现、算子逻辑、CI 配置或其他测试用例，也未通过添加 `skip` 或 `xfail` 绕过测试。

## 验证环境

* 硬件：Ascend A3
* SoC：Ascend910_9392
* CANN：9.1.0
* Python：3.12.13
* PyTorch：2.7.1+cpu
* torch-npu：2.7.1.post2

## 验证结果

修改后完整 `bench_test` 运行通过：