### PR TITLE
[Bugfix] Flatten multidimensional scalar buffer indices

### DIFF
--- a/testing/python/language/test_tilelang_ascend_language_scalar_from_2d_operand.py
+++ b/testing/python/language/test_tilelang_ascend_language_scalar_from_2d_operand.py
@@ -1,0 +1,63 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+
+# Regression for using an element of a 2D UB tile as a scalar tile operand.
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+}
+
+
+def _run_scalar_from_2d_operand(target, M=8, N=8):
+    """Accumulate vectors scaled by elements loaded from a 2D UB buffer."""
+
+    @tilelang.jit(out_idx=[2], pass_configs=pass_configs, target=target)
+    def kernel():
+        @T.prim_func
+        def main(n2d: T.Tensor([M, N], "float32"), x: T.Tensor([N], "float32"), out: T.Tensor([N], "float32")):
+            with T.Kernel(1, is_npu=True) as (cid, vid):
+                n_ub = T.alloc_ub([M, N], "float32")
+                x_ub = T.alloc_ub([N], "float32")
+                o_ub = T.alloc_ub([N], "float32")
+                row_ub = T.alloc_ub([N], "float32")
+                with T.Scope("V"):
+                    T.copy(n2d, n_ub)
+                    T.copy(x, x_ub)
+                    T.tile.fill(o_ub, 0.0)
+                    for i in range(M):
+                        for j in range(i):
+                            T.tile.mul(row_ub, x_ub, n_ub[i, j])
+                            T.tile.add(o_ub, o_ub, row_ub)
+                    T.copy(o_ub, out)
+
+        return main
+
+    torch.manual_seed(0)
+    n2d = torch.randn(M, N, dtype=torch.float32).npu()
+    x = torch.randn(N, dtype=torch.float32).npu()
+    got = kernel()(n2d, x)
+
+    n_ref = n2d.cpu()
+    x_ref = x.cpu()
+    expect = torch.zeros(N)
+    for i in range(M):
+        for j in range(i):
+            expect += n_ref[i, j] * x_ref
+    torch.testing.assert_close(got.cpu(), expect, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_scalar_operand_from_2d_ub(target):
+    _run_scalar_from_2d_operand(target)
+
+
+if __name__ == "__main__":
+    test_scalar_operand_from_2d_ub("ascendc")
+    print("ascendc PASS")

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -987,13 +987,16 @@ def binary_op(
     if isinstance(src1, BufferLoad):
         buffer_1 = src1.buffer
         indices_1 = src1.indices
+        # Account for every index, explicit strides, and the element offset.
+        # Using only the first index would lower n[i, j] to GetValue(i).
+        scalar_offset = buffer_1.offset_of(indices_1)[0]
         return T.call_intrin(
             "handle",
             tir.op.Op.get(f"tl.ascend_{op}s"),
             dst_ptr,
             src0_ptr,
             buffer_1.access_ptr("r"),
-            indices_1[0],
+            scalar_offset,
             size_0,
         )
 


### PR DESCRIPTION
Closes #1763

## 变更摘要

Fix scalar tile operands loaded from multidimensional buffers.

`binary_op()` previously passed only `indices[0]` to the scalar `GetValue` lowering. For a load such as `n_ub[i, j]`, this generated `GetValue(i)` and silently ignored `j`, producing incorrect numerical results on both AscendC and PTO.

The scalar offset now uses TVM Buffer's `offset_of(indices)`, which handles every dimension as well as explicit strides and element offsets.

## 变更类型

- [x] `[Bugfix]` Bug 修复
- [x] `[Testing]` 测试

## 测试

- [x] Added a 2D UB scalar-operand numerical regression for AscendC and PTO.
- [x] Ruff 0.16.6 format and lint pass for all changed Python files.
- [x] Python syntax compilation passes.
- [x] `git diff --check` passes.
- [x] Original NPU validation passed on both AscendC and PTO.
- [ ] Upstream CI / NPU rerun pending.

## 风险与边界

- One-dimensional loads retain the same effective offset.
- The fix reuses TVM's existing Buffer offset computation instead of duplicating row-major arithmetic.
- No public API changes.

## 提交前确认

- [x] Commit message is English and contains `[Bugfix]`.
- [x] The PR contains one focused fix and its regression.
