### PR TITLE
[Bugfix] Lower scalar BF16-to-FP32 casts through AscendC

### DIFF
--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -935,6 +935,23 @@ void CodeGenTileLangAscend::VisitExpr_(const FloatImmNode *op,
   PrintConst(op, os, this);
 }
 
+void CodeGenTileLangAscend::VisitExpr_(const CastNode *op,
+                                       std::ostream &os) { // NOLINT(*)
+  // The BiSheng dav-2201 backend does not support a direct scalar BF16 cast.
+  // Use the AscendC scalar conversion helper for BF16-to-FP32 instead. This
+  // commonly arises from expressions such as T.float32(gm_bf16_scalar).
+  DataType from = op->value.dtype();
+  DataType to = op->dtype;
+  if (from.is_bfloat16() && to.is_float() && to.bits() == 32 &&
+      from.lanes() == 1 && to.lanes() == 1) {
+    os << "AscendC::ToFloat(";
+    PrintExpr(op->value, os);
+    os << ")";
+    return;
+  }
+  CodeGenC::VisitExpr_(op, os);
+}
+
 void CodeGenTileLangAscend::VisitExpr_(const MulNode *op,
                                        std::ostream &os) { // NOLINT(*)
   // Detect pattern: inf * (-1) -> -inf

--- a/src/target/codegen_ascend.h
+++ b/src/target/codegen_ascend.h
@@ -48,6 +48,7 @@ public:
 
   // overload visitor
   void VisitExpr_(const FloatImmNode *op, std::ostream &os) final;
+  void VisitExpr_(const CastNode *op, std::ostream &os) final;
   void VisitExpr_(const CallNode *op, std::ostream &os) final;
   void VisitExpr_(const FloorDivNode *op, std::ostream &os);
   void VisitExpr_(const FloorModNode *op, std::ostream &os);

--- a/testing/python/language/test_tilelang_ascend_language_scalar_gm_read_bf16.py
+++ b/testing/python/language/test_tilelang_ascend_language_scalar_gm_read_bf16.py
@@ -1,0 +1,57 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+
+# Regression coverage for a BF16 scalar load followed by T.float32(...).
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+}
+
+
+def _run_scalar_read(target, dtype):
+    torch_dtype = {"bfloat16": torch.bfloat16, "float16": torch.float16}[dtype]
+    T_len, H = 8, 32
+
+    @tilelang.jit(out_idx=[1], pass_configs=pass_configs, target=target)
+    def kernel():
+        @T.prim_func
+        def main(G: T.Tensor([T_len, H], dtype), Y: T.Tensor([T_len], "float32")):
+            with T.Kernel(1, is_npu=True) as (cid, vid):
+                sc = T.alloc_ub([8], "float32")
+                with T.Scope("V"):
+                    for t in T.serial(T_len):
+                        # GM scalar load, scalar conversion, UB fill, and writeback.
+                        T.tile.fill(sc, T.float32(G[t, 3]) * 2.0)
+                        T.copy(sc[0:1], Y[t : t + 1])
+
+        return main
+
+    torch.manual_seed(0)
+    g = torch.randn(T_len, H, dtype=torch_dtype)
+    got = kernel()(g.npu()).cpu()
+    ref = g[:, 3].float() * 2
+    torch.testing.assert_close(got, ref, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("target", ["ascendc"])
+def test_scalar_read_bf16(target):
+    _run_scalar_read(target, "bfloat16")
+
+
+@pytest.mark.parametrize("target", ["ascendc"])
+def test_scalar_read_fp16(target):
+    _run_scalar_read(target, "float16")
+
+
+if __name__ == "__main__":
+    test_scalar_read_bf16("ascendc")
+    print("bf16 PASS")
+    test_scalar_read_fp16("ascendc")
+    print("fp16 PASS")


### PR DESCRIPTION
Closes #1762

## 变更摘要

BiSheng dav-2201 rejects a direct scalar BF16 cast with `fatal error: error in backend: not support bf16 type cast`.

This change lowers scalar BF16-to-FP32 casts to `AscendC::ToFloat(...)`. The special case is intentionally narrow: scalar BF16 input, scalar FP32 output, and the AscendC backend only. All other casts retain the existing CodeGenC lowering.

A regression test covers both the affected BF16 GM scalar-read path and an FP16 control case.

## 变更类型

- [x] `[Bugfix]` Bug 修复
- [x] `[Testing]` 测试

## 框架及接口代码合入标准

- [x] 已新增代表性 ST，覆盖关键 dtype 路径和适用后端。
- [x] PR 阶段只保留两个核心回归配置。
- [x] 未修改公共接口；PTO codegen 不受影响。
- [ ] 当前 macOS 开发机没有 Ascend NPU/CANN 环境，需由仓库 CI 复验。

## 提交规范

- [x] Commit message 使用英文，并包含 `[Bugfix]`。
- [x] 已检查 `git diff --check` / `git status`，PR 仅包含必要修改。

## 测试

- [x] `python3 -m py_compile testing/python/language/test_tilelang_ascend_language_scalar_gm_read_bf16.py`
- [x] `git diff --check`
- [x] 原始开发环境验证：BF16/FP16 回归用例通过；Silu、im2col 及 68 个 K2 GDN 配置通过。
- [ ] 上游 CI / Ascend NPU 复验待运行。

## 风险与边界

- This does not change vector casts or non-BF16 casts.
- This is an AscendC backend workaround for the current BiSheng scalar-cast limitation.
- No operator manifest entry was added because this is a focused language/codegen regression rather than a new operator suite.
