### PR TITLE
[Bugfix] Reject copy sources with more than two active dimensions

### DIFF
--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -88,6 +88,37 @@ AscendCopy::AscendCopy(Array<PrimExpr> args, BufferMap vmap) : args_(args) {
   std::tie(this->src, this->dst) = std::tie(bf[0], bf[1]);
   std::tie(this->src_range, this->dst_range) = std::tie(rgs[0], rgs[1]);
   std::tie(this->src_extents, this->dst_extents) = std::tie(ets[0], ets[1]);
+
+  // Guard: reject a source region with more than two active (extent != 1)
+  // dims.  The lowering (find_active_dim_indices in Lower) only honours the
+  // LAST TWO active dims of the source region; a source with >= 3 active dims
+  // (e.g. Q[b, s0:s0+bs, g0:g0+G, :] with extents [1, bs, G, D]) would have its
+  // leading active dim(s) silently dropped -- only the trailing two are DMA'd
+  // and no error is raised.  Turn that silent data loss into an explicit
+  // compile-time error.  A dim counts as active unless its extent is a
+  // compile-time IntImm equal to 1 (symbolic extents are conservatively
+  // active, mirroring find_active_dim_indices).  Only the source side is
+  // checked: destination slices of a 2-D on-chip buffer (L1 row splice) are a
+  // supported pattern, and full-buffer sources (transpose / cross-CV paths)
+  // never exceed two active dims in legal use.
+  {
+    int n_active_src = 0;
+    for (const auto &e : this->src_extents) {
+      if (auto *imm = e.as<IntImmNode>()) {
+        if (imm->value == 1)
+          continue;
+      }
+      n_active_src++;
+    }
+    ICHECK_LE(n_active_src, 2)
+        << "T.copy source region has " << n_active_src
+        << " active dims (extents " << this->src_extents
+        << "); the ascend lowering only supports source regions with at most "
+           "2 active (extent != 1) dims -- leading active dims would be "
+           "silently dropped. Loop over the leading dims and issue one "
+           "2-active-dim copy per iteration (e.g. T.copy(Q[b, s, g0:g0+G, :], "
+           "buf) inside a serial s loop).";
+  }
 }
 
 AscendAtomicAdd::AscendAtomicAdd(Array<PrimExpr> args, BufferMap vmap)

--- a/testing/python/language/test_tilelang_ascend_language_copy_active_dims.py
+++ b/testing/python/language/test_tilelang_ascend_language_copy_active_dims.py
@@ -1,0 +1,104 @@
+import pytest
+import tilelang
+import tilelang.language as T
+
+"""
+T.copy source-region active-dimension guard.
+
+Feature under test
+------------------
+``tl.ascend_copy`` lowering (src/op/ascend.cc ``find_active_dim_indices``) only
+honours the **last two** active (extent != 1) dimensions of the source region.
+A source region with >= 3 active dimensions -- e.g. a 4-D global slice
+``Q[b, s0:s0+bs, g0:g0+G, :]`` with extents ``[1, bs, G, D]`` -- silently drops
+the leading active dimension(s): only ``[G, D]`` is DMA'd, the ``bs`` extent is
+never transferred, no error is raised, and the result is silently wrong.
+
+The guard
+---------
+``src/op/ascend.cc::AscendCopy`` now raises a lowering-time error when the
+*source* region of a copy has more than two active dimensions (message contains
+"active dims").  This turns the silent data loss into an explicit, searchable
+compile-time error.
+
+Legal patterns that must NOT trip the guard
+-------------------------------------------
+  * Leading dims with extent == 1 (the FA/GQA pattern):
+    ``Q[bz, s, g0:g0+G, :]`` -> extents ``[1, 1, G, D]`` -> 2 active dims.
+  * Symbolic extents count as active (they may be != 1 at runtime), so a
+    symbolic leading dim on the source is rejected -- this is intentional: the
+    lowering cannot prove it is 1, and silently dropping it would be wrong.
+  * The destination side is not restricted by this guard (L1 row-splice writes
+    into a 2-D buffer slice remain legal).
+"""
+
+TARGET = "ascendc"
+
+DEV_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+def copy_src_3_active_dims(batch, bs, groups, dim, dtype):
+    """Illegal: source region [1, bs, G, D] has 3 active dims (bs, G, D).
+
+    The destination is a UB buffer so the copy itself is otherwise legal
+    (GM -> UB): without the guard this compiles silently and drops the bs
+    extent, producing wrong results with no error.
+    """
+
+    @T.prim_func
+    def main(
+        Q: T.Tensor([batch, bs, groups, dim], dtype),  # type: ignore
+        Out: T.Tensor([bs, groups, dim], dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            buf = T.alloc_ub([groups, dim], dtype)
+            # extents [1, bs, G, D] -> 3 active dims -> must raise
+            T.copy(Q[0, 0:bs, 0:groups, :], buf)
+            T.copy(buf, Out[0, :, :])
+
+    return main
+
+
+def copy_src_leading_dim_one(batch, seq, groups, dim, dtype):
+    """Legal: source region [1, 1, G, D] has only 2 active dims (G, D).
+
+    This is the FA/GQA load pattern; the guard must not trip on it.  The
+    destination is UB so the whole kernel is a supported GM -> UB -> GM flow.
+    """
+
+    @T.prim_func
+    def main(
+        Q: T.Tensor([batch, seq, groups, dim], dtype),  # type: ignore
+        Out: T.Tensor([groups, dim], dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            buf = T.alloc_ub([groups, dim], dtype)
+            T.copy(Q[0, 0, 0:groups, :], buf)
+            T.copy(buf, Out[:, :])
+
+    return main
+
+
+def test_copy_src_3_active_dims_raises():
+    """A >=3-active-dim source region must raise a compile-time error."""
+    func = copy_src_3_active_dims(1, 4, 8, 128, "float16")
+    with pytest.raises(Exception, match="active dims"):
+        tilelang.compile(func, pass_configs=DEV_CONFIGS, target=TARGET)
+
+
+def test_copy_src_leading_dim_one_ok():
+    """The FA/GQA pattern (leading extent-1 dims) must still compile."""
+    func = copy_src_leading_dim_one(1, 4, 8, 128, "float16")
+    # Should compile without raising; no need to run on device.
+    tilelang.compile(func, out_idx=[-1], pass_configs=DEV_CONFIGS, target=TARGET)
+
+
+if __name__ == "__main__":
+    test_copy_src_3_active_dims_raises()
+    test_copy_src_leading_dim_one_ok()
+    print("PASS")


### PR DESCRIPTION
Closes #1768

## 变更摘要

Ascend copy lowering only consumes the last two active dimensions of a source region. A source such as `Q[b, s0:s0+bs, g0:g0+G, :]` therefore silently dropped the leading active dimension and produced incomplete DMA data.

This PR rejects source regions with more than two active dimensions during `LowerTileOp`, with an actionable diagnostic telling users to loop over leading dimensions. Extent-1 leading dimensions remain legal.

## 变更类型

- [x] `[Bugfix]` Bug 修复

## 2. 框架及接口代码合入标准

- [x] 已新增代表性回归测试，覆盖非法 3-active-dim source 和合法的 FA/GQA extent-1 leading dims。
- [x] 修改仅影响此前会静默丢数据的 unsupported source region。
- [x] 无新增算子，operator manifest 不适用。
- [x] 无 API 文档变更；错误消息明确给出能力边界和改写方式。

## 3. PR 提交规范

- [x] Commit message 使用英文并包含 `[Bugfix]`。
- [x] PR 仅包含 guard 与对应测试。

## 其他补充

- 回归测试的非法路径在本地通过（修复前不抛错，修复后抛出 `active dims`）。
- 合法路径需要启用 Ascend codegen 的构建；当前 macOS 本地构建未注册 `target.build.tilelang_ascend`，交由 NPU CI 验证。
- 原开发验证曾覆盖 language copy/mma suites，并对 GQA 20 个 case 做过 baseline 对比。