### PR TITLE
[Fix] bench_sfa: close UB buffer return-token lifecycle for acc_s_half / acc_o_ub_temp

### DIFF
--- a/examples/sparse_flash_attention/bench_sfa/sparse_flash_attn_pa.py
+++ b/examples/sparse_flash_attention/bench_sfa/sparse_flash_attn_pa.py
@@ -156,6 +156,12 @@ def sparse_attention_fwd(
                         T.tile.fill(log_sum, 0.0)
                         T.tile.fill(score_max, 2.0**30)
 
+                        # acc_s_half / acc_o_ub_temp are single physical UB buffers reused
+                        # across pipeline iterations. Pre-release the return tokens so the
+                        # first iteration's wait_flag does not block on a never-set flag.
+                        T.set_flag("mte3", "v", 1)
+                        T.set_flag("v", "mte2", 2)
+
                         # for i_i in T.serial(n_block_num):
                         for i_i in T.Pipelined(n_block_num, num_stages=2):
                             # ******************** V0 ********************
@@ -260,6 +266,9 @@ def sparse_attention_fwd(
                             T.tile.exp(score_max_pre, score_max_pre)
                             T.pipe_barrier("v")
 
+                            # wait for MTE3 of the previous iteration to finish reading
+                            # acc_s_half before Vector overwrites it
+                            T.wait_flag("mte3", "v", 1)
                             T.copy(acc_s_ub, acc_s_half)
                             T.pipe_barrier("v")
 
@@ -267,6 +276,8 @@ def sparse_attention_fwd(
                             T.wait_flag("v", "mte3", 1)
 
                             T.copy(acc_s_half, workspace_4[cid, vid * m_base_size_v : vid * m_base_size_v + m_base_size_v, :])
+                            # return acc_s_half to Vector once MTE3 has finished reading it
+                            T.set_flag("mte3", "v", 1)
 
                             # ******************** BMM2(S*V) ********************
                             T.copy(workspace_4[cid, :, :], acc_s_l1)
@@ -278,10 +289,15 @@ def sparse_attention_fwd(
                             T.copy(acc_o_l0c, workspace_5[cid, :, :])
 
                             # ******************** VEC2 ********************
-                            T.copy(workspace_5[cid, vid * m_base_size_v : vid * m_base_size_v + m_base_size_v, :], acc_o_ub_temp)
-
                             T.reduce_sum(acc_s_ub, score_sum, dim=-1)
                             T.pipe_barrier("v")
+
+                            # wait for Vector of the previous iteration to finish reading
+                            # acc_o_ub_temp before MTE2 overwrites it; placed right before
+                            # the producing copy (runs on the AIV's own MTE2 pipe) inside
+                            # the VEC2 stage
+                            T.wait_flag("v", "mte2", 2)
+                            T.copy(workspace_5[cid, vid * m_base_size_v : vid * m_base_size_v + m_base_size_v, :], acc_o_ub_temp)
 
                             T.tile.mul(log_sum, log_sum, score_max_pre)
                             T.pipe_barrier("v")
@@ -299,6 +315,8 @@ def sparse_attention_fwd(
                             T.wait_flag("mte2", "v", 2)
 
                             T.tile.add(acc_o_ub, acc_o_ub, acc_o_ub_temp)
+                            # return acc_o_ub_temp to MTE2 once Vector has finished reading it
+                            T.set_flag("v", "mte2", 2)
 
                         T.tile.broadcast(log_sum_broadcast, log_sum)
                         T.pipe_barrier("v")
@@ -307,9 +325,13 @@ def sparse_attention_fwd(
                         T.pipe_barrier("v")
 
                         T.copy(acc_o_ub, acc_o_half)
-                        T.set_flag("v", "mte3", 9)
-                        T.wait_flag("v", "mte3", 9)
+                        T.set_flag("v", "mte3", 3)
+                        T.wait_flag("v", "mte3", 3)
                         T.copy(acc_o_half, Output[b_i, s_i, H0 + vid * m_base_size_v : H0 + (vid + 1) * m_base_size_v, :])
+                        # consume the last return tokens so the token ring stays balanced
+                        # across the outer block_idx loop
+                        T.wait_flag("mte3", "v", 1)
+                        T.wait_flag("v", "mte2", 2)
 
     return main_pipelined
 

--- a/examples/sparse_flash_attention/bench_sfa/sparse_flash_attn_pa.py
+++ b/examples/sparse_flash_attention/bench_sfa/sparse_flash_attn_pa.py
@@ -1,5 +1,5 @@
 import tilelang
-from tilelang import DataType, language as T
+from tilelang import language as T
 import torch
 import os
 import sys

--- a/examples/sparse_flash_attention/bench_sfa/sparse_flash_attn_pa.py
+++ b/examples/sparse_flash_attention/bench_sfa/sparse_flash_attn_pa.py
@@ -119,7 +119,7 @@ def sparse_attention_fwd(
             acc_s_half = T.alloc_ub([m_base_size_v, n_base_size], dtype)
 
             # vec2
-            acc_o_ub_temp = T.alloc_ub([m_base_size_v, dim], accum_dtype)
+            acc_o_ub_temp = T.alloc_ub([2, m_base_size_v, dim], accum_dtype)
             acc_o_ub = T.alloc_ub([m_base_size_v, dim], accum_dtype)
             log_sum_broadcast = T.alloc_ub([m_base_size_v, dim], accum_dtype)
             acc_o_half = T.alloc_ub([m_base_size_v, dim], dtype)
@@ -156,11 +156,16 @@ def sparse_attention_fwd(
                         T.tile.fill(log_sum, 0.0)
                         T.tile.fill(score_max, 2.0**30)
 
-                        # acc_s_half / acc_o_ub_temp are single physical UB buffers reused
-                        # across pipeline iterations. Pre-release the return tokens so the
-                        # first iteration's wait_flag does not block on a never-set flag.
+                        # acc_s_half is a single physical UB buffer reused across pipeline
+                        # iterations (one return token); acc_o_ub_temp is double-slotted
+                        # (task_id parity, two return tokens) so its return sync only pairs
+                        # with the use two iterations back, keeping the next iteration's
+                        # MTE2 gathers overlapped with this iteration's Vector compute.
+                        # Pre-release all return tokens so the first iteration's wait_flag
+                        # does not block on a never-set flag.
                         T.set_flag("mte3", "v", 1)
                         T.set_flag("v", "mte2", 2)
+                        T.set_flag("v", "mte2", 3)
 
                         # for i_i in T.serial(n_block_num):
                         for i_i in T.Pipelined(n_block_num, num_stages=2):
@@ -292,12 +297,15 @@ def sparse_attention_fwd(
                             T.reduce_sum(acc_s_ub, score_sum, dim=-1)
                             T.pipe_barrier("v")
 
-                            # wait for Vector of the previous iteration to finish reading
-                            # acc_o_ub_temp before MTE2 overwrites it; placed right before
-                            # the producing copy (runs on the AIV's own MTE2 pipe) inside
-                            # the VEC2 stage
-                            T.wait_flag("v", "mte2", 2)
-                            T.copy(workspace_5[cid, vid * m_base_size_v : vid * m_base_size_v + m_base_size_v, :], acc_o_ub_temp)
+                            # double-slotted acc_o_ub_temp: the return token pairs with the
+                            # use of the same slot two iterations back. The wait stays right
+                            # before the producing copy (AIV's own MTE2 pipe) inside the
+                            # VEC2 stage.
+                            task_id = i_i % 2
+                            T.wait_flag("v", "mte2", 2 + task_id)
+                            T.copy(
+                                workspace_5[cid, vid * m_base_size_v : vid * m_base_size_v + m_base_size_v, :], acc_o_ub_temp[task_id, :, :]
+                            )
 
                             T.tile.mul(log_sum, log_sum, score_max_pre)
                             T.pipe_barrier("v")
@@ -311,12 +319,12 @@ def sparse_attention_fwd(
                             T.tile.mul(acc_o_ub, acc_o_ub, score_scale_broadcast)
                             T.pipe_barrier("v")
 
-                            T.set_flag("mte2", "v", 2)
-                            T.wait_flag("mte2", "v", 2)
+                            T.set_flag("mte2", "v", 2 + task_id)
+                            T.wait_flag("mte2", "v", 2 + task_id)
 
-                            T.tile.add(acc_o_ub, acc_o_ub, acc_o_ub_temp)
-                            # return acc_o_ub_temp to MTE2 once Vector has finished reading it
-                            T.set_flag("v", "mte2", 2)
+                            T.tile.add(acc_o_ub, acc_o_ub, acc_o_ub_temp[task_id, :, :])
+                            # return this slot to MTE2 once Vector has finished reading it
+                            T.set_flag("v", "mte2", 2 + task_id)
 
                         T.tile.broadcast(log_sum_broadcast, log_sum)
                         T.pipe_barrier("v")
@@ -328,10 +336,11 @@ def sparse_attention_fwd(
                         T.set_flag("v", "mte3", 3)
                         T.wait_flag("v", "mte3", 3)
                         T.copy(acc_o_half, Output[b_i, s_i, H0 + vid * m_base_size_v : H0 + (vid + 1) * m_base_size_v, :])
-                        # consume the last return tokens so the token ring stays balanced
+                        # consume the last return tokens so the token rings stay balanced
                         # across the outer block_idx loop
                         T.wait_flag("mte3", "v", 1)
                         T.wait_flag("v", "mte2", 2)
+                        T.wait_flag("v", "mte2", 3)
 
     return main_pipelined
 


### PR DESCRIPTION
Fixes #1660

## 问题

`examples/sparse_flash_attention/bench_sfa/sparse_flash_attn_pa.py` 的手写同步流水线中，两块单缓冲 UB 在相邻 stage 间复用，但只有就绪方向（producer -> consumer）的同步，缺少归还方向（consumer -> producer）的同步：

| UB | 生命周期 | 竞态 |
|---|---|---|
| `acc_s_half` | Vector 写 -> MTE3 读（写 workspace_4） | 下一 stage 的 Vector 可能在 MTE3 读完前覆盖 |
| `acc_o_ub_temp` | MTE2 写（读 workspace_5）-> Vector 读（`T.tile.add`） | 下一 stage 的 MTE2 可能在 Vector 读完前覆盖 |

低压力单次运行通常通过，需要 32 进程绑同一 NPU + 固定输入各重复 100 次才能稳定复现（复现方法见 issue #1660）。

## 修复

**1. 归还 token 环（按 issue #1660 @platelett 的归因分析）**

- `acc_s_half`：补 `MTE3 -> V` 归还同步（单 slot，event ID 1）
- `acc_o_ub_temp`：补 `V -> MTE2` 归还同步，并采用双 slot 轮换（见下）
- 最终输出 event ID 9 -> 3（dav-c220 合法范围 `[0, 8)`，原 ID 越界）

完整的 token 环结构：scope 入口预归还 token -> 生产者写前 wait -> 消费者用完 set -> 退出前消费最后一个 token。

**2. acc_o_ub_temp 双 slot 轮换（消除归还同步的流水线代价）**

单缓冲归还同步会让下一外层迭代的 MTE2 gathers 排队等待上一迭代的 `T.tile.add`，实测损失 ~16%。参照 V0 段已有的 `kv_ub_gather[task_id]` 模式：

- `acc_o_ub_temp` 分配为 `[2, m_base_size_v, dim]`，`task_id = i_i % 2` 按 slot 轮换
- 就绪（MTE2->V）与归还（V->MTE2）两个方向的 event ID 均按 slot 交替（`2 + task_id`），避免二元事件语义下的 token 折叠
- 归还 token 只配对两个迭代前的同 slot 使用，恢复一整圈流水松弛，下一迭代的 gathers 与当前迭代的 Vector 计算重新重叠
- scope 入口预归还两个 slot 的 token，退出前逐一消费

`acc_s_half` 保持单 slot 环：它等待的 MTE3 store 只有 1KB（8x64 bf16 UB->GM），远早于 Vector 到达下一次写入，不在关键路径上。

**3. flag 摆放约束（摆放错误会 aicore timeout，已通过 dump 生成代码逐行核对）**

- `wait_flag("v", "mte2", ...)` 必须位于 Vector 段内、紧贴 `workspace_5 -> acc_o_ub_temp` 生产拷贝之前（借助 `T.reduce_sum` 等 AIV 语句建立 Vector 语境）。若放在 AIC 语句（如 L0C->GM copy）之后，CV 分离 pass 会将其落到 AIC 侧，而配对的 SetFlag 在 AIV 侧——HardEvent 是核内事件，AIC 上永远等不到 -> 死锁。
- 该 wait 必须与生产拷贝位于同一条流水 stage 语句组。pass 会把流水循环重构成 `for outer(16){ for i_2{V0} for i_3{V1} for i_5{VEC2} }`，wait 若落在 i_3 组而配对 set 在 i_5 组，同一外层迭代内 2 个 wait 先堆积 -> MTE2 阻塞。
- `i_i % 2` 作为 event ID 会被 pass 正确重映射为内层循环变量（生成代码中为 `i_5 + 2`），与 V0 段 `g_copy_out_time % 2` 的行为一致。

**4. topk 入口约束（per @platelett review）**

每块处理 64 个索引、流水每组执行两块，要求 `topk` 为 128 的正整数倍，但原入口只检查 64 的倍数——`topk=192` 会被接受，实际只计算前 128 个索引（CrossCorePipeline 将 `T.Pipelined(num_stages=2)` 展开为外层 `n_block_num // 2` 次迭代，整数除法截断，奇数块数时尾块被静默丢弃）。

- 补上 `topk > 0` 和 `topk % (2 * n_base_size) == 0` 入口检查
- `sparse_attn_tilelang` 中 topk 由硬编码 2048 改为从 `sparse_indices.shape[-1]` 推导，检查覆盖真实调用路径
- 选择补检查而非实现尾块处理：后者需修改 CrossCorePipeline pass 的外层循环展开逻辑，影响面覆盖所有走该 pass 的算子，适合独立 issue 跟进

**5. wrapper 清理**

- 移除 10 处调试 print（打印 NPU tensor 值会触发 device 同步）
- `q_heads` / `dim` / `rope_dim` 由硬编码 128/512/64 改为从输入 shape 推导（非 128 头的调用原先会静默算错）

## acc_s_ub 为什么不需要手动同步

生成代码中 `acc_s_ub` 被自动分配了 2x512 元素（DSL 只声明 512）——pipeline pass 对无手写 flag 干扰的跨迭代复用 buffer 会自动双缓冲。`acc_s_half` / `acc_o_ub_temp` 因为读写之间夹着已有的手写 ready 同步，pass 的复用分析放弃处理而保持单缓冲——这正是 issue 只报这两块 buffer 的原因。

## 验证

压力测试（Ascend 910B / CANN 9.0.0，与 issue 方法一致：32 个进程绑同一 NPU、固定输入、每进程重复 100 次并与 `npu_sparse_flash_attention` 对比，覆盖 bench_sfa 全部三组 case）：

| Case (KV_S) | 原实现出现漂移的进程 | 本修复 |
|---|---|---|
| 1 (2560) | 30 / 32 | **0 / 32** |
| 2 (6400) | 28 / 32 | **0 / 32** |
| 3 (48000) | 29 / 32 | **0 / 32** |

性能（do_bench warmup=20 rep=100，每 case 3 次平均，交错 A/B 两轮验证）：

| Case (KV_S) | 原实现 (ms) | 单缓冲归还同步（中间版本，case 1） | 本修复双 slot (ms) |
|---|---|---|---|
| 1 (2560) | 1.35 | 1.52 (+16%) | 1.33 |
| 2 (6400) | 1.31 | - | 1.34 |
| 3 (48000) | 1.40 | - | 1.42 |

交错 A/B 两轮中修复版差异符号正负交替（-4.5% / +3.1%），差异在 ±4% 测量噪声内，与原实现性能平价；单缓冲中间版本的 +16% 开销已被双 slot 消除。

topk 约束与 wrapper 清理（commit 4/5，不改 kernel 生成代码）：

- 拒绝检查：topk=0 / 64 / 192 均在入口被拒绝
- 正确性：topk=128（最小合法值）/ 256 与 `npu_sparse_flash_attention` 对比一致
- 回归：原 3 组 topk=2048 case 通过；`no_cv_pipeline` 等其他版本行为不变
- E2E（do_bench，含 host 开销）：移除 print 同步开销后 3.70ms -> 2.63ms（-28.8%）
- ruff check / ruff format 通过

## Reviewer

@ShareableXue