### PR TITLE
[Bugfix] Diagnose misaligned on-chip copy addresses

### DIFF
--- a/src/target/codegen_ascend.cc
+++ b/src/target/codegen_ascend.cc
@@ -14,6 +14,8 @@
 
 #include <tvm/tir/expr.h>
 
+#include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <sstream>
 #include <string>
@@ -2887,6 +2889,70 @@ void CodeGenTileLangAscend::CopyCodegen(const CallNode *op) {
       auto expr = op->args[3 + i];
       std::string var_name = PrintExpr(expr);
       var_names.push_back(var_name);
+    }
+
+    // ---- Address-alignment compile-time error (hardening) ------------------
+    // AscendC DataCopyPad requires the LocalTensor (UB/L1) start address to be
+    // 32-Byte aligned (the GM side has no alignment constraint).  A copy whose
+    // UB/L1 base offset is a compile-time constant that is NOT a 32-Byte
+    // multiple (in the buffer dtype) is a latent correctness bug: the DMA would
+    // operate on a misaligned on-chip base.  Make the violation explicit at
+    // compile time, naming the buffer, the offset, and the alignment
+    // requirement.  Runtime (non-constant) offsets are let through -- they may
+    // be aligned at run time, so rejecting them would be a false positive.
+    auto tmpl_dtype_bytes = [](const std::string &opn) -> int {
+      auto lt = opn.find('<');
+      auto gt = opn.find('>', lt == std::string::npos ? lt : lt + 1);
+      if (lt == std::string::npos || gt == std::string::npos)
+        return 0;
+      std::string t = opn.substr(lt + 1, gt - lt - 1);
+      auto comma = t.find(',');
+      if (comma != std::string::npos)
+        t = t.substr(0, comma);
+      t.erase(std::remove_if(t.begin(), t.end(), ::isspace), t.end());
+      if (t == "half" || t == "float16" || t == "bfloat16_t" ||
+          t == "int16_t" || t == "uint16_t" || t == "float16_t")
+        return 2;
+      if (t == "float" || t == "float32" || t == "int" || t == "int32_t" ||
+          t == "uint32_t" || t == "uint")
+        return 4;
+      if (t == "int8_t" || t == "uint8_t" || t == "char" || t == "uchar")
+        return 1;
+      if (t == "int64_t" || t == "uint64_t" || t == "double")
+        return 8;
+      return 0; // unknown dtype -> skip the check (do not false-positive)
+    };
+    int elem_bytes = tmpl_dtype_bytes(op_name);
+    if (elem_bytes > 0) {
+      auto check_side_align = [&](const PrimExpr &off_expr,
+                                  const std::string &buf_name,
+                                  const char *side) {
+        const auto *imm = off_expr.as<IntImmNode>();
+        if (imm == nullptr)
+          return; // runtime offset -> let through
+        int64_t byte_off = imm->value * elem_bytes;
+        if (byte_off % 32 != 0) {
+          LOG(FATAL) << "Ascend copy alignment violation: the " << side
+                     << " on-chip (UB/L1) base of \"" << op_name
+                     << "\" has a compile-time-constant element offset "
+                     << imm->value << " in buffer \"" << buf_name
+                     << "\" = " << byte_off
+                     << " bytes, which is not a 32-Byte multiple. "
+                        "LocalTensor start addresses must be 32-Byte aligned; "
+                        "pad the offset or use a 32-Byte-aligned window.";
+        }
+      };
+      bool dst_is_onchip =
+          (op_name.find("copy_gm_to_ub") != std::string::npos) ||
+          (op_name.find("copy_gm_to_l1") != std::string::npos) ||
+          (op_name.find("copy_ub_to_ub") != std::string::npos);
+      bool src_is_onchip =
+          (op_name.find("copy_ub_to_gm") != std::string::npos) ||
+          (op_name.find("copy_ub_to_ub") != std::string::npos);
+      if (dst_is_onchip)
+        check_side_align(dst_offset_expr, dst_var_id, "dst");
+      if (src_is_onchip)
+        check_side_align(src_offset_expr, src_var_id, "src");
     }
 
     this->PrintIndent();

--- a/testing/python/language/test_tilelang_ascend_language_copy_misaligned_error.py
+++ b/testing/python/language/test_tilelang_ascend_language_copy_misaligned_error.py
@@ -1,0 +1,89 @@
+import pytest
+import tilelang
+import tilelang.language as T
+import torch
+
+"""
+Copy address-alignment compile-time error (codegen hardening).
+
+Feature under test
+------------------
+AscendC's DataCopyPad requires the **LocalTensor (UB) start address** to be
+32-Byte aligned (the GlobalMemory side has no alignment constraint).  A UB copy
+destination / source whose column offset is a *compile-time constant* that is
+NOT a 32-Byte multiple (in the buffer's dtype) is a latent correctness bug: the
+DMA engine silently operates on a misaligned UB base.
+
+This hardening makes the violation explicit at compile time: when a copy's UB
+base offset is a compile-time constant whose byte value is not a 32-Byte
+multiple, the codegen raises a clear error naming the buffer, the offset, and
+the alignment requirement.  Runtime (non-constant) offsets are let through
+(they may be aligned at run time; rejecting them would be a conservative
+false-positive).
+
+Cases
+-----
+  * misaligned constant UB dst offset (fp32 offset 1 -> 4 B): must FAIL to
+    compile.
+  * aligned constant UB dst offset (fp32 offset 8 -> 32 B): compiles and runs.
+
+NOTE: the misaligned case asserts a compile-time failure; it never reaches the
+device.
+"""
+
+VEC_MIN_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_cache():
+    tilelang.cache.clear_cache()
+    yield
+
+
+def _ub_dst_offset_kernel(dst_off, N=8, dtype="float"):
+    """Copy X[0:N] into win[dst_off : dst_off+N] (UB), then store the window
+    back.  ``dst_off`` is a compile-time constant column offset into the UB
+    buffer."""
+
+    @T.prim_func
+    def main(X: T.Tensor((N,), dtype), Y: T.Tensor((2 * N,), dtype)):
+        with T.Kernel(1, is_npu=True) as (cid, vid):
+            win = T.alloc_ub((2 * N,), dtype)
+            T.copy(X[0:N], win[dst_off : dst_off + N])
+            T.copy(win, Y[0 : 2 * N])
+
+    return main
+
+
+def test_misaligned_const_ub_offset_compile_error():
+    """A compile-time-constant UB dst offset of 1 fp32 element (4 B, not a 32 B
+    multiple) must raise a compile-time error mentioning alignment."""
+    func = _ub_dst_offset_kernel(dst_off=1, N=8, dtype="float")
+    with pytest.raises(Exception) as exc_info:
+        tilelang.compile(func, out_idx=[-1], pass_configs=VEC_MIN_CONFIGS, target="ascendc")
+    msg = str(exc_info.value).lower()
+    # The error must mention alignment / 32-byte so the author knows the cause.
+    assert ("align" in msg) or ("32" in msg), f"error message should mention alignment, got: {exc_info.value}"
+
+
+def test_aligned_const_ub_offset_ok():
+    """A compile-time-constant UB dst offset of 8 fp32 elements (32 B, aligned)
+    compiles and runs correctly."""
+    N = 8
+    func = _ub_dst_offset_kernel(dst_off=8, N=N, dtype="float")
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=VEC_MIN_CONFIGS, target="ascendc")
+    torch.manual_seed(0)
+    x = torch.randn(N, dtype=torch.float32).npu()
+    torch.npu.synchronize()
+    y = func(x).cpu()
+    x = x.cpu()
+    # The window [8:16) holds X; the rest is whatever the UB held (we only check
+    # the copied region).
+    torch.testing.assert_close(y[8:16], x, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #1773

## 变更摘要

Diagnose statically misaligned UB/L1 copy addresses in AscendC code generation.

CANN requires the LocalTensor side of `DataCopy`/`DataCopyPad` to start at a 32-byte-aligned address. This PR checks constant on-chip offsets for GM→UB, UB→GM, UB→UB, and GM→L1 copies and reports a source-oriented compile error before an invalid operation reaches BiSheng or hardware.

Runtime-dependent offsets remain accepted because they may be aligned at execution time. GM addresses are not restricted by this check.

## 变更类型

- [x] `[Bugfix]` Bug 修复
- [x] `[Testing]` 测试

## 测试

- [x] Constant FP32 UB offset 1 (4 bytes) is rejected with an alignment diagnostic.
- [x] Constant FP32 UB offset 8 (32 bytes) compiles and executes correctly.
- [x] Ruff 0.16.6 format/lint and clang-format 18 pass.
- [x] Python syntax compilation and `git diff --check` pass.
- [ ] Upstream CI / NPU rerun pending.

## 风险与边界

- Only compile-time constant offsets are rejected.
- Unknown template dtypes skip the check to avoid false positives.
- This modifies AscendC codegen only; PTO is unchanged.
