### PR TITLE
[Fix] Reject non flat-contiguous BufferRegions in T.tile binary ops(#1680)

### DIFF
--- a/testing/python/language/test_tilelang_ascend_language_elementwise.py
+++ b/testing/python/language/test_tilelang_ascend_language_elementwise.py
@@ -3066,6 +3066,82 @@ def test_vec_max(dtype, target, shape):
     run_test_vec_max(M, N, 64, 128, dtype, target=target)
 
 
+def vec_max_row_region(dtype):
+    @T.prim_func
+    def main(
+        A: T.Tensor((4, 64), dtype),  # type: ignore
+        B: T.Tensor((4, 64), dtype),  # type: ignore
+        C: T.Tensor((4, 64), dtype),  # type: ignore
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            a_ub = T.alloc_ub((4, 64), dtype)
+            b_ub = T.alloc_ub((4, 64), dtype)
+            c_ub = T.alloc_ub((4, 64), dtype)
+            T.copy(A, a_ub)
+            T.copy(B, b_ub)
+            T.tile.max(c_ub[1:3, :], a_ub[1:3, :], b_ub[1:3, :])
+            T.copy(c_ub, C)
+
+    return main
+
+
+def run_test_vec_max_row_region(dtype, target):
+    func = vec_max_row_region(dtype)
+    func = tilelang.compile(func, out_idx=[-1], pass_configs=pass_configs, target=target)
+
+    torch_dtype = torch.float32 if dtype == "float" else torch.float16
+    a = torch.randn(4, 64, dtype=torch_dtype).npu()
+    b = torch.randn(4, 64, dtype=torch_dtype).npu()
+
+    torch.npu.synchronize()
+
+    c = func(a, b)
+
+    ref_c = torch.max(a, b)
+    torch.testing.assert_close(c[1:3, :], ref_c[1:3, :], rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16"])
+@pytest.mark.parametrize("target", ["ascendc", "pto"])
+def test_vec_max_row_region(dtype, target):
+    run_test_vec_max_row_region(dtype, target)
+
+
+def test_binary_op_region_validation():
+    dst = tir.decl_buffer((4, 64), "float32", scope="shared.ub")
+    src0 = tir.decl_buffer((4, 64), "float32", scope="shared.ub")
+    src1 = tir.decl_buffer((4, 64), "float32", scope="shared.ub")
+
+    # Flat-contiguous regions keep the linear vector semantics and are accepted.
+    whole = T.tile.max(dst[:, :], src0[:, :], src1[:, :])
+    assert int(whole.args[3]) == 4 * 64
+    rows = T.tile.max(dst[1:3, :], src0[1:3, :], src1[1:3, :])
+    assert int(rows.args[3]) == 2 * 64
+    single_row = T.tile.max(dst[2, :], src0[2, :], src1[2, :])
+    assert int(single_row.args[3]) == 64
+    row_window = T.tile.max(dst[2, 8:40], src0[2, 8:40], src1[2, 8:40])
+    assert int(row_window.args[3]) == 32
+
+    vec_dst = tir.decl_buffer((256,), "float32", scope="shared.ub")
+    vec_src0 = tir.decl_buffer((256,), "float32", scope="shared.ub")
+    vec_src1 = tir.decl_buffer((256,), "float32", scope="shared.ub")
+    span = T.tile.max(vec_dst[8:40], vec_src0[8:40], vec_src1[8:40])
+    assert int(span.args[3]) == 32
+
+    # Column-offset slices are rejected at trace time instead of silently
+    # producing wrong results (aligned offset) or aicore exception 507015
+    # (unaligned offset). See issue #1680.
+    column_window = r"must be contiguous when flattened"
+    with pytest.raises(ValueError, match=column_window):
+        T.tile.max(dst[:, 8:40], src0[:, 8:40], src1[:, 8:40])
+    with pytest.raises(ValueError, match=column_window):
+        T.tile.max(dst[:, 8:40], src0[:, 8:40], 1.0)
+    with pytest.raises(ValueError, match=column_window):
+        T.tile.max(dst, src0, src1[:, 8:40])
+    with pytest.raises(ValueError, match=column_window):
+        T.tile.add(dst[:, 8:40], src0[:, 8:40], src1[:, 8:40])
+
+
 def vec_maxs(M, N, block_M, block_N, scalar, dtype="float"):
     m_num = M // block_M
     n_num = N // block_N

--- a/tilelang/language/ascend_tile.py
+++ b/tilelang/language/ascend_tile.py
@@ -964,6 +964,27 @@ def brcb_experiment(
     )
 
 
+def _validate_binary_op_region(br: BufferRegion, op: str, arg_name: str) -> None:
+    """Reject BufferRegions that are not contiguous when flattened.
+
+    ``binary_op`` lowers a region to a single linear vector operation, so a
+    column-offset slice such as ``buf[:, 8:40]`` silently loses its per-row
+    layout: a 32-byte-aligned offset computes over the wrong elements and an
+    unaligned one raises aicore exception 507015. Only regions that select a
+    contiguous linear span (whole buffer, whole rows, a single row, or a 1D
+    slice) keep the linear semantics.
+    """
+    try:
+        _validate_buffer_region_contiguity(br, require_flat_contiguous=True)
+    except ValueError as err:
+        raise ValueError(
+            f"T.tile.{op} requires {arg_name} to be contiguous when flattened; only "
+            f"whole-row / whole-buffer / 1D contiguous regions are supported, and "
+            f"column-offset slices produce wrong results or aicore exception 507015. "
+            f"Detail: {err}"
+        ) from err
+
+
 def binary_op(
     dst: Buffer | BufferRegion,
     src0: Buffer | BufferRegion,
@@ -971,11 +992,13 @@ def binary_op(
     op: str,
 ):
     if isinstance(dst, BufferRegion):
+        _validate_binary_op_region(dst, op, "dst")
         dst_ptr, dst_extent = _handle_buffer_region(dst, "w")
     else:
         dst_ptr = dst.access_ptr("w")
         dst_extent = dst.shape
     if isinstance(src0, BufferRegion):
+        _validate_binary_op_region(src0, op, "src0")
         src0_ptr, src0_extent = _handle_buffer_region(src0, "r")
     else:
         src0_ptr = src0.access_ptr("r")
@@ -1000,6 +1023,7 @@ def binary_op(
     elif isinstance(src1, (PrimExpr, float, int)):
         return T.call_intrin("handle", tir.op.Op.get(f"tl.ascend_{op}s"), dst_ptr, src0_ptr, src1, size_0)
     elif isinstance(src1, BufferRegion):
+        _validate_binary_op_region(src1, op, "src1")
         src1_ptr, src1_extent = _handle_buffer_region(src1, "r")
         size_2 = math.prod(src1_extent)
         assert size_0 == size_2, "size must be same"


### PR DESCRIPTION
Fixes #1680

## Root cause

`T.tile.*` 二元算子共享同一个前端（`tilelang/language/ascend_tile.py` 中的 `binary_op`）。
它通过 `_handle_buffer_region` 把任意 BufferRegion 展平为
`(offset = offset_of(各维起点), count = prod(各维范围))`，再发射一条 count 型线性向量
intrinsic——该 intrinsic 的签名只能携带“一个基址 + 一个元素数”，既没有行步长，
也无法表达多段区域。

对 (4, 64) buffer 的列偏移切片 `buf[:, 8:40]`，这一压缩得到的是“从元素 8 开始的
连续 128 个元素”，而真实选择集是 4 个独立段、每段 32 个元素、段间隔 32 个元素。
两个后端上的后果：

- **float16**（列偏移 8 × 2B = 16B，落在 block 正中间）：向量指令操作数地址违反
  32 字节 block 对齐要求 → aicore exception 507015；
- **float32**（8 × 4B = 32B，恰好对齐）：指令正常执行，但作用在错误的线性区间上
  → 静默错误结果。

该限制本有文档说明（“仅支持整行/整 buffer 的连续区域”），但前端从未校验 slice 形状，
于是无法表达的几何被静默降级成了另一个请求。

## What this PR does

- 新增 `_validate_binary_op_region`，在 `binary_op` 的三个 BufferRegion 入口
  （dst / src0 / src1）展平之前调用。它复用既有的
  `_validate_buffer_region_contiguity(require_flat_contiguous=True)` 校验器——与 #1495
  为 row_expand 家族引入的守卫相同——将该惯例推广到 8 个通用二元算子
  （add / sub / mul / div / max / min / bitwise_and / bitwise_or）。
- 继续放行、行为不变：整 buffer、整行窗口（`buf[1:3, :]`）、单行（`buf[2, :]`）、
  行内切片（`buf[2, 8:40]`）、1D 区间（`v[8:40]`）。
- 非法形式在 trace 期即被拒绝，错误信息包含算子名、违规参数、支持的合法形式与
  出错位置，例如：

```
error: T.tile.max requires dst to be contiguous when flattened; only whole-row /
whole-buffer / 1D contiguous regions are supported, and column-offset slices
produce wrong results or aicore exception 507015. Detail: BufferRegion must be
contiguous when flattened; axis 1 is not selected in full.
```

- 不涉及任何后端 / intrinsic / pass 改动——拦截点就设在产生错误数值的前端。

我们也评估过完整支持（strided repeat）方案并有意未采用：行间步长永远可以表达，但每段
起点必须落在 32 字节边界上——fp32/offset=8 恰好满足，而 fp16/offset=8（16B）在硬件上
无解（需要“掐头 mask 机制 + dst 头部 read-modify-write”，两者均无现成原语）。部分支持
会制造 dtype 相关的陷阱，且需要携带每操作数独立步长的新 intrinsic 加上双后端
codegen——这是 feature 级工作量，不属于本 bugfix 范围。用户当前即可通过按行循环、
或把列窗口拷贝到连续临时 buffer 来正确表达意图。

## Test results

Ascend 910B3 / CANN 8.5.2 / 本地构建（commit `1e2d6a81`，基于 `upstream/ascendc_pto`）。

Issue 复现脚本（双后端 × 双 dtype）：

| target | dtype | 修复前 | 修复后 |
|--------|-------|--------|--------|
| ascendc | float16 | aicore exception 507015 | trace 期 `ValueError`，指向出错行 |
| ascendc | float32 | 切片区域静默错误结果 | trace 期 `ValueError` |
| pto     | float16 | aicore exception 507015 | trace 期 `ValueError` |
| pto     | float32 | 切片区域静默错误结果 | trace 期 `ValueError` |

正向对照：整行 region（`buf[1:3, :]`）在全部 4 种组合下编译运行、结果正确。

新增测试：`test_binary_op_region_validation`（前端校验矩阵：5 种合法形式含 extent 断言
+ 4 种非法形式，覆盖 dst/src0/src1 三个入口与标量路径）；`test_vec_max_row_region`
（上板正确性，ascendc/pto × float/float16）。

回归：121 个既有测试通过（elementwise 二元 op 80 个、row_expand 15 个、parallel
21 个、其他 5 个）。`ruff check` / `ruff format --check` 通过。

## 后续跟踪（不在本 PR 内）

`unary_op`（exp / ln / abs 等）及其他接收 BufferRegion 的 tile op 存在同类展平隐患，
将在后续变更中按同一模式补齐守卫。
