### PR TITLE
[Bugfix] Preserve floor semantics for negative division and modulo

### DIFF
--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -416,18 +416,20 @@ void CodeGenTileLangAscend::PrintStorageScope(const std::string &scope,
 
 void CodeGenTileLangAscend::VisitExpr_(const FloorDivNode *op,
                                        std::ostream &os) {
-  os << "(";
+  // floor 语义降到 tl::ascend::tl_floordiv(C / 是截断,负数不符 floor——
+  // conv strip 闭式错位实录,见 common.h 注释)
+  os << "tl::ascend::tl_floordiv(";
   PrintExpr(op->a, os);
-  os << " / ";
+  os << ", ";
   PrintExpr(op->b, os);
   os << ")";
 }
 
 void CodeGenTileLangAscend::VisitExpr_(const FloorModNode *op,
                                        std::ostream &os) {
-  os << "(";
+  os << "tl::ascend::tl_floormod(";
   PrintExpr(op->a, os);
-  os << " % ";
+  os << ", ";
   PrintExpr(op->b, os);
   os << ")";
 }

--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -165,6 +165,22 @@ CATLASS_DEVICE void mma(LocalTensor<T1> const A, LocalTensor<T1> const B,
   // }
 }
 
+// C and C++ integer division truncates toward zero, while TIR FloorDiv and
+// FloorMod round toward negative infinity.  Preserve TIR semantics when an
+// operand is negative instead of lowering these nodes directly to / and %.
+template <typename T, typename U>
+CATLASS_DEVICE __forceinline__ auto tl_floordiv(T a, U b) -> decltype(a / b) {
+  auto q = a / b;
+  auto r = a % b;
+  return (r != 0 && ((r < 0) != (b < 0))) ? q - 1 : q;
+}
+
+template <typename T, typename U>
+CATLASS_DEVICE __forceinline__ auto tl_floormod(T a, U b) -> decltype(a % b) {
+  auto r = a % b;
+  return (r != 0 && ((r < 0) != (b < 0))) ? r + b : r;
+}
+
 template <typename T1, typename T2, typename LayoutGM, uint32_t srcM,
           uint32_t srcN, bool enRelu = false>
 CATLASS_DEVICE void

--- a/testing/python/language/test_tilelang_ascend_language_floordiv_neg.py
+++ b/testing/python/language/test_tilelang_ascend_language_floordiv_neg.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""FloorDiv/FloorMod 负数语义回归(codegen 曾把 floordiv 直降为 C 的 `/`
+截断除法——(-3)/4=0 而非 -1,conv strip 闭式 s0 在 pad 边界 band 上错位,
+实测首/末 band 输出错,见 conv2d trace 2026-08-30)。
+
+验证: 运行期数据驱动,核内计算 floordiv/floormod 负数组合并与 python
+// % (floor 语义)逐点对照。
+"""
+
+import torch
+
+import tilelang
+import tilelang.language as T
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+}
+
+N = 64
+
+
+def build():
+    @tilelang.jit(out_idx=[1, 2], pass_configs=pass_configs, target="ascendc")
+    def kernel():
+        @T.prim_func
+        def main(X: T.Tensor([N], "int32"), D: T.Tensor([N], "int32"), M: T.Tensor([N], "int32")):
+            with T.Kernel(1, is_npu=True) as (cid, vid):
+                xb = T.alloc_ub([N], "int32")
+                db = T.alloc_ub([N], "int32")
+                mb = T.alloc_ub([N], "int32")
+                with T.Scope("V"):
+                    T.copy(X, xb)
+                    for i in T.serial(N):
+                        db[i] = T.floordiv(xb[i] - 5, 4)
+                        mb[i] = T.floormod(xb[i] - 5, 4)
+                    T.copy(db, D)
+                    T.copy(mb, M)
+
+        return main
+
+    return kernel()
+
+
+def test_negative_floordiv_and_floormod():
+    torch.manual_seed(0)
+    x = torch.randint(0, 12, (N,), dtype=torch.int32).npu()  # x-5 ∈ [-5, 6]
+    k = build()
+    d, m = k(x)
+    torch.npu.synchronize()
+    xd = (x.cpu() - 5).numpy()
+    import numpy as np
+
+    ref_d = np.floor_divide(xd, 4)
+    ref_m = np.mod(xd, 4)  # python 语义 = floor mod
+    ok_d = (d.cpu().numpy() == ref_d).all()
+    ok_m = (m.cpu().numpy() == ref_m).all()
+    print(f"floordiv: {'PASS' if ok_d else 'FAIL'}, floormod: {'PASS' if ok_m else 'FAIL'}")
+    if not ok_d:
+        bad = d.cpu().numpy() != ref_d
+        i = np.nonzero(bad)[0][0]
+        print(f"  样例: floordiv({xd[i]},4) 核={d.cpu().numpy()[i]} 应为 {ref_d[i]}")
+    assert ok_d and ok_m
+
+
+if __name__ == "__main__":
+    test_negative_floordiv_and_floormod()


### PR DESCRIPTION
Closes #1764

## 变更摘要

AscendC codegen lowered TIR `FloorDiv`/`FloorMod` directly to C++ `/` and `%`. C++ truncates integer division toward zero, while TIR floor division rounds toward negative infinity. Negative indices at padded boundaries therefore selected the wrong convolution strip/band.

This PR lowers the nodes to small helpers that adjust quotient/remainder signs and preserve TIR semantics.

## 变更类型

- [x] `[Bugfix]` Bug 修复

## 2. 框架及接口代码合入标准

- [x] Added an NPU runtime regression covering negative and positive operands.
- [x] The regression compares both division and modulo against NumPy floor semantics.
- [x] Change is limited to AscendC FloorDiv/FloorMod code generation.
- [x] No new operator or public API; manifest/performance requirements are not applicable.

## 3. PR 提交规范

- [x] English `[Bugfix]` commit message.
- [x] PR contains only the semantic lowering fix and regression.

## 其他补充

The original failure was reproduced in conv2d padded boundary bands: C++ `(-3)/4 == 0`, while TIR requires `floor_divide(-3,4) == -1`.