### PR TITLE
[Fix] Resolve multi-dim scalar BufferLoad index in T.tile binary ops (#1679)

### DIFF
--- a/src/target/codegen_ascend_pto.cc
+++ b/src/target/codegen_ascend_pto.cc
@@ -2612,11 +2612,35 @@ void CodeGenTileLangAscendPto::CompareScalarCodegen(
   ShapeInfo src0_shape_info = GetSliceInfo(op->args[1].as<CallNode>());
   ShapeInfo dst_shape_info =
       GetCompareMaskInfo(op->args[0].as<CallNode>(), src0_shape_info);
-  auto src1_name = PrintExpr(op->args[2]);
-  auto mode = Downcast<StringImm>(op->args[3])->value;
+  // The scalar operand comes either as an immediate expression (args[2],
+  // mode at args[3]) or as a buffer pointer plus element index (args[2] is a
+  // tvm_access_ptr, index at args[3], mode at args[4]).
+  const auto *scalar_buf = op->args[2].as<CallNode>();
+  const bool is_buffer_scalar =
+      scalar_buf != nullptr &&
+      scalar_buf->op.same_as(builtin::tvm_access_ptr());
+  std::string src1_name;
+  int mode_idx = 3;
+  if (is_buffer_scalar) {
+    std::string buf_offset = PrintBufferOffset(scalar_buf);
+    std::string temp_name = GetTempVarName(buf_offset + "_scalar");
+    this->PrintIndent();
+    this->stream << "set_flag(PIPE_V, PIPE_S, EVENT_ID0);\n";
+    this->PrintIndent();
+    this->stream << "wait_flag(PIPE_V, PIPE_S, EVENT_ID0);\n";
+    this->PrintIndent();
+    this->stream << "auto " << temp_name << " = " << buf_offset << ".GetValue("
+                 << PrintExpr(op->args[3]) << ");\n";
+    src1_name = temp_name;
+    mode_idx = 4;
+  } else {
+    src1_name = PrintExpr(op->args[2]);
+  }
+  auto mode = Downcast<StringImm>(op->args[mode_idx])->value;
 
   DataType src_dtype = GetAccessPtrDtypePto(op->args[1].as<CallNode>());
-  DataType scalar_dtype = op->args[2].dtype();
+  DataType scalar_dtype =
+      is_buffer_scalar ? GetAccessPtrDtypePto(scalar_buf) : op->args[2].dtype();
   if (scalar_dtype != src_dtype) {
     src1_name = getType(src_dtype) + "(" + src1_name + ")";
   }

--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -299,6 +299,49 @@ def test_adds(dtype, target, shape):
     run_test_adds(M, N, 64, 32, scalar, dtype, target=target)
 
 
+def max_scalar_from_multidim_buffer(M, N, block_M, block_N, dtype="float16"):
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        S: T.Tensor((2, 8), dtype),  # type: ignore
+        C: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+            s_ub = T.alloc_ub((2, 8), dtype)
+            c_ub = T.alloc_ub((block_M, block_N), dtype)
+            T.copy(A, a_ub)
+            T.copy(S, s_ub)
+            # Multi-dim BufferLoad must resolve to S[1, 3], not S.flatten()[1].
+            T.tile.max(c_ub, a_ub, s_ub[1, 3])
+            T.copy(c_ub, C)
+
+    return main
+
+
+@pytest.mark.parametrize("dtype", ["float16", "float"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_binary_scalar_from_multidim_buffer(dtype, target, setup_random_seed):
+    # float16: 8 halves per row exercise the 32B-padded UB row stride;
+    # float: 8 floats per row keep the dense row-major stride.
+    M, N = 128, 128
+    func = max_scalar_from_multidim_buffer(M, N, M, N, dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch_dtype = torch.float32 if dtype == "float" else torch.float16
+    a = torch.randn(M, N, dtype=torch_dtype).npu()
+    # Distinct values: s[1, 3] == 11 while s.flatten()[1] == 1.
+    s = torch.arange(16, dtype=torch_dtype).reshape(2, 8).npu()
+
+    c = func(a, s)
+    torch.npu.synchronize()
+
+    ref_true_index = torch.max(a, s[1, 3])
+    ref_first_index = torch.max(a, s.view(-1)[1])
+    assert not torch.allclose(c, ref_first_index)
+    torch.testing.assert_close(c, ref_true_index, rtol=1e-2, atol=1e-2)
+
+
 def bitwise_and(M, N, block_M, block_N, dtype="int16"):
     m_num = M // block_M
     n_num = N // block_N
@@ -1712,6 +1755,50 @@ compare_dtype_target_params = [
 def test_compare(out_dtype, dtype, target, shape):
     M, N = shape
     run_test_compare(M, N, 128, 256, "LT", dtype, out_dtype, target)
+
+
+def compare_scalar_from_multidim_buffer(M, N, block_M, block_N, mode, dtype="float16", out_dtype="uint8"):
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        S: T.Tensor((2, 8), dtype),  # type: ignore
+        C: T.Tensor((M, N // 8), out_dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((block_M, block_N), dtype)
+            s_ub = T.alloc_ub((2, 8), dtype)
+            c_ub = T.alloc_ub((block_M, block_N // 8), out_dtype)
+            T.copy(A, a_ub)
+            T.copy(S, s_ub)
+            # Multi-dim BufferLoad must resolve to S[1, 3], not S.flatten()[1].
+            T.tile.compare(c_ub, a_ub, s_ub[1, 3], mode)
+            T.copy(c_ub, C)
+
+    return main
+
+
+@pytest.mark.parametrize("dtype", ["float16", "float"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_compare_scalar_from_multidim_buffer(dtype, target, setup_random_seed):
+    # float16: 8 halves per row exercise the 32B-padded UB row stride;
+    # float: 8 floats per row keep the dense row-major stride.
+    M, N = 128, 256
+    func = compare_scalar_from_multidim_buffer(M, N, M, N, "LT", dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch_dtype = torch.float32 if dtype == "float" else torch.float16
+    a = torch.randn(M, N, dtype=torch_dtype).npu()
+    # Distinct values: s[1, 3] == 11 while s.flatten()[1] == 1.
+    s = torch.arange(16, dtype=torch_dtype).reshape(2, 8).npu()
+
+    c = func(a, s)
+    torch.npu.synchronize()
+
+    ref_c = torch.zeros(M, N // 8, dtype=torch.uint8).npu()
+    ref_true_index = compare_and_set_bits(a, s[1, 3], ref_c, "uint8")
+    ref_first_index = compare_and_set_bits(a, s.view(-1)[1], ref_c, "uint8")
+    assert not torch.equal(c, ref_first_index)
+    torch.testing.assert_close(c, ref_true_index)
 
 
 def compare_slice(M, N, block_M, block_N, mode, dtype="float", out_dtype="uint8"):

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -81,6 +81,39 @@ def _handle_buffer_region(br: BufferRegion, mask):
     return bf.access_ptr(mask, offset=offset, extent=size_extent), extent
 
 
+def _scalar_load_offset(load: BufferLoad) -> PrimExpr:
+    """Resolve a scalar BufferLoad into its element offset in the buffer.
+
+    A multi-dimensional element access such as ``s_ub[1, 3]`` must address the
+    requested element; forwarding only the first index would silently read
+    ``s_ub.flatten()[1]``.
+
+    ``shared.ub`` buffers are physically laid out with each row padded to a
+    32-byte boundary (MTE burst granularity on AscendC, aligned columns in
+    PTO's ``TileUbDataND``, mirrored by ``Flatten2DBuffer``'s 256-bit
+    inner-dim alignment and the UB memory planner), so their row stride is the
+    padded one. 1-D buffers, unit-inner-dim buffers (PTO stores them as a flat
+    ``[1, M]`` DN tile) and non-UB buffers keep dense row-major offsets.
+    """
+    buf = load.buffer
+    indices = load.indices
+    if len(indices) <= 1 or buf.scope() != "shared.ub":
+        return buf.offset_of(indices)[0]
+    last_dim = buf.shape[-1]
+    if isinstance(last_dim, IntImm) and last_dim.value == 1:
+        return buf.offset_of(indices)[0]
+    bits = DataType(buf.dtype).bits
+    elem_align = 256 // bits if bits <= 256 else 1
+    if isinstance(last_dim, IntImm):
+        stride = -(-last_dim.value // elem_align) * elem_align
+    else:
+        stride = (last_dim + (elem_align - 1)) // elem_align * elem_align
+    outer = indices[0]
+    for dim, idx in zip(buf.shape[1:-1], indices[1:-1]):
+        outer = outer * dim + idx
+    return outer * stride + indices[-1]
+
+
 def _is_const_one(val) -> bool:
     """Check if a value is constant 1 (int or IntImm)."""
     if isinstance(val, (int, float)):
@@ -810,7 +843,6 @@ def select(
 
         src1_type = 0
         buffer_1 = src1.buffer
-        indices_1 = src1.indices
         return _call_intrin_with_optional_tmp(
             "select",
             [
@@ -819,7 +851,7 @@ def select(
                 src0_ptr,
                 src1_type,
                 buffer_1.access_ptr("r"),
-                indices_1[0],
+                _scalar_load_offset(src1),
                 selMode,
                 size_0,
             ],
@@ -999,14 +1031,13 @@ def binary_op(
     assert size_0 == size_1, "size must be same"
     if isinstance(src1, BufferLoad):
         buffer_1 = src1.buffer
-        indices_1 = src1.indices
         return T.call_intrin(
             "handle",
             tir.op.Op.get(f"tl.ascend_{op}s"),
             dst_ptr,
             src0_ptr,
             buffer_1.access_ptr("r"),
-            indices_1[0],
+            _scalar_load_offset(src1),
             size_0,
         )
 
@@ -1904,14 +1935,13 @@ def compare(
 
     if isinstance(src1, BufferLoad):
         buffer_1 = src1.buffer
-        indices_1 = src1.indices
         return T.call_intrin(
             "handle",
             tir.op.Op.get("tl.ascend_compare_scalar"),
             dst_ptr,
             src0_ptr,
             buffer_1.access_ptr("r"),
-            indices_1[0],
+            _scalar_load_offset(src1),
             mode,
             dst_size,
         )


### PR DESCRIPTION
Fixes #1679

## Root cause

本 issue 实为**两层 bug 叠加**，issue 报告的是第一层；只修第一层结果依然是错的。

### 第一层（issue 报告的）：前端丢弃多维索引

`tilelang/language/ascend_tile.py` 的 `binary_op`（`add/sub/mul/div/max/min/bitwise_*` 共用）
在 `src1` 为 BufferLoad 时只转发 `indices_1[0]`：

```python
return T.call_intrin(..., buffer_1.access_ptr("r"),
                     indices_1[0],   # ← s_ub[1, 3] 只剩 1，"3" 被静默丢弃
                     size_0)
```

两个后端 codegen（AscendC `AddsAndMulsOpCodegen` / PTO `BinaryVecOpsCodegen`）都把该参数直接
用作 `GetValue(index)`，于是 `T.tile.max(c_ub, a_ub, s_ub[1, 3])` 生成
`s_ub.GetValue(1)` → 读到 `S.flatten()[1] = S[0][1]`，静默出错。同一模式还存在于 `compare`
（`compare_scalar`）与 `select` 的 BufferLoad 分支。

### 第二层（验证时发现）：稠密扁平偏移 ≠ UB 物理布局

把偏移改成"正确的"稠密值 `1×8+3 = 11` 后**结果仍错**。上板做索引探针实验（(4,8) fp16 UB
buffer，逐个验证 `GetValue(N)` 实际读到的元素）：

| 请求 | 稠密偏移 | 实际读到 |
|---|---|---|
| `s_ub[0,3]` | 3 | `S[0][3]` ✓ |
| `s_ub[1,3]` | 11 | **pad 区垃圾** ✗ |
| `s_ub[2,3]` | 19 | **`S[1][3]`** ✓ |
| `s_ub[2,0]` | 16 | **`S[1][0]`** ✓ |

即 **S 的第 r 行物理上存放在元素 `16r` 处，而非稠密布局的 `8r`**。原因是系统级的既有契约：
`shared.ub` 窄行 tile 的每一行物理 padding 到 32 字节——

- AscendC：`copy_gm_to_ub` 按 DataCopyPad 逐行 burst，MTE burst 粒度使每个不足 32B 的行各占一个 32B 槽；
- PTO：显式建模为 `TileUbDataND<half, 2, 16, 2, 8>`（物理列 16 = 32B/2B，valid 列 8，pad 区填 `PadValue`）；
- `Flatten2DBuffer` pass 对 `shared.ub` 做 256bit 内维对齐（`kScopeForAlignment`），UB 内存规划器按 padding 后的形状分配（(2,8) fp16 实际分到 64B）。

**唯一没遵守这个契约的就是前端标量偏移的计算**（TIR buffer 的 `offset_of` 是稠密行主序）。
因此 `s_ub[1,3]` 的正确偏移是 `1×16+3 = 19`，实测 `GetValue(19)` 精确返回 `S[1][3]`。

## What this PR does

| 文件 | 改动 |
|---|---|
| `tilelang/language/ascend_tile.py` | 新增 `_scalar_load_offset()`：多维标量 BufferLoad 按 **32B padding 行 stride** 解析为物理元素偏移（`s_ub[1,3]` 于 (2,8) fp16 → 19）；1-D buffer、内维为 1 的 buffer（PTO 以 `[1, M]` DN tile 平铺存储，稠密偏移正确）、非 UB buffer 保持稠密偏移——`scale_ub[h_i]` 等 1-D 符号索引用法 byte 级不变。`binary_op` / `compare` / `select` 三处 `indices_1[0]` 全部替换 |
| `src/target/codegen_ascend_pto.cc` | PTO `CompareScalarCodegen` 补上 buffer+index 形式的标量支持（该形式此前直接 `Unresolved call Op(tir.tvm_access_ptr)` 崩溃，属预先存在的缺陷，修复前后 arg 布局相同）；实现镜像同文件 `BinaryVecOpsCodegen` 的 `GetValue` 提取模式 |
| `testing/python/language/test_tilelang_ascend_language_elementwise.py` | 回归测试 ×2 组：`test_binary_scalar_from_multidim_buffer`（max）/ `test_compare_scalar_from_multidim_buffer`（compare+packed mask），各参数化 fp16/fp32 × ascendc/pto。fp16 走 padding stride 路径、fp32 走稠密路径；用 `arange` 保证 `s[1,3] ≠ s.flatten()[1]`，并显式断言结果不等于"first-index"参考 |

## Test results

Ascend910B3 / CANN 9.0.0 / 本地构建（commit `a61eeee9`，基于 `upstream/ascendc_pto` `0e9a1a5b` rebase，rebase 后重建并复验通过）。

| 验证 | 结果 |
|---|---|
| issue 原始复现脚本（ascendc + pto） | 修复前 `out == max(a, S.flatten()[1]): True`；修复后双后端 `out == max(a, S[1,3]): True`，且 `flatten()[1]: False` |
| 新增回归测试 | 8/8 通过（含修复前后 A/B 语义：`assert not allclose(out, ref_first_index)`） |
| 既有回归：elementwise 全量 | 492 passed / 2 xfailed |
| 既有回归：tail_mask_codegen + tail_block / select + explicit_tmp / vid_reduction（含 `scale_ub[h_i]` 1-D 符号索引路径） | 316 / 76 / 17 全部通过 |
| `ruff check` / `clang-format --dry-run -Werror` | 干净 |

## ⚠️ 遗留的更深层次问题（本 PR 未修，建议单独跟踪）

1. **窄行 2-D UB buffer 的整块 elementwise 算子**：`T.tile.exp` 等以稠密元素数（`prod(shape)`）
   作为操作长度，而物理布局是行 padding 的——第二行起读到 pad 区。实测 `exp` 在 (2,8) fp16
   buffer 上第二行输出负值（exp 不可能为负）。这是同一布局契约的系统性矛盾（本 PR 只修标量
   读取路径），建议另立 issue。
2. **`T.tile.select` 的 BufferLoad 分支**：AscendC `SelectCodegen` 的 `src1_type==0` 分支把
   `args[4]`（access_ptr）同时当作 buffer 指针和 GetValue 下标（下标实际在 `args[5]`），
   编译期即 `TVMError`。已实测修复前后行为相同（都崩），属预先存在的独立 codegen 缺陷；
   本 PR 修了该路径的前端偏移计算，未动其 codegen。
3. **(M,1) 内维为 1 的 UB buffer**：PTO 平铺为 `[1, M]` DN tile（稠密偏移正确），AscendC
   逐行 burst 会按 32B 槽摆放——两后端物理布局可能不一致。本 PR 对内维为 1 的 buffer 保持
   稠密偏移（与现状一致，零行为变化），该潜在分歧留待后续核查。

## Reproduce snippet（issue 原始复现，修复前）

```python
@T.prim_func
def kernel(A: T.Tensor((4, 64), "float16"), S: T.Tensor((2, 8), "float16"), C: T.Tensor((4, 64), "float16")):
    with T.Kernel(1, is_npu=True) as (cid, _):
        a_ub = T.alloc_ub((4, 64), "float16")
        s_ub = T.alloc_ub((2, 8), "float16")
        c_ub = T.alloc_ub((4, 64), "float16")
        T.copy(A, a_ub)
        T.copy(S, s_ub)
        T.tile.max(c_ub, a_ub, s_ub[1, 3])  # intended scalar: S[1,3]
        T.copy(c_ub, C)
```

修复前（两后端一致）：

```text
out == max(a, S.flatten()[1]): True   # 实际用了 1.7646 (S[0][1])
out == max(a, S[1,3]):          False # 用户要的 0.6372 没用上
```

修复后（两后端一致）：

```text
out == max(a, S.flatten()[1]): False
out == max(a, S[1,3]):          True
```
