### PR TITLE
fix: causal_conv1d_decode 1:2 MIX 下双 AIV 重复执行导致错误结果 (#1662)

### DIFF
--- a/examples/causal_conv1d/causal_conv1d_decode.py
+++ b/examples/causal_conv1d/causal_conv1d_decode.py
@@ -42,7 +42,7 @@ def build_causal_conv1d_decode_kernel(
         bias: T.Tensor((symbol_dim,), dtype_str),
         y: T.Tensor((symbol_batch, symbol_dim), dtype_str),
     ):
-        with T.Kernel(total_tasks, is_npu=True) as (cid, vid):
+        with T.Kernel(total_tasks, threads=2, is_npu=True) as (cid):
             batch_id = cid // dim_chunks
             dim_chunk_id = cid % dim_chunks
 

--- a/src/transform/ascend_vid_reduction.cc
+++ b/src/transform/ascend_vid_reduction.cc
@@ -512,7 +512,10 @@ private:
         // compare: dst_size = math.prod(src0_extent)
         "tl.ascend_compare", "tl.ascend_compare_scalar",
         // sin/cos: size = math.prod(src_extent), assert size_0 == size_2
-        "tl.ascend_sin", "tl.ascend_cos", "tl.ascend_fill"};
+        "tl.ascend_sin", "tl.ascend_cos", "tl.ascend_fill",
+        // cast/mul_add_dst/silu: last arg is the element count, all buffer
+        // extents must match (see tilelang/language/ascend_tile.py)
+        "tl.ascend_cast", "tl.ascend_mul_add_dst", "tl.ascend_silu"};
     return tile_ops.find(op_name) != tile_ops.end();
   }
 

--- a/testing/python/language/cvseparate/test_tilelang_ascend_language_vid_reduction.py
+++ b/testing/python/language/cvseparate/test_tilelang_ascend_language_vid_reduction.py
@@ -294,6 +294,71 @@ def test_vid_reduction_tile_ops(setup_random_seed, target):
 
 
 # ============================================================
+# 4b) cast / mul_add_dst / silu tile ops
+#
+# Mirrors: T.tile.cast(w0, w_half0, "CAST_NONE", dim_per_core) /
+#          T.tile.mul_add_dst(state0, x_ub, w3) / T.tile.silu(y_ub, tmp)
+#          (from causal_conv1d_decode.py)
+# Pass: tile op last size arg halved (ModifyTileOpSize +
+# IsTileOp in ascend_vid_reduction.cc).
+# Chain: a16 -> cast fp32 -> mul_add_dst (acc += a*a) -> silu ->
+# cast back to fp16, so any incorrect size halving propagates to
+# the final result silu(a + a^2).
+# ============================================================
+
+
+def tile_cast_ops_kernel(M, N, block_M, block_N):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), "float16"), B: T.Tensor((M, N), "float16")):
+        with T.Kernel(m_num * n_num, threads=2, is_npu=True) as (cid):
+            bx = cid // n_num
+            by = cid % n_num
+            a_ub = T.alloc_shared((block_M, block_N), "float16")
+            w_ub = T.alloc_shared((block_M, block_N), "float16")
+            a_f32 = T.alloc_shared((block_M, block_N), "float32")
+            w_f32 = T.alloc_shared((block_M, block_N), "float32")
+            out_f32 = T.alloc_shared((block_M, block_N), "float32")
+            b_ub = T.alloc_shared((block_M, block_N), "float16")
+
+            T.copy(A[bx * block_M, by * block_N], a_ub)
+            T.copy(A[bx * block_M, by * block_N], w_ub)
+
+            # cast: last arg is the element count
+            T.tile.cast(a_f32, a_ub, "CAST_NONE", block_M * block_N)
+            T.tile.cast(w_f32, w_ub, "CAST_NONE", block_M * block_N)
+
+            # mul_add_dst: a_f32 = w_f32 * w_f32 + a_f32
+            T.tile.mul_add_dst(a_f32, w_f32, w_f32)
+
+            # silu: out = a / (1 + exp(-a))
+            T.tile.silu(out_f32, a_f32)
+
+            # cast back to fp16
+            T.tile.cast(b_ub, out_f32, "CAST_RINT", block_M * block_N)
+
+            T.copy(b_ub, B[bx * block_M, by * block_N])
+
+    return main
+
+
+@pytest.mark.parametrize("target", ["ascendc"])
+def test_vid_reduction_tile_cast_ops(setup_random_seed, target):
+    M, N, block_M, block_N = 256, 128, 64, 128
+    func = tilelang.compile(tile_cast_ops_kernel(M, N, block_M, block_N), out_idx=[1], pass_configs=pass_configs, target=target)
+    a = torch.randn(M, N, dtype=torch.float16).npu()
+    torch.npu.synchronize()
+    b = func(a)
+    torch.npu.synchronize()
+    af = a.float()
+    acc = af + af * af
+    ref = (acc / (1.0 + torch.exp(-acc))).half()
+    torch.testing.assert_close(b, ref, rtol=1e-2, atol=1e-2)
+
+
+# ============================================================
 # 5) T.tile + T.Parallel (LoopVarUsedInVidReducedUbFirstDim)
 #
 # Mirrors: for h_i, j in T.Parallel(v_block, D):


### PR DESCRIPTION
# fix: causal_conv1d_decode 1:2 MIX 下双 AIV 重复执行导致错误结果

Fixes #1662

## 问题

`examples/causal_conv1d/causal_conv1d_decode.py` 使用显式 `(cid, vid)` 启动两个 AIV，但 kernel 体内从未使用 `vid` 划分工作——两个 AIV 以相同 `cid` 把同一个 decode 任务完整执行两遍。

`causal_conv1d_decode` 是有状态操作：读取 `conv_state` → 计算 `y` → 把更新后的状态写回同一 cache line。两个 AIV 并发执行读-改-写序列：

```
AIV0: 读旧状态 -> 计算 -> 写回新状态
AIV1: 读旧状态 -> 计算 -> 写回新状态
```

若 AIV0 在 AIV1 读完之前开始写回，AIV1 会读到部分更新的状态，产生错误的 `y` 与 `conv_state`。单次运行通常通过（两 AIV 常以接近进度读完旧状态）；按 issue 协议（32 个独立进程绑定同一张 NPU，固定 seed=43、dim=3072，同时校验 `y` 与 `conv_state`）可稳定复现。

## 为什么 pass 没有自动拆分

`AscendVidReduction` 只处理 `T.Kernel(..., threads=2) as cid` 这种由编译器负责拆分的写法；显式 `(cid, vid)` 不会介入。

## 修复

**example（1 行）**：改为 compiler-managed 1:2 MIX：

```diff
-        with T.Kernel(total_tasks, is_npu=True) as (cid, vid):
+        with T.Kernel(total_tasks, threads=2, is_npu=True) as (cid):
```

**pass（3 行）**：`AscendVidReduction` 的 `IsTileOp` 增加 `tl.ascend_cast`、`tl.ascend_mul_add_dst`、`tl.ascend_silu`。这三个 op 的末参均为处理长度（见 `tilelang/language/ascend_tile.py`），与既有条目共用 `ModifyTileOpSize` 的末参减半机制。

这一步不可省略：只改 `threads=2` 时，copy 和 UB 会被拆成每个 AIV 处理 1024 个元素，但这三个 op 仍处理 2048 个元素，反而越界。

修复后每个 AIV 只处理自己的 1024 元素半块，所有 `y` 与 `conv_state` 地址均带 `vid * 1024` 偏移，两者不再读写同一段状态。

**test（+65 行）**：新增 `test_vid_reduction_tile_cast_ops` 数值回归，以 `cast(fp16→fp32) → mul_add_dst → silu → cast(→fp16)` 链式覆盖三个 op——任何错误的 size 减半都会传播到最终结果 `silu(a + a²)`。

## 验证

测试环境：Ascend910（本复现环境为 910，issue 为 Atlas A3 / 9392，同一 1:2 MIX 行为）、CANN 9.0.0、基于 upstream `ascendc_pto` 最新提交 `89a9364e`（2026-09-08）。

32 进程同卡压测（issue 复现协议：seed=43、dim=3072，每进程 8 次迭代，每迭代同时校验 `y` 与 `conv_state`）：

| 变体 | 结果 |
|---|---|
| 修复前（HEAD） | 30/32 通过；2 例静默错误（分别 882/3072、1957/3072 个 `y` 元素错误，`conv_state` 同步损坏） |
| 修复后（第 1 轮） | 32/32 通过 |
| 修复后（第 2 轮） | 32/32 通过 |

其他回归：

- `examples/causal_conv1d/causal_conv1d_decode.py` 自测（decode_bs1_sl1 dim=2048 + qwen35_2b_tp2 dim=3072）：PASS
- `testing/python/language/cvseparate/test_tilelang_ascend_language_vid_reduction.py` 全量：**18/18 通过**（含新增测试）
- `ruff check` / `ruff format` / `clang-format --Werror`：通过

## 影响面

- pass 改动为纯增量（`IsTileOp` 集合新增 3 个 op），只影响 `threads=2` 且使用这三个 op 的 kernel；既有 17 项 VidReduction 测试全部通过
- example 改动仅 1 行，接口与数值行为不变（仍为 1:2 MIX，每 AIV 半块）
