### PR TITLE
[Feature] Add a coalesced GM-to-L1 row-copy path

### DIFF
--- a/src/tl_templates/ascend/common.h
+++ b/src/tl_templates/ascend/common.h
@@ -71,6 +71,20 @@ copy_gm_to_l1(LocalTensor<T> dstTensor, GlobalTensor<T> srcTensor,
         {1, static_cast<uint16_t>(dstM * dstN * sizeof(T) / 32), 0, 0});
     AscendC::PipeBarrier<PIPE_MTE2>();
   }
+  // A full-width 32-byte row of 16-bit elements has byte-identical linear and
+  // zN representations. Coalesce consecutive rows into one DMA instead of
+  // issuing one 32-byte transfer per row. FP32 C0=8 does not have this layout
+  // equivalence and intentionally stays on the generic path. A column tail
+  // must also stay generic to avoid reading a complete row past valid GM data.
+  if (realSrcN == dstN && tailN == dstN && dstN * sizeof(T) == 32 &&
+      sizeof(T) == 2) {
+    AscendC::DataCopy(dstTensor, srcTensor,
+                      AscendC::DataCopyParams(
+                          static_cast<uint16_t>(1),
+                          static_cast<uint16_t>(tailM * dstN * sizeof(T) / 32),
+                          0, 0));
+    return;
+  }
   auto layout = MakeLayoutFromTag(LayoutGM{tailM, realSrcN});
   auto src_LAYOUT = MakeLayoutTile(layout, tla::MakeShape(tailM, tailN));
   auto src = tla::MakeTensor<decltype(srcTensor), decltype(src_LAYOUT),

--- a/testing/python/language/test_tilelang_ascend_language_gm2l1_coalesce.py
+++ b/testing/python/language/test_tilelang_ascend_language_gm2l1_coalesce.py
@@ -1,0 +1,53 @@
+"""Regression for coalesced 32-byte-row GM-to-L1 copies."""
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+
+PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+}
+
+
+def _copy_band_through_identity_mma(rows=64, cols=16):
+    @tilelang.jit(out_idx=[2], pass_configs=PASS_CONFIGS, target="ascendc")
+    def kernel():
+        @T.prim_func
+        def main(
+            source: T.Tensor((rows, cols), "float16"),
+            identity: T.Tensor((cols, cols), "float16"),
+            output: T.Tensor((rows, cols), "float32"),
+        ):
+            with T.Kernel(1, is_npu=True) as (cid, vid):
+                source_l1 = T.alloc_L1((rows, cols), "float16")
+                identity_l1 = T.alloc_L1((cols, cols), "float16")
+                source_l0 = T.alloc_L0A((rows, cols), "float16")
+                identity_l0 = T.alloc_L0B((cols, cols), "float16")
+                output_l0 = T.alloc_L0C((rows, cols), "float32")
+                with T.Scope("C"):
+                    T.copy(source, source_l1)
+                    T.copy(identity, identity_l1)
+                    T.copy(source_l1, source_l0)
+                    T.copy(identity_l1, identity_l0)
+                    T.mma(source_l0, identity_l0, output_l0, init=True)
+                    T.copy(output_l0, output)
+
+        return main
+
+    return kernel()
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "npu") and torch.npu.is_available()),
+    reason="coalesced GM-to-L1 correctness requires an Ascend NPU runtime",
+)
+def test_coalesced_gm_to_l1_band_is_bit_complete():
+    torch.manual_seed(0)
+    rows, cols = 64, 16
+    source = torch.randn(rows, cols, dtype=torch.float16)
+    identity = torch.eye(cols, dtype=torch.float16)
+    output = _copy_band_through_identity_mma(rows, cols)(source.npu(), identity.npu()).cpu()
+    torch.testing.assert_close(output, source.float(), rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
Closes #1775

## 变更摘要

Add a coalesced AscendC GM-to-L1 path for contiguous bands whose complete row is exactly one 32-byte block of 16-bit elements.

For this specific layout, linear and zN storage are byte-identical. The new path transfers all valid rows with one `DataCopy` instead of issuing a separate 32-byte TLA transfer for every row.

The guard requires equal complete inner widths, no column tail, a 32-byte row, and 16-bit elements. FP32 and all non-equivalent layouts remain on the generic path.

## 变更类型

- [x] `[Feature]` 后端性能路径
- [x] `[Testing]` 测试

## 测试与性能

- [x] Added an independent FP16 GM → L1 → L0 → identity MMA numerical regression.
- [x] Ruff 0.16.6 format/lint and clang-format 18 pass.
- [x] Python syntax compilation and `git diff --check` pass.
- [x] Original copy microbenchmark: about 1128 us → 313 us.
- [x] Original Conv2D case: about 8767 us → 1339 us (6.5×).
- [x] Original validation: Conv2D 19/19 local, 20/20 cann-bench, transpose 12/12, and Mamba2Bwd 50/50.
- [ ] Upstream CI / NPU rerun pending.

## 风险与边界

- A column tail explicitly disables the fast path to prevent an out-of-range full-row read.
- FP32 C0=8 remains generic because its linear and fractal layouts are not byte-identical.
- PTO is unchanged.
