### PR TITLE
[Feature] Enable FP32 GEMM on the AscendC backend

### DIFF
--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -72,14 +72,12 @@ copy_gm_to_l1(LocalTensor<T> dstTensor, GlobalTensor<T> srcTensor,
     AscendC::PipeBarrier<PIPE_MTE2>();
   }
   auto layout = MakeLayoutFromTag(LayoutGM{tailM, realSrcN});
-  auto src_LAYOUT = MakeLayoutTile(layout, tla::MakeShape(tailM, tailN));
-  auto src = tla::MakeTensor<decltype(srcTensor), decltype(src_LAYOUT),
-                             AscendC::TPosition::GM>(srcTensor, src_LAYOUT);
+  auto src_LAYOUT = GetTileLayout(layout, tla::MakeShape(tailM, tailN),
+                                  tla::MakeShape(uint32_t(0), uint32_t(0)));
+  auto src = tla::MakeTensor(srcTensor, src_LAYOUT, Arch::PositionGM{});
 
-  using LayoutL1_ = Catlass::detail::TagToLayout_t<T, LayoutL1>;
-  constexpr auto layoutInL1 = tla::MakeLayout<T, LayoutL1_>(dstM, dstN);
-  auto dst = tla::MakeTensor<decltype(dstTensor), decltype(layoutInL1),
-                             AscendC::TPosition::A1>(dstTensor, layoutInL1);
+  auto layoutInL1 = tla::MakeLayout<T, LayoutL1>(dstM, dstN);
+  auto dst = tla::MakeTensor(dstTensor, layoutInL1, Arch::PositionL1{});
 
   TileCopyTla<ArchTag, decltype(src), decltype(dst)> tileCopier;
   tileCopier(dst, src);
@@ -89,20 +87,15 @@ template <typename T, uint32_t srcM, uint32_t srcN, bool transpose = false>
 CATLASS_DEVICE void copy_l1_to_l0a(LocalTensor<T> dstTensor,
                                    LocalTensor<T> srcTensor, uint32_t dstM,
                                    uint32_t dstN) {
-  using LayoutL1_ =
-      std::conditional_t<transpose,
-                         Catlass::detail::TagToLayout_t<T, LayoutL1T>,
-                         Catlass::detail::TagToLayout_t<T, LayoutL1>>;
-  constexpr auto layout = transpose ? tla::MakeLayout<T, LayoutL1_>(srcN, srcM)
-                                    : tla::MakeLayout<T, LayoutL1_>(srcM, srcN);
-  auto src_LAYOUT = MakeLayoutTile(layout, tla::MakeShape(dstM, dstN));
-  auto src = MakeTensor<decltype(srcTensor), decltype(src_LAYOUT),
-                        AscendC::TPosition::A1>(srcTensor, src_LAYOUT);
+  using LayoutL1Tag_ = std::conditional_t<transpose, LayoutL1T, LayoutL1>;
+  auto layout = transpose ? tla::MakeLayout<T, LayoutL1Tag_>(srcN, srcM)
+                          : tla::MakeLayout<T, LayoutL1Tag_>(srcM, srcN);
+  auto src_LAYOUT = GetTileLayout(layout, tla::MakeShape(dstM, dstN),
+                                  tla::MakeShape(uint32_t(0), uint32_t(0)));
+  auto src = MakeTensor(srcTensor, src_LAYOUT, Arch::PositionL1{});
 
-  using LayoutL0A_ = Catlass::detail::TagToLayout_t<T, LayoutL0A>;
-  auto layoutAInL0 = tla::MakeLayout<T, LayoutL0A_>(dstM, dstN);
-  auto dst = tla::MakeTensor<decltype(dstTensor), decltype(layoutAInL0),
-                             AscendC::TPosition::A2>(dstTensor, layoutAInL0);
+  auto layoutAInL0 = tla::MakeLayout<T, LayoutL0A>(dstM, dstN);
+  auto dst = tla::MakeTensor(dstTensor, layoutAInL0, Arch::PositionL0A{});
   TileCopyTla<ArchTag, decltype(src), decltype(dst)> tileCopier;
   tileCopier(dst, src);
 }
@@ -111,20 +104,15 @@ template <typename T, uint32_t srcM, uint32_t srcN, bool transpose = false>
 CATLASS_DEVICE void copy_l1_to_l0b(LocalTensor<T> dstTensor,
                                    LocalTensor<T> srcTensor, uint32_t dstM,
                                    uint32_t dstN) {
-  using LayoutL1_ =
-      std::conditional_t<transpose,
-                         Catlass::detail::TagToLayout_t<T, LayoutL1T>,
-                         Catlass::detail::TagToLayout_t<T, LayoutL1>>;
-  constexpr auto layout = transpose ? tla::MakeLayout<T, LayoutL1_>(srcN, srcM)
-                                    : tla::MakeLayout<T, LayoutL1_>(srcM, srcN);
-  auto src_LAYOUT = MakeLayoutTile(layout, tla::MakeShape(dstM, dstN));
-  auto src = MakeTensor<decltype(srcTensor), decltype(src_LAYOUT),
-                        AscendC::TPosition::A1>(srcTensor, src_LAYOUT);
+  using LayoutL1Tag_ = std::conditional_t<transpose, LayoutL1T, LayoutL1>;
+  auto layout = transpose ? tla::MakeLayout<T, LayoutL1Tag_>(srcN, srcM)
+                          : tla::MakeLayout<T, LayoutL1Tag_>(srcM, srcN);
+  auto src_LAYOUT = GetTileLayout(layout, tla::MakeShape(dstM, dstN),
+                                  tla::MakeShape(uint32_t(0), uint32_t(0)));
+  auto src = MakeTensor(srcTensor, src_LAYOUT, Arch::PositionL1{});
 
-  using LayoutL0B_ = Catlass::detail::TagToLayout_t<T, LayoutL0B>;
-  auto layoutBInL0 = tla::MakeLayout<T, LayoutL0B_>(dstM, dstN);
-  auto dst = tla::MakeTensor<decltype(dstTensor), decltype(layoutBInL0),
-                             AscendC::TPosition::B2>(dstTensor, layoutBInL0);
+  auto layoutBInL0 = tla::MakeLayout<T, LayoutL0B>(dstM, dstN);
+  auto dst = tla::MakeTensor(dstTensor, layoutBInL0, Arch::PositionL0B{});
 
   TileCopyTla<ArchTag, decltype(src), decltype(dst)> tileCopier;
   tileCopier(dst, src);
@@ -156,6 +144,8 @@ CATLASS_DEVICE void mma(LocalTensor<T1> const A, LocalTensor<T1> const B,
   // existing caller is byte-for-byte unchanged.
   mmadParams.unitFlag = unitFlag;
 
+  // Keep the default FP32 mode. Enabling HF32 here reduces FP32 accuracy and
+  // is not required once the operands use the correct LoadData3D path.
   Mmad(C, A, B, mmadParams);
 
   constexpr uint32_t PIPE_M_BARRIER_THRESHOLD = 10;
@@ -174,15 +164,14 @@ copy_l0c_to_gm(GlobalTensor<T2> dstTensor, LocalTensor<T1> srcTensor,
   uint32_t tailM = realTailM == 0 ? srcM : realTailM;
   uint32_t tailN = realTailN == 0 ? srcN : realTailN;
   auto layoutInL0C = tla::MakeLayoutL0C(srcM, srcN);
-  auto src = tla::MakeTensor<decltype(srcTensor), decltype(layoutInL0C),
-                             AscendC::TPosition::CO1>(srcTensor, layoutInL0C);
+  auto src = tla::MakeTensor(srcTensor, layoutInL0C, Arch::PositionL0C{});
   LayoutGM gm{tailM, realDstN};
   auto layout = MakeLayoutFromTag(gm);
   auto dTensor = MakeTensor(dstTensor, layout, Arch::PositionGM{});
   auto layout_ = dTensor.layout();
-  auto dst_LAYOUT = MakeLayoutTile(layout_, tla::MakeShape(tailM, tailN));
-  auto dst = MakeTensor<decltype(dstTensor), decltype(dst_LAYOUT),
-                        AscendC::TPosition::GM>(dstTensor, dst_LAYOUT);
+  auto dst_LAYOUT = GetTileLayout(layout_, tla::MakeShape(tailM, tailN),
+                                  tla::MakeShape(uint32_t(0), uint32_t(0)));
+  auto dst = MakeTensor(dstTensor, dst_LAYOUT, Arch::PositionGM{});
 
   CopyL0CToGmTla<ArchTag, decltype(src), decltype(dst),
                  ScaleGranularity::NO_QUANT, enRelu>

--- a/testing/python/language/test_tilelang_ascend_language_gemm_v0.py
+++ b/testing/python/language/test_tilelang_ascend_language_gemm_v0.py
@@ -375,6 +375,15 @@ def test_gemm_v0_bfloat16_precision(target):
     not (hasattr(torch, "npu") and torch.npu.is_available()),
     reason="gemm_v0 correctness requires an Ascend NPU runtime",
 )
+def test_gemm_v0_float32_ascendc_precision():
+    """FP32 L1-to-L0 loads and MMA must preserve all input elements."""
+    _run_dtype_precision("float32", "float", "ascendc", shape_group="C")
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="gemm_v0 correctness requires an Ascend NPU runtime",
+)
 @pytest.mark.parametrize(
     "transpose_A,transpose_B",
     [

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -165,6 +165,11 @@ class LibraryGenerator:
                 f"-I{TL_ROOT}/3rdparty/shmem/include",
                 f"-I{TL_ROOT}/3rdparty/shmem/src/device",
                 "-DBACKEND_HYBM",
+                # New catlass (>=v2.0) gates all arch-specific tile-copy
+                # specializations behind CATLASS_ARCH; without the define the
+                # GEMM copy templates silently fall back to the unspecialized
+                # primary template and fail to compile.
+                "-DCATLASS_ARCH=3510" if self.platform == "A5" else "-DCATLASS_ARCH=2201",
                 "-I" + TILELANG_TEMPLATE_PATH,
                 f"-L{ASCEND_HOME_PATH}/lib64",
                 "-Wno-macro-redefined",


### PR DESCRIPTION
Closes #1396

Related to #1349

## 变更摘要

Enable correct FP32 GEMM execution on the AscendC backend.

The current Catlass revision has no FP32 specialization for the L1-to-L0A/L0B tile copy. FP32 operands therefore enter a 16-bit `LoadData2D` path and are corrupted (typically every other element). This PR upgrades Catlass to the official v2.0.0 tag, which uses the FP32 `SetFmatrix` + `LoadData3D` path, and adapts TileLang's TLA calls to the v2 API.

Catlass v2 also gates architecture-specific tile-copy implementations behind `CATLASS_ARCH`, so the JIT command now selects 2201 for A2/A3 and 3510 for A5.

No HF32 mode is enabled: the corrected load path allows native FP32 MMA accuracy, while HF32 would reduce precision.

## 变更类型

- [x] `[Feature]` 新功能
- [x] `[Testing]` 测试

## 主要改动

- `3rdparty/catlass`: official v2.0.0 (`769cd40a`).
- Adapt TLA layout/tensor construction to Catlass v2.
- Pass the required `CATLASS_ARCH` definition to BiSheng.
- Add a focused FP32 `gemm_v0` AscendC regression.

## 测试与格式检查

- [x] Confirmed the pinned Catlass commit is reachable from `https://gitcode.com/cann/catlass.git` and tagged `v2.0.0`.
- [x] Ruff 0.16.6 format and lint pass for all changed Python files.
- [x] clang-format 18 passes for the changed C++ template.
- [x] Python syntax compilation passes.
- [x] Original 910B3 validation: flash-attention general-case set 50/50 passed, including 16 FP32 cases and 34 FP16/BF16 cases.
- [x] Original FP32 comparison had max absolute error about `4.4e-6` against an FP64 golden result.
- [ ] Upstream CI / NPU rerun pending.

## 风险与兼容性

- This intentionally upgrades a core template dependency, so existing FP16/BF16 coverage is important; the original 34 non-FP32 FA cases passed.
- PTO codegen does not consume these AscendC Catlass template paths.
- The submodule points to an official tagged release, not a personal fork.

## 提交前确认

- [x] Commit message is English and contains `[Feature]`.
- [x] `git diff --check` passes.
- [x] A representative FP32 NPU regression is included.
