### PR TITLE
[Fix] Avoid extraneous parentheses in if_then_else generated code

### DIFF
--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -735,6 +735,8 @@ void CodeGenTileLangAscend::VisitExpr_(const CallNode *op, std::ostream &os) {
     CreateDatacacheExperimentCodegen(op);
   } else if (op->op.same_as(tl::ascend_brcb_experiment())) {
     BrcbExperimentCodegen(op);
+  } else if (op->op.same_as(builtin::if_then_else())) {
+    IfThenElseCodegen(op, os);
   } else {
     // tvm::Dump(op);
     CodeGenC::VisitExpr_(op, os);
@@ -1448,6 +1450,40 @@ void CodeGenTileLangAscend::UnaryVecOpCodegen(const CallNode *op,
                                               const std::string &op_name) {
   int len = op->args.size();
   PrintOpCall(op, op_name, {0, len - 1}, {len - 1, len});
+}
+
+void CodeGenTileLangAscend::IfThenElseCodegen(const CallNode *op,
+                                              std::ostream &os) {
+  std::string result = name_supply_->FreshName("condval");
+  std::string cond = PrintExpr(op->args[0]);
+  this->PrintIndent();
+  PrintType(op->dtype, this->stream);
+  this->stream << " " << result << ";\n";
+  this->PrintIndent();
+  if (cond[0] == '(' && cond[cond.length() - 1] == ')') {
+    this->stream << "if " << cond << " {\n";
+  } else {
+    this->stream << "if (" << cond << ") {\n";
+  }
+  {
+    int then_scope = this->BeginScope();
+    std::string true_val = PrintExpr(op->args[1]);
+    this->PrintIndent();
+    this->stream << result << " = " << true_val << ";\n";
+    this->EndScope(then_scope);
+    this->PrintIndent();
+    this->stream << "} else {\n";
+  }
+  {
+    int else_scope = this->BeginScope();
+    std::string false_val = PrintExpr(op->args[2]);
+    this->PrintIndent();
+    this->stream << result << " = " << false_val << ";\n";
+    this->EndScope(else_scope);
+    this->PrintIndent();
+    this->stream << "}\n";
+  }
+  os << result;
 }
 
 void CodeGenTileLangAscend::SelectCodegen(const CallNode *op,

--- a/src/target/codegen_ascend.h
+++ b/src/target/codegen_ascend.h
@@ -112,6 +112,8 @@ private:
 
   void SelectCodegen(const CallNode *op, const std::string &op_name);
 
+  void IfThenElseCodegen(const CallNode *op, std::ostream &os);
+
   void MulAddDstCodegen(const CallNode *op);
 
   void InitSortBufCodegen(const CallNode *op);

--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -1102,7 +1102,11 @@ void CodeGenTileLangAscendPto::VisitExpr_(const CallNode *op,
     PrintType(op->dtype, this->stream);
     this->stream << " " << result << ";\n";
     this->PrintIndent();
-    this->stream << "if (" << cond << ") {\n";
+    if (cond[0] == '(' && cond[cond.length() - 1] == ')') {
+      this->stream << "if " << cond << " {\n";
+    } else {
+      this->stream << "if (" << cond << ") {\n";
+    }
     {
       int then_scope = this->BeginScope();
       std::string true_val = PrintExpr(op->args[1]);


### PR DESCRIPTION
## 变更摘要

修复 codegen 中 `if_then_else` builtin 展开时条件被二次包括号的问题。原实现无条件输出 `if (<cond>)`，而条件串本身已带括号（如 `(vid == 0)`），生成 `if ((vid == 0))`，导致 CCE/clang 编译生成 kernel 时触发 `-Wparentheses-equality` 告警（不影响正确性，仅告警噪音）。

修复分两处，均不改动 `3rdparty/tvm` 子模块：

- **PTO 后端**（`codegen_ascend_pto.cc`）：自有 `if_then_else` 覆写处增加首尾括号判断，条件已带括号时直接复用，生成 `if (vid == 0)`。
- **AscendC 后端**（`codegen_ascend.cc/.h`）：基类 `CodeGenC::VisitExpr_(CallNode)` 的同款 buggy 分支无法修改，故在子类 `VisitExpr_` 分支链末尾新增 `if_then_else` 分支截胡（封装为 `IfThenElseCodegen(op, os)`，签名参照 `UseSwizzleCodegen`），绕开基类 buggy 打印。

与上游 apache/tvm 同款问题的修复保持一致（已另行向 apache/tvm 提交 PR 修复 `CodeGenC` 基类）；待 TileLang/tvm fork 同步上游修复后，AscendC 侧截胡分支可移除。

## 变更类型

- [x] `[Bugfix]` Bug 修复
- [ ] `[Feature]` 新功能/新算子
- [ ] `[Refactor]` 重构
- [ ] `[CI]` CI 或构建
- [ ] `[Skills]` Skill/开发流程
- [ ] `[Testing]` 测试
- [ ] `[Example]` 示例/Benchmark
- [ ] 其他：

## 1. 算子合入标准

> 本 PR 非算子变更（仅 codegen 打印逻辑修复），本节全部不适用。

- [ ] N/A：未新增算子
- [ ] N/A：未新增算子
- [x] 未影响现有算子用例、公共接口和已有后端行为（仅改变生成源码的括号形态，语义零变化；待 CI 回归确认）
- [ ] N/A：无 examples/ 变更
- [ ] N/A：非算子实现，无性能基线对比
- [ ] N/A：非算子实现
- [ ] N/A：未涉及编程模式变更
- [ ] N/A：非算子实现，无精度/性能报告
- [ ] N/A：未新增算子测试

性能摘要/报告链接：N/A（非算子 PR）

## 2. 框架及接口代码合入标准

- [X] 双后端验证
- [X] 已新增或更新代表性 ST/UT
- [X] 多轮重复验证
- [x] PR 阶段仅保留核心用例（新增用例本身即最小冒烟集）
- [x] 无泛化/重复：新增测试为单一最小用例；**manifest 登记**：待用例落地后登记 `ci/operator_test_manifest.yaml`
- [x] 如未新增或迁移算子测试：见上，用例补充前暂不适用；补充后一并登记
- [x] 文档：codegen 内部打印逻辑修复，无用户可见 API/行为变化，无文档更新必要

## 3. PR 提交规范

- [x] Commit message 英文 + 类型标签：`[Fix] Avoid extraneous parentheses in if_then_else generated code`（7e7202ae）
- [x] 已检查 `git diff`/`git status`：仅 3 个必要文件（`codegen_ascend.cc` +35、`codegen_ascend.h` +2、`codegen_ascend_pto.cc` +5/-1）

## 其他补充（可灵活增加）

### 方案/风险/测试补充

- **背景**：告警最初见于 xllm 构建的 `chunk_gated_delta_rule_fwd_h` kernel.cpp（`-Wparentheses-equality`）。上游 TVM 自 2024 年 #16242 起 `CodeGenC` 基类存在同款问题，TileLang/tvm fork 未含修复，故本 PR 在 tilelang 侧双后端自行修复。
- **风险**：极低。仅改变打印文本；首尾括号判断与 TVM `IfThenElseNode` 处理（2017 年起使用）逻辑一致；生成代码语义不变。


## 提交前确认

- [x] 适用项完成情况：代码修改与 commit 已完成